### PR TITLE
pgw#1431: read a DEFERRED import — discovery stops refusing the endpoints its own convention creates

### DIFF
--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -84,32 +84,42 @@ def _entrypoint_specs(module: Any) -> List[Any]:
     return out
 
 
-def _deferred_imports(tree: ast.AST) -> Dict[str, str]:
-    """Local name -> dotted path, for imports written INSIDE ``load``.
+def _import_sites(tree: ast.AST) -> Dict[str, str]:
+    """Local name -> dotted path, from every ``from x.y import Name`` in
+    ``tree``. Imports NOTHING.
 
-    pgw#1431. An endpoint whose upstream runtime is source-built cannot import
-    it at module top: the package is not on PyPI and compiles CUDA extensions,
-    so a discovery runner has nothing to import. The SDK's own convention says
-    to defer it (``trellis-3d/main.py:1-7``: *"deferring a source-built extra
-    ... is exactly what keeps discovery (and the CPU test suite) importable"*).
+    pgw#1431. The runtime lookup recovers the pipeline class by importing and
+    type-checking, and it fails in TWO measured shapes that have one cause —
+    the AST already carried the answer:
 
-    A deferred import binds no module-level name, so the ``getattr(module, …)``
-    lookup below finds nothing and the whole parse used to yield "" — which
-    :func:`_pipeline_class_or_refuse` turns into a hard publish refusal. The
-    convention that keeps discovery importable was the one that made discovery
-    refuse.
+    * **deferred (function-body) import.** An endpoint whose upstream runtime
+      is source-built cannot import it at module top: the package is not on
+      PyPI and compiles CUDA extensions, so a discovery runner has nothing to
+      import. The SDK's own convention says to defer it (``trellis-3d/main.py``:
+      *"deferring a source-built extra ... is exactly what keeps discovery (and
+      the CPU test suite) importable"*). A deferred import binds no
+      module-level name, so ``getattr(module, …)`` finds nothing.
+    * **module-top import of a STUBBED package.** ``internvl-U`` writes
+      ``from internvlu import InternVLUPipeline`` at module top with
+      ``discovery_heavy_deps = ["internvlu"]``; off-image, the stub finder
+      binds a MODULE OBJECT, so ``isinstance(target, type)`` is False even
+      though the import is module-top and sanctioned. In-image publish is
+      fine; every off-image gate broke — the caller is
+      ``serverless-endpoints/scripts/lint_discovery.py:121``.
 
-    Reading the ``ImportFrom`` node recovers the dotted name and imports
-    NOTHING, so it keeps the promise the rest of this function makes: no author
-    code runs at discovery. ``import a.b.c`` is deliberately not handled — it
-    binds ``a``, so the pipeline would be spelled ``a.b.c.Name`` as an
-    ``ast.Attribute`` rather than the ``ast.Name`` this parse accepts.
+    So the fallback is scoped to the CAUSE, not to either symptom: whenever the
+    runtime lookup fails to yield a type, resolve the name statically from any
+    ``ImportFrom`` in the module OR in ``load`` itself.
+
+    ``import a.b.c`` is deliberately not handled — it binds ``a``, so the
+    pipeline would be spelled ``a.b.c.Name`` as an ``ast.Attribute`` rather
+    than the ``ast.Name`` this parse accepts.
     """
     found: Dict[str, str] = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom) or node.module is None:
             continue
-        if node.level:  # a relative import inside load(); no dotted path to state
+        if node.level:  # relative import — no absolute dotted path to state
             continue
         for alias in node.names:
             if alias.name == "*":
@@ -134,11 +144,14 @@ def _pipeline_class(model_cls: type) -> str:
     1. the name bound on the endpoint's MODULE — a real class object, so the
        answer carries its true ``__module__``/``__qualname__`` even when the
        import site spells an alias or a re-export;
-    2. failing that, a ``from x.y import Name`` written INSIDE ``load`` — the
-       dotted path read off the AST, importing nothing.
+    2. failing that, a ``from x.y import Name`` — at module top OR inside
+       ``load`` — resolved statically off the AST, importing nothing.
 
-    (2) is strictly a fallback: when the class is importable at discovery, (1)
-    is what runs, so this change cannot move any answer that already resolved.
+    (2) is strictly a fallback keyed on (1) not yielding a TYPE, so it covers a
+    deferred import (nothing bound) and a stubbed heavy dep (a module object
+    bound where a class was expected) with one branch. When the class really is
+    importable at discovery, (1) still wins, so this cannot move any answer
+    that already resolved.
     """
     load = getattr(model_cls, "load", None)
     if load is None:
@@ -148,7 +161,19 @@ def _pipeline_class(model_cls: type) -> str:
     except (OSError, TypeError, SyntaxError):
         return ""
     module = inspect.getmodule(model_cls)
-    deferred = _deferred_imports(tree)
+    # Module-top imports first, then load()'s own — the inner scope wins on a
+    # name collision, exactly as Python binds it.
+    static: Dict[str, str] = {}
+    try:
+        module_source = inspect.getsource(module) if module is not None else ""
+    except (OSError, TypeError):
+        module_source = ""
+    if module_source:
+        try:
+            static.update(_import_sites(ast.parse(module_source)))
+        except SyntaxError:
+            pass
+    static.update(_import_sites(tree))
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -163,7 +188,7 @@ def _pipeline_class(model_cls: type) -> str:
         target = getattr(module, arg.id, None)
         if isinstance(target, type):
             return f"{target.__module__}.{target.__qualname__}"
-        dotted = deferred.get(arg.id)
+        dotted = static.get(arg.id)
         if dotted:
             return dotted
     return ""

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -84,6 +84,40 @@ def _entrypoint_specs(module: Any) -> List[Any]:
     return out
 
 
+def _deferred_imports(tree: ast.AST) -> Dict[str, str]:
+    """Local name -> dotted path, for imports written INSIDE ``load``.
+
+    pgw#1431. An endpoint whose upstream runtime is source-built cannot import
+    it at module top: the package is not on PyPI and compiles CUDA extensions,
+    so a discovery runner has nothing to import. The SDK's own convention says
+    to defer it (``trellis-3d/main.py:1-7``: *"deferring a source-built extra
+    ... is exactly what keeps discovery (and the CPU test suite) importable"*).
+
+    A deferred import binds no module-level name, so the ``getattr(module, …)``
+    lookup below finds nothing and the whole parse used to yield "" — which
+    :func:`_pipeline_class_or_refuse` turns into a hard publish refusal. The
+    convention that keeps discovery importable was the one that made discovery
+    refuse.
+
+    Reading the ``ImportFrom`` node recovers the dotted name and imports
+    NOTHING, so it keeps the promise the rest of this function makes: no author
+    code runs at discovery. ``import a.b.c`` is deliberately not handled — it
+    binds ``a``, so the pipeline would be spelled ``a.b.c.Name`` as an
+    ``ast.Attribute`` rather than the ``ast.Name`` this parse accepts.
+    """
+    found: Dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        if node.level:  # a relative import inside load(); no dotted path to state
+            continue
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            found[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return found
+
+
 def _pipeline_class(model_cls: type) -> str:
     """The dotted pipeline class ``load()`` builds, read STATICALLY.
 
@@ -94,6 +128,17 @@ def _pipeline_class(model_cls: type) -> str:
     class header makes. Unreadable (a dynamic class, no ``load``) returns "",
     and the caller decides what an absent one means; guessing a pipeline here
     would be a manifest that lies about what the worker will build.
+
+    Two resolutions, in order of authority (pgw#1431):
+
+    1. the name bound on the endpoint's MODULE — a real class object, so the
+       answer carries its true ``__module__``/``__qualname__`` even when the
+       import site spells an alias or a re-export;
+    2. failing that, a ``from x.y import Name`` written INSIDE ``load`` — the
+       dotted path read off the AST, importing nothing.
+
+    (2) is strictly a fallback: when the class is importable at discovery, (1)
+    is what runs, so this change cannot move any answer that already resolved.
     """
     load = getattr(model_cls, "load", None)
     if load is None:
@@ -103,6 +148,7 @@ def _pipeline_class(model_cls: type) -> str:
     except (OSError, TypeError, SyntaxError):
         return ""
     module = inspect.getmodule(model_cls)
+    deferred = _deferred_imports(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -117,6 +163,9 @@ def _pipeline_class(model_cls: type) -> str:
         target = getattr(module, arg.id, None)
         if isinstance(target, type):
             return f"{target.__module__}.{target.__qualname__}"
+        dotted = deferred.get(arg.id)
+        if dotted:
+            return dotted
     return ""
 
 

--- a/tests/test_endpoint_discovery.py
+++ b/tests/test_endpoint_discovery.py
@@ -1,4 +1,8 @@
-"""pgw#1431: `pipeline_class` must survive a DEFERRED import.
+"""What v2 discovery can READ off an endpoint's `load()` — and what it cannot.
+
+`pipeline_class` is the hub's required field on every model slot, recovered by
+parsing `ctx.load(<PlainName>)`. These tests fix which spellings resolve, which
+do not, and where the boundary sits.
 
 The three arms below are the ones measured against `e0725c71` when the defect
 was found. They are kept as fixtures because each answers a different question,
@@ -79,6 +83,7 @@ def test_the_control_arm_resolves_through_the_module() -> None:
     assert got == f"{RealPipeline.__module__}.{RealPipeline.__qualname__}"
 
 
+# pgw#1431: a deferred import bound no module-level name, so discovery refused.
 def test_a_deferred_import_resolves_to_its_dotted_path() -> None:
     """pgw#1431, the fix. Nothing is imported to answer this — `trellis2` is
     not installed in this environment, and that is the point."""
@@ -100,6 +105,7 @@ def test_a_deferred_import_under_an_alias_resolves_to_the_real_name() -> None:
     )
 
 
+# pgw#1431: the boundary — self-loading needs its own marker (pgw#1421 ruling).
 def test_a_self_loading_model_still_reads_as_absent() -> None:
     """The BOUNDARY of this fix, asserted so it cannot quietly widen.
 

--- a/tests/test_endpoint_discovery.py
+++ b/tests/test_endpoint_discovery.py
@@ -8,12 +8,19 @@ The three arms below are the ones measured against `e0725c71` when the defect
 was found. They are kept as fixtures because each answers a different question,
 and the control is what makes the other two mean anything:
 
-    ArmControl       module-level class     -> resolves      (the control)
-    ArmLazyImport    `from x import C` in load() -> resolved by this fix
-    ArmSelfLoading   no `ctx.load` at all   -> still ""      (needs pgw#1421's
-                                                              typed self_loading
-                                                              marker, a Paul
-                                                              ruling; NOT this)
+    ArmControl       module-level class          -> resolves   (the control)
+    ArmLazyImport    `from x import C` in load()  -> fixed here
+    ArmStubbedDep    module-top import of a STUB  -> fixed here (internvl lane)
+    ArmSelfLoading   no `ctx.load` at all         -> still ""   (needs pgw#1421's
+                                                                 typed self_loading
+                                                                 marker, a Paul
+                                                                 ruling; NOT this)
+
+The two fixed shapes have ONE cause: the reader recovered the class by
+importing and type-checking when the AST already carried the answer. So the
+fallback is keyed on "the runtime lookup did not yield a TYPE", which covers a
+name that is unbound (deferred import) and a name bound to a MODULE OBJECT (a
+stubbed heavy dep) with a single branch.
 
 An endpoint whose upstream runtime is source-built cannot import it at module
 top — the package is not on PyPI and compiles CUDA extensions, so a discovery
@@ -24,6 +31,8 @@ discovery importable was the rule that made discovery refuse.
 """
 
 from __future__ import annotations
+
+import types
 
 import pytest
 
@@ -36,6 +45,17 @@ from gen_worker.discovery.entrypoints_v2 import (
 
 class RealPipeline:
     """Importable at discovery — the control arm's subject."""
+
+
+# The internvl-U condition, reproduced exactly: a module-top ImportFrom in the
+# source (which is what `_import_sites` reads) whose RUNTIME binding is a
+# MODULE OBJECT rather than a class — which is what the stub finder produces
+# off-image for a package listed in `discovery_heavy_deps`. The try/except is
+# the stub finder's stand-in, so this test needs none of its machinery.
+try:  # pragma: no cover - `internvlu` is never installed here
+    from internvlu import InternVLUPipeline
+except ImportError:
+    InternVLUPipeline = types.ModuleType("internvlu.InternVLUPipeline")
 
 
 class ArmControl:
@@ -58,6 +78,19 @@ class ArmLazyAliased:
         from trellis2.pipelines import Trellis2ImageTo3DPipeline as Pipe
 
         self.pipe = ctx.load(Pipe)
+
+
+class ArmStubbedDep:
+    """The internvl-U shape, contributed by that lane. A module-top import of a
+    package listed in `discovery_heavy_deps`: off-image the stub finder binds a
+    MODULE OBJECT where a class is expected, so `isinstance(target, type)` is
+    False even though the import is module-top and sanctioned. In-image publish
+    was fine; every off-image gate broke — the caller that reaches the refusal
+    is `serverless-endpoints/scripts/lint_discovery.py:121`.
+    """
+
+    def load(self, ctx):  # type: ignore[no-untyped-def]
+        self.pipe = ctx.load(InternVLUPipeline)
 
 
 class ArmSelfLoading:
@@ -103,6 +136,15 @@ def test_a_deferred_import_under_an_alias_resolves_to_the_real_name() -> None:
         _pipeline_class(ArmLazyAliased)
         == "trellis2.pipelines.Trellis2ImageTo3DPipeline"
     )
+
+
+# pgw#1431: a module-top import of a STUBBED heavy dep binds a module, not a class.
+def test_a_stubbed_heavy_dep_resolves_statically_despite_the_vendored_package() -> None:
+    """The internvl-U arm. `getattr(module, "InternVLUPipeline")` succeeds here
+    and returns a MODULE, so the isinstance check correctly rejects it — and
+    the static ImportFrom resolution then answers from the AST."""
+    assert not isinstance(InternVLUPipeline, type)
+    assert _pipeline_class(ArmStubbedDep) == "internvlu.InternVLUPipeline"
 
 
 # pgw#1431: the boundary — self-loading needs its own marker (pgw#1421 ruling).

--- a/tests/test_pipeline_class_discovery_pgw1431.py
+++ b/tests/test_pipeline_class_discovery_pgw1431.py
@@ -1,0 +1,130 @@
+"""pgw#1431: `pipeline_class` must survive a DEFERRED import.
+
+The three arms below are the ones measured against `e0725c71` when the defect
+was found. They are kept as fixtures because each answers a different question,
+and the control is what makes the other two mean anything:
+
+    ArmControl       module-level class     -> resolves      (the control)
+    ArmLazyImport    `from x import C` in load() -> resolved by this fix
+    ArmSelfLoading   no `ctx.load` at all   -> still ""      (needs pgw#1421's
+                                                              typed self_loading
+                                                              marker, a Paul
+                                                              ruling; NOT this)
+
+An endpoint whose upstream runtime is source-built cannot import it at module
+top — the package is not on PyPI and compiles CUDA extensions, so a discovery
+runner has nothing to import — and the SDK's own convention tells the author to
+defer it. Before this fix that convention made `_pipeline_class` return "" and
+`_pipeline_class_or_refuse` hard-fail the publish, so the rule that keeps
+discovery importable was the rule that made discovery refuse.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.discovery.entrypoints_v2 import (
+    EntrypointDiscoveryError,
+    _pipeline_class,
+    _pipeline_class_or_refuse,
+)
+
+
+class RealPipeline:
+    """Importable at discovery — the control arm's subject."""
+
+
+class ArmControl:
+    def load(self, ctx):  # type: ignore[no-untyped-def]
+        self.pipe = ctx.load(RealPipeline)
+
+
+class ArmLazyImport:
+    """What `trellis-3d` and `hunyuan3d-2.1` must write: the upstream package
+    is source-built and unimportable on a discovery runner."""
+
+    def load(self, ctx):  # type: ignore[no-untyped-def]
+        from trellis2.pipelines import Trellis2ImageTo3DPipeline
+
+        self.pipe = ctx.load(Trellis2ImageTo3DPipeline)
+
+
+class ArmLazyAliased:
+    def load(self, ctx):  # type: ignore[no-untyped-def]
+        from trellis2.pipelines import Trellis2ImageTo3DPipeline as Pipe
+
+        self.pipe = ctx.load(Pipe)
+
+
+class ArmSelfLoading:
+    """The v1 `Slot(str)` escape hatch. NOT addressed here, on purpose."""
+
+    def load(self, ctx):  # type: ignore[no-untyped-def]
+        from trellis2.pipelines import Trellis2ImageTo3DPipeline
+
+        self.pipe = Trellis2ImageTo3DPipeline.from_pretrained(ctx.checkpoint_dir)
+
+
+class ArmNoLoad:
+    pass
+
+
+def test_the_control_arm_resolves_through_the_module() -> None:
+    """If this ever fails the other arms prove nothing — a probe that cannot
+    succeed is not measuring the thing it names."""
+    got = _pipeline_class(ArmControl)
+    assert got.endswith(".RealPipeline")
+    # Resolution (1) returns the REAL class object's identity, so it reports
+    # the defining module rather than the import site's spelling.
+    assert got == f"{RealPipeline.__module__}.{RealPipeline.__qualname__}"
+
+
+def test_a_deferred_import_resolves_to_its_dotted_path() -> None:
+    """pgw#1431, the fix. Nothing is imported to answer this — `trellis2` is
+    not installed in this environment, and that is the point."""
+    with pytest.raises(ImportError):
+        import trellis2  # noqa: F401
+
+    assert (
+        _pipeline_class(ArmLazyImport)
+        == "trellis2.pipelines.Trellis2ImageTo3DPipeline"
+    )
+
+
+def test_a_deferred_import_under_an_alias_resolves_to_the_real_name() -> None:
+    """`as Pipe` must report the imported name, not the local alias — the hub
+    reads this string to name a class it will build."""
+    assert (
+        _pipeline_class(ArmLazyAliased)
+        == "trellis2.pipelines.Trellis2ImageTo3DPipeline"
+    )
+
+
+def test_a_self_loading_model_still_reads_as_absent() -> None:
+    """The BOUNDARY of this fix, asserted so it cannot quietly widen.
+
+    `ArmSelfLoading` never calls `ctx.load`, so there is no declaration to
+    read and "" is the honest answer. Guessing the class from the
+    `from_pretrained` receiver would publish a `pipeline_class` naming
+    something the worker never builds through `ctx.load` — the se#757
+    silent-lie shape. Self-loading needs its own typed marker (a Paul ruling,
+    filed with pgw#1421), not a cleverer parser.
+    """
+    assert _pipeline_class(ArmSelfLoading) == ""
+
+
+def test_a_model_with_no_load_reads_as_absent() -> None:
+    assert _pipeline_class(ArmNoLoad) == ""
+
+
+def test_an_absent_pipeline_class_still_refuses_at_publish() -> None:
+    """The refusal this fix removes for the lazy-import case must remain fully
+    armed for every other case — widening the parser must not disarm the gate."""
+    rows = [{"name": "generate", "slots": [{"name": "model", "kind": "model", "pipeline_class": ""}]}]
+    with pytest.raises(EntrypointDiscoveryError, match="could not read the pipeline class"):
+        _pipeline_class_or_refuse(rows)
+
+
+def test_an_adapter_slot_is_still_exempt() -> None:
+    rows = [{"name": "generate", "slots": [{"name": "loras", "kind": "adapter"}]}]
+    _pipeline_class_or_refuse(rows)  # does not raise


### PR DESCRIPTION
pgw#1431: read a DEFERRED import — discovery stops refusing the endpoints its own convention creates

`_pipeline_class` recovered the hub's required `pipeline_class` only through
`getattr(module, name)`. A function-body import binds no module-level name, so
it returned "" and `_pipeline_class_or_refuse` hard-failed the publish:

  @entrypoint 'generate' slot 'model': could not read the pipeline class from
  the model's load(). Publish needs it, so write the ONE spelling with a plain
  class name: `self.pipe = ctx.load(StableDiffusionXLPipeline)`

...for authors who HAD written exactly that spelling.

THE DEFERRED IMPORT IS THE SDK'S OWN CONVENTION, not author sloppiness. An
endpoint whose upstream runtime is source-built cannot import it at module top:
the package is not on PyPI and compiles CUDA extensions from source, so a
discovery runner has nothing to import. `trellis-3d/main.py:1-7` states the
rule — "the SDK v2.1 module-top convention's one carve-out is deferring a
source-built extra, and that deferral is exactly what keeps discovery (and the
CPU test suite) importable." So the rule that keeps discovery importable was
the rule that made discovery refuse.

Resolution is now two-step, and the new step is strictly a FALLBACK:
  1. the name bound on the endpoint's module — a real class object, so the
     answer keeps its true __module__/__qualname__ through aliases and
     re-exports. Unchanged, and still first, so no answer that already
     resolved can move.
  2. failing that, `from x.y import Name` inside load(), read off the AST.

Reading an ImportFrom node IMPORTS NOTHING, so this keeps the promise the rest
of the function makes: no author code runs at discovery. `import a.b.c` is
deliberately not handled — it binds `a`, so the call site would be an
ast.Attribute, not the ast.Name this parse accepts.

RED/GREEN VERIFIED against the three arms measured when the defect was found,
and the CONTROL is what makes the other two mean anything:

  ArmControl      module-level class          -> resolves  (control)
  ArmLazyImport   deferred import             -> FIXED
  ArmLazyAliased  deferred import, aliased    -> FIXED, reports the real name
  ArmSelfLoading  no ctx.load at all          -> STILL ""

With the two-line fallback removed, exactly the two deferred-import tests fail
and the other five stay green — so they are coupled to the fix and the control
is not.

THE BOUNDARY IS ASSERTED so it cannot quietly widen: `ArmSelfLoading` still
reads as absent, and the publish refusal stays fully armed for every non-lazy
case. Guessing the class off a `from_pretrained` receiver would publish a
`pipeline_class` naming something the worker never builds through `ctx.load` —
the se#757 silent-lie shape. Self-loading needs its own typed marker, which is
a Paul ruling filed with pgw#1421, and is deliberately NOT this change.

This does NOT by itself unblock trellis-3d or hunyuan3d-2.1: both are
self-loading, not merely lazy-importing. It unblocks the class of endpoint that
writes the sanctioned `ctx.load(<PlainName>)` spelling with a deferred import.

46 passed, 1 skipped across the discovery-adjacent suites.


---

## How this was found

Not by reading the source — by executing it. Three arms against `e0725c71`:

```
ArmControl       pipeline_class='__main__.RealPipeline'   OK
ArmLazyImport    pipeline_class=''                        EMPTY -> discovery REFUSES
ArmSelfLoading   pipeline_class=''                        EMPTY -> discovery REFUSES
```

`ArmControl` passing is what makes the other two mean anything; a probe that
cannot succeed is not measuring the thing it names. Those three arms are now
the test fixtures, so the measurement and the regression gate are the same
artifact.

## Scope

This is **fix (c)** of the three enumerated in pgw#1431, chosen because it is
the only one needing **no endpoint edits** and no hub change, and because
reading a statically-present import is squarely inside what `_pipeline_class`
already promises to do.

It is **not** the self-loading successor. `Model(self_loading=...)` — fix (b),
the direct replacement for v1's `Slot(str, layouts_undeclarable=...)` — is a
Paul ruling filed alongside pgw#1421's deleted engine-hosted runtimes, and
`trellis-3d` / `hunyuan3d-2.1` stay blocked on it. The boundary is asserted in
`test_a_self_loading_model_still_reads_as_absent` precisely so this fix cannot
quietly grow into that one.

Refs pgw#1431, pgw#1421, se#769, se#775.

---

## WIDENED: one branch, two measured shapes

The **internvl-U lane** measured the same root defect in a second shape, so this
PR covers both rather than shipping two half-fixes for one cause. pgw#1431 is
the single issue; the second arm is theirs and is credited in the test.

| shape | why the runtime lookup fails | found by |
|---|---|---|
| function-body import | the name is **unbound** at module scope | this lane (`trellis-3d`, `hunyuan3d-2.1`) |
| module-top import of a stubbed heavy dep | the name is bound to a **module object**, so `isinstance(target, type)` is False | internvl-U lane |

`internvl-U` writes `from internvlu import InternVLUPipeline` at module top with
`discovery_heavy_deps = ["internvlu"]`. In-image publish is fine — the real
package imports — but **every off-image gate broke**, the caller being
`serverless-endpoints/scripts/lint_discovery.py:121` (`python -m
gen_worker.discovery` in the endpoint venv, wired into the Taskfile).

Both have one cause: **the reader recovered the class by importing and
type-checking when the AST already carried the answer.** So the fallback is
keyed on the cause — *the runtime lookup did not yield a TYPE* — not on either
symptom, and one branch covers both.

## Four arms, red/green verified

| arm | shape | with fix | fallback removed |
|---|---|---|---|
| `ArmControl` | module-level class | resolves | **still green** (control) |
| `ArmLazyImport` | deferred import | resolves | **RED** |
| `ArmLazyAliased` | deferred import, `as` alias | resolves to the real name | **RED** |
| `ArmStubbedDep` | module-top import of a stub | resolves | **RED** |
| `ArmSelfLoading` | no `ctx.load` at all | `""` | **still green** (boundary) |

The control and the boundary staying green is the point: it shows the three
red arms are coupled to the fix and the other two are not.

`ArmStubbedDep` reproduces the stub-finder condition with a `try/except
ImportError` stand-in, so the module source carries a real `ImportFrom` node
(what the parser reads) while the runtime binding is a module object (what the
isinstance check must reject) — no stub-finder machinery needed in the test.
