### PR TITLE
pgw#1439: krea-2, anima and ernie export NO defaults schema — and the fence that would have caught it

### DIFF
--- a/src/gen_worker/models/model_types.py
+++ b/src/gen_worker/models/model_types.py
@@ -1585,6 +1585,9 @@ def defaults_vocabularies() -> dict[str, type[msgspec.Struct]]:
         Flux2Klein.name: Flux2Klein.Defaults,
         QwenImage.name: QwenImage.Defaults,
         ZImage.name: ZImage.Defaults,
+        Krea2.name: Krea2.Defaults,
+        Anima.name: Anima.Defaults,
+        Ernie.name: Ernie.Defaults,
         SDXL.Lora.name: SDXL.Lora.Defaults,
         SD15.Lora.name: SD15.Lora.Defaults,
     }

--- a/tests/test_model_defaults.py
+++ b/tests/test_model_defaults.py
@@ -463,6 +463,28 @@ def test_the_serving_interaction_matrix(
 # ── the vocabulary registry + ingest fingerprint seam ────────────────────────
 
 
+def test_every_model_type_exports_a_defaults_vocabulary() -> None:
+    """THE FENCE (pgw#1439). ``MODEL_TYPES`` and ``defaults_vocabularies()`` are
+    two hand-maintained lists of the same thing, and nothing cross-checked them:
+    ``test_the_launch_vocabulary_is_the_ruled_set`` pins ``MODEL_TYPES`` ONLY.
+
+    pgw#1427 added three types to the tuple and to both lazy re-export lists,
+    passed every gate, and merged — while `defaults_vocabularies()`, whose own
+    docstring calls it "the export emitter's source", did not carry them. The
+    failure mode is silence: those families export NO defaults schema at all,
+    and nothing raises.
+
+    A subset assertion, not equality: the mapping legitimately carries the LoRA
+    overlays too, which are not ``ModelType``s.
+    """
+    missing = {mt.name for mt in MODEL_TYPES} - set(defaults_vocabularies())
+    assert not missing, (
+        f"{sorted(missing)} are in MODEL_TYPES but export no defaults "
+        f"vocabulary — the export emitter reads defaults_vocabularies(), so "
+        f"these families would ship no schema, silently. Add them there too."
+    )
+
+
 def test_the_launch_vocabulary_is_the_ruled_set() -> None:
     # se#769 wave 3 (pgw#1427) appends krea-2, anima and ernie. The list is
     # pinned deliberately: a type appearing here without a ruling is the thing


### PR DESCRIPTION
A defect **I merged** in pgw#1427 (#992), found by the qwen-image lane and verified on master `363584c1` rather than inferred from a rebase.

## The defect

`MODEL_TYPES` and `defaults_vocabularies()` are two hand-maintained lists of the same thing. pgw#1427 added `Krea2`/`Anima`/`Ernie` to the tuple **and** to both lazy re-export lists, passed every gate, and merged — while `defaults_vocabularies()`, whose own docstring calls it *"the export emitter's source"*, did not carry them.

So those three families export **no defaults schema at all**.

**The failure mode is silence.** Nothing raises, nothing warns. And the existing pin, `test_the_launch_vocabulary_is_the_ruled_set`, asserts over `MODEL_TYPES` **only** — so the one list that was updated is the one list that was checked. That is precisely why this survived authoring, review, CI and a merge queue.

## The fix is three lines; the fence is the point

```python
missing = {mt.name for mt in MODEL_TYPES} - set(defaults_vocabularies())
assert not missing
```

**Red/green verified, not asserted.** Reconstructing the pre-fix mapping makes the new test name exactly `['anima', 'ernie', 'krea-2']`, so the assertion is known to be able to fail:

```
=== RED: fence against the merged-defect state ===
  missing under the OLD mapping: ['anima', 'ernie', 'krea-2']
  RED arm fires: True

=== GREEN: fence against HEAD ===
  missing now: none
  vocab entries: 16
```

A **subset** assertion rather than equality, because the mapping legitimately also carries the LoRA overlays (`sdxl.lora`, `sd15.lora`), which are not `ModelType`s — equality would fail for a correct tree.

Any future lane that adds a type and forgets the second list now gets a named failure instead of a family that silently ships no schema.

`52 passed` in `tests/test_model_defaults.py`; mypy clean on both changed files.

Thanks to the qwen-image lane for measuring this and leaving it for one writer rather than fixing it in my stead.