### PR TITLE
#1428: the se#769 WAVE-WIDE vendor sync — one writer, one cut rev, both tables

### DIFF
--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -169,6 +169,42 @@ LOCAL-ONLY tests/test_author_ci_harness_pgw1150.py|serverless-endpoints is not c
 # corpus does not, the test FAILS rather than skipping — a rename must not turn
 # this gate into a `continue` (WORKSPACE-GIT-POLICY, "read the COUNT").
 LOCAL-ONLY tests/test_planner_grid.py|no tensorfs checkout beside this repo (set tensorfs_repo)
+# pgw#1428. TWO rows, the same shape as the planner-vector row above and for the
+# same reason: the vendored contract library and the vendored conformance corpus
+# compared against tensorfs AT THE REV `VENDORED.toml` PINS. No CI runner has a
+# tensorfs checkout, so neither can run there — and what they add over what CI
+# already proves is only "the snapshot is faithful to the rev it claims".
+# Everything else about those bytes IS measured in CI: every vendored document
+# is digest-pinned in `[packages.tensorfs.files]` and enforced as a SET by
+# `test_every_vendored_file_matches_its_recorded_digest`, and all sixteen golden
+# vectors are re-derived through the pure-Python port and compared to Rust's own
+# digests.
+#
+# WHY THE REASON STRING CHANGED, since that is what put these keys here: these
+# checks used to read the sibling's WORKING TREE, which asserts this repo is
+# always at tensorfs TIP and contradicts pinning a rev at all. Worse, the path
+# they used (`ROOT.parent.parent.parent`) resolved only from a WORKTREE — from
+# the main checkout it landed on `/home/tensorfs` and both rows skipped
+# silently, including here. So they were already skipping in CI; they were just
+# skipping under a reason nobody had to classify. Naming them is the fix, not a
+# new exemption. Set up a sibling `~/cozy/tensorfs` with the pinned rev fetched
+# to run them anywhere.
+CI-SKIPPED tests/test_lane_contracts.py|no sibling tensorfs checkout carrying contract_plane_rev
+# PRE-EXISTING, classified here because this change is already in this file and
+# the census step is red on clean origin/master for exactly these two keys
+# (verified: master job 95860438657 fails with the same two, one of them under
+# this row's reason verbatim). Leaving it would keep a fleet-wide step red for
+# every PR in the repo.
+#
+# What it says: `tensorfs#115` added `TensorStreamReader`, and the tensorfs the
+# CI env INSTALLS predates it — so the native weight-streaming suite has no
+# subject to test there. This is a genuine CI-SKIPPED, not a LOCAL-ONLY: the
+# property is measured wherever a current tensorfs is installed, and it becomes
+# runnable in CI the moment the installed tensorfs advances past #115. It is a
+# STAGED-shaped row wearing CI-SKIPPED clothes; if it is still here after the
+# next tensorfs bump, that bump did not reach this env and the row should be
+# re-read rather than re-blessed.
+CI-SKIPPED tests/test_weight_streaming_native_store.py|the installed tensorfs predates tensorfs#115 — it carries no tensorstreamreader, which is the whole subject of this suit
 # pgw#978. The full local mint cycle: a real child spawn, a real torch.export +
 # AOTInductor compile, a real publish over the wire and a real second-process
 # adopt. It is opt-in EVERYWHERE, CI included — not because CI could run it and

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -199,15 +199,44 @@ read_plane_files = ["__init__.py", "gguf.py", "project.py", "tensors.py", "write
 # out of a source-vendored wheel. Taking it straight would have imported a
 # module that cannot exist here.
 #
-# ELEVEN documents, not six: `contract_plane_rev` advanced from `c3a831d` to
-# `107b8ac` (tensorfs#121) and then `2abc1b76` (tensorfs#124) inside pgw#1391
-# itself, and those bumps are the whole point rather than a chore. #121
-# authored the four se#757 blocker-A lane documents (`sd15`, `sd2`,
+# TWENTY documents, not six, and this bump is the se#769 WAVE-WIDE SYNC — one
+# writer, one cut rev, the whole wave's lane documents at once. Before it, five
+# lanes were each bumping this file on their own schedule and racing through
+# one table; the arbitration was that the qwen lane landed a SUBSET (honest for
+# pgw's own set-equality fence, but it hand-trimmed the vendored corpus to match
+# rather than shipping upstream's bytes), everyone else held, and this sync
+# brings the set back to EQUAL the real upstream corpus.
+#
+# `contract_plane_rev` advanced c3a831d -> `107b8ac` (tensorfs#121) ->
+# `2abc1b76` (#124/#125) -> `b8bb39fd` (#134) -> `272103e4`, the cut. The
+# documents arriving here belong to OTHER LANES and are vendored bytes-only,
+# named so the ownership is readable rather than implied:
+#
+#   flux1.diffusers-bf16          se#778   tensorfs#136
+#   qwen-image / z-image          se#776   tensorfs#131   (already present)
+#   internvl-u.diffusers-bf16     se#779   tensorfs#137
+#   ltx-2.diffusers-bf16          se#772   tensorfs#135
+#   trellis2.dit-bf16             se#775   tensorfs#132
+#   ernie.diffusers-bf16          se#—     tensorfs#142
+#   minimax.h3-dit-fp8-rowwise    —        tensorfs#128
+#   sdxl.diffusers-fp8-rowwise    —        tensorfs#128
+#
+# #121 authored the four se#757 blocker-A lane documents (`sd15`, `sd2`,
 # `hidream-o1`, `wan22` — sd15 and sd2 are SEPARATE documents with separate
 # digests) and gave `minimax.h3-dit-diffusers@1` the top-level `dtype` it owed;
-# #124 added `flux2-klein.diffusers-bf16@1`. Clearing the four
-# `MissingContract` sentinels in `models/model_types.py` took NO code change,
-# which is the property the sentinel shape exists to have.
+# #124 added `flux2-klein.diffusers-bf16@1` and then `flux1.diffusers-bf16@1`.
+# Clearing the FIVE `MissingContract` sentinels in `models/model_types.py` took
+# NO code change, which is the property the sentinel shape exists to have —
+# `Flux1.canonical_contract` resolves now purely because its document is here.
+#
+# THE FENCE READS TWO TABLES AND A BUMP MUST TOUCH BOTH. `contract_plane_files`
+# is the contract-plane inventory; `[packages.tensorfs.files]` is the
+# path -> sha256 table `test_every_vendored_file_matches_its_recorded_digest`
+# enforces AS A SET. Updating one and not the other is the defect this sync
+# exists to stop repeating — and the failure modes differ, so neither catches
+# the other: the digest fence caught three documents "only on disk", while a
+# list that silently GREW duplicate rows (34 entries for a 20-document library)
+# was invisible to it, because the fence reads the other table.
 #
 # Two documents RE-DIGESTED across that bump and it is deliberate upstream:
 # `minimax.h3-dit-diffusers@1` gained its dtype, and `sdxl.diffusers-bf16@1`
@@ -222,14 +251,19 @@ read_plane_files = ["__init__.py", "gguf.py", "project.py", "tensors.py", "write
 # They are FRAGMENTS (a family-shared block spelling and two CLIP component
 # spellings) that a `lanes=` header never names on its own. Do not "fix" them,
 # and do not let a declaration-time dtype read treat them as lanes.
-contract_plane_rev = "b8bb39fdef1ce0c327bc482db0563ba97e114372"
+contract_plane_rev = "272103e414184c7935105afa48416b95fd5a10ee"
 contract_plane_files = [
   "contract.py",
   "contracts.py",
   "_contracts/dit.blocks-fused-qkv.v1.json",
+  "_contracts/ernie.diffusers-bf16.v1.json",
+  "_contracts/flux1.diffusers-bf16.v1.json",
   "_contracts/flux2-klein.diffusers-bf16.v1.json",
   "_contracts/hidream-o1.diffusers-bf16.v1.json",
+  "_contracts/internvl-u.diffusers-bf16.v1.json",
+  "_contracts/ltx-2.diffusers-bf16.v1.json",
   "_contracts/minimax.h3-dit-diffusers.v1.json",
+  "_contracts/minimax.h3-dit-fp8-rowwise.v1.json",
   "_contracts/minimax.h3-dit-native.v1.json",
   "_contracts/qwen-image.diffusers-bf16.v1.json",
   "_contracts/sd15.diffusers-bf16.v1.json",
@@ -237,11 +271,13 @@ contract_plane_files = [
   "_contracts/sdxl.clip-g-fused-qkv.v1.json",
   "_contracts/sdxl.clip-g-split-qkv.v1.json",
   "_contracts/sdxl.diffusers-bf16.v1.json",
+  "_contracts/sdxl.diffusers-fp8-rowwise.v1.json",
+  "_contracts/trellis2.dit-bf16.v1.json",
   "_contracts/wan22.diffusers-bf16.v1.json",
   "_contracts/z-image.diffusers-bf16.v1.json",
 ]
 rewrites = [
-  "`contract.py` (pgw#1391): the parse/validate/canonical/digest half is restored in pure Python instead of `from .native import contract_info`, because pgw#1310 rules a compiled extension out of a source-vendored wheel — the `planner.py` precedent exactly. The PUBLIC SURFACE is upstream's attribute for attribute (`Contract.from_document`, `.name/.version/.digest/.stamp/.label/.document/.description/.tensors/.sets`, the RAISING `.dtype`, `MissingDtype`, `TensorDecl`/`Fusion`/`Permute`), so a future pure-Python upstream re-vendor is a deletion rather than a migration. It adds one name upstream does not export, `ContractError`, carrying the kebab-case `reason` label the Rust and Go validators already share — the refusal corpus is keyed on it. Conformance is NOT asserted: `tests/test_lane_contracts.py` runs upstream's released `spec/v1/contract-vectors` corpus (tensorfs#114, the same one the Rust and Go implementations satisfy), vendored at `tests/testdata/contract-vectors/`, over the THIRTEEN VENDORED DOCUMENTS plus the two anonymous customs — 15 golden digests and 19 typed refusals. A SHA-256 over a hand-built line rendering cannot agree by luck. It has already caught a real divergence rather than merely certifying agreement: tensorfs#121 relaxed the contract-name grammar to admit a hyphen in the PRODUCER segment (`hidream-o1`, `flux-2`, `wan-2`; a LEADING hyphen still refuses) and the port refused `hidream-o1.diffusers-bf16` until it followed. NO KNOWN DIVERGENCE TODAY.",
+  "`contract.py` (pgw#1391): the parse/validate/canonical/digest half is restored in pure Python instead of `from .native import contract_info`, because pgw#1310 rules a compiled extension out of a source-vendored wheel — the `planner.py` precedent exactly. The PUBLIC SURFACE is upstream's attribute for attribute (`Contract.from_document`, `.name/.version/.digest/.stamp/.label/.document/.description/.tensors/.sets`, the RAISING `.dtype`, `MissingDtype`, `TensorDecl`/`Fusion`/`Permute`), so a future pure-Python upstream re-vendor is a deletion rather than a migration. It adds one name upstream does not export, `ContractError`, carrying the kebab-case `reason` label the Rust and Go validators already share — the refusal corpus is keyed on it. Conformance is NOT asserted: `tests/test_lane_contracts.py` runs upstream's released `spec/v1/contract-vectors` corpus (tensorfs#114, the same one the Rust and Go implementations satisfy), vendored at `tests/testdata/contract-vectors/`, over the TWENTY VENDORED DOCUMENTS plus the two anonymous customs — 22 golden digests and 19 typed refusals. A SHA-256 over a hand-built line rendering cannot agree by luck. It has already caught a real divergence rather than merely certifying agreement: tensorfs#121 relaxed the contract-name grammar to admit a hyphen in the PRODUCER segment (`hidream-o1`, `flux-2`, `wan-2`; a LEADING hyphen still refuses) and the port refused `hidream-o1.diffusers-bf16` until it followed. NO KNOWN DIVERGENCE TODAY.",
   "`tensors.py`: `TensorReader._map` maps through a pure-Python `_MappedObject` (an `mmap` exported via PEP 688) instead of the compiled `tensorfs.native.MappedObject`, because pgw#1310 rules a compiled extension out of a source-vendored wheel. Upstream's weak-mapping ownership rule is preserved exactly; see the paragraph above. No other file is edited, so the remaining digests are upstream's verbatim.",
   "`planner.py` REPLACES `chunking.py` (pgw#1365): a pure-Python port of `crates/tensorfs-core/src/planner/{mod,safetensors,gguf}.rs` at `read_plane_rev`, because upstream deleted the Python chunker at `00c57c1` in favour of the Rust planner and pgw#1310 rules a compiled extension out of a source-vendored wheel. Conformance is asserted against upstream's released `spec/v1/planner-vectors` corpus, vendored at `tests/testdata/planner-vectors/`. Two knowing divergences, both tested by name: `plan_chunks` cuts a >64 MiB blob on the fixed grid (tensorhub's single-PUT promotion cap — pgw#1366), and a duplicate GGUF metadata key is planned as `gguf-v1` here and `blob-v1` upstream, because `gguf.read_header` does not record metadata keys.",
   "`local.py`: one line — `from .chunking import plan_chunks` becomes `from .planner import plan_chunks`. Every other line is `8bafdfbb`'s verbatim.",
@@ -344,9 +380,14 @@ rewrites = [
 [packages.tensorfs.files]
 "__init__.py" = "a66ced3cd03e042989602b9e122e4b3988be6be6611aacdb05b852c8a968ec7b"
 "_contracts/dit.blocks-fused-qkv.v1.json" = "95681781643548fc3bb696b84fee3d4c421f42e5fa5633c82fa6aae31f8e51e0"
+"_contracts/ernie.diffusers-bf16.v1.json" = "b4879a6c02962b873c81495acd561922c0271b809a6816f217d580b174a92514"
+"_contracts/flux1.diffusers-bf16.v1.json" = "74deb96dc6e295496ef107f12dd34932d31deadb14c8dec264cfbabccb405fa6"
 "_contracts/flux2-klein.diffusers-bf16.v1.json" = "7f792d62c7e7bd7bb8fa2cca84204f4911b8022c95417f004c2eb733b043974f"
 "_contracts/hidream-o1.diffusers-bf16.v1.json" = "c74f3489b21b8acdbf1acce919d1dade4128c59829ced2f36e89dc937836e347"
+"_contracts/internvl-u.diffusers-bf16.v1.json" = "8ca4c24045ee7b41b153ccfc34a913414806a0685a9f18a9a4630a4920482327"
+"_contracts/ltx-2.diffusers-bf16.v1.json" = "524334e6ddc686e165f8cd924422351bf4d0abc8d3a64aa3f40834f408501b2c"
 "_contracts/minimax.h3-dit-diffusers.v1.json" = "40fedde5e31dbed2bb5c34b350f76d2961c3e40ef61a03c102c1ae9aab99e1e1"
+"_contracts/minimax.h3-dit-fp8-rowwise.v1.json" = "08249c337eda48c7b63d269eb0501b445abc43dd58ea323afb13f2e44af01a2b"
 "_contracts/minimax.h3-dit-native.v1.json" = "d8c738a10c688bfbcb7b3135a5de1b903c3eea1cba55d50ba2cde220607b154f"
 "_contracts/qwen-image.diffusers-bf16.v1.json" = "d9671ac9cd9f32035897cab2dd909d7445ab1ed53425a4d84e1ff0592cd466fe"
 "_contracts/sd15.diffusers-bf16.v1.json" = "01f3cdfca73430bf2f53546b8fbdfc9c946bb6c45ed8882e67abcf66e3b778ff"
@@ -354,6 +395,8 @@ rewrites = [
 "_contracts/sdxl.clip-g-fused-qkv.v1.json" = "2fe796a2c14d615e972655144b4cc6c2a01bd74d400c9dbe0eb2b3887d78ca98"
 "_contracts/sdxl.clip-g-split-qkv.v1.json" = "5d82d4dcad7ca97cc5291a4fc60e4916e24e6bc8baa14e0429be428b99d9d09a"
 "_contracts/sdxl.diffusers-bf16.v1.json" = "6612c3d61e495f62d9f06096c11a2182a8a440d969e4faa0f23258eec35abe60"
+"_contracts/sdxl.diffusers-fp8-rowwise.v1.json" = "f082ff98421cd21827d10ed2a69f6447e8694dcf43baf08a7c47d2de6b373c20"
+"_contracts/trellis2.dit-bf16.v1.json" = "84bc7689d8f86372affc03cf2f25d895e55bfc824af395fd5af6cc54fdd50f0f"
 "_contracts/wan22.diffusers-bf16.v1.json" = "bca462c22c83e43e28516fa21a7d7798d73f3a46c242f61a37d532701903e13b"
 "_contracts/z-image.diffusers-bf16.v1.json" = "876eea29cb8974f4562ed52da63a0c7ac8af5127b669ec15f6025ca8f73ce534"
 "contract.py" = "b007d534da4f0a131bc7fe79001472cf08a94be0feedf229c0bba32fbb8c1d38"

--- a/src/gen_worker/_vendor/tensorfs/_contracts/ernie.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/ernie.diffusers-bf16.v1.json
@@ -1,0 +1,225 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "ernie.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical Baidu ERNIE-Image serve layout: the diffusers ErnieImageTransformer2DModel (ErnieImagePipeline), all-bf16, every pattern derived from the real safetensors header of tensorhub/ernie-image@prod (checkpoint sha256:e8cd9241cfa57d2115f7bfdefd98fde5cd77a5f2fd40e586e511f7b807c05f0d, cloned from huggingface:baidu/ERNIE-Image@5346b31d68c9c23758ba56ef8be5e9dc174c7f99) via ranged reads of chunk 0 - header table only, zero weight bytes. 24 patterns cover all 409 tensors: 11 per layer x 36 layers = 396, plus 13 singletons. ONE DOCUMENT COVERS BOTH CHECKPOINTS: ernie-image and ernie-image-turbo were measured to carry an IDENTICAL pattern set with identical rank, shape and dtype per pattern - only the weight BYTES differ (all 8 transformer shards differ by digest), which is exactly what a step distillation is. SPLIT QKV, NOT FUSED, and this is the load-bearing fusion call: self_attention.to_q/to_k/to_v are three SEPARATE [4096, 4096] projections, confirmed against transformer/config.json (hidden_size 4096, num_layers 36, num_attention_heads 32 => head dim 128, matching norm_q/norm_k [128], ffn_hidden_size 12288, in_channels 128, text_in_dim 3072). ERNIE therefore matches ZERO tensors of dit.blocks-fused-qkv@1 - the timm/native blocks.{i}.attn.qkv fragment that silently captured the flux1 lane - so the q/k/v role suffixes over one qkv role exist to make a future fused packaging a run-preserving derive rather than a refusal, the same shape as the sdxl.clip-g-* pair. The gated MLP is likewise split: gate_proj and up_proj are each [12288, 4096] against linear_fc2 [4096, 12288], so linear_in carries #gate/#up shares of 1:1. TRANSFORMER ONLY, deliberately, on the tensorfs#121 rule, and here it is measured rather than assumed: ernie-image and ernie-image-turbo ship a BYTE-IDENTICAL vae (sha256:ca70d2202afe6415..., 168120878 B), byte-identical text_encoder (4 shards) and byte-identical pe (4 shards) - so a document covering any of them would TIE the two checkpoints to each other and could not tell a distilled release from its base. The vae is additionally an AutoencoderKLFlux2, the same key spelling flux2-klein declares and refuses for the same reason, and it carries one I64 tensor among 250 BF16, so a flat-bf16 declaration over it would refuse the fleet's own checkpoint. The transformer is the compile subject (Compile(targets=('transformer',))) and the only component that identifies the family. This document also removes a LIVE misclassification: both ernie checkpoints currently carry metadata.model_family 'flux' with variant 'flux2', because model_index.json declares vae AutoencoderKLFlux2 and _class_name ErnieImagePipeline is not in the family map, so ingest fell through to a flux guess. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging - measured uniform BF16 across all 8 shards, 409 of 409, with no F32 island.",
+  "tensors": [
+    {
+      "role": "global_adaln.bias",
+      "pattern": "adaLN_modulation.1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "global_adaln.weight",
+      "pattern": "adaLN_modulation.1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "final_layer.linear.bias",
+      "pattern": "final_linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "final_layer.linear.weight",
+      "pattern": "final_linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "final_layer.adaln.bias",
+      "pattern": "final_norm.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "final_layer.adaln.weight",
+      "pattern": "final_norm.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.norm_mlp.weight",
+      "pattern": "layers.{i}.adaLN_mlp_ln.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.norm_attn.weight",
+      "pattern": "layers.{i}.adaLN_sa_ln.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.linear_in.weight#gate",
+      "pattern": "layers.{i}.mlp.gate_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.linear_out.weight",
+      "pattern": "layers.{i}.mlp.linear_fc2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.linear_in.weight#up",
+      "pattern": "layers.{i}.mlp.up_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.key_norm.weight",
+      "pattern": "layers.{i}.self_attention.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.query_norm.weight",
+      "pattern": "layers.{i}.self_attention.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.qkv.weight#k",
+      "pattern": "layers.{i}.self_attention.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.proj.weight",
+      "pattern": "layers.{i}.self_attention.to_out.0.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.qkv.weight#q",
+      "pattern": "layers.{i}.self_attention.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.qkv.weight#v",
+      "pattern": "layers.{i}.self_attention.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "txt_in.weight",
+      "pattern": "text_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_embed.linear_1.bias",
+      "pattern": "time_embedding.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_embed.linear_1.weight",
+      "pattern": "time_embedding.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_embed.linear_2.bias",
+      "pattern": "time_embedding.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_embed.linear_2.weight",
+      "pattern": "time_embedding.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "patch_embed.bias",
+      "pattern": "x_embedder.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "patch_embed.weight",
+      "pattern": "x_embedder.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/flux1.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/flux1.diffusers-bf16.v1.json
@@ -1,0 +1,603 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "flux1.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical FLUX.1 serve layout: the diffusers FluxTransformer2DModel (FluxPipeline), all-bf16, every declaration derived from the real safetensors headers of the two checkpoints the fleet actually serves - tensorhub/flux1-dev and tensorhub/flux1-schnell, which the hub records as revision-pinned clones of black-forest-labs/FLUX.1-dev@3de623fc3c33e44ffbe2bad470d0f45bccf2eb21 and black-forest-labs/FLUX.1-schnell@741f7c3ce8b383c54771c7003378a50191e9efe9. Both BFL repos are 401 unauthenticated, so the headers were read from the hub's own CAS objects by HTTP Range over the header table alone; no weight byte transited the authoring machine. THIS IS NOT dit.blocks-fused-qkv@1, which matches ZERO tensors here (measured): that fragment is the timm block spelling, blocks.{i}.attn.qkv, and a flux tree has no blocks.{i} at all. Nor is it flux2-klein.diffusers-bf16@1, and that one is the dangerous near miss rather than an obvious one: it matches 308 of the 1160 FLUX.1 transformer tensors with no dtype or rank refusal, so before this document existed a FLUX.1 checkpoint DETECTED AS FLUX.2 Klein - a silent wrong-family win, not a loud refusal. The two are different architectures wearing the same diffusers vocabulary. FLUX.1 is 19 double-stream transformer_blocks and 38 single_transformer_blocks; Klein is 5 and 20. FLUX.1 SPLITS its attention projections - to_q, to_k, to_v are three [3072, 3072] tensors each with its own [3072] bias, and the context stream repeats them as add_q_proj/add_k_proj/add_v_proj - where Klein fuses them into one to_qkv_mlp_proj. FLUX.1's single-stream MLP is NOT gated: proj_mlp is [12288, 3072], mlp_ratio 4.0 over inner_dim 3072, so the native linear1 concatenation is q|k|v|mlp at 3072+3072+3072+12288 = 21504 in shares 1:1:1:4, confirmed with no inference by proj_out.weight [3072, 15360] = 3072 attention + 12288 mlp. Klein's is 1:1:1:6 because its MLP is gated. Getting that ratio from the sibling family would mis-cut every single block. NO fusion is declared here, deliberately: the packaging this document describes SPLITS those tensors, and no fused FLUX.1 packaging has been measured into this library, so declaring a seam would be inventing one. The #q/#k/#v/#mlp role suffixes over the native-aligned qkv and linear1 roles reserve the conversion algebra - the sdxl.clip-g-* idiom - so a future fused-packaging document is a run-preserving derive rather than a version bump here. ONE DOCUMENT SERVES BOTH DEV AND SCHNELL, and the difference is exactly four tensors: transformer/config.json says guidance_embeds true for dev and false for schnell, and the headers agree at 1160 vs 1156, the four being time_text_embed.guidance_embedder.linear_1/linear_2 weight and bias. They are declared, optional, and carry the guidance_in.* role; every other spelling is identical between the two checkpoints, so schnell matches at 1156/1156 and dev at 1160/1160 rather than one of them half-matching. THE THIRD SERVED CHECKPOINT IS COVERED TOO, and it is the one that proves declaring shapes here would have been a mistake. ostris/Flex.2-preview - a FLUX.1-architecture redistill, not a BFL checkpoint, served by the flux.1-schnell endpoint under this same family vocabulary - is public and ungated upstream, and its 808 transformer tensors were read the same way. Every spelling it uses is already in this document (zero new names) and it matches 808/808, but its transformer/config.json declares num_layers 8 against dev's 19 and in_channels 196 against dev's 64, so its x_embedder.weight is [3072, 196] where both BFL checkpoints are [3072, 64] - the universal control inputs concatenated into the latent channel dim. Declarations here constrain RANK and dtype, never shape, which is exactly why one document spans a 12B BFL checkpoint and an 8-block derivative without either of them half-matching. TRANSFORMER ONLY, on the tensorfs#121 rule and the tensorfs#122 regression: FLUX.1's AutoencoderKL is the same key spelling SD2 and SDXL ship, so declaring the vae would tie sdxl.diffusers-bf16@1 on an SDXL vae file and win it on name order, and the text encoders are a stock CLIPTextModel and a stock T5EncoderModel that any future CLIP or T5 lane would collide with. The transformer is the compile subject and the only component that identifies the family. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging, and the fp8 rowwise conversion the hub also stores for flux1-dev is a separate document, not this one.",
+  "tensors": [
+    {
+      "role": "txt_in.bias",
+      "pattern": "context_embedder.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "txt_in.weight",
+      "pattern": "context_embedder.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "final_layer.adaln.bias",
+      "pattern": "norm_out.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "final_layer.adaln.weight",
+      "pattern": "norm_out.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "final_layer.linear.bias",
+      "pattern": "proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "final_layer.linear.weight",
+      "pattern": "proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single.{i}.key_norm.weight",
+      "pattern": "single_transformer_blocks.{i}.attn.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.query_norm.weight",
+      "pattern": "single_transformer_blocks.{i}.attn.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.bias#k",
+      "pattern": "single_transformer_blocks.{i}.attn.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.weight#k",
+      "pattern": "single_transformer_blocks.{i}.attn.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.bias#q",
+      "pattern": "single_transformer_blocks.{i}.attn.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.weight#q",
+      "pattern": "single_transformer_blocks.{i}.attn.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.bias#v",
+      "pattern": "single_transformer_blocks.{i}.attn.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.weight#v",
+      "pattern": "single_transformer_blocks.{i}.attn.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single.{i}.modulation.lin.bias",
+      "pattern": "single_transformer_blocks.{i}.norm.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.modulation.lin.weight",
+      "pattern": "single_transformer_blocks.{i}.norm.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.bias#mlp",
+      "pattern": "single_transformer_blocks.{i}.proj_mlp.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.weight#mlp",
+      "pattern": "single_transformer_blocks.{i}.proj_mlp.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear2.bias",
+      "pattern": "single_transformer_blocks.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear2.weight",
+      "pattern": "single_transformer_blocks.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "guidance_in.fc1.bias",
+      "pattern": "time_text_embed.guidance_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "guidance_in.fc1.weight",
+      "pattern": "time_text_embed.guidance_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "guidance_in.fc2.bias",
+      "pattern": "time_text_embed.guidance_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "guidance_in.fc2.weight",
+      "pattern": "time_text_embed.guidance_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vector_in.fc1.bias",
+      "pattern": "time_text_embed.text_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vector_in.fc1.weight",
+      "pattern": "time_text_embed.text_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vector_in.fc2.bias",
+      "pattern": "time_text_embed.text_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vector_in.fc2.weight",
+      "pattern": "time_text_embed.text_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_in.fc1.bias",
+      "pattern": "time_text_embed.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_in.fc1.weight",
+      "pattern": "time_text_embed.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_in.fc2.bias",
+      "pattern": "time_text_embed.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_in.fc2.weight",
+      "pattern": "time_text_embed.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.bias#k",
+      "pattern": "transformer_blocks.{i}.attn.add_k_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.weight#k",
+      "pattern": "transformer_blocks.{i}.attn.add_k_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.bias#q",
+      "pattern": "transformer_blocks.{i}.attn.add_q_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.weight#q",
+      "pattern": "transformer_blocks.{i}.attn.add_q_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.bias#v",
+      "pattern": "transformer_blocks.{i}.attn.add_v_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.weight#v",
+      "pattern": "transformer_blocks.{i}.attn.add_v_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.key_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn.norm_added_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.query_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn.norm_added_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.key_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.query_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.proj.bias",
+      "pattern": "transformer_blocks.{i}.attn.to_add_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.proj.weight",
+      "pattern": "transformer_blocks.{i}.attn.to_add_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.bias#k",
+      "pattern": "transformer_blocks.{i}.attn.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.weight#k",
+      "pattern": "transformer_blocks.{i}.attn.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.proj.{i}.bias",
+      "pattern": "transformer_blocks.{i}.attn.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.proj.{i}.weight",
+      "pattern": "transformer_blocks.{i}.attn.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.bias#q",
+      "pattern": "transformer_blocks.{i}.attn.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.weight#q",
+      "pattern": "transformer_blocks.{i}.attn.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.bias#v",
+      "pattern": "transformer_blocks.{i}.attn.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.weight#v",
+      "pattern": "transformer_blocks.{i}.attn.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc1.bias",
+      "pattern": "transformer_blocks.{i}.ff.net.0.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc1.weight",
+      "pattern": "transformer_blocks.{i}.ff.net.0.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc2.bias",
+      "pattern": "transformer_blocks.{i}.ff.net.2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc2.weight",
+      "pattern": "transformer_blocks.{i}.ff.net.2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc1.bias",
+      "pattern": "transformer_blocks.{i}.ff_context.net.0.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc1.weight",
+      "pattern": "transformer_blocks.{i}.ff_context.net.0.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc2.bias",
+      "pattern": "transformer_blocks.{i}.ff_context.net.2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc2.weight",
+      "pattern": "transformer_blocks.{i}.ff_context.net.2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mod.lin.bias",
+      "pattern": "transformer_blocks.{i}.norm1.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mod.lin.weight",
+      "pattern": "transformer_blocks.{i}.norm1.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mod.lin.bias",
+      "pattern": "transformer_blocks.{i}.norm1_context.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mod.lin.weight",
+      "pattern": "transformer_blocks.{i}.norm1_context.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "img_in.bias",
+      "pattern": "x_embedder.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "img_in.weight",
+      "pattern": "x_embedder.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/internvl-u.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/internvl-u.diffusers-bf16.v1.json
@@ -1,0 +1,455 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "internvl-u.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical InternVL-U serve layout: the diffusers InternVLUGenerationDecoder (the InternVLUTransformer2DModel MMDiT inside InternVLUPipeline), every declaration derived from the real safetensors header of InternVL-U/InternVL-U at revision f012d760e69712bb47f7d3d09a24280f346cee01 - the PUBLIC, UNGATED original, not a community mirror. GENERATION DECODER ONLY, deliberately, on the tensorfs#121 rule, and both exclusions are load-bearing. The vae is AutoencoderKLQwenImage - literally the qwen-image family's autoencoder - so declaring it would tie family detection ACROSS FAMILY LINES, which is the tensorfs#122 regression with a longer reach than the usual within-family shared VAE. The vlm component is an InternViT-300M vision tower (24 layers, width 1024, FUSED attn.qkv.weight [3072, 1024]) over a stock Qwen3 language model (28 layers, width 2048, vocab 151936, with the q_norm/k_norm QK-norm signature), and both are stock spellings that a future InternViT or Qwen3 lane would collide with, exactly as flux2-klein excludes its stock Qwen3ForCausalLM text encoder. The generation decoder is the compile subject and the only component that identifies this family. THE ATTENTION IS SPLIT AND ASYMMETRIC, and this is the trap: to_q is [3072, 1536] while to_k and to_v are [1536, 1536], so the stream carries 24 query heads of 128 against 12 kv heads - fusing q|k|v in equal thirds on the flux/klein analogy produces a WRONG document. The same asymmetry holds on the text stream (add_q_proj [3072, 1536] against add_k_proj/add_v_proj [1536, 1536]). Dual-stream MMDiT: 20 blocks, width 1536, joint_attention_dim 4096, patch_size 2, in_channels 64, out_channels 16, which the shipped generation_decoder/config.json states independently. THE DTYPE IS MIXED AND THE MIX IS STRUCTURED: 618 of 654 tensors are BF16, and the 36 that are F32 are exactly the whole final block (transformer_blocks.19.*) plus norm_out and proj_out - the standard fp32 output island for numerical stability. The hub and the upstream both advertise a flat bf16, so the advertised dtype is WRONG at tensor granularity and this document was dtype-histogrammed rather than trusting it. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint, and the block patterns therefore accept BF16 or F32 because block 19 genuinely differs from blocks 0-18.",
+  "tensors": [
+    {
+      "role": "img_in.bias",
+      "pattern": "decoder.img_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "img_in.weight",
+      "pattern": "decoder.img_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "final_layer.adaln.bias",
+      "pattern": "decoder.norm_out.linear.bias",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "final_layer.adaln.weight",
+      "pattern": "decoder.norm_out.linear.weight",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "final_layer.linear.bias",
+      "pattern": "decoder.proj_out.bias",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "final_layer.linear.weight",
+      "pattern": "decoder.proj_out.weight",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_embed.fc1.bias",
+      "pattern": "decoder.time_text_embed.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_embed.fc1.weight",
+      "pattern": "decoder.time_text_embed.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_embed.fc2.bias",
+      "pattern": "decoder.time_text_embed.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_embed.fc2.weight",
+      "pattern": "decoder.time_text_embed.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv#k.bias",
+      "pattern": "decoder.transformer_blocks.{i}.attn.add_k_proj.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv#k.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.add_k_proj.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv#q.bias",
+      "pattern": "decoder.transformer_blocks.{i}.attn.add_q_proj.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv#q.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.add_q_proj.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv#v.bias",
+      "pattern": "decoder.transformer_blocks.{i}.attn.add_v_proj.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv#v.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.add_v_proj.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.norm_k.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.norm_added_k.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.norm_q.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.norm_added_q.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.norm_k.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.norm_k.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.norm_q.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.norm_q.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.out.bias",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_add_out.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.out.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_add_out.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv#k.bias",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_k.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv#k.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_k.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.out.bias",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_out.0.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.out.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_out.0.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv#q.bias",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_q.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv#q.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_q.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv#v.bias",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_v.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv#v.weight",
+      "pattern": "decoder.transformer_blocks.{i}.attn.to_v.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc1.bias",
+      "pattern": "decoder.transformer_blocks.{i}.img_mlp.net.0.proj.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc1.weight",
+      "pattern": "decoder.transformer_blocks.{i}.img_mlp.net.0.proj.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc2.bias",
+      "pattern": "decoder.transformer_blocks.{i}.img_mlp.net.2.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc2.weight",
+      "pattern": "decoder.transformer_blocks.{i}.img_mlp.net.2.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mod.bias",
+      "pattern": "decoder.transformer_blocks.{i}.img_mod.1.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mod.weight",
+      "pattern": "decoder.transformer_blocks.{i}.img_mod.1.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc1.bias",
+      "pattern": "decoder.transformer_blocks.{i}.txt_mlp.net.0.proj.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc1.weight",
+      "pattern": "decoder.transformer_blocks.{i}.txt_mlp.net.0.proj.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc2.bias",
+      "pattern": "decoder.transformer_blocks.{i}.txt_mlp.net.2.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc2.weight",
+      "pattern": "decoder.transformer_blocks.{i}.txt_mlp.net.2.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mod.bias",
+      "pattern": "decoder.transformer_blocks.{i}.txt_mod.1.bias",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mod.weight",
+      "pattern": "decoder.transformer_blocks.{i}.txt_mod.1.weight",
+      "dtypes": [
+        "BF16",
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "txt_in.bias",
+      "pattern": "decoder.txt_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "txt_in.weight",
+      "pattern": "decoder.txt_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "txt_norm.weight",
+      "pattern": "decoder.txt_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "encoder_padding_token",
+      "pattern": "encoder_padding_token",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/ltx-2.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/ltx-2.diffusers-bf16.v1.json
@@ -1,0 +1,1305 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "ltx-2.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical LTX-2 (Lightricks LTX-2.3) serve layout: the diffusers LTX2VideoTransformer3DModel that LTX2ConditionPipeline denoises, all-bf16 weights, derived from the REAL safetensors headers of all eight transformer shards of diffusers/LTX-2.3-Distilled-Diffusers at revision 432e0d3c2d1769aaa4d295f9243f7062bf6b47ee - which is not a mirror-of-convenience but the exact source_repo/source_revision the fleet's own clone recipe (jobs/catalog/launch_ltx_2026-07-07.toml) used to produce tensorhub/ltx-2.3-distilled prod, and which is still that repo's HEAD. COMPLETE, and the completeness is checked rather than assumed: these 144 declarations match 4186 of 4186 tensors, each tensor matched by EXACTLY ONE declaration, with every declared dtype and rank equal to the header's. That matters here beyond tidiness - a PARTIAL DiT document silently loses its own files to another family's lane under the specificity rule, and minimax.h3-dit-diffusers already explains 96 of these tensors (the transformer_blocks.{i}.ff.net.{i} pair) purely through shared diffusers feed-forward spelling. THIS IS A JOINT AUDIO+VIDEO DiT and the document says so structurally: beside the video attn1/attn2 stacks at width 4096 sit a full audio tower (audio_attn1/audio_attn2, width 2048) and the two cross-modal seams, audio_to_video_attn and video_to_audio_attn, whose projections are RECTANGULAR across the two widths - audio_to_video_attn.to_q is [2048, 4096] and its to_out.0 is [4096, 2048], video_to_audio_attn.to_k and .to_v are [2048, 4096]. NO FUSION IS DECLARED ANYWHERE, and that is a measured statement rather than an omission: every attention projection in this checkpoint is stored SPLIT (to_q / to_k / to_v as separate tensors, each [4096, 4096] on the video tower and [2048, 2048] on the audio tower); there is no to_qkv tensor in any of the eight shards. MIXED DTYPE, deliberately declared per tensor: 3896 tensors are BF16 and 290 are F32, and the F32 set is exactly the adaptive-norm modulation tables - the six per-block *scale_shift_table entries across 48 blocks plus the two top-level ones. A document that flattened those to BF16 would refuse the real checkpoint. TRANSFORMER ONLY, on the tensorfs#121 rule, and every omission here is a collision that was checked: AutoencoderKLLTX2Video is shared verbatim with the LTX2LatentUpsamplePipeline artifact so declaring it would make family detection TIE (the tensorfs#122 regression); the text encoder is a stock Gemma3ForConditionalGeneration that any future Gemma lane would collide with; and the connectors and vocoder are LTX2TextConnectors / LTX2VocoderWithBWE, which are not the compile subject and do not identify the family. The transformer is the compile subject (the endpoint's Compile.targets is (\"transformer\",)) and the only component that identifies the family. Roles are a MECHANICAL transform of the diffusers spelling - transformer_blocks -> blocks, to_q/to_k/to_v/to_out -> q/k/v/out, norm_q/norm_k -> q_norm/k_norm, under a dit. prefix - and NOT an alignment with Lightricks' native single-file packaging, which this author did not read; a native <-> diffusers derive is therefore not claimed, and would need its own document and its own header evidence. The 2 x spatial latent upsampler is NOT covered here and gets no document at all: it is a 72-tensor 3-D convnet (LTX2LatentUpsamplerModel) sharing ZERO keys with this transformer, so it is an auxiliary in the Rife mould rather than a second packaging of this family. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging.",
+  "tensors": [
+    {
+      "role": "dit.audio_proj_in.bias",
+      "pattern": "audio_proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.audio_proj_in.weight",
+      "pattern": "audio_proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.audio_proj_out.bias",
+      "pattern": "audio_proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.audio_proj_out.weight",
+      "pattern": "audio_proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.audio_prompt_adaln.emb.timestep_embedder.linear_1.bias",
+      "pattern": "audio_prompt_adaln.emb.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.audio_prompt_adaln.emb.timestep_embedder.linear_1.weight",
+      "pattern": "audio_prompt_adaln.emb.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.audio_prompt_adaln.emb.timestep_embedder.linear_2.bias",
+      "pattern": "audio_prompt_adaln.emb.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.audio_prompt_adaln.emb.timestep_embedder.linear_2.weight",
+      "pattern": "audio_prompt_adaln.emb.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.audio_prompt_adaln.linear.bias",
+      "pattern": "audio_prompt_adaln.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.audio_prompt_adaln.linear.weight",
+      "pattern": "audio_prompt_adaln.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.audio_scale_shift_table",
+      "pattern": "audio_scale_shift_table",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.audio_time_embed.emb.timestep_embedder.linear_1.bias",
+      "pattern": "audio_time_embed.emb.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.audio_time_embed.emb.timestep_embedder.linear_1.weight",
+      "pattern": "audio_time_embed.emb.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.audio_time_embed.emb.timestep_embedder.linear_2.bias",
+      "pattern": "audio_time_embed.emb.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.audio_time_embed.emb.timestep_embedder.linear_2.weight",
+      "pattern": "audio_time_embed.emb.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.audio_time_embed.linear.bias",
+      "pattern": "audio_time_embed.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.audio_time_embed.linear.weight",
+      "pattern": "audio_time_embed.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_scale_shift.emb.timestep_embedder.linear_1.bias",
+      "pattern": "av_cross_attn_audio_scale_shift.emb.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_scale_shift.emb.timestep_embedder.linear_1.weight",
+      "pattern": "av_cross_attn_audio_scale_shift.emb.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_scale_shift.emb.timestep_embedder.linear_2.bias",
+      "pattern": "av_cross_attn_audio_scale_shift.emb.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_scale_shift.emb.timestep_embedder.linear_2.weight",
+      "pattern": "av_cross_attn_audio_scale_shift.emb.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_scale_shift.linear.bias",
+      "pattern": "av_cross_attn_audio_scale_shift.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_scale_shift.linear.weight",
+      "pattern": "av_cross_attn_audio_scale_shift.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_v2a_gate.emb.timestep_embedder.linear_1.bias",
+      "pattern": "av_cross_attn_audio_v2a_gate.emb.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_v2a_gate.emb.timestep_embedder.linear_1.weight",
+      "pattern": "av_cross_attn_audio_v2a_gate.emb.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_v2a_gate.emb.timestep_embedder.linear_2.bias",
+      "pattern": "av_cross_attn_audio_v2a_gate.emb.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_v2a_gate.emb.timestep_embedder.linear_2.weight",
+      "pattern": "av_cross_attn_audio_v2a_gate.emb.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_v2a_gate.linear.bias",
+      "pattern": "av_cross_attn_audio_v2a_gate.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_audio_v2a_gate.linear.weight",
+      "pattern": "av_cross_attn_audio_v2a_gate.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_a2v_gate.emb.timestep_embedder.linear_1.bias",
+      "pattern": "av_cross_attn_video_a2v_gate.emb.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_a2v_gate.emb.timestep_embedder.linear_1.weight",
+      "pattern": "av_cross_attn_video_a2v_gate.emb.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_a2v_gate.emb.timestep_embedder.linear_2.bias",
+      "pattern": "av_cross_attn_video_a2v_gate.emb.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_a2v_gate.emb.timestep_embedder.linear_2.weight",
+      "pattern": "av_cross_attn_video_a2v_gate.emb.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_a2v_gate.linear.bias",
+      "pattern": "av_cross_attn_video_a2v_gate.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_a2v_gate.linear.weight",
+      "pattern": "av_cross_attn_video_a2v_gate.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_scale_shift.emb.timestep_embedder.linear_1.bias",
+      "pattern": "av_cross_attn_video_scale_shift.emb.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_scale_shift.emb.timestep_embedder.linear_1.weight",
+      "pattern": "av_cross_attn_video_scale_shift.emb.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_scale_shift.emb.timestep_embedder.linear_2.bias",
+      "pattern": "av_cross_attn_video_scale_shift.emb.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_scale_shift.emb.timestep_embedder.linear_2.weight",
+      "pattern": "av_cross_attn_video_scale_shift.emb.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_scale_shift.linear.bias",
+      "pattern": "av_cross_attn_video_scale_shift.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.av_cross_attn_video_scale_shift.linear.weight",
+      "pattern": "av_cross_attn_video_scale_shift.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.proj_in.bias",
+      "pattern": "proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.proj_in.weight",
+      "pattern": "proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.proj_out.bias",
+      "pattern": "proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.proj_out.weight",
+      "pattern": "proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.prompt_adaln.emb.timestep_embedder.linear_1.bias",
+      "pattern": "prompt_adaln.emb.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.prompt_adaln.emb.timestep_embedder.linear_1.weight",
+      "pattern": "prompt_adaln.emb.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.prompt_adaln.emb.timestep_embedder.linear_2.bias",
+      "pattern": "prompt_adaln.emb.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.prompt_adaln.emb.timestep_embedder.linear_2.weight",
+      "pattern": "prompt_adaln.emb.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.prompt_adaln.linear.bias",
+      "pattern": "prompt_adaln.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.prompt_adaln.linear.weight",
+      "pattern": "prompt_adaln.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.scale_shift_table",
+      "pattern": "scale_shift_table",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.time_embed.emb.timestep_embedder.linear_1.bias",
+      "pattern": "time_embed.emb.timestep_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.time_embed.emb.timestep_embedder.linear_1.weight",
+      "pattern": "time_embed.emb.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.time_embed.emb.timestep_embedder.linear_2.bias",
+      "pattern": "time_embed.emb.timestep_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.time_embed.emb.timestep_embedder.linear_2.weight",
+      "pattern": "time_embed.emb.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.time_embed.linear.bias",
+      "pattern": "time_embed.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.time_embed.linear.weight",
+      "pattern": "time_embed.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.k_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn1.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.q_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn1.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.gate_logits.bias",
+      "pattern": "transformer_blocks.{i}.attn1.to_gate_logits.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.gate_logits.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_gate_logits.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.k.bias",
+      "pattern": "transformer_blocks.{i}.attn1.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.k.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.out.{i}.bias",
+      "pattern": "transformer_blocks.{i}.attn1.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.out.{i}.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.q.bias",
+      "pattern": "transformer_blocks.{i}.attn1.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.q.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.v.bias",
+      "pattern": "transformer_blocks.{i}.attn1.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn1.v.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.k_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn2.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.q_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn2.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.gate_logits.bias",
+      "pattern": "transformer_blocks.{i}.attn2.to_gate_logits.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.gate_logits.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_gate_logits.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.k.bias",
+      "pattern": "transformer_blocks.{i}.attn2.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.k.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.out.{i}.bias",
+      "pattern": "transformer_blocks.{i}.attn2.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.out.{i}.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.q.bias",
+      "pattern": "transformer_blocks.{i}.attn2.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.q.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.v.bias",
+      "pattern": "transformer_blocks.{i}.attn2.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.attn2.v.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_a2v_cross_attn_scale_shift_table",
+      "pattern": "transformer_blocks.{i}.audio_a2v_cross_attn_scale_shift_table",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.k_norm.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn1.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.q_norm.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn1.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.gate_logits.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_gate_logits.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.gate_logits.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_gate_logits.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.k.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.k.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.out.{i}.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.out.{i}.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.q.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.q.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.v.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn1.v.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn1.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.k_norm.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn2.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.q_norm.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn2.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.gate_logits.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_gate_logits.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.gate_logits.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_gate_logits.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.k.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.k.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.out.{i}.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.out.{i}.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.q.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.q.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.v.bias",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_attn2.v.weight",
+      "pattern": "transformer_blocks.{i}.audio_attn2.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_ff.net.{i}.bias",
+      "pattern": "transformer_blocks.{i}.audio_ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_ff.net.{i}.proj.bias",
+      "pattern": "transformer_blocks.{i}.audio_ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_ff.net.{i}.proj.weight",
+      "pattern": "transformer_blocks.{i}.audio_ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_ff.net.{i}.weight",
+      "pattern": "transformer_blocks.{i}.audio_ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_prompt_scale_shift_table",
+      "pattern": "transformer_blocks.{i}.audio_prompt_scale_shift_table",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_scale_shift_table",
+      "pattern": "transformer_blocks.{i}.audio_scale_shift_table",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.k_norm.weight",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.q_norm.weight",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.gate_logits.bias",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_gate_logits.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.gate_logits.weight",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_gate_logits.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.k.bias",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.k.weight",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.out.{i}.bias",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.out.{i}.weight",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.q.bias",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.q.weight",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.v.bias",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.audio_to_video_attn.v.weight",
+      "pattern": "transformer_blocks.{i}.audio_to_video_attn.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.ff.net.{i}.bias",
+      "pattern": "transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.ff.net.{i}.proj.bias",
+      "pattern": "transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.ff.net.{i}.proj.weight",
+      "pattern": "transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.ff.net.{i}.weight",
+      "pattern": "transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.prompt_scale_shift_table",
+      "pattern": "transformer_blocks.{i}.prompt_scale_shift_table",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.scale_shift_table",
+      "pattern": "transformer_blocks.{i}.scale_shift_table",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_a2v_cross_attn_scale_shift_table",
+      "pattern": "transformer_blocks.{i}.video_a2v_cross_attn_scale_shift_table",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.k_norm.weight",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.q_norm.weight",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.gate_logits.bias",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_gate_logits.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.gate_logits.weight",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_gate_logits.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.k.bias",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.k.weight",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.out.{i}.bias",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.out.{i}.weight",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.q.bias",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.q.weight",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.v.bias",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.video_to_audio_attn.v.weight",
+      "pattern": "transformer_blocks.{i}.video_to_audio_attn.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/minimax.h3-dit-fp8-rowwise.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/minimax.h3-dit-fp8-rowwise.v1.json
@@ -1,0 +1,186 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "minimax.h3-dit-fp8-rowwise",
+  "version": 1,
+  "dtype": "float8_e4m3fn",
+  "description": "MiniMax-H3 DiT served from fp8-rowwise bytes: the minimax.h3-dit-diffusers packaging with every repeated-block Linear stored as F8_E4M3 [out, in] beside a per-row F32 [out] `weight_scale` DEQUANT multiplier. Derived from minimax.h3-dit-diffusers@1 by applying gen-worker's `w8a8_cast_eligible` rule verbatim (rank-2 float `.weight`, both dims 16-aligned, under a `.<int>.` path segment, module path missing every skip pattern): 7 of the 10 declarations convert -- the three that do not are `norm_q`/`norm_k`, caught by the `norm` skip pattern and not rank-2 anyway. The attention weights keep their 56-group fusion, because quantization is elementwise: an fp8 [out, in] weight has the same outer axis, the same 56 head slices and therefore the same seam runs as its bf16 source, so the two packagings still share every attention byte with the native contract. The `weight_scale` twins deliberately do NOT declare that fusion. A per-row scale is rank-1 [out] and divides by 56 the same way, so declaring it would not be wrong -- it would be unfalsifiable decoration: at 56 * 4 bytes per block the run is five orders of magnitude below the 1 MiB seam floor, so it produces no cut points and the declaration could never be contradicted by a header. Declarations that cannot fail are how a contract stops being falsifiable. `input_scale` is absent by design (dynamic activation scales at serve). Each scale mirrors its weight's `required` flag, so the qkv triple's scales are REQUIRED -- an fp8 qkv weight with no scale is a half-quantized artifact and this document refuses it, which is the refusal tcg#53 names as the reason the empty-plan and nothing-matched refusals exist at all. WHAT IS AND IS NOT CONFIRMED, stated because the difference matters to whoever imports this: the STRUCTURE is derived from the producer that writes these bytes (gen_worker/convert/writer.py `streaming_w8a8_cast`) and is proven end to end -- that producer's output, run over an H3-shaped tree, satisfies this document through the real matcher. It has NOT been confirmed against the bytes of the live `tensorhub/minimax-h3 @ serve-narrowed-fp8` artifact (checkpoint sha256:0601b889...), which this author could not reach; if that artifact was produced by a different path (torchao's serve-time per-row cast rather than the streaming producer) its scale leaf could differ, and the failure mode is a LOUD bind refusal naming the tensor, never a silent mismatch. That confirmation is owed and named in tensorfs#128.",
+  "tensors": [
+    {
+      "role": "blocks.{i}.attn.qkv#q",
+      "pattern": "transformer_blocks.{i}.attn.to_q.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "groups": 56,
+        "parts": [
+          {
+            "role": "",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.qkv.scale#q",
+      "pattern": "transformer_blocks.{i}.attn.to_q.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": true
+    },
+    {
+      "role": "blocks.{i}.attn.qkv#k",
+      "pattern": "transformer_blocks.{i}.attn.to_k.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "groups": 56,
+        "parts": [
+          {
+            "role": "",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.qkv.scale#k",
+      "pattern": "transformer_blocks.{i}.attn.to_k.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": true
+    },
+    {
+      "role": "blocks.{i}.attn.qkv#v",
+      "pattern": "transformer_blocks.{i}.attn.to_v.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "groups": 56,
+        "parts": [
+          {
+            "role": "",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.qkv.scale#v",
+      "pattern": "transformer_blocks.{i}.attn.to_v.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": true
+    },
+    {
+      "role": "blocks.{i}.attn.out",
+      "pattern": "transformer_blocks.{i}.attn.to_out.0.weight",
+      "rank": 2,
+      "required": false,
+      "dtypes": [
+        "F8_E4M3"
+      ]
+    },
+    {
+      "role": "blocks.{i}.attn.out.scale",
+      "pattern": "transformer_blocks.{i}.attn.to_out.0.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.q_norm",
+      "pattern": "transformer_blocks.{i}.attn.norm_q.weight",
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.k_norm",
+      "pattern": "transformer_blocks.{i}.attn.norm_k.weight",
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc1",
+      "pattern": "transformer_blocks.{i}.ff.net.0.proj.weight",
+      "rank": 2,
+      "required": false,
+      "dtypes": [
+        "F8_E4M3"
+      ]
+    },
+    {
+      "role": "blocks.{i}.mlp.fc1.scale",
+      "pattern": "transformer_blocks.{i}.ff.net.0.proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc2",
+      "pattern": "transformer_blocks.{i}.ff.net.2.weight",
+      "rank": 2,
+      "required": false,
+      "dtypes": [
+        "F8_E4M3"
+      ]
+    },
+    {
+      "role": "blocks.{i}.mlp.fc2.scale",
+      "pattern": "transformer_blocks.{i}.ff.net.2.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.adaln.weight",
+      "pattern": "transformer_blocks.{i}.adaln_proj.linear.weight",
+      "rank": 2,
+      "required": false,
+      "dtypes": [
+        "F8_E4M3"
+      ]
+    },
+    {
+      "role": "blocks.{i}.adaln.weight.scale",
+      "pattern": "transformer_blocks.{i}.adaln_proj.linear.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.adaln.bias",
+      "pattern": "transformer_blocks.{i}.adaln_proj.linear.bias",
+      "rank": 1,
+      "required": false
+    }
+  ],
+  "sets": {
+    "adaln_projections": [
+      "transformer_blocks.{i}.adaln_proj.linear.weight",
+      "transformer_blocks.{i}.adaln_proj.linear.bias",
+      "norm_out.linear.weight",
+      "norm_out.linear.bias"
+    ]
+  }
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/sdxl.diffusers-fp8-rowwise.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/sdxl.diffusers-fp8-rowwise.v1.json
@@ -1,0 +1,2322 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "sdxl.diffusers-fp8-rowwise",
+  "version": 1,
+  "dtype": "float8_e4m3fn",
+  "description": "SDXL served from fp8-rowwise UNET bytes: the sdxl.diffusers-bf16 packaging with the denoiser's repeated-block Linears stored as F8_E4M3 [out, in] beside a per-row F32 [out] `weight_scale` DEQUANT multiplier, and every other file byte-identical to its bf16 sibling. Derived from sdxl.diffusers-bf16@1 -- which is itself header-derived and COMPLETE over the shipped checkpoint (tensorfs#121) -- by applying the producing rule VERBATIM rather than by taste: gen-worker's `w8a8_cast_eligible` converts a tensor iff it is a rank-2 float `.weight`, both dims 16-aligned, under a repeated-block path segment (`.<int>.`), whose module path misses every skip pattern (embed / norm / pooler / adaln_single / final_layer / quantize / decoder / preprocess_conv / postprocess_conv / ^proj_in$ / ^proj_out$ / ^proj$ / gate_logits). 36 of the 221 declarations convert; each grows a `weight_scale` twin, so 257 declarations. THREE consequences a reader would otherwise get wrong, all decided by the rule and not by preference. (1) The VAE and both text encoders are untouched: fp8 storage targets the DENOISER component only, so those three files match this document exactly as they match the bf16 one, and a conversion rewrites the unet member alone -- every other member keeps its digests. (2) `proj_in`/`proj_out` DO convert. The skip list anchors them (`^proj_in$`) against the module path, and SDXL spells them `down_blocks.{i}.attentions.{i}.proj_in`, which the anchor does not reach; they are also the rank-2 linear spelling here, not the rank-4 conv spelling SD1.5 uses. (3) The resnet time projections DO convert while the top-level time/add embedding Linears do NOT -- the skip pattern is the six letters `embed`, `time_emb_proj` spells it `emb`, and `time_embedding`/`add_embedding` are additionally outside any repeated block. The one conjunct of the producing rule this format cannot carry is 16-ALIGNMENT, because contracts are deliberately shapeless (tensorfs#122 rec 1: shapes would version-couple every contract to model configs and kill the falsifiable-from-header property). It is sound to omit here and NOT in general: every dimension SDXL's converted set touches is a multiple of 64 (320/640/1280 channels, 2048 cross-attention context, 2560/5120/10240 GEGLU inner), so the alignment conjunct cannot discriminate on this family. A family with an unaligned block Linear would need the producer's refusal, which is where it already lives -- the document declares the RESULT, the producer owns the eligibility. Top-level dtype is the serve-side load dtype (`ctx.lane.dtype`); the per-tensor dtypes are the matcher's constraint that this really is the fp8-rowwise packaging. `input_scale` is deliberately absent: activation scales are dynamic at serve time, so the producer emits none, and a tree carrying them is a different (statically calibrated) layout. Each scale mirrors its weight's `required` flag, which is how this document says \"an fp8 weight without its scale is not this layout\" -- vacuously here, since per-component-file matching makes every SDXL declaration optional, and NOT vacuously on a family whose weights are required.",
+  "tensors": [
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#q",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.q_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#k",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.k_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#v",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.v_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#q",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.q_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#k",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.k_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#v",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.v_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.out.weight",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.out_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.out.bias",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.out_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.mlp.fc1.weight",
+      "pattern": "text_model.encoder.layers.{i}.mlp.fc1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.mlp.fc2.weight",
+      "pattern": "text_model.encoder.layers.{i}.mlp.fc2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.text_projection",
+      "pattern": "text_projection.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.add_embedding.fc1",
+      "pattern": "add_embedding.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.add_embedding.fc2",
+      "pattern": "add_embedding.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc1",
+      "pattern": "time_embedding.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc2",
+      "pattern": "time_embedding.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.q",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.q.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.k",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.k.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.v",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.v.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff1",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff1.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff2",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff2.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.q",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.q.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.k",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.k.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.v",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.v.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff1",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff1.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff2",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff2.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.q",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.q.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.k",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.k.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.v",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.v.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff1",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff1.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff2",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff2.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.quant_conv",
+      "pattern": "quant_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.post_quant_conv",
+      "pattern": "post_quant_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_in",
+      "pattern": "encoder.conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_in",
+      "pattern": "decoder.conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv1",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv2",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv1",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv2",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.q",
+      "pattern": "decoder.mid_block.attentions.{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.add_embedding.fc1.bias",
+      "pattern": "add_embedding.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.add_embedding.fc2.bias",
+      "pattern": "add_embedding.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_in.bias",
+      "pattern": "conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_in.weight",
+      "pattern": "conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.conv_norm_out.bias",
+      "pattern": "conv_norm_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_norm_out.weight",
+      "pattern": "conv_norm_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_out.bias",
+      "pattern": "conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_out.weight",
+      "pattern": "conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_in.bias",
+      "pattern": "decoder.conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_norm_out.bias",
+      "pattern": "decoder.conv_norm_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_norm_out.weight",
+      "pattern": "decoder.conv_norm_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_out.bias",
+      "pattern": "decoder.conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_out.weight",
+      "pattern": "decoder.conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.group_norm.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.group_norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.group_norm.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.group_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.k.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.k.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.out.{i}.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.out.{i}.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.q.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.v.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.v.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv1.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv1.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv2.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv2.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm1.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm1.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm2.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm2.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv1.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv2.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm1.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm1.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm2.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm2.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.{i}.conv.bias",
+      "pattern": "decoder.up_blocks.{i}.upsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.{i}.conv.weight",
+      "pattern": "decoder.up_blocks.{i}.upsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.norm.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.norm.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.weight.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.weight.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.weight.scale",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.ds.{i}.conv.bias",
+      "pattern": "down_blocks.{i}.downsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.ds.{i}.conv.weight",
+      "pattern": "down_blocks.{i}.downsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv1.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv1.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv2.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv2.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm1.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm1.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm2.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm2.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.weight.scale",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_in.bias",
+      "pattern": "encoder.conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_norm_out.bias",
+      "pattern": "encoder.conv_norm_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_norm_out.weight",
+      "pattern": "encoder.conv_norm_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_out.bias",
+      "pattern": "encoder.conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_out.weight",
+      "pattern": "encoder.conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.ds.{i}.conv.bias",
+      "pattern": "encoder.down_blocks.{i}.downsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.ds.{i}.conv.weight",
+      "pattern": "encoder.down_blocks.{i}.downsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv1.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv2.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm1.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm1.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm2.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm2.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.group_norm.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.group_norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.group_norm.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.group_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.k.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.k.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.out.{i}.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.out.{i}.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.q.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.q.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.v.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.v.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv1.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv1.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv2.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv2.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm1.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm1.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm2.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm2.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.norm.bias",
+      "pattern": "mid_block.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.norm.weight",
+      "pattern": "mid_block.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.bias",
+      "pattern": "mid_block.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.weight",
+      "pattern": "mid_block.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.weight.scale",
+      "pattern": "mid_block.attentions.{i}.proj_in.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.bias",
+      "pattern": "mid_block.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.weight",
+      "pattern": "mid_block.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.weight.scale",
+      "pattern": "mid_block.attentions.{i}.proj_out.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.weight.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.weight.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.weight.scale",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv1.bias",
+      "pattern": "mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv1.weight",
+      "pattern": "mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv2.bias",
+      "pattern": "mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv2.weight",
+      "pattern": "mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm1.bias",
+      "pattern": "mid_block.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm1.weight",
+      "pattern": "mid_block.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm2.bias",
+      "pattern": "mid_block.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm2.weight",
+      "pattern": "mid_block.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.bias",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.weight",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.weight.scale",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.post_quant_conv.bias",
+      "pattern": "post_quant_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.quant_conv.bias",
+      "pattern": "quant_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.embeddings.position_embedding.weight",
+      "pattern": "text_model.embeddings.position_embedding.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.embeddings.token_embedding.weight",
+      "pattern": "text_model.embeddings.token_embedding.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.layer_norm1.bias",
+      "pattern": "text_model.encoder.layers.{i}.layer_norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.layer_norm1.weight",
+      "pattern": "text_model.encoder.layers.{i}.layer_norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.layer_norm2.bias",
+      "pattern": "text_model.encoder.layers.{i}.layer_norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.layer_norm2.weight",
+      "pattern": "text_model.encoder.layers.{i}.layer_norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.mlp.fc1.bias",
+      "pattern": "text_model.encoder.layers.{i}.mlp.fc1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.mlp.fc2.bias",
+      "pattern": "text_model.encoder.layers.{i}.mlp.fc2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.final_layer_norm.bias",
+      "pattern": "text_model.final_layer_norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.final_layer_norm.weight",
+      "pattern": "text_model.final_layer_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc1.bias",
+      "pattern": "time_embedding.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc2.bias",
+      "pattern": "time_embedding.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.norm.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.norm.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.weight.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.weight.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.weight.scale",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv1.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv1.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv2.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv2.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm1.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm1.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm2.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm2.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "F8_E4M3"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.weight.scale",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.weight_scale",
+      "dtypes": [
+        "F32"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.us.{i}.conv.bias",
+      "pattern": "up_blocks.{i}.upsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.us.{i}.conv.weight",
+      "pattern": "up_blocks.{i}.upsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/trellis2.dit-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/trellis2.dit-bf16.v1.json
@@ -1,0 +1,348 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "trellis2.dit-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical TRELLIS.2 serve layout: the sparse-structure and SLAT flow DiTs of microsoft/TRELLIS.2-4B, all-bf16, every declaration derived from the REAL safetensors headers of that repo at revision af44b45f2e35a493886929c6d786e563ec68364d via ranged reads of the header table only. This is NOT the timm block spelling dit.blocks-fused-qkv@1 declares - that fragment requires blocks.{i}.attn.qkv.weight and matches ZERO of these 640 tensors (measured), because TRELLIS spells its fused self-attention blocks.{i}.self_attn.to_qkv.weight; its adaLN patterns are per-block while TRELLIS's adaLN_modulation is TOP-LEVEL, so it collides on neither arm. ONE DOCUMENT COVERS ALL FIVE DiT CHECKPOINTS. ss_flow_img_dit_1_3B_64, slat_flow_img2shape_dit_1_3B_{512,1024} and slat_flow_imgshape2tex_dit_1_3B_{512,1024} have IDENTICAL tensor name sets (640 each, frozenset equality asserted across all five, every tensor BF16, every header 66960 bytes) and differ in exactly two declarations, by channel count only: input_layer.weight is [1536,8]/[1536,32]/[1536,64] and out_layer is [8,1536]/[32,1536]/[32,1536]. That is an I/O-channel fact, not a mechanism difference - no rope change, no pipeline class change, no CFG mechanism change - so it is the Flux2Klein 4B/9B case, and contracts pin rank and dtypes rather than shapes, so the deltas do not surface here at all. The \"4B\" is three 1.3B DiTs sharing one architecture. THE FUSIONS ARE SHAPES-BACKED AND THEY DIFFER BETWEEN THE TWO ATTENTIONS. Self-attention fuses in equal thirds: to_qkv.weight is [4608, 1536] = 3 x 1536, runs of 4718592 bytes, above MIN_SEAM_PART_BYTES so real cut points. Cross-attention SPLITS Q AND FUSES ONLY KV: to_q.weight is [1536,1536] standalone while to_kv.weight is [3072, 1024] = 2 x 1536 over a 1024-dim context, runs of 3145728 bytes, also above the floor. Reading cross-attention as equal thirds would mis-cut every block. That 1024 context width is also independent corroboration that the image conditioner is DINOv3 ViT-L/16 (hidden 1024), read off the weights rather than off a config. The matching .bias entries carry the same fusion declarations for role and derive purposes and fall BELOW the 1 MiB floor, so they correctly produce no cut points and grid plainly - the fused and split packagings cross the floor together, so this degrades on neither side. Geometry: 30 blocks, hidden 1536, 12 heads x 128 head dim, and note that the QK-RMSNorm gammas are RANK 2 [12,128] - per head, not a flat [1536] - which is a falsifiable constraint a rank-1 guess would have got wrong; MLP 1536 -> 8192 -> 1536; adaLN_modulation.1.weight [9216,1536] = 6 x 1536; a per-block modulation [9216]; t_embedder 256 -> 1536 -> 1536. DiT ONLY, deliberately, on the tensorfs#121/#122 rule: the same repo ships shape_enc/shape_dec and tex_enc/tex_dec autoencoder checkpoints, and declaring an autoencoder is what makes family detection TIE. The DiT is the component that identifies the family. Three auxiliary models reached only by rewriting pipeline.json are likewise out and get no contract of any kind - DINOv3 ViT-L/16 (image conditioner), BiRefNet (background removal) and microsoft/TRELLIS-image-large (cross-repo sparse-structure decoder) - each shared and family-plural. DINOv3 carries a second independent disqualifier: the serve image bakes it from camenduru/dinov3-vitl16-pretrain-lvd1689m, an ungated community mirror of a click-through-gated original, and a document may not be derived from a mirror that is not proven byte-identical to what the fleet ships. NAMED dit-bf16 AND NOT diffusers-bf16 ON PURPOSE: this is not a diffusers tree, it is upstream's own ckpts/ layout, and calling it diffusers would be the wrong-packaging lie tensorfs#124 warns about. The source is the ORIGINAL and it is PUBLIC AND UNGATED (gated: false, 1.44M downloads), so the mirror ban is not engaged; trellis-3d's README calls tensorhub/trellis.2-4b a mirror of it, but that hub repo does not exist - measured, with family=flux1, family=sdxl and family=wan22 answering as controls while every trellis family root returns empty. EVERY DECLARATION IS OPTIONAL, which is the shipped convention (sdxl 221/221, wan22 119/119) and is load-bearing rather than lax: the matcher reads ONE CONTAINER per call, so a `required` declaration absent from a container refuses THAT container - an anchor living in shard 1 would refuse shards 2-4 of the same checkpoint. These five DiTs are single-container today, but a document must not encode that as a precondition. Identification therefore rests on SPECIFICITY alone (the winner explains the most of the file's tensors), which is sufficient here because these 31 patterns explain all 640; a residual tie surfaces as Detection::ambiguous, detectable rather than silent. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging.",
+  "tensors": [
+    {
+      "role": "adaln.bias",
+      "pattern": "adaLN_modulation.1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "adaln.weight",
+      "pattern": "adaLN_modulation.1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.cross_attn.key_norm.weight",
+      "pattern": "blocks.{i}.cross_attn.k_rms_norm.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.cross_attn.query_norm.weight",
+      "pattern": "blocks.{i}.cross_attn.q_rms_norm.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.cross_attn.kv.bias",
+      "pattern": "blocks.{i}.cross_attn.to_kv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.cross_attn.kv.weight",
+      "pattern": "blocks.{i}.cross_attn.to_kv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.cross_attn.proj.bias",
+      "pattern": "blocks.{i}.cross_attn.to_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.cross_attn.proj.weight",
+      "pattern": "blocks.{i}.cross_attn.to_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.cross_attn.q.bias",
+      "pattern": "blocks.{i}.cross_attn.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.cross_attn.q.weight",
+      "pattern": "blocks.{i}.cross_attn.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc1.bias",
+      "pattern": "blocks.{i}.mlp.mlp.0.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc1.weight",
+      "pattern": "blocks.{i}.mlp.mlp.0.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc2.bias",
+      "pattern": "blocks.{i}.mlp.mlp.2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc2.weight",
+      "pattern": "blocks.{i}.mlp.mlp.2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.modulation",
+      "pattern": "blocks.{i}.modulation",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.norm2.bias",
+      "pattern": "blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.norm2.weight",
+      "pattern": "blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.self_attn.key_norm.weight",
+      "pattern": "blocks.{i}.self_attn.k_rms_norm.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.self_attn.query_norm.weight",
+      "pattern": "blocks.{i}.self_attn.q_rms_norm.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.self_attn.proj.bias",
+      "pattern": "blocks.{i}.self_attn.to_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.self_attn.proj.weight",
+      "pattern": "blocks.{i}.self_attn.to_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.self_attn.qkv.bias",
+      "pattern": "blocks.{i}.self_attn.to_qkv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.self_attn.qkv.weight",
+      "pattern": "blocks.{i}.self_attn.to_qkv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "x_in.bias",
+      "pattern": "input_layer.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "x_in.weight",
+      "pattern": "input_layer.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "x_out.bias",
+      "pattern": "out_layer.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "x_out.weight",
+      "pattern": "out_layer.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_in.fc1.bias",
+      "pattern": "t_embedder.mlp.0.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_in.fc1.weight",
+      "pattern": "t_embedder.mlp.0.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_in.fc2.bias",
+      "pattern": "t_embedder.mlp.2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_in.fc2.weight",
+      "pattern": "t_embedder.mlp.2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/models/model_types.py
+++ b/src/gen_worker/models/model_types.py
@@ -417,20 +417,28 @@ Z_IMAGE_DIFFUSERS_BF16: Final = _library("z-image.diffusers-bf16", 1)
 #: migratable, and it is what ``Flux2Klein.canonical_contract`` points at.
 FLUX2_KLEIN_DIFFUSERS_BF16: Final = _library("flux2-klein.diffusers-bf16", 1)
 
-#: NO DOCUMENT YET — tensorfs#124 owes it (blocked on HF access to the BFL
-#: repos), so this is a ``MissingContract`` sentinel and ``Model[Flux1]``
-#: refuses loudly, naming the document it wants.
+#: REAL as of tensorfs#124's second half (tensorfs#136). It was a
+#: ``MissingContract`` sentinel until this document was vendored, and clearing
+#: it took NO code change — the property the sentinel shape exists to have.
 #:
-#: THAT IS DELIBERATE, AND IT IS SAFER THAN WHAT IT REPLACED. ``Flux1``
-#: pointed at ``dit.blocks-fused-qkv@1``, which is a family-PLURAL
-#: block-spelling FRAGMENT in the timm/native ``blocks.{i}.attn.qkv``
-#: spelling — it declares that pattern ``required: true`` and matches ZERO of
-#: the 169 tensors in a real Flux transformer header, whose tree is
-#: ``transformer_blocks.*``/``single_transformer_blocks.*``. So it was not a
-#: lane that MIGHT fail; it was a guaranteed refusal dressed as a resolved
-#: lane, which is exactly the silent lie pgw#1391 exists to kill. Pointing at
-#: nothing beats pointing at something that cannot match, and spelling the
-#: fragment in ``lanes=`` explicitly does not rescue it either.
+#: THE SENTINEL WAS RIGHT TWICE OVER, and the second reason was only measured
+#: when the document was authored. ``Flux1`` once pointed at
+#: ``dit.blocks-fused-qkv@1``, a family-PLURAL block-spelling FRAGMENT in the
+#: timm/native ``blocks.{i}.attn.qkv`` spelling: it declares that pattern
+#: ``required: true`` and matches ZERO tensors in a real Flux transformer
+#: header, whose tree is
+#: ``transformer_blocks.*``/``single_transformer_blocks.*``. That was a
+#: guaranteed refusal dressed as a resolved lane. But the alternative on offer
+#: was worse and quieter — ``flux2-klein.diffusers-bf16@1`` explains 308 of a
+#: FLUX.1 transformer's 1160 tensors with NO dtype or rank refusal, so it WON
+#: every FLUX.1 file until this document existed (measured upstream on dev,
+#: schnell and Flex.2-preview alike). Pointing at nothing beat both.
+#:
+#: The document is transformer-only and covers all three checkpoints the fleet
+#: serves: FLUX.1-dev 1160/1160, FLUX.1-schnell 1156/1156 (the four-tensor
+#: ``guidance_embedder`` delta is declared optional) and ostris/Flex.2-preview
+#: 808/808, whose ``x_embedder`` is 196 channels wide rather than 64 — its
+#: declarations constrain rank and dtype and never shape.
 FLUX1_DIFFUSERS_BF16: Final = _library("flux1.diffusers-bf16", 1)
 
 #: REAL, and the only shipped document whose own ``description`` names the Flux
@@ -787,12 +795,26 @@ class Flux1Defaults(msgspec.Struct, frozen=True):
     and ``:277-280``); schnell pins ``guidance_scale=0.0``
     (``flux.1-schnell/main.py:388-389``). A Flex.2 row flips it on.
 
-    DELIBERATELY ABSENT: ``canonical_scheduler_config`` (Flux is flow-matching
-    — no beta schedule to record, and ``FlowMatchEulerDiscreteScheduler``'s
-    shift parameters are RESOLUTION-dependent; BFL's own
+    DELIBERATELY ABSENT: ``canonical_scheduler_config``, and the REASON was
+    corrected at tensorfs#136 — the old one ("BFL's
     ``scheduler/scheduler_config.json`` is HF-gated and unfetchable from the
-    workspace, so it stays ``{}`` like SD2/HiDreamO1/Wan22 rather than being
-    invented); no ``.Lora`` overlay (no flux endpoint registers a lora
+    workspace") has DISSOLVED and must not be left standing, because a ``{}``
+    with a stale reason gets cleared by the next reader who assumes it was
+    only ever an access problem. The file is fetchable: it is a whole-file
+    entry in the hub's own resolve manifest for ``tensorhub/flux1-dev`` and
+    ``tensorhub/flux1-schnell``, and both were read.
+
+    It stays ``{}`` on the MEASURED fact instead, which is a stronger reason
+    than the access one ever was: the two checkpoints under this one family
+    root DISAGREE. Both are ``FlowMatchEulerDiscreteScheduler`` with
+    ``base_shift`` 0.5, ``max_shift`` 1.15 and image_seq_len 256..4096, but
+    dev is ``shift`` 3.0 with ``use_dynamic_shifting`` TRUE while schnell is
+    ``shift`` 1.0 with it FALSE. One canonical schedule for the root would
+    therefore be wrong for one of the two, and copying FLUX.2 Klein's
+    (3.0/dynamic — see :data:`FLUX2_KLEIN_SCHEDULER_CONFIG`) by family
+    resemblance would be right for dev and wrong for schnell. The per-arm
+    values are CHECKPOINT facts and belong in the catalog row, not here.
+    No ``.Lora`` overlay (no flux endpoint registers a lora
     vocabulary, so there is no strength range or scheduler demand to source);
     no ``timesteps`` ladder (no flux endpoint passes one).
     """

--- a/tests/test_lane_contracts.py
+++ b/tests/test_lane_contracts.py
@@ -31,7 +31,26 @@ from gen_worker._vendor.tensorfs.contract import (
 ROOT = Path(__file__).resolve().parents[1]
 VECTORS = ROOT / "tests" / "testdata" / "contract-vectors"
 DOCUMENTS = ROOT / "src" / "gen_worker" / "_vendor" / "tensorfs" / "_contracts"
-UPSTREAM = ROOT.parent.parent.parent / "tensorfs"
+def _sibling_tensorfs() -> Path:
+    """The neighbouring tensorfs checkout, from a worktree OR the main clone.
+
+    The old spelling was `ROOT.parent.parent.parent / "tensorfs"`, which is
+    correct for exactly one layout. From a worktree
+    (`~/cozy/.worktrees/python-gen-worker/<branch>`) it lands on
+    `~/cozy/tensorfs` and the drift checks run; from the MAIN checkout
+    (`~/cozy/python-gen-worker`) the same three hops land on `/home/tensorfs`,
+    which does not exist, so both checks SKIP. An instrument that is invisible
+    exactly where reviewers and CI run it reports green by not looking.
+    """
+
+    for ancestor in ROOT.parents:
+        candidate = ancestor / "tensorfs"
+        if (candidate / ".git").exists():
+            return candidate
+    return ROOT.parent / "tensorfs"  # a stable non-existent path -> honest skip
+
+
+UPSTREAM = _sibling_tensorfs()
 
 CORPUS = json.loads((VECTORS / "contract-vectors.json").read_text())
 
@@ -92,6 +111,8 @@ def test_the_library_loads_and_names_what_the_corpus_names() -> None:
         "HIDREAM_O1_DIFFUSERS_BF16",
         "WAN22_DIFFUSERS_BF16",
         "FLUX2_KLEIN_DIFFUSERS_BF16",
+        # tensorfs#136 — the last of the five sentinels to clear.
+        "FLUX1_DIFFUSERS_BF16",
     ):
         assert getattr(contracts, constant).dtype == "bfloat16"
     assert contracts.SD15_DIFFUSERS_BF16.digest != contracts.SD2_DIFFUSERS_BF16.digest
@@ -158,25 +179,60 @@ def test_the_document_property_is_the_canonical_json_string() -> None:
     assert document == json.dumps(parsed, sort_keys=True, separators=(",", ":"))
 
 
-def test_the_corpus_matches_the_sibling_tensorfs_checkout() -> None:
+def _upstream_blob(path: str) -> bytes | None:
+    """One upstream file AT `contract_plane_rev`, or None if unavailable.
+
+    THE REV, NOT THE SIBLING'S WORKING TREE, and the difference is the whole
+    point of pinning one. Both drift checks below used to read
+    `UPSTREAM / <path>` — whatever the neighbouring checkout happened to have
+    checked out — which asserts that this repo is always at tensorfs TIP. That
+    contradicts `contract_plane_rev` existing at all, and it goes red for
+    reasons that have nothing to do with the change under test: while tensorfs
+    is under active multi-lane development its master gains a lane document
+    every few hours, so every vendor PR inherits an unrelated failure and the
+    honest fix looks like "vendor three other lanes' documents".
+
+    A snapshot is faithful to the REV IT RECORDS. That is what is asserted.
+    """
+
+    import subprocess
+
+    if not (UPSTREAM / ".git").exists():
+        return None
+    manifest = tomllib.loads(
+        (ROOT / "src" / "gen_worker" / "_vendor" / "VENDORED.toml").read_text()
+    )
+    rev = manifest["packages"]["tensorfs"]["contract_plane_rev"]
+    done = subprocess.run(
+        ["git", "-C", str(UPSTREAM), "show", f"{rev}:{path}"],
+        capture_output=True,
+    )
+    # An unfetched rev is "cannot check here", never "drifted": the sibling is
+    # a convenience, and CI has no sibling at all.
+    return done.stdout if done.returncode == 0 else None
+
+
+def test_the_corpus_matches_the_pinned_upstream_rev() -> None:
     """The vendored corpus is a SNAPSHOT; when the real repo is beside us,
-    prove the snapshot has not drifted from it."""
+    prove the snapshot has not drifted from the rev it claims."""
 
-    upstream = UPSTREAM / "spec" / "v1" / "contract-vectors" / "contract-vectors.json"
-    if not upstream.exists():
-        pytest.skip("no sibling tensorfs checkout")
+    theirs = _upstream_blob("spec/v1/contract-vectors/contract-vectors.json")
+    if theirs is None:
+        pytest.skip("no sibling tensorfs checkout carrying contract_plane_rev")
     ours = (VECTORS / "contract-vectors.json").read_bytes()
-    assert hashlib.sha256(upstream.read_bytes()).hexdigest() == hashlib.sha256(ours).hexdigest()
+    assert hashlib.sha256(theirs).hexdigest() == hashlib.sha256(ours).hexdigest()
 
 
-def test_the_vendored_documents_match_the_sibling_tensorfs_checkout() -> None:
-    upstream = UPSTREAM / "spec" / "v1" / "contracts"
-    if not upstream.exists():
-        pytest.skip("no sibling tensorfs checkout")
+def test_the_vendored_documents_match_the_pinned_upstream_rev() -> None:
+    checked = 0
     for path in DOCUMENTS.glob("*.json"):
-        theirs = upstream / path.name
-        assert theirs.exists(), f"{path.name} is not an upstream document"
-        assert path.read_bytes() == theirs.read_bytes(), f"{path.name} drifted from upstream"
+        theirs = _upstream_blob(f"spec/v1/contracts/{path.name}")
+        if theirs is None:
+            pytest.skip("no sibling tensorfs checkout carrying contract_plane_rev")
+        assert path.read_bytes() == theirs, f"{path.name} drifted from upstream"
+        checked += 1
+    # A loop that checked nothing is not a passing drift check.
+    assert checked == len(list(DOCUMENTS.glob("*.json"))) >= 14
 
 
 def test_the_contract_plane_rev_is_recorded_in_vendored_toml() -> None:
@@ -217,38 +273,44 @@ def test_a_dtypeless_FRAGMENT_is_importable_but_refuses_as_a_serve_lane() -> Non
             def load(self, ctx: object) -> None: ...
 
 
-def test_flux1_points_at_no_document_rather_than_one_that_cannot_match() -> None:
-    """tensorfs#124's finding, and the reason the sentinel machinery stayed.
+def test_the_two_flux_roots_resolve_to_their_own_documents() -> None:
+    """tensorfs#124, both halves, and the reason the sentinel machinery stayed.
 
-    `Flux1.canonical_contract` used to be `dit.blocks-fused-qkv@1`, which
-    declares `blocks.{i}.attn.qkv.weight` REQUIRED and matches 0 of the 169
-    tensors in a real Flux transformer header (the tree is
-    `transformer_blocks.*` / `single_transformer_blocks.*`). That is a
-    GUARANTEED refusal wearing a resolved lane's clothes — the pgw#1391 bug
-    exactly. Pointing at a document that does not exist yet is strictly safer,
-    because it refuses by NAME and says what is owed.
+    `Flux1.canonical_contract` was a `MissingContract` from pgw#1393 until
+    tensorfs#136 authored `flux1.diffusers-bf16@1`, and clearing it took NO
+    code change in `model_types.py` — vendoring the document was the whole
+    edit. That is the property the sentinel shape exists to have, and this is
+    the second time it has been exercised (tensorfs#121 cleared four).
+
+    Before either document existed, `Flux1.canonical_contract` pointed at
+    `dit.blocks-fused-qkv@1`, which declares `blocks.{i}.attn.qkv.weight`
+    REQUIRED and matches 0 tensors in a real Flux transformer header (the tree
+    is `transformer_blocks.*` / `single_transformer_blocks.*`) — a GUARANTEED
+    refusal wearing a resolved lane's clothes, the pgw#1391 bug exactly. The
+    quieter hazard, measured upstream when the document was authored, was the
+    OTHER flux document: `flux2-klein.diffusers-bf16@1` explains 308 of a
+    FLUX.1 transformer's 1160 tensors with no dtype or rank refusal, so it won
+    every FLUX.1 file outright. Two roots, two documents, and neither may
+    borrow the other's.
     """
 
     from gen_worker.models import Flux1, Flux2Klein
-    from gen_worker.models.model_types import MissingContract, MissingContractError
-    from gen_worker.serving import Model, ModelDeclarationError
+    from gen_worker.serving import Model
 
-    assert isinstance(Flux1.canonical_contract, MissingContract)
-    with pytest.raises(MissingContractError, match="flux1.diffusers-bf16@1"):
-        Flux1.canonical_contract.stamp
-
-    with pytest.raises(ModelDeclarationError, match="DOES NOT EXIST"):
-
-        class Flux1Model(Model[Flux1]):
-            def load(self, ctx: object) -> None: ...
-
-    # Klein DOES have its own document now, so it must resolve.
+    assert Flux1.canonical_contract.stamp == "flux1.diffusers-bf16@1"
+    assert Flux1.canonical_contract.dtype == "bfloat16"
     assert Flux2Klein.canonical_contract.stamp == "flux2-klein.diffusers-bf16@1"
     assert Flux2Klein.canonical_contract.dtype == "bfloat16"
+    # Separate documents, separate digests — never one shared "flux" lane.
+    assert Flux1.canonical_contract.digest != Flux2Klein.canonical_contract.digest
+
+    class Flux1Model(Model[Flux1]):
+        def load(self, ctx: object) -> None: ...
 
     class KleinModel(Model[Flux2Klein]):
         def load(self, ctx: object) -> None: ...
 
+    assert Flux1Model.__cozy_model_type__ is Flux1
     assert KleinModel.__cozy_model_type__ is Flux2Klein
 
 

--- a/tests/test_model_defaults.py
+++ b/tests/test_model_defaults.py
@@ -576,9 +576,17 @@ def test_canonical_scheduler_configs_are_the_training_schedules() -> None:
     assert Rife.canonical_scheduler_config == {}
     # pgw#1393: Flux is FLOW-MATCHING — there is no beta schedule to record at
     # all, and FlowMatchEulerDiscreteScheduler's shift parameters are
-    # resolution-dependent. BFL's own scheduler_config.json is HF-gated and
-    # could not be fetched, so this stays empty rather than borrowing SDXL's
-    # scaled_linear betas.
+    # resolution-dependent, so this never borrows SDXL's scaled_linear betas.
+    #
+    # tensorfs#136 CORRECTED THE REASON. pgw#1393 recorded "HF-gated and could
+    # not be fetched", which has since dissolved: both files are whole-file
+    # entries in the hub's resolve manifest for tensorhub/flux1-dev and
+    # tensorhub/flux1-schnell, and both were read. It stays empty on the
+    # measured fact instead — the two checkpoints under this one root DISAGREE
+    # (dev shift 3.0 with use_dynamic_shifting True; schnell shift 1.0 with it
+    # False), so no single value is right for the root, and Klein's 3.0/dynamic
+    # would be right for dev and wrong for schnell. A `{}` whose reason has
+    # gone stale is the one the next reader clears wrongly.
     from gen_worker.models import Flux1, Flux2Klein
 
     assert Flux1.canonical_scheduler_config == {}

--- a/tests/testdata/contract-vectors/contract-vectors.json
+++ b/tests/testdata/contract-vectors/contract-vectors.json
@@ -8,6 +8,18 @@
       "stamp": "dit.blocks-fused-qkv@1"
     },
     {
+      "name": "ernie.diffusers-bf16.v1",
+      "file": "contracts/ernie.diffusers-bf16.v1.json",
+      "digest": "b4e726e157035529a98a594a211b3d085cc5c3577182ed1e3b9bb4c1d5811c67",
+      "stamp": "ernie.diffusers-bf16@1"
+    },
+    {
+      "name": "flux1.diffusers-bf16.v1",
+      "file": "contracts/flux1.diffusers-bf16.v1.json",
+      "digest": "392e9b54605ef75e18e7b7a29da3501f59215c091c228a16d18d403463320a63",
+      "stamp": "flux1.diffusers-bf16@1"
+    },
+    {
       "name": "flux2-klein.diffusers-bf16.v1",
       "file": "contracts/flux2-klein.diffusers-bf16.v1.json",
       "digest": "4d9fada187e6e086a1c4c496d81b785ce9419fc089e64d0141f6427b88e9d40d",
@@ -20,10 +32,28 @@
       "stamp": "hidream-o1.diffusers-bf16@1"
     },
     {
+      "name": "internvl-u.diffusers-bf16.v1",
+      "file": "contracts/internvl-u.diffusers-bf16.v1.json",
+      "digest": "9ee028aea999f92c4d93609f59ba476f0c6aad8dee3269cee1a22abec97d199d",
+      "stamp": "internvl-u.diffusers-bf16@1"
+    },
+    {
+      "name": "ltx-2.diffusers-bf16.v1",
+      "file": "contracts/ltx-2.diffusers-bf16.v1.json",
+      "digest": "71038ae11883111d367077eec59a457b97c8746439c3b7bc0885555e26b7aa12",
+      "stamp": "ltx-2.diffusers-bf16@1"
+    },
+    {
       "name": "minimax.h3-dit-diffusers.v1",
       "file": "contracts/minimax.h3-dit-diffusers.v1.json",
       "digest": "22bbb607d3e4351c18ac55e8d86c8a8a3d03296309b80e4419d4bc5153481f28",
       "stamp": "minimax.h3-dit-diffusers@1"
+    },
+    {
+      "name": "minimax.h3-dit-fp8-rowwise.v1",
+      "file": "contracts/minimax.h3-dit-fp8-rowwise.v1.json",
+      "digest": "69a2cc8f338ba925d4415f67719f1ed1643e9d31f43e4af04d9b2ff1dc035d1f",
+      "stamp": "minimax.h3-dit-fp8-rowwise@1"
     },
     {
       "name": "minimax.h3-dit-native.v1",
@@ -62,22 +92,22 @@
       "stamp": "sdxl.diffusers-bf16@1"
     },
     {
+      "name": "sdxl.diffusers-fp8-rowwise.v1",
+      "file": "contracts/sdxl.diffusers-fp8-rowwise.v1.json",
+      "digest": "7b78f2e44382dc5a3fe413e0f8f0a62ba63efefc810123304151c2ded931ee37",
+      "stamp": "sdxl.diffusers-fp8-rowwise@1"
+    },
+    {
+      "name": "trellis2.dit-bf16.v1",
+      "file": "contracts/trellis2.dit-bf16.v1.json",
+      "digest": "f9763a5aa4b82d552c7b582d7b540cd0fdf576cc5bd234bb9e73ec617738ab52",
+      "stamp": "trellis2.dit-bf16@1"
+    },
+    {
       "name": "wan22.diffusers-bf16.v1",
       "file": "contracts/wan22.diffusers-bf16.v1.json",
       "digest": "91036beea9878c462311d97a878a5dc94128283182fbf0948b30118852d97bd5",
       "stamp": "wan22.diffusers-bf16@1"
-    },
-    {
-      "name": "custom-interleaved",
-      "document": "{\n    \"format\": \"tensorfs-contract-v1\",\n    \"tensors\": [\n        {\"role\": \"b.{i}.qkv\", \"pattern\": \"b.{i}.qkv.weight\", \"rank\": 2,\n         \"fusion\": {\"axis\": 0, \"groups\": 56,\n                    \"parts\": [{\"role\": \"q\", \"share\": 1}, {\"role\": \"k\", \"share\": 1},\n                              {\"role\": \"v\", \"share\": 1}]}},\n        {\"role\": \"b.{i}.qkv#q\", \"pattern\": \"b.{i}.q.weight\", \"rank\": 2, \"required\": false,\n         \"fusion\": {\"axis\": 0, \"groups\": 56, \"parts\": [{\"role\": \"\", \"share\": 1}]}}\n    ]\n}",
-      "digest": "d57b11915fe4e389472da10707d7307bf03636d522b12887f39c7efbf1abe9b1",
-      "stamp": "sha256:d57b11915fe4e389472da10707d7307bf03636d522b12887f39c7efbf1abe9b1"
-    },
-    {
-      "name": "custom-rich",
-      "document": "{\n    \"format\": \"tensorfs-contract-v1\",\n    \"description\": \"vector fixture: every declaration branch\",\n    \"dtype\": \"bfloat16\",\n    \"tensors\": [\n        {\"role\": \"blocks.{i}.attn.qkv\", \"pattern\": \"blocks.{i}.attn.qkv_proj.weight\",\n         \"rank\": 2, \"dtypes\": [\"BF16\", \"F16\"],\n         \"fusion\": {\"axis\": 0, \"parts\": [{\"role\": \"q\", \"share\": 2}, {\"role\": \"k\", \"share\": 1},\n                                         {\"role\": \"v\", \"share\": 1}]}},\n        {\"role\": \"blocks.{i}.rope\", \"pattern\": \"blocks.{i}.rope.weight\", \"required\": false,\n         \"permute\": {\"view\": [4, \"shape[0]/2\", \"auto\", \"shape[1]\"], \"axes\": [0, 2, 1, 3]}}\n    ],\n    \"sets\": {\"adaln\": [\"blocks.{i}.adaln.weight\", \"norm_out.weight\"], \"rope\": [\"blocks.{i}.rope.weight\"]}\n}",
-      "digest": "840107df52fe82b735067c3649b14cde234235ac28792be6f915c357fc786a0f",
-      "stamp": "sha256:840107df52fe82b735067c3649b14cde234235ac28792be6f915c357fc786a0f"
     },
     {
       "name": "qwen-image.diffusers-bf16.v1",
@@ -90,6 +120,18 @@
       "file": "contracts/z-image.diffusers-bf16.v1.json",
       "digest": "f726fae567c094783ac5aa41822b77f4ae3387bfc07daf22f3ca189ed74c1af5",
       "stamp": "z-image.diffusers-bf16@1"
+    },
+    {
+      "name": "custom-rich",
+      "document": "{\n    \"format\": \"tensorfs-contract-v1\",\n    \"description\": \"vector fixture: every declaration branch\",\n    \"dtype\": \"bfloat16\",\n    \"tensors\": [\n        {\"role\": \"blocks.{i}.attn.qkv\", \"pattern\": \"blocks.{i}.attn.qkv_proj.weight\",\n         \"rank\": 2, \"dtypes\": [\"BF16\", \"F16\"],\n         \"fusion\": {\"axis\": 0, \"parts\": [{\"role\": \"q\", \"share\": 2}, {\"role\": \"k\", \"share\": 1},\n                                         {\"role\": \"v\", \"share\": 1}]}},\n        {\"role\": \"blocks.{i}.rope\", \"pattern\": \"blocks.{i}.rope.weight\", \"required\": false,\n         \"permute\": {\"view\": [4, \"shape[0]/2\", \"auto\", \"shape[1]\"], \"axes\": [0, 2, 1, 3]}}\n    ],\n    \"sets\": {\"adaln\": [\"blocks.{i}.adaln.weight\", \"norm_out.weight\"], \"rope\": [\"blocks.{i}.rope.weight\"]}\n}",
+      "digest": "840107df52fe82b735067c3649b14cde234235ac28792be6f915c357fc786a0f",
+      "stamp": "sha256:840107df52fe82b735067c3649b14cde234235ac28792be6f915c357fc786a0f"
+    },
+    {
+      "name": "custom-interleaved",
+      "document": "{\n    \"format\": \"tensorfs-contract-v1\",\n    \"tensors\": [\n        {\"role\": \"b.{i}.qkv\", \"pattern\": \"b.{i}.qkv.weight\", \"rank\": 2,\n         \"fusion\": {\"axis\": 0, \"groups\": 56,\n                    \"parts\": [{\"role\": \"q\", \"share\": 1}, {\"role\": \"k\", \"share\": 1},\n                              {\"role\": \"v\", \"share\": 1}]}},\n        {\"role\": \"b.{i}.qkv#q\", \"pattern\": \"b.{i}.q.weight\", \"rank\": 2, \"required\": false,\n         \"fusion\": {\"axis\": 0, \"groups\": 56, \"parts\": [{\"role\": \"\", \"share\": 1}]}}\n    ]\n}",
+      "digest": "d57b11915fe4e389472da10707d7307bf03636d522b12887f39c7efbf1abe9b1",
+      "stamp": "sha256:d57b11915fe4e389472da10707d7307bf03636d522b12887f39c7efbf1abe9b1"
     }
   ],
   "refusals": [


### PR DESCRIPTION
**This PR changed shape.** It began as flux1's own vendor bump; master then took the qwen lane's subset vendoring, and per the coordinator's single-writer arbitration this is now **the wave-wide sync**.

## Cut rev: `272103e414184c7935105afa48416b95fd5a10ee` — 20 documents

Taken **after** tensorfs#137 (internvl-u) and #142 (ernie) landed, so neither lane owes a post-sync bump.

The vendored set now **equals the real upstream corpus**, and `tests/testdata/contract-vectors/contract-vectors.json` is upstream's file **verbatim** again — squaring up the subset required hand-trimming it, which quietly stopped it being upstream's bytes.

Documents arriving here belong to **other lanes**, vendored bytes-only and named in the manifest so ownership is readable rather than implied:

| document | lane | tensorfs |
|---|---|---|
| `flux1.diffusers-bf16` | se#778 | #136 |
| `internvl-u.diffusers-bf16` | se#779 | #137 |
| `ltx-2.diffusers-bf16` | se#772 | #135 |
| `trellis2.dit-bf16` | se#775 | #132 |
| `ernie.diffusers-bf16` | kae | #142 |
| `qwen-image` / `z-image` | se#776 | #131 (already present) |
| `minimax.h3-dit-fp8-rowwise`, `sdxl.diffusers-fp8-rowwise` | — | #128 |

## 🔴 A bump must touch BOTH tables, and they fail in opposite directions

`contract_plane_files` is the contract-plane inventory; `[packages.tensorfs.files]` is the path→sha256 table `test_every_vendored_file_matches_its_recorded_digest` enforces **as a set**. Measured, both ways:

- updating only the inventory → the digest fence caught three documents as **"only on disk"**;
- a list that silently **grew duplicate rows** — **34 entries for a 20-document library** — was **invisible** to that fence, because the fence reads the *other* table.

Both tables are regenerated from the cut rev's bytes, and the generator refuses to write a half-edit if either block fails to match.

## Flux1: the sentinel clears with no code change

Which is the property the `MissingContract` shape exists to have, and the second time it has been exercised. Worth stating what it was protecting against, because **the loud hazard was not the dangerous one**: `dit.blocks-fused-qkv@1` matches **zero** tensors in a Flux transformer and refuses noisily, but `flux2-klein.diffusers-bf16@1` explains **308 of a FLUX.1 transformer's 1160** with no dtype or rank refusal and therefore **won every FLUX.1 file** — dev, schnell and Flex.2-preview alike. Pointing at nothing beat both.

## A stale `{}` reason corrected

`Flux1Defaults.canonical_scheduler_config = {}` was recorded because BFL's `scheduler_config.json` was *"HF-gated and unfetchable"*. **That reason has dissolved** — it is a whole-file entry in the hub's own resolve manifest and both were read. It stays `{}` on a stronger, measured reason: the two checkpoints under this one root **disagree** (dev `shift 3.0` / dynamic; schnell `1.0` / static), so no single value is right for the root, and copying Klein's 3.0/dynamic by family resemblance would be right for dev and **wrong for schnell**.

> A `{}` with a stale reason gets "fixed" wrong by the next reader.

## The drift checks now read `contract_plane_rev`, not the sibling's working tree

They compared against whatever `~/cozy/tensorfs` happened to have checked out — which asserts this repo is always at tensorfs **tip** and contradicts pinning a rev at all. Measured: tensorfs master gained **four** unrelated lane documents while this was in flight.

Worse, the path (`ROOT.parent.parent.parent`) resolved **only from a worktree**; from the main checkout it lands on `/home/tensorfs` and both rows skipped **silently — CI included**. An instrument invisible exactly where reviewers run it reports green by not looking.

Both skips are now **classified** in `scripts/skip_census.txt`, which was failing on clean `origin/master` for two undisposed keys — one this change's, one pre-existing and classified here because it blocked every PR in the repo.

## Gates

- `test_vendored_snapshot_pgw1310` `test_lane_contracts` `test_contract_package_data` `test_model_defaults` `test_model_authoring` — **157 passed**.
- Red-verified: tampering with one vendored document's `description` fails the pinned-rev drift check.
- `fast gates` (the only required context) green.
- **Baseline note:** pgw master's `tests` job is independently red (`3 failed, 6325 passed`), and a CI env difference — not this diff — collects ~1988 items against master's 6369 (locally both collect ~1950, so the gap is environmental). Every test touching this change passes locally.

> **Env note for reviewers:** `uv sync` in a fresh worktree resolves Python **3.13** and drops `torch`, which makes `tests/test_model_authoring.py` error at fixture import in a way that looks like a code defect. Use `uv sync --all-extras --all-groups -p 3.12`.