### PR TITLE
pgw#1440: `gen-worker release derive` raised ModuleNotFoundError on line two of its handler

### DIFF
--- a/changelog.d/pgw1440-derive-syspath.md
+++ b/changelog.d/pgw1440-derive-syspath.md
@@ -1,0 +1,18 @@
+- **`gen-worker release derive` runs again.** `cli/release.py`'s `_run_derive` imported
+  `_ensure_sys_path` from `cli/run.py`, which pgw#1373 (`cd46c957`) deleted with the v1 SDK — the
+  symbol was defined nowhere in `src/`, so the derive raised `ModuleNotFoundError` on the second
+  line of its handler, on every tree, since that hardcut. It blocked the pgw#1371 mint
+  demonstration: the graph blob a runtime mint compiles has no publish leg and no fetch leg, and
+  the one workaround (derive on the pod with `--graph-cas`) went through this CLI.
+
+- **Fixed by de-duplication, not resurrection.** The deleted helper's own docstring said it existed
+  to "match discover.py's sys.path priming", while `discovery/discover.py` had the same logic
+  inlined — two copies of one rule, which is what let a deletion break a caller silently. There is
+  now one exported `discovery.discover.prime_sys_path(root)`, called by both `discover_manifest`
+  and `_run_derive`. `cli/run.py` stays deleted. Note the order is load-bearing: both inserts go to
+  position 0, so the statements read root-then-src to leave `src` ahead of `root`, and that
+  precedence is now asserted.
+
+- **`test_cli_entry_orders` stops parametrizing over three deleted modules.** `cli.serve`,
+  `cli.run` and `cli.invoke` all went in `cd46c957`, so three of its four cases had been failing on
+  master ever since; re-pointed at the CLI's actual surface.

--- a/src/gen_worker/cli/release.py
+++ b/src/gen_worker/cli/release.py
@@ -68,8 +68,8 @@ def add_subparser(sub: Any) -> None:
 def _run_derive(args: argparse.Namespace) -> int:
     import importlib
 
+    from ..discovery.discover import prime_sys_path
     from ..release.derive import DeriveError, derive_release
-    from .run import _ensure_sys_path
 
     root = Path(args.dir).resolve()
     if not root.is_dir():
@@ -79,7 +79,7 @@ def _run_derive(args: argparse.Namespace) -> int:
     if not checkpoint.is_dir():
         print(f"error: --checkpoint {checkpoint} is not a directory", file=sys.stderr)
         return 2
-    _ensure_sys_path(root)
+    prime_sys_path(root)
     try:
         module = importlib.import_module(args.module)
     except Exception as exc:  # noqa: BLE001 - author import errors are the check

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -165,6 +165,39 @@ def _fail_build_input(*messages: str) -> None:
     sys.exit(1)
 
 
+def prime_sys_path(root: Path) -> None:
+    """Put an endpoint tree on ``sys.path`` so its own imports resolve.
+
+    ``<root>`` then ``<root>/src``, each only when absent, front-inserted so a
+    same-named installed package cannot shadow the tree being read. Discovery
+    and the release derive both read an UNINSTALLED source tree, so both need
+    this and both must do it identically — a derive that primed the path
+    differently from the discovery that produced the manifest would derive
+    against a different module than the one the image ships.
+
+    pgw#1440: this is the one implementation. It was inlined here and copied
+    into the v1 `cli/run.py` as `_ensure_sys_path`, whose own docstring said it
+    existed to "match discover.py's sys.path priming" — a duplicate that named
+    its own original. pgw#1373 (`cd46c957`) deleted the v1 SDK and with it that
+    copy, leaving `cli/release.py` importing a symbol that no longer existed,
+    so `gen-worker release derive` raised `ModuleNotFoundError` on the second
+    line of its handler. Two copies of one rule is what let a deletion break a
+    caller silently; there is now one, and it is exported.
+
+    ROOT THEN SRC, in that order, because each insert goes to position 0 — so
+    the resulting precedence is ``src`` ahead of ``root``, which is what a
+    ``src/``-layout endpoint needs. Reversing the two statements silently
+    reverses the precedence, so the order here is load-bearing, not stylistic.
+    """
+    root = Path(root)
+    root_text, src = str(root), root / "src"
+    if root_text not in sys.path:
+        sys.path.insert(0, root_text)
+    src_text = str(src)
+    if src.exists() and src_text not in sys.path:
+        sys.path.insert(0, src_text)
+
+
 
 def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
     """The complete endpoint.lock manifest for the project at ``root``.
@@ -182,12 +215,7 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
     # Discovery also runs in an uninstalled source tree, so the tree is on the
     # path — and `_audit_source_only_imports` below is what stops that
     # injection from hiding a module the built wheel forgot to package.
-    root_str = str(root)
-    src_str = str(root / "src")
-    if root_str not in sys.path:
-        sys.path.insert(0, root_str)
-    if (root / "src").exists() and src_str not in sys.path:
-        sys.path.insert(0, src_str)
+    prime_sys_path(root)
     top_level = cfg.main.split(".", 1)[0]
     preloaded = frozenset(sys.modules)
 

--- a/tests/test_import_cycles_pgw981.py
+++ b/tests/test_import_cycles_pgw981.py
@@ -129,13 +129,28 @@ def test_no_module_fails_to_import_for_any_other_reason(outcomes: List[Outcome])
 
 @pytest.mark.parametrize(
     "module",
-    ["gen_worker.cli.serve", "gen_worker.cli.run", "gen_worker.cli.invoke", "gen_worker.cli"],
+    [
+        "gen_worker.cli.release",
+        "gen_worker.cli.models_export",
+        "gen_worker.cli.protocol",
+        "gen_worker.cli.args",
+        "gen_worker.cli",
+    ],
 )
 def test_cli_entry_orders(module: str) -> None:
-    """The four entry orders into the cli package, named individually.
+    """Every entry order into the cli package, named individually.
 
-    `cli/__init__` reaching `run` before `serve` is what masked the original
-    defect, so "the CLI works" was never evidence about `cli.serve`.
+    `cli/__init__` reaching one submodule before another is what masked the
+    original defect, so "the CLI works" was never evidence about any single
+    entry point.
+
+    pgw#1440: the list used to name `cli.serve`, `cli.run` and `cli.invoke`,
+    all three of which pgw#1373 (`cd46c957`) deleted with the v1 SDK — so
+    three of the four parametrizations had been failing on master ever since,
+    and the one surviving name (`gen_worker.cli`) is the one that proves the
+    least. Re-pointed at the modules the package ACTUALLY has. The `cli.run`
+    row is the same stale reference that left `cli/release.py` importing a
+    deleted symbol; this is that fallout, in the test half.
     """
     outcome = _import_alone(module)
     assert outcome.returncode == 0, f"{module} as a first import:\n{outcome.stderr}"

--- a/tests/test_release_derive.py
+++ b/tests/test_release_derive.py
@@ -223,3 +223,71 @@ def test_lockfile_closure_is_the_env_identity(
     assert [record["graph"] for lane in locked["graphs"]["lanes"] for record in lane["graphs"]] == [
         record["graph"] for lane in installed["graphs"]["lanes"] for record in lane["graphs"]
     ]
+
+
+# --- the sys.path priming the derive shares with discovery -------------------
+
+
+def test_the_derive_cli_can_resolve_its_own_imports() -> None:
+    """pgw#1440 REGRESSION. `_run_derive` imported `_ensure_sys_path` from
+    `cli/run.py`, which pgw#1373 (`cd46c957`) deleted with the v1 SDK, so
+    `gen-worker release derive` raised `ModuleNotFoundError` on the second
+    line of its handler — every derive, on every tree.
+
+    Asserted by RESOLVING the handler's imports rather than by grepping for
+    the module: the failure was an import that could not be satisfied, so the
+    check has to be one that a second dead import would also fail.
+    """
+    from gen_worker.cli import release as release_cli
+
+    source = Path(release_cli.__file__).read_text()
+    assert "cli.run" not in source and "from .run import" not in source
+
+    # The real gate: run the handler's own import block in a clean process.
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "from gen_worker.discovery.discover import prime_sys_path;"
+         "from gen_worker.release.derive import DeriveError, derive_release;"
+         "print('ok')"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+
+
+def test_priming_puts_src_ahead_of_root_and_repeats_cleanly(tmp_path: Path) -> None:
+    """The ORDER is load-bearing and was nearly lost in the extraction.
+
+    Both inserts go to position 0, so writing them root-then-src yields
+    `src` ahead of `root` — which is what a `src/`-layout endpoint needs.
+    Swapping the two statements reverses the precedence silently, and the
+    only thing that catches it is an assertion on the resulting order.
+    """
+    from gen_worker.discovery.discover import prime_sys_path
+
+    root = tmp_path / "endpoint"
+    (root / "src").mkdir(parents=True)
+    saved = list(sys.path)
+    try:
+        prime_sys_path(root)
+        assert sys.path.index(str(root / "src")) < sys.path.index(str(root))
+        before = list(sys.path)
+        prime_sys_path(root)  # idempotent: no duplicate entries
+        assert sys.path == before
+    finally:
+        sys.path[:] = saved
+
+
+def test_priming_omits_a_src_dir_that_does_not_exist(tmp_path: Path) -> None:
+    """A flat endpoint has no `src/`, and a path entry to a missing directory
+    is a silent import-order hazard rather than a harmless no-op."""
+    from gen_worker.discovery.discover import prime_sys_path
+
+    root = tmp_path / "flat"
+    root.mkdir()
+    saved = list(sys.path)
+    try:
+        prime_sys_path(root)
+        assert str(root) in sys.path
+        assert str(root / "src") not in sys.path
+    finally:
+        sys.path[:] = saved


### PR DESCRIPTION
`cli/release.py:72`, inside `_run_derive`, did `from .run import _ensure_sys_path`. **`src/gen_worker/cli/run.py` does not exist**, and `_ensure_sys_path` was defined **nowhere** in `src/` — two occurrences in the whole tree, both in `cli/release.py` (the import, and the call at `:82`). The deleting commit is **`cd46c957`** ("#1373: the v1 SDK is DELETED"), so **the derive CLI has been unable to run at all since that hardcut**. It is also the `tests/test_release_derive.py` red in CI's `tests` job.

## Why this was urgent

pgw#1371's runtime mint compiles each graph's serialized `ExportedProgram`, and that blob has **no publish leg and no fetch leg** — `release/derive.py:_program_sink` writes it to a *local* `--graph-cas` directory on the deriving machine, nothing uploads it, and th#2133's adopt answer presigns only the compiled artifact. The one workaround for a lane that cannot stage 105 GB locally is *run the derive **on the pod** with `--graph-cas $TENSORHUB_CACHE_DIR/cas`* — which goes through this CLI. With it broken, gate 1 of the mint demonstration had no workaround and a rental would have bought a zero.

Root cause co-established with the se#780 H3 lane, which found the deleting commit.

## The fix is a de-duplication, not a resurrection

The deleted helper's own docstring said it existed to *"match discover.py's sys.path priming"* — a copy that **named its own original**, while `discovery/discover.py` had the identical logic inlined. Two copies of one rule is exactly what let a deletion break a caller silently.

So the rule is now one exported function, `discovery.discover.prime_sys_path(root)`, called by both `discover_manifest` and `_run_derive`. **`cli/run.py` is not restored** — the v1 hardcut stands.

### ⚠️ The order inside it is load-bearing, and I nearly lost it

Both inserts go to position 0, so the statements must read **root-then-src** for the resulting precedence to be `src` ahead of `root` — which is what a `src/`-layout endpoint needs. My first draft used a tidy `for entry in (root / "src", root)` loop and silently reversed it. There is now an assertion on the resulting order, red-verified by swapping the two statements:

```
M1: statements swapped -> FAILED test_priming_puts_src_ahead_of_root_and_repeats_cleanly
```

## Also cleared, same fallout family

`tests/test_import_cycles_pgw981.py::test_cli_entry_orders` parametrized over `cli.serve`, `cli.run` and `cli.invoke` — **all three deleted by `cd46c957`** — so three of its four cases had been failing on master ever since, and the only surviving name (`gen_worker.cli`) proves the least. Re-pointed at the modules the package actually has.

## Proof

- `tests/test_release_derive.py` — **7 passed** (this was the CI red), plus three new assertions: the handler's own imports resolve in a clean subprocess, `src` precedes `root`, and a flat endpoint gets no phantom `src/` entry.
- `tests/test_import_cycles_pgw981.py` — **7 passed** (was 3 failed / 4 passed).
- `ruff`, `mypy`, and `lint_unreached_surface` / `lint_incident_test_names` / `lint_config_reads` / `lint_serving_process_compiles` / `lint_retired_sdk_spellings` / `lint_mypy_ratchet` all green.

Net: two pre-existing CI reds cleared and none added.