### PR TITLE
pgw#1442 (se#769 audio lane): vendor `stable-audio.diffusers-fp16@1` — the sentinel resolves with no code change

### DIFF
--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -208,7 +208,8 @@ read_plane_files = ["__init__.py", "gguf.py", "project.py", "tensors.py", "write
 # brings the set back to EQUAL the real upstream corpus.
 #
 # `contract_plane_rev` advanced c3a831d -> `107b8ac` (tensorfs#121) ->
-# `2abc1b76` (#124/#125) -> `b8bb39fd` (#134) -> `272103e4`, the cut. The
+# `2abc1b76` (#124/#125) -> `b8bb39fd` (#134) -> `272103e4` -> `86bfa80f`
+# (tensorfs#140, the audio lane's document — pgw#1442, this bump). The
 # documents arriving here belong to OTHER LANES and are vendored bytes-only,
 # named so the ownership is readable rather than implied:
 #
@@ -220,6 +221,18 @@ read_plane_files = ["__init__.py", "gguf.py", "project.py", "tensors.py", "write
 #   ernie.diffusers-bf16          se#—     tensorfs#142
 #   minimax.h3-dit-fp8-rowwise    —        tensorfs#128
 #   sdxl.diffusers-fp8-rowwise    —        tensorfs#128
+#   stable-audio.diffusers-fp16   se#769   tensorfs#140   (THIS bump, pgw#1442)
+#
+# `stable-audio.diffusers-fp16` is the FIRST vendored document whose top-level
+# dtype is `float16` rather than `bfloat16` — the served checkpoints histogram
+# {F16: 445} and the hub records dtype=fp16, so the document describes the
+# bytes the fleet actually serves. Do not "correct" it toward its siblings, and
+# do not widen its per-tensor `dtypes` to admit BF16: a bf16 repack of this
+# architecture would be a SEPARATE document (`stable-audio.diffusers-bf16@1`),
+# the way sdxl carries both a bf16 and an fp8-rowwise lane. It is also the only
+# document serving TWO checkpoints deliberately — `stable-audio-open` and
+# `foundation-1` share an identical transformer header sha256 and differ only
+# in weight values, which is a checkpoint row rather than a second layout.
 #
 # #121 authored the four se#757 blocker-A lane documents (`sd15`, `sd2`,
 # `hidream-o1`, `wan22` — sd15 and sd2 are SEPARATE documents with separate
@@ -251,7 +264,7 @@ read_plane_files = ["__init__.py", "gguf.py", "project.py", "tensors.py", "write
 # They are FRAGMENTS (a family-shared block spelling and two CLIP component
 # spellings) that a `lanes=` header never names on its own. Do not "fix" them,
 # and do not let a declaration-time dtype read treat them as lanes.
-contract_plane_rev = "272103e414184c7935105afa48416b95fd5a10ee"
+contract_plane_rev = "86bfa80fd42cf8c107f16ab649a2afcebc45dd88"
 contract_plane_files = [
   "contract.py",
   "contracts.py",
@@ -272,6 +285,7 @@ contract_plane_files = [
   "_contracts/sdxl.clip-g-split-qkv.v1.json",
   "_contracts/sdxl.diffusers-bf16.v1.json",
   "_contracts/sdxl.diffusers-fp8-rowwise.v1.json",
+  "_contracts/stable-audio.diffusers-fp16.v1.json",
   "_contracts/trellis2.dit-bf16.v1.json",
   "_contracts/wan22.diffusers-bf16.v1.json",
   "_contracts/z-image.diffusers-bf16.v1.json",
@@ -396,6 +410,7 @@ rewrites = [
 "_contracts/sdxl.clip-g-split-qkv.v1.json" = "5d82d4dcad7ca97cc5291a4fc60e4916e24e6bc8baa14e0429be428b99d9d09a"
 "_contracts/sdxl.diffusers-bf16.v1.json" = "6612c3d61e495f62d9f06096c11a2182a8a440d969e4faa0f23258eec35abe60"
 "_contracts/sdxl.diffusers-fp8-rowwise.v1.json" = "f082ff98421cd21827d10ed2a69f6447e8694dcf43baf08a7c47d2de6b373c20"
+"_contracts/stable-audio.diffusers-fp16.v1.json" = "ad06436e3b67c92a843ad8778a7fdfc04cf237e9fcedd1718552d3c8e9d1958a"
 "_contracts/trellis2.dit-bf16.v1.json" = "84bc7689d8f86372affc03cf2f25d895e55bfc824af395fd5af6cc54fdd50f0f"
 "_contracts/wan22.diffusers-bf16.v1.json" = "bca462c22c83e43e28516fa21a7d7798d73f3a46c242f61a37d532701903e13b"
 "_contracts/z-image.diffusers-bf16.v1.json" = "876eea29cb8974f4562ed52da63a0c7ac8af5127b669ec15f6025ca8f73ce534"

--- a/src/gen_worker/_vendor/tensorfs/_contracts/stable-audio.diffusers-fp16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/stable-audio.diffusers-fp16.v1.json
@@ -1,0 +1,252 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "stable-audio.diffusers-fp16",
+  "version": 1,
+  "dtype": "float16",
+  "description": "The canonical Stable Audio serve layout: the diffusers StableAudioDiTModel (StableAudioPipeline), all-fp16, every family derived from the real safetensors header of tensorhub/stable-audio-open (stabilityai/stable-audio-open-1.0 @f21265c1e2710b3bd2386596943f0007f55f802e) and cross-checked byte-for-byte in names/shapes/dtypes against tensorhub/foundation-1 (tintwotin/Foundation-1-Diffusers @bc4bd07e4c10f8e794e48336582448171f5dbd5f). ONE document serves BOTH checkpoints: their transformer headers share an identical sha256, and they differ only in weight VALUES, which is a checkpoint row rather than a second layout. TRANSFORMER ONLY. The AutoencoderOobleck and the T5 text encoder are deliberately absent: both are BYTE-IDENTICAL across the two checkpoints (vae af3c43eb..., text_encoder 6cf39d0c...), so declaring either would make family detection TIE between them; and the T5 encoder is name-identical (Jaccard 1.0, all 99 tensors) with musicgen's, which would tie two unrelated audio families to each other. fp16, not bf16: the served checkpoints histogram {F16: 445} and the hub records dtype=fp16; the endpoints' inherited plain.bf16@1 layout string disagrees with the bytes and dies with the se#769 migration. QKV is SPLIT (to_q/to_k/to_v are separate tensors), so no fusion is declared; the cross-attention k/v are 768-wide against 1536-wide q, the cross_attention_dim=768 asymmetry visible in the shapes.",
+  "tensors": [
+    {
+      "role": "audio_in.conv.weight",
+      "pattern": "preprocess_conv.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 3,
+      "required": false
+    },
+    {
+      "role": "audio_out.conv.weight",
+      "pattern": "postprocess_conv.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 3,
+      "required": false
+    },
+    {
+      "role": "latent_in.proj.weight",
+      "pattern": "proj_in.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "latent_out.proj.weight",
+      "pattern": "proj_out.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_embed.fourier.weight",
+      "pattern": "time_proj.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "time_embed.mlp.{i}.weight",
+      "pattern": "timestep_proj.{i}.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_embed.mlp.{i}.bias",
+      "pattern": "timestep_proj.{i}.bias",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "global_cond.mlp.{i}.weight",
+      "pattern": "global_proj.{i}.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "cross_cond.mlp.{i}.weight",
+      "pattern": "cross_attention_proj.{i}.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.norm1.weight",
+      "pattern": "transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.norm1.bias",
+      "pattern": "transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.norm2.weight",
+      "pattern": "transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.norm2.bias",
+      "pattern": "transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.norm3.weight",
+      "pattern": "transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.norm3.bias",
+      "pattern": "transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.self_attn.q.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_q.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.self_attn.k.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_k.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.self_attn.v.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_v.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.self_attn.out.{i}.weight",
+      "pattern": "transformer_blocks.{i}.attn1.to_out.{i}.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.cross_attn.q.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_q.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.cross_attn.k.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_k.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.cross_attn.v.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_v.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.cross_attn.out.{i}.weight",
+      "pattern": "transformer_blocks.{i}.attn2.to_out.{i}.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.ff.{i}.geglu.weight",
+      "pattern": "transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.ff.{i}.geglu.bias",
+      "pattern": "transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.ff.{i}.out.weight",
+      "pattern": "transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.{i}.ff.{i}.out.bias",
+      "pattern": "transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "F16"
+      ],
+      "rank": 1,
+      "required": false
+    }
+  ]
+}

--- a/tests/testdata/contract-vectors/contract-vectors.json
+++ b/tests/testdata/contract-vectors/contract-vectors.json
@@ -98,6 +98,12 @@
       "stamp": "sdxl.diffusers-fp8-rowwise@1"
     },
     {
+      "name": "stable-audio.diffusers-fp16.v1",
+      "file": "contracts/stable-audio.diffusers-fp16.v1.json",
+      "digest": "c580a73fda845048b99b3d3f2093be9c282da4166e1e5521fea139957b454ed3",
+      "stamp": "stable-audio.diffusers-fp16@1"
+    },
+    {
       "name": "trellis2.dit-bf16.v1",
       "file": "contracts/trellis2.dit-bf16.v1.json",
       "digest": "f9763a5aa4b82d552c7b582d7b540cd0fdf576cc5bd234bb9e73ec617738ab52",


### PR DESCRIPTION
tensorfs#140 landed the document (tensorfs `86bfa80f`); this carries its bytes into the vendored contract plane so `StableAudio.canonical_contract` stops being a `MissingContract`. Unblocks the `stable-audio-open` and `foundation-1` endpoint migrations.

## What moves

- `contract_plane_rev` `272103e4` → `86bfa80f`
- **BOTH tables together**, per the standing hazard: `contract_plane_files` and `[packages.tensorfs.files]`, 20 → 21
- `tests/testdata/contract-vectors/contract-vectors.json` re-synced to the same rev — which is what the three red gates were actually asking for, not a corpus edit

The vendored document is upstream's bytes **verbatim**: sha256 `ad06436e3b67c92a843ad8778a7fdfc04cf237e9fcedd1718552d3c8e9d1958a`, identical to `git show origin/master:spec/v1/contracts/stable-audio.diffusers-fp16.v1.json` in tensorfs.

## RED → GREEN, measured

Before this bump `STABLE_AUDIO_DIFFUSERS_FP16` was a `MissingContract`. After it, the same expression reads:

```
stamp        stable-audio.diffusers-fp16@1
dtype        float16          (the RAISING read — no MissingDtype)
declarations 27
digest       c580a73fda845048b99b3d3f2093be9c282da4166e1e5521fea139957b454ed3
StableAudio.canonical_contract is it -> True
```

The digest matches tensorfs's own three pin sites. **No line of `model_types.py` changed** — which is precisely the property the sentinel shape exists to have, and the same way `sd15`/`sd2`/`hidream-o1`/`wan22` cleared across pgw#1391's re-vendor.

## The one thing a later reader will want to "fix"

This is the **first vendored document whose top-level `dtype` is `float16`** rather than `bfloat16`. That is correct: the served checkpoints histogram `{F16: 445}` (verified two ways — the hub's `validator_metadata.dtype_counts` and recomputation from ranged headers) and the hub records `dtype=fp16`. Recorded in `VENDORED.toml` beside the entry, together with two standing rules:

- a **bf16 repack** of this architecture would be a SEPARATE document (`stable-audio.diffusers-bf16@1`), never a widening of this one's per-tensor `dtypes` — sdxl carries both a bf16 and an fp8-rowwise lane for the same reason;
- this document deliberately serves **two checkpoints** — `stable-audio-open` and `foundation-1` share an identical transformer header sha256 and differ only in weight values, which is a checkpoint row rather than a second layout.

## Gates

`tests/test_lane_contracts.py` + `tests/test_vendored_snapshot_pgw1310.py` — **69 passed**. The three that were red (`..._are_exactly_the_corpus_library`, `..._loads_and_names_what_the_corpus_names`, `..._matches_the_pinned_upstream_rev`) were red for the corpus sync, and are green on it rather than on a relaxed assertion.