### PR TITLE
pgw#1435 / th#2182: the front door is not the hub on the LAST call either

### DIFF
--- a/src/gen_worker/hubio/client.py
+++ b/src/gen_worker/hubio/client.py
@@ -37,7 +37,7 @@ from gen_worker.transfer.grants import TransferGrant, upload
 from gen_worker.transfer.journal import TransferJournal, TransferSession
 
 from .. import activity as _activity
-from ..http_origin import is_definite_hub_answer
+from ..http_origin import is_definite_hub_answer, response_is_from_hub
 from ..models.cache_paths import open_worker_cas
 from ..stall import SilenceWindow
 from .publish_state import JOURNAL_NAME, STATE_NAME, ProducerRecovery
@@ -77,14 +77,21 @@ _EXPIRY_REPLAN_ATTEMPTS = 3
 _COMPLETE_TIMEOUT_S = 600.0
 
 # How long the client tolerates hearing NOTHING DEFINITE from the hub before
-# giving up — network errors, edge-masked 5xx, proxy-shaped 404s.
-# Silence-bounded, never attempt-counted: a hub restart is seconds and a tunnel
-# re-dial is minutes, and an attempt cap classifies both FATAL and throws away
-# paid GPU work at the finish line. Six verify-lengths, because a container
-# rebuild is tens of minutes and an hour parked on the CPU rig costs about what
-# re-downloading costs — and unlike the re-download it cannot fail the same
-# way twice. Waiting stays observable: the loop beats liveness every pass.
-_COMPLETE_SILENCE_WINDOW_S = 6.0 * _COMPLETE_TIMEOUT_S
+# giving up on the completion — network errors, edge-masked 5xx, proxy-shaped
+# 404s. Silence-bounded, never attempt-counted: a hub restart is seconds and a
+# tunnel re-dial is minutes, and an attempt cap classifies both FATAL and
+# throws away paid work at the finish line.
+#
+# BOUNDED BY THE HUB'S OWN PATIENCE, not by what the pod could afford to wait.
+# `note_progress()` below is a HEARTBEAT and the orchestrator's stall guard
+# refuses to be fooled by one — it kills a job whose DECLARED POSITION has not
+# moved for its 10-minute phase budget, and a retry loop does not move the
+# position. A window at or past that budget therefore does not buy patience; it
+# only guarantees that the verdict on the job is the guard's untyped
+# `job_progress_stalled` instead of this client's typed, classified refusal.
+# Four minutes rides out every front-door blip measured so far (a re-dial is
+# seconds to tens of seconds) and still leaves the client the one to speak.
+_COMPLETE_SILENCE_WINDOW_S = 240.0
 
 def _dtype_token(v: str) -> str:
     """Publish-body dtype hygiene: the internal dtype-axis colon
@@ -216,6 +223,24 @@ def _retry_after_s(resp: requests.Response) -> Optional[float]:
     except Exception:
         return None
     return min(value, _RETRY_MAX_DELAY_S) if value > 0 else None
+
+
+#: The classification for "the front door answered, the hub did not". Typed and
+#: RETRYABLE-WITHOUT-A-NEW-POD: the bytes are staged, the audit passed, and the
+#: only thing that failed is the edge. th#2182.
+FRONT_DOOR_UNAVAILABLE = "front_door_unavailable"
+
+
+def _non_hub_origin(resp: requests.Response) -> str:
+    """A non-hub response reduced to the two facts worth keeping: what status
+    rode on it and what media type it was. Never its body — a proxy's body is
+    a web page, and a web page in a failure `cause` is noise that survives into
+    every report built from it."""
+    try:
+        ctype = str(resp.headers.get("Content-Type") or "").split(";")[0].strip()
+    except Exception:  # noqa: BLE001 - header access must never mask the real error
+        ctype = ""
+    return f"HTTP {int(getattr(resp, 'status_code', 0))}, {ctype or 'no content-type'}"
 
 
 def _error_code_of(resp: requests.Response) -> str:
@@ -443,29 +468,47 @@ class HubClient:
         except Exception:  # noqa: BLE001 — best effort; the session TTL backstops it
             logger.debug("publish %s abort failed", publish_id, exc_info=True)
 
-    def _post_v2_complete(self, path: str) -> requests.Response:
-        """POST the hub's idempotent v2 completion.
+    @staticmethod
+    def _v2_complete_is_definite(resp: requests.Response) -> bool:
+        """Did the HUB answer this completion, or did the front door?
 
-        `_send_with_retries` decides "did we hear from the hub?" from the body's
-        SHAPE, and a v2 completion's refusal is a projection rather than an
-        error envelope — so it would read a real, typed, `retryable: false`
-        refusal as a proxy non-answer and retry it. The retry then finds the
-        session already terminal and returns 409 `publish_repudiated`: a
-        consequence in place of the cause, which is gone.
+        Three shapes are the hub speaking and end the loop:
 
-        Tensorhub makes this route idempotent: completing an already-promoted
-        session returns its terminal status and checkpoint id. Network-level
-        failures therefore retry safely, including a lost success response;
-        an HTTP answer of any status is the hub speaking and is returned as-is
-        for the typed handling below.
+          * 2xx/3xx — nothing in front of us fabricates a promotion.
+          * the th#1301 PROJECTION (`status.failure.code`) at ANY status — a v2
+            refusal is not an error envelope, so the generic shape heuristic
+            would read a real, typed, `retryable: false` repudiation as a proxy
+            non-answer and retry it. The retry then finds the session terminal
+            and returns 409 `publish_repudiated`: a consequence in place of the
+            cause, which is gone (pgw#743's defect, in a different route).
+          * the hub's `{"error": {...}}` envelope — `is_definite_hub_answer`.
+
+        Everything else did NOT come from the hub. This is the pgw#1435 /
+        th#2182 defect: this predicate used to be `lambda resp: True`, so the
+        690-byte ngrok "no healthy backend" HTML page that rides a transient
+        503 counted as a verdict, and TWO ingests — 16.2 GB and 17.9 GB, both
+        already uploaded, staged and AUDITED — were destroyed at their last
+        call, in two different lanes, in the same window. The completion is the
+        one call where a non-answer is most expensive and where retrying is
+        free: tensorhub's `/complete` is idempotent (an already-promoted
+        session returns its terminal status and checkpoint id) and RESUMABLE (a
+        retryable stage failure leaves the session live, so a later pass copies
+        only what is still missing).
         """
+        if HubClient._v2_failure(resp) is not None:
+            return True
+        return is_definite_hub_answer(resp)
+
+    def _post_v2_complete(self, path: str) -> requests.Response:
+        """POST the hub's idempotent, resumable v2 completion."""
         return _send_with_retries(
             f"POST {path}",
             lambda: _http_session().post(
                 f"{self.base_url}{path}", headers=self._headers(),
                 timeout=(_CONNECT_TIMEOUT_S, _COMPLETE_TIMEOUT_S),
             ),
-            definite=lambda resp: True,
+            silence_window_s=_COMPLETE_SILENCE_WINDOW_S,
+            definite=HubClient._v2_complete_is_definite,
         )
 
     def publish_v2(
@@ -841,6 +884,22 @@ class HubClient:
                         status=done.status_code, code=str(failure.get("code") or ""),
                         retryable=bool(failure.get("retryable")),
                     )
+                if not response_is_from_hub(done):
+                    # NOT the hub. Only the front door can answer here after
+                    # the retry above has run its silence window out, and its
+                    # answer is a web page: pasting 690 bytes of ngrok HTML
+                    # into a job's `cause` gives an operator `<!DOCTYPE html>`
+                    # and gives every consumer downstream nothing to group by.
+                    # Collapse it to what it actually is — one classified,
+                    # retryable token plus the status and the media type.
+                    raise _publish_refusal(
+                        f"publish {publish_id}: the hub never answered complete — "
+                        f"{FRONT_DOOR_UNAVAILABLE} ({_non_hub_origin(done)}). "
+                        "Every declared object is staged and audited; the "
+                        "session is live and /complete is idempotent, so a "
+                        "retry resumes it without re-uploading a byte",
+                        status=done.status_code, code=FRONT_DOOR_UNAVAILABLE,
+                        retryable=True)
                 raise _publish_refusal(
                     f"publish complete failed ({done.status_code}): {done.text[:800]}",
                     status=done.status_code, code=_error_code_of(done))

--- a/tests/convert/fake_hub.py
+++ b/tests/convert/fake_hub.py
@@ -159,6 +159,15 @@ class _FakeHub(BaseHTTPRequestHandler):
         if "/publishes/" in self.path and self.path.endswith("/complete"):
             pid = self.path.split("/publishes/")[1].split("/")[0]
             st.setdefault("complete_attempts", []).append(pid)
+            # pgw#1435 / th#2182: the front door alone is down, and only for
+            # the LAST call. `proxy_posts` cannot express this — it fails the
+            # declare too, so nothing is ever staged and the shape under test
+            # (16-18 GB uploaded, staged, AUDITED, then destroyed) never
+            # occurs. Counted BEFORE any state moves: the hub never saw it.
+            if st.get("proxy_completes", 0) > 0:
+                st["proxy_completes"] -= 1
+                self._send_proxy_page(int(st.get("proxy_status", 503)))
+                return
             completed = st.setdefault("v2_completed", {})
             if pid in completed:
                 self._send(200, {

--- a/tests/convert/test_complete_front_door_pgw1435.py
+++ b/tests/convert/test_complete_front_door_pgw1435.py
@@ -1,0 +1,118 @@
+"""pgw#1435 / th#2182: the front door is not the hub, on the LAST call too.
+
+Two ingests — `microsoft/TRELLIS.2-4B` (16.2 GB) and `unsloth/Qwen3.6-27B-MTP-GGUF`
+(17.9 GB) — plus a third lane's release publish were destroyed in one window by
+`publish complete failed (503): <!DOCTYPE html>… ngrok…`, each after every byte
+was uploaded, staged and AUDITED. `_post_v2_complete` passed
+``definite=lambda resp: True``, so a proxy's offline page counted as the hub's
+verdict and the silence-bounded retry that wraps every other call never ran.
+
+Three behaviours, and the third is why the escape hatch was there in the first
+place — a v2 refusal is a PROJECTION, not an error envelope, and must stay
+terminal or a repudiation turns into a later 409 `publish_repudiated` with the
+cause gone (pgw#743's defect, one route over).
+
+Red-verified against the pre-fix module: reinstating ``definite=lambda resp: True``
+fails the first two (the transient case raises `publish complete failed (503)`
+with the HTML page in the message; the classified case has code "" and the page
+in `str(exc)`), and leaves the third green.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker.hubio import client as hub_mod
+from gen_worker.hubio.client import CommitFile, HubPublishError
+
+from fake_hub import _FakeHub, _client
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(hub_mod, "_RETRY_BASE_DELAY_S", 0.01)
+    monkeypatch.setattr(hub_mod, "_RETRY_MAX_DELAY_S", 0.05)
+    monkeypatch.setattr(hub_mod, "_COMPLETE_SILENCE_WINDOW_S", 2.0)
+
+
+def _one_file(tmp_path: Path) -> CommitFile:
+    p = tmp_path / "model.safetensors"
+    p.write_bytes(b"weights-bytes")
+    return CommitFile(path="model.safetensors", local_path=p)
+
+
+def test_transient_front_door_503_on_complete_does_not_destroy_the_publish(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """The measured incident, made to end the other way.
+
+    Everything is staged; only `complete` meets the offline page, three times.
+    The publish must land, and it must land on the SAME session — a second
+    declare would mean the staged bytes were abandoned, which is the cost this
+    issue exists to stop.
+    """
+    _FakeHub.state["proxy_completes"] = 3
+    _FakeHub.state["proxy_status"] = 503
+
+    res = _client(fake_hub).publish_v2(
+        release="r1", destination_repo="acme/repo", files=[_one_file(tmp_path)])
+
+    assert res.checkpoint_id
+    attempts = _FakeHub.state["complete_attempts"]
+    assert len(attempts) == 4, attempts
+    assert len(set(attempts)) == 1, "retried a DIFFERENT session — bytes abandoned"
+    assert _FakeHub.state["proxy_completes"] == 0
+
+
+def test_front_door_that_never_recovers_is_classified_never_pasted(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """A front door that stays down still must not put HTML in `cause`.
+
+    The operator-visible failure carries a token to group by and the hub's
+    absence as a fact — not 690 bytes of someone else's web page.
+    """
+    _FakeHub.state["proxy_completes"] = 10_000
+    _FakeHub.state["proxy_status"] = 503
+
+    with pytest.raises(HubPublishError) as caught:
+        _client(fake_hub).publish_v2(
+            release="r1", destination_repo="acme/repo", files=[_one_file(tmp_path)])
+
+    exc = caught.value
+    assert exc.code == "front_door_unavailable"
+    assert exc.retryable is True, "the bytes are staged; a new pod is not the remedy"
+    assert exc.status == 503
+    message = str(exc)
+    assert "DOCTYPE" not in message and "<html" not in message, message
+    assert "HTTP 503, text/html" in message
+    assert len(_FakeHub.state["complete_attempts"]) > 1, "never retried at all"
+
+
+def test_typed_repudiation_stays_terminal_on_one_attempt(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """The reason the escape hatch existed, kept working.
+
+    A v2 refusal answers with the th#1301 projection and no `{"error": ...}`
+    envelope. The generic shape heuristic reads that as proxy-shaped, so
+    without an explicit projection arm the fix would retry a repudiation and
+    report the 409 that follows it instead of the reason.
+    """
+    _FakeHub.state["complete_failure"] = {
+        "code": "audit_findings", "retryable": False,
+        "message": "the artifact did not pass the pre-publication audit",
+    }
+
+    with pytest.raises(HubPublishError) as caught:
+        _client(fake_hub).publish_v2(
+            release="r1", destination_repo="acme/repo", files=[_one_file(tmp_path)])
+
+    exc = caught.value
+    assert exc.code == "audit_findings"
+    assert exc.retryable is False
+    assert len(_FakeHub.state["complete_attempts"]) == 1, \
+        _FakeHub.state["complete_attempts"]


### PR DESCRIPTION
Two ingests — `microsoft/TRELLIS.2-4B` (16.2 GB) and `unsloth/Qwen3.6-27B-MTP-GGUF` (17.9 GB) — and a third lane's release publish died in one window on `publish complete failed (503): <!DOCTYPE html>… ngrok…`, each **after every byte was uploaded, staged and audited**. See th#2182.

`_post_v2_complete` passed `definite=lambda resp: True`, so a proxy's offline page counted as the hub's verdict: the silence-bounded retry that wraps every other hub call never ran, and the page was pasted verbatim into the job's `cause`.

**The escape hatch was there for a real reason** and is not simply deleted. A v2 refusal answers with the th#1301 PROJECTION, not an `{"error": ...}` envelope, so the generic shape heuristic reads a typed `retryable: false` repudiation as a proxy non-answer, retries it, and reports the 409 `publish_repudiated` that follows instead of the cause (pgw#743's defect, one route over). The predicate becomes three-armed: 2xx/3xx, a projection carrying `status.failure.code` at any status, or the hub's error envelope.

Retrying is free here: `/complete` is idempotent (already-promoted returns its terminal status + checkpoint id) and resumable (a retryable stage failure leaves the session live).

`_COMPLETE_SILENCE_WINDOW_S` was defined and never wired. Wired, and re-justified at **240s** rather than an hour: `note_progress()` is a heartbeat, and the orchestrator's stall guard kills on a DECLARED POSITION that has not moved for its 10-minute phase budget, which a retry loop does not move. A window at or past that budget only guarantees the verdict is the guard's untyped `job_progress_stalled` instead of this client's typed one.

Second, separable defect: a non-hub answer collapses to `front_door_unavailable` + status + media type, never its body, and is retryable-without-a-new-pod.

**Red-verified:** reinstating `definite=lambda resp: True` fails the transient case and the "never retried at all" assertion, and leaves the typed-repudiation guard green. `proxy_completes` is a new fake-hub hook because `proxy_posts` fails the DECLARE too, so the shape under test never occurs under it.

`tests/convert/` — 141 passed.