### PR TITLE
pgw#1444: the mint's compile child must BE the parent — the v2 path had no such check, and v1's was silently off

### DIFF
--- a/changelog.d/pgw1444-child-contract.md
+++ b/changelog.d/pgw1444-child-contract.md
@@ -1,0 +1,17 @@
+- **The v2 mint's compile child now proves it is the parent, and refuses before it compiles.**
+  `serving/mint.py` spawns `python -m gen_worker.serving.mint_child`, which produces the bytes the
+  parent then publishes and arms — while every decision around it runs in the parent. That
+  assignment is only sound while both are the same code, and `-m` resolves whatever the
+  interpreter's path yields (a second checkout, an inherited `PYTHONPATH`, a stale wheel, or this
+  tree edited between the mint's import and the spawn). pgw#840 documented the hazard for the v1
+  pool; the v2 path shipped with **no protection at all**. The parent now stamps a digest of the
+  contract source into every request and the child recomputes and compares — in the CHILD, before
+  any work, so skew costs nothing.
+
+- **A guard that lost its digest source now says so instead of turning off.** `cd46c957` deleted
+  `aot_compile_child.py`; `aot_compile_pool._CONTRACT_MODULES` kept naming it; `_code_digest()`
+  returned `""` through a branch meant for zipimport; and `_verify_child_code`'s
+  `if not CODE_DIGEST: return` became a silent no-op — the pgw#840 check disabled by an unrelated
+  deletion, still looking like a guard. An absent NAMED contract module is now distinguished from
+  "no source anywhere" and refuses. Recorded rather than raised at import, because the module is
+  import-time reachable and a raise there would take the import with it.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -119,6 +119,11 @@ PACKAGE_ROOT = str(Path(__file__).resolve().parent.parent)
 _CONTRACT_MODULES = ("aot_compile_child.py", "aot_compile_pool.py")
 
 
+#: Contract modules this install does not have. Non-empty means the code
+#: identity check CANNOT run and the reason is a DEFECT, not the frozen case —
+#: `_verify_child_code` refuses on it instead of skipping.
+_CONTRACT_MISSING: list[str] = []
+
 def _code_digest() -> str:
     """A digest of the parent/child contract source, taken AT IMPORT.
 
@@ -136,13 +141,33 @@ def _code_digest() -> str:
     """
 
     here = Path(__file__).resolve().parent
-    digest = hashlib.sha256()
+    digests: list[bytes] = []
+    missing: list[str] = []
     for name in _CONTRACT_MODULES:
         try:
-            digest.update(hashlib.sha256((here / name).read_bytes()).digest())
-        except OSError:  # zipimport / frozen: no source to compare
-            return ""
-    return digest.hexdigest()[:16]
+            digests.append(hashlib.sha256((here / name).read_bytes()).digest())
+        except OSError:
+            missing.append(name)
+    if not digests:
+        # zipimport / frozen: no source ANYWHERE. The only honest fail-open —
+        # we genuinely cannot prove either way.
+        return ""
+    if missing:
+        # pgw#1444: a NAMED contract module is absent while its sibling is
+        # present. That is a broken install, not an unprovable one, and it
+        # must not read as the frozen case. `cd46c957` deleted
+        # `aot_compile_child.py` and left this module naming it, so
+        # `_code_digest()` returned "" and `_verify_child_code`'s
+        # `if not CODE_DIGEST: return` became a silent no-op — the pgw#840
+        # guard turned OFF by an unrelated deletion, with nothing anywhere
+        # saying so. Recorded rather than raised: this module is import-time
+        # reachable and a raise here would take the import with it.
+        _CONTRACT_MISSING.extend(missing)
+        return ""
+    combined = hashlib.sha256()
+    for digest in digests:
+        combined.update(digest)
+    return combined.hexdigest()[:16]
 
 
 #: Computed once per process, so parent and child each carry their OWN.
@@ -2179,6 +2204,23 @@ class EntryCompilePool:
         Refused, not warned: an artifact compiled by unknown code must not be
         packed into a compiled graph whose identity claims the parent's.
         """
+        if _CONTRACT_MISSING:
+            # pgw#1444, the C10 case: this guard was OFF and said nothing.
+            # `cd46c957` deleted `aot_compile_child.py`, `_CONTRACT_MODULES`
+            # kept naming it, `_code_digest()` returned "" for a reason that
+            # has nothing to do with zipimport, and the branch below skipped
+            # the check on every entry. A guard disabled by an upstream
+            # deletion must be LOUD, because the alternative is exactly what
+            # happened: it looked like it was running.
+            raise EntryCompileFailed(
+                row.entry,
+                f"entry {row.entry!r}: the code-identity check cannot run — "
+                f"this install is missing {_CONTRACT_MISSING}, which "
+                f"`_CONTRACT_MODULES` names as part of the parent/child "
+                f"contract. That is a BROKEN INSTALL, not the frozen case, so "
+                f"it refuses instead of skipping: pgw#840 exists because an "
+                f"artifact compiled by unknown code must not be packed into a "
+                f"compiled graph whose identity claims this parent's.")
         if not CODE_DIGEST:
             return  # no source to compare (zipimport) — cannot prove either way
         if report.code_digest == CODE_DIGEST:

--- a/src/gen_worker/serving/mint.py
+++ b/src/gen_worker/serving/mint.py
@@ -61,6 +61,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 from .. import activity as activity_mod
 from .. import compile_posture
 from ..stall import SilenceWindow
+from .mint_child import ContractModuleMissing, contract_digest
 
 logger = logging.getLogger(__name__)
 
@@ -708,6 +709,12 @@ def _child_compiler(
                 "cas": str(cas),
                 "destination": str(destination),
                 "result": str(result),
+                # pgw#1444/pgw#840: THIS parent's contract source, so the
+                # child can refuse before compiling if it is a different
+                # gen_worker. The child recomputes its own and compares —
+                # cheaper and stricter than the v1 shape (child reports,
+                # parent judges after the work is already done).
+                "contract": contract_digest(),
             }))
             proc = subprocess.run(
                 [sys.executable, "-m", "gen_worker.serving.mint_child",
@@ -1074,6 +1081,7 @@ __all__ = [
     "SERVING_RESERVE_CPUS",
     "ArtifactUnreadable",
     "ChildCompileFailed",
+    "ContractModuleMissing",
     "MissingProgramDigest",
     "PROGRAM_DIGEST_FIELD",
     "artifact_constraints",

--- a/src/gen_worker/serving/mint_child.py
+++ b/src/gen_worker/serving/mint_child.py
@@ -24,14 +24,88 @@ its exit status.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from pathlib import Path
 from typing import Any, Mapping
 
+#: The modules that DEFINE the parent/child contract: this entrypoint and the
+#: mint that spawns it. Their bytes are the request/response shape, so a child
+#: whose copies differ from the parent's is not running the parent's contract.
+CONTRACT_MODULES = ("mint.py", "mint_child.py")
+
+#: Sentinel for "no source to digest ANYWHERE" — a frozen or zipimported
+#: install. The only honest fail-open: we genuinely cannot prove either way.
+NO_SOURCE = ""
+
+
+class ContractModuleMissing(RuntimeError):
+    """A NAMED contract module is absent while others are readable.
+
+    Distinguished from :data:`NO_SOURCE` deliberately. pgw#1444: the v1 pool's
+    digest returned ``""`` for both cases, so when `cd46c957` deleted the
+    module its `_CONTRACT_MODULES` named, the pgw#840 guard's
+    ``if not CODE_DIGEST: return`` silently became a no-op — a guard turned off
+    by an unrelated deletion, with nothing to say so. An absent named module is
+    a BROKEN INSTALL, not an unprovable one, and it refuses.
+    """
+
+
+def contract_digest() -> str:
+    """Digest the parent/child contract source, or say why it cannot.
+
+    Taken from the FILES rather than from a version string on purpose: the
+    hazard (pgw#840) is a second ``gen_worker`` on the path — a stray checkout,
+    an inherited ``PYTHONPATH``, a stale wheel, or this tree edited between the
+    parent's import and the child's spawn — and every one of those can carry
+    the same version while shipping different bytes.
+    """
+    here = Path(__file__).resolve().parent
+    digests, missing = [], []
+    for name in CONTRACT_MODULES:
+        try:
+            digests.append(hashlib.sha256((here / name).read_bytes()).digest())
+        except OSError:
+            missing.append(name)
+    if not digests:
+        return NO_SOURCE  # frozen/zipimport: nothing to compare, and we say so
+    if missing:
+        raise ContractModuleMissing(
+            f"the mint's parent/child contract names {missing} and this "
+            f"install does not have them, while {[n for n in CONTRACT_MODULES if n not in missing]} "
+            f"IS present — a partial install or a deletion that left its "
+            f"callers behind. Refusing rather than skipping the code-identity "
+            f"check: an artifact compiled by unknown code must not be "
+            f"published under this parent's identity."
+        )
+    combined = hashlib.sha256()
+    for digest in digests:
+        combined.update(digest)
+    return combined.hexdigest()[:16]
+
 
 def compile_one(request: Mapping[str, Any]) -> Path:
     """Deserialize one graph blob and AOTI-compile it into ``destination``."""
+    # pgw#1444/pgw#840, BEFORE any work: this child must BE the parent. It is
+    # about to produce the bytes the parent publishes and arms, while every
+    # decision around it runs in the parent — an assignment that is only sound
+    # while both are the same code. Checked here rather than in the parent's
+    # report so a skewed child costs nothing: it refuses before it compiles.
+    stated = str(request.get("contract", ""))
+    mine = contract_digest()
+    if stated and mine and stated != mine:
+        raise ContractModuleMissing(
+            f"the compile child ran a DIFFERENT gen_worker than the mint that "
+            f"spawned it — parent contract {stated}, child contract {mine} "
+            f"from {Path(__file__).resolve().parent.parent.parent}. "
+            f"`python -m gen_worker.serving.mint_child` resolves whatever the "
+            f"interpreter's path yields (a second checkout, an inherited "
+            f"PYTHONPATH, a stale wheel, or this tree edited between the "
+            f"mint's import and this spawn). Refusing before compiling: this "
+            f"artifact would be published and armed under the parent's "
+            f"identity."
+        )
     import torch
 
     from .._vendor.torchcg import Engine, GraphClassSpec, RuntimeCompatibility

--- a/tests/test_self_mint_wiring.py
+++ b/tests/test_self_mint_wiring.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable, List
 
 import pytest
@@ -711,3 +712,90 @@ def test_the_reuse_hit_is_a_wire_fact_a_rental_can_capture(
     # vocabulary is hit/miss/no_export_declaration. One kind, one vocabulary.
     assert not [e for e in wire if e[0] == "boot_adopt"], (
         "the per-boot roll-up collided with the per-key event's kind")
+
+
+# --- pgw#1444: the compile child must BE the parent ------------------------
+
+
+def test_a_skewed_compile_child_refuses_before_it_compiles(tmp_path: Path) -> None:
+    """pgw#840's hazard on the v2 mint path, which had NO protection at all.
+
+    The child produces the bytes the parent publishes and arms, while every
+    decision around it runs in the parent — sound only while both are the same
+    code. `python -m gen_worker.serving.mint_child` resolves whatever the
+    interpreter's path yields, so a second checkout, an inherited PYTHONPATH or
+    a stale wheel silently substitutes a different compiler.
+
+    Refused in the CHILD, before any work: a skewed child then costs nothing,
+    where the v1 shape (child reports, parent judges) paid for the whole
+    compile first.
+    """
+    from gen_worker.serving.mint_child import (
+        ContractModuleMissing,
+        compile_one,
+        contract_digest,
+    )
+
+    mine = contract_digest()
+    assert mine and mine != "", "the contract digest must have a real source"
+
+    with pytest.raises(ContractModuleMissing, match="DIFFERENT gen_worker"):
+        compile_one({"contract": "0" * 16})
+
+    # An unstamped request (an older parent) still runs: absent is not skew,
+    # and refusing it would break the mint on a mixed-version rollout.
+    with pytest.raises(KeyError):  # got past the check, died on a real field
+        compile_one({})
+
+
+def test_a_missing_contract_module_refuses_instead_of_skipping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE C10 REGRESSION. A guard whose digest source vanished must say so.
+
+    `cd46c957` deleted the module v1's `_CONTRACT_MODULES` named; the digest
+    became `""`; `if not CODE_DIGEST: return` turned the pgw#840 check into a
+    no-op that still looked like a guard. Here an absent NAMED module is a
+    typed refusal, distinguished from the frozen case where nothing is
+    readable and we honestly cannot prove either way.
+    """
+    from gen_worker.serving import mint_child
+
+    monkeypatch.setattr(
+        mint_child, "CONTRACT_MODULES", ("mint.py", "not_a_real_module.py"))
+    with pytest.raises(mint_child.ContractModuleMissing, match="partial install"):
+        mint_child.contract_digest()
+
+    # Frozen/zipimport: NOTHING is readable, so there is no claim to make.
+    monkeypatch.setattr(
+        mint_child, "CONTRACT_MODULES", ("nope_a.py", "nope_b.py"))
+    assert mint_child.contract_digest() == mint_child.NO_SOURCE
+
+
+def test_the_mint_stamps_its_contract_into_every_child_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The parent half: without the stamp the child has nothing to compare."""
+    import subprocess
+
+    from gen_worker.serving.mint_child import contract_digest
+
+    seen: List[dict] = []
+
+    def fake_run(argv: Any, **kw: Any) -> Any:
+        request = json.loads(Path(argv[-1]).read_text())
+        seen.append(request)
+        Path(request["result"]).write_text(str(elf(tmp_path / "a.so")))
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    compile_one = mint_mod._child_compiler(
+        cas=tmp_path / "cas", target_arch="sm_89", toolchain={"cc": "1"})
+    compile_one(
+        tmp_path / "blob.pt2",
+        SimpleNamespace(
+            graph="g", target="unet",
+            ingress=SimpleNamespace(as_dict=lambda: {})),
+        tmp_path / "out.so")
+
+    assert seen and seen[0]["contract"] == contract_digest()


### PR DESCRIPTION
Routed from the master-green sweep as pgw#1371/#1372's call. Two halves of one hazard (**pgw#840**): a compile child produces the bytes the parent publishes and arms, while every decision around it runs in the parent. That assignment is sound only while both are the same code — and `python -m gen_worker.serving.mint_child` resolves whatever the interpreter's path yields (a second checkout, an inherited `PYTHONPATH`, a stale wheel, or this tree edited between the mint's import and the spawn).

## 1. The live path had nothing

pgw#1371's `serving/mint.py` shipped with **no code-identity check whatsoever**. Verified: `git grep code_digest` over `serving/mint.py` and `serving/mint_child.py` returned nothing.

The parent now stamps `contract_digest()` — a digest of the two modules that *define* the parent/child contract — into every request; the child recomputes its own and compares. Two deliberate choices:

- **Checked in the CHILD, before any work.** A skewed child costs nothing, where v1's shape (child reports, parent judges) paid for the entire compile first.
- **Digested from FILES, not a version string**, because every substitution above can carry the same version while shipping different bytes.

An *unstamped* request (an older parent, mid-rollout) still runs — absent is not skew, and refusing it would break the mint on a mixed-version fleet.

## 2. v1's guard was off, silently — the C10 shape

`cd46c957` deleted `aot_compile_child.py`. `aot_compile_pool._CONTRACT_MODULES` still named it, so `_code_digest()` hit its `except OSError: return ""` — a branch written for **zipimport** — and `_verify_child_code`'s `if not CODE_DIGEST: return` skipped the check on every entry. A guard turned off by an unrelated deletion, with nothing anywhere saying so, still reading as a guard.

Confirmed against the real tree at HEAD:

```
CODE_DIGEST = ''
_CONTRACT_MISSING = ['aot_compile_child.py']
```

An absent **named** module is now distinguished from "no source anywhere" and refuses with the reason. Recorded in a sentinel rather than raised at import, because the module is import-time reachable and a raise there would take the import with it.

## Why re-home rather than delete the spawners

The v1 pool is **genuinely orphaned** — nothing imports it. Every remaining mention in `procsplit/oom_rank`, `process_role`, `mint_workers`, `serve/role` and `compile_posture` is a comment or a string literal, and there is no path from `worker.py` / `entrypoint.py` / `serving/`. So deleting it is the pgw#1373 sweep's job, not a fix.

Deleting it *without* guarding v2 would have removed the documentation of a hazard while leaving the live path exposed to it — the worst of the two options. Hence: guard the live path properly, and make v1's vacuous digest typed so it cannot mislead whoever does the sweep.

## Proof

13 tests in `test_self_mint_wiring.py`, three new:

| test | what it pins |
|---|---|
| `test_a_skewed_compile_child_refuses_before_it_compiles` | a mismatched contract raises before any compile; an unstamped request still runs |
| `test_a_missing_contract_module_refuses_instead_of_skipping` | a missing **named** module refuses; a fully absent source honestly returns "cannot prove" |
| `test_the_mint_stamps_its_contract_into_every_child_request` | the parent half — without the stamp the child has nothing to compare |

Red-verified with two mutations, each red at the right assertion:

```
M1 (child skips the comparison)  -> FAILED test_a_skewed_compile_child_refuses_before_it_compiles
M2 (missing module returns "")   -> FAILED test_a_missing_contract_module_refuses_instead_of_skipping
```

35 adjacent mint tests green. `ruff`, `mypy`, `lint_unreached_surface` / `lint_incident_test_names` / `lint_config_reads` / `lint_serving_process_compiles` / `lint_mypy_ratchet`, and `check_worker_value_contracts_digest.py` all green.

## Left to the sweep lane

The two vacuous fences they flagged (`lint_unreached_surface.DECLARATION_MODULES` naming deleted modules → `{}` → green no-op, and `lint_serve_role_closure`'s selftest rooted at the deleted `mint_adapter`) do not intersect this surface — theirs on PR #1006.