### PR TITLE
pgw#1441: the adopt roll-up needs its own kind — one kind, one phase vocabulary

### DIFF
--- a/changelog.d/pgw1441-adopt-summary-kind.md
+++ b/changelog.d/pgw1441-adopt-summary-kind.md
@@ -1,0 +1,13 @@
+- **The adopt roll-up gets its own activity kind, `boot_adopt_summary`.** pgw#1371 emitted the
+  per-BOOT reuse verdict under `boot_adopt`, whose `phase` is a per-KEY gate token
+  (`hit`/`miss`/`no_export_declaration`, one row per graph). One kind then carried two `phase`
+  vocabularies, and the hub keys `info.Activities` on kind alone — so
+  `count(*) where kind='boot_adopt' and phase='reused'` reads 0 on every pod predating the code,
+  which is indistinguishable from "nothing reused". This is pgw#1067's `warmup`/`warmup_summary`
+  incident exactly, caught before it shipped instead of after.
+
+- **The reuse counts are numeric, not prose.** `step` = graphs adopted, `total_steps` = graphs
+  claimed, so the reuse ratio is a query rather than a regex over `detail` — and `total_steps` IS
+  the lane's graph-class count, readable directly instead of inferred by counting per-key rows.
+  `emit_event` gained `step`/`total_steps` for this; both default to 0, which honestly means "not
+  a count" for every other event.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -163,6 +163,20 @@ KIND_APPLIED_ATTENTION = "applied_attention"
 # (`boot_adopt.REASONS`, countable hub-side); `detail` names family, function,
 # derived key and the sentence; `duration_ms` is the derivation's own wall.
 KIND_BOOT_ADOPT = "boot_adopt"
+# pgw#1441: the PER-BOOT roll-up, and it needs its own kind for exactly the
+# reason `warmup_summary` above does. `boot_adopt`'s `phase` is a PER-KEY gate
+# token (`hit`/`miss`/`no_export_declaration`, one row per graph); pgw#1371's
+# adopt outcome is a PER-BOOT verdict over all of them. Emitting both under one
+# kind gives that kind two vocabularies, and the hub keys `info.Activities` on
+# kind alone — so `count(*) where kind='boot_adopt' and phase='reused'` reads 0
+# on every pre-#1371 pod, which is indistinguishable from "nothing reused".
+# Same trap as pgw#1067's, caught before it shipped rather than after.
+#
+# `phase` is `reused` (this boot adopted everything and mints nothing) /
+# `minting` (holes remain) / `empty_lane`. THE COUNTS ARE NUMERIC, not prose:
+# `step` = graphs adopted, `total_steps` = graphs claimed, so the reuse ratio
+# is a query rather than a regex over `detail`. `detail` keeps the sentence.
+KIND_BOOT_ADOPT_SUMMARY = "boot_adopt_summary"
 # pgw#1328: the ADOPT-ONLY role's answer where an eager-capable pod would have
 # served eager and minted (§4.28). It is the only thing that role produces on a
 # miss, so it must be readable off-pod or the role is unobservable. `phase` is
@@ -510,6 +524,7 @@ class Activity:
 def emit_event(
     kind: str, detail: str, phase: str = "", duration_ms: int = 0,
     *, family: str = "", compiled_graph_key: str = "", graph_class: str = "",
+    step: int = 0, total_steps: int = 0,
 ) -> None:
     """One self-contained COMPLETED ActivityUpdate — a countable typed
     EVENT (pgw#680 ``guard_miss``), not a running activity.
@@ -526,10 +541,18 @@ def emit_event(
     Deliberately bypasses :func:`begin`: begin() swaps the module-global
     ``_current``, and ending an event would strand a concurrently open
     long-running activity (background mint) without its progress beat.
+    ``step``/``total_steps`` (pgw#1441) carry a COUNT this event is about, in
+    the typed numeric columns rather than interpolated into ``detail``. An
+    event whose whole point is a ratio -- "N of M graphs adopted" -- is
+    otherwise only readable by regexing a sentence, which is how a reader ends
+    up building a metric on a column that renders 0 because nothing writes it.
+    Leave both 0 when the event is not about a count.
+
     Thread-safe; without a bound sink it lands on the logger like every
     other report."""
     _emit(pb.ActivityUpdate(
         kind=kind, phase=phase[:300], seq=_next_seq(),
+        step=max(0, int(step)), total_steps=max(0, int(total_steps)),
         state=pb.ActivityState.ACTIVITY_STATE_COMPLETED,
         detail=detail[:2000],
         family=str(family or "")[:200],

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -209,11 +209,25 @@ class ServeAdoption:
         A serve pod's stdout goes nowhere (pgw#760), so "this pod adopted N
         graphs and compiled none" cannot be a log line: it is the single
         observation the whole mint-and-reuse program is judged on, and it has
-        to be readable off-pod. `boot_adopt` is the hub-known kind for exactly
-        this, and the two boots of a reuse proof read straight off it:
+        to be readable off-pod. The two boots of a reuse proof read straight
+        off it:
 
-            first  boot -> adopted=0 holes=N   (this pod pays)
-            second boot -> adopted=N holes=0   (this pod reuses)
+            first  boot -> phase=minting  step=0 total_steps=N
+            second boot -> phase=reused   step=N total_steps=N
+
+        **Its own kind, `boot_adopt_summary` (pgw#1441).** `boot_adopt` is a
+        PER-KEY event whose `phase` is `hit`/`miss`/`no_export_declaration` —
+        one row per graph. This is a PER-BOOT verdict over all of them, and
+        putting both under one kind gives that kind two `phase` vocabularies:
+        `count(*) where kind='boot_adopt' and phase='reused'` then reads 0 on
+        every pod that predates this code, which is indistinguishable from
+        "nothing reused". `warmup`/`warmup_summary` is the same split, made
+        for the same reason, one incident earlier (pgw#1067).
+
+        **The counts are NUMERIC.** `step` = graphs adopted, `total_steps` =
+        graphs claimed, so the reuse ratio is a query instead of a regex over
+        `detail`. Prose in `detail` alone is how a reader ends up building a
+        metric on whatever nearby column looks numeric.
 
         Emitted from :meth:`loaded`, not from :meth:`_build`, because the
         counts are only final once the author's ``ctx.compile`` calls have
@@ -224,12 +238,14 @@ class ServeAdoption:
             return
         adopted, holes = len(session.adopted), len(session.holes)
         activity_mod.emit_event(
-            activity_mod.KIND_BOOT_ADOPT,
+            activity_mod.KIND_BOOT_ADOPT_SUMMARY,
             f"release={self.release_id} lane={contract} sm={self.sm}: "
             f"{adopted} graph(s) adopted from the store, {holes} hole(s) for "
             f"the background mint, {len(session.unclaimed)} unclaimed",
             phase="reused" if holes == 0 and adopted else (
                 "minting" if holes else "empty_lane"),
+            step=adopted,
+            total_steps=adopted + holes,
         )
 
     def _refuse(self, phase: str, detail: str) -> None:

--- a/tests/test_self_mint_wiring.py
+++ b/tests/test_self_mint_wiring.py
@@ -191,10 +191,14 @@ def counting_loader(
 
 @pytest.fixture()
 def wire(monkeypatch: pytest.MonkeyPatch) -> List[tuple]:
+    """Captured events as (kind, phase, detail, kwargs) — the kwargs matter
+    because pgw#1441 moved the reuse COUNTS into typed numeric fields, and a
+    recorder that dropped them could not tell a wired count from prose."""
     seen: List[tuple] = []
     monkeypatch.setattr(
         activity_mod, "emit_event",
-        lambda kind, detail, phase="", **kw: seen.append((kind, phase, detail)))
+        lambda kind, detail, phase="", **kw: seen.append(
+            (kind, phase, detail, kw)))
     return seen
 
 
@@ -688,9 +692,22 @@ def test_the_reuse_hit_is_a_wire_fact_a_rental_can_capture(
     assert mints[1].join(timeout=60.0).state == self_mint_mod.NOTHING_TO_MINT
     assert reusing.calls == [], "the second pod compiled: that is not reuse"
 
-    phases = [e[1] for e in wire if e[0] == "boot_adopt"]
+    phases = [e[1] for e in wire if e[0] == "boot_adopt_summary"]
     assert phases == ["minting", "reused"], (
         f"the reuse hit must be readable off-pod, got {wire}")
-    detail = [e[2] for e in wire if e[0] == "boot_adopt"][1]
+    rows = [e for e in wire if e[0] == "boot_adopt_summary"]
+    detail = rows[1][2]
     assert f"{len(expected)} graph(s) adopted" in detail and "0 hole(s)" in detail
     assert [e for e in wire if e[0] == self_mint_mod.KIND_SKIPPED]
+
+    # pgw#1441: THE COUNTS ARE NUMERIC, so the reuse ratio is a query and not
+    # a regex over a sentence. Paying boot 0/N, reusing boot N/N.
+    assert rows[0][3]["step"] == 0
+    assert rows[0][3]["total_steps"] == len(expected)
+    assert rows[1][3]["step"] == len(expected)
+    assert rows[1][3]["total_steps"] == len(expected)
+
+    # And the per-BOOT roll-up never lands in the per-KEY kind, whose `phase`
+    # vocabulary is hit/miss/no_export_declaration. One kind, one vocabulary.
+    assert not [e for e in wire if e[0] == "boot_adopt"], (
+        "the per-boot roll-up collided with the per-key event's kind")


### PR DESCRIPTION
pgw#1371 emitted the per-**BOOT** adopt verdict (`reused` / `minting` / `empty_lane`) under `boot_adopt`, whose `phase` is a per-**KEY** gate token (`hit` / `miss` / `no_export_declaration`, one row per graph). One kind, two vocabularies.

The hub keys `info.Activities` on kind alone, so `count(*) where kind='boot_adopt' and phase='reused'` reads **0** on every pod that predates this code — indistinguishable from "nothing reused", which is the exact wrong answer to the one question the mint program is judged on.

## This is pgw#1067's incident, caught before it shipped

`activity.py` already records the precedent: `warmup` was one kind carrying a running activity **and** a terminal roll-up; the roll-up overwrote the live activity and a still-loading worker read as finished to the stall monitor, the cap-turnover test and the unservable reaper. The fix was a separate kind (`warmup_summary`).

Same shape here. So `boot_adopt_summary` is the per-boot roll-up and `boot_adopt` keeps its per-key meaning untouched. **No hub change** — every kind is stored generically and served at `GET /v1/admin/worker-activity-events?kind=`.

## And the counts become numbers

The roll-up put `adopted`/`holes` only in `detail` prose, so a reader had to regex a sentence — and a reader who doesn't will reach for whatever nearby column looks numeric and get a confident zero. (`cache_hits`/`cache_misses` are `ModelEvent` fields, not `ActivityUpdate`'s, so they are *absent* for this row family, not 0.)

`ActivityUpdate` already carries `step`/`total_steps`. `emit_event` now exposes them, and the roll-up sets:

| field | meaning |
|---|---|
| `step` | graphs adopted from the store |
| `total_steps` | graphs claimed by `ctx.compile` — i.e. **the lane's graph-class count** |
| `phase` | `reused` / `minting` / `empty_lane` |
| `detail` | the sentence, for humans |

So the reuse ratio is a query, and `total_steps` reads the class count directly instead of inferring it by counting per-key rows. Both fields default to 0, which honestly means "not a count" for every other event.

Raised by the se#780 H3 lane, which was about to build a harness query on `phase='reused'` and on regexing `detail`. Both are now safe.

## Proof

The two-boot reuse test asserts the paying boot is `0/N` and the reusing boot `N/N` **in the typed fields**, and that the roll-up never lands in the per-key kind:

```
assert rows[0][3]["step"] == 0
assert rows[0][3]["total_steps"] == len(expected)
assert rows[1][3]["step"] == len(expected)
assert not [e for e in wire if e[0] == "boot_adopt"]
```

`tests/test_self_mint_wiring.py` **10 passed**. `ruff`, `mypy`, `lint_unreached_surface` / `lint_incident_test_names` / `lint_config_reads` / `lint_serving_process_compiles` / `lint_mypy_ratchet`, and `check_worker_value_contracts_digest.py` (the wire-shared kind vocabulary gate) all green.

The 8 failures in the adjacent sweep are **pre-existing pgw#1373 fallout** — `fleet_compiled_graphs.py` is deleted at master, plus `gen_worker.mint_child`, `gen_worker.aot_mint`, `harness.toy_endpoints` — already red in CI's `tests` job and none of them touch these files.