### PR TITLE
pgw#1446: pgw#1444's refusal fired where it destroyed measurements, on a tier Paul parked

### DIFF
--- a/changelog.d/pgw1446-guard-placement.md
+++ b/changelog.d/pgw1446-guard-placement.md
@@ -1,0 +1,13 @@
+- **pgw#1444's missing-contract refusal no longer destroys the measurements it fires beside.**
+  It refused unconditionally on `_CONTRACT_MISSING`, and `entry_phases` is banked *after* that gate
+  — so every reap raised before the fold and `entry_phases` came back empty, breaking pgw#1189's
+  law that the attempt which FAILED is exactly the attempt whose measurement the next one sizes
+  against (pgw#877 states that rule three lines above the call site). The refusal is now
+  conditioned on a child having actually reported a digest: real work whose provenance cannot be
+  checked, which is the hazard pgw#840 names. No reported digest means no artifact of unknown
+  origin to refuse.
+
+- **The C10 fix that was right is kept.** The original defect was *silence* — `cd46c957` deleted
+  `aot_compile_child.py`, `_code_digest()` returned `""` through a branch written for zipimport,
+  and the guard skipped while still reading as a guard. `_CONTRACT_MISSING` records the cause and
+  makes it inspectable; only the blanket raise is withdrawn.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -2204,21 +2204,43 @@ class EntryCompilePool:
         Refused, not warned: an artifact compiled by unknown code must not be
         packed into a compiled graph whose identity claims the parent's.
         """
-        if _CONTRACT_MISSING:
-            # pgw#1444, the C10 case: this guard was OFF and said nothing.
-            # `cd46c957` deleted `aot_compile_child.py`, `_CONTRACT_MODULES`
-            # kept naming it, `_code_digest()` returned "" for a reason that
-            # has nothing to do with zipimport, and the branch below skipped
-            # the check on every entry. A guard disabled by an upstream
-            # deletion must be LOUD, because the alternative is exactly what
-            # happened: it looked like it was running.
+        if _CONTRACT_MISSING and report.code_digest:
+            # pgw#1444's C10 fix, CORRECTED by pgw#1446. The silence is what
+            # was wrong — `cd46c957` deleted `aot_compile_child.py`,
+            # `_CONTRACT_MODULES` kept naming it, `_code_digest()` returned ""
+            # through a branch written for zipimport, and the check below
+            # skipped on every entry while still reading as a guard. That is
+            # fixed by RECORDING the cause in `_CONTRACT_MISSING`, which is
+            # inspectable and non-silent.
+            #
+            # Refusing UNCONDITIONALLY on it was wrong twice over, and both
+            # were measured:
+            #   1. It pre-empted the measurement fold. `entry_phases` is
+            #      banked below, AFTER this gate, so a blanket raise here
+            #      emptied it — breaking pgw#1189's law that the attempt which
+            #      FAILED is exactly the attempt whose measurement the next one
+            #      sizes against. pgw#877 states that rule three lines above
+            #      the call site; this violated it.
+            #   2. It fired on a tier that cannot run. Paul PARKED this tier on
+            #      pgw#1371/#1372 (`c4f2caaa`, pgw#1438: "PARKED ... not
+            #      retired"), staged its tests behind
+            #      `find_spec(ENTRY_CHILD_MODULE)` so they return by themselves
+            #      when the wiring lands, and there is no production path to
+            #      the pool at all. A fatal refusal there protects nothing that
+            #      can execute while breaking tests that were deliberately kept.
+            #
+            # So the refusal is now conditioned on a child having actually
+            # REPORTED a digest — i.e. real work whose provenance we cannot
+            # check, which is the hazard pgw#840 names. No report digest means
+            # no artifact of unknown origin to refuse.
             raise EntryCompileFailed(
                 row.entry,
-                f"entry {row.entry!r}: the code-identity check cannot run — "
-                f"this install is missing {_CONTRACT_MISSING}, which "
+                f"entry {row.entry!r}: a child reported code "
+                f"{report.code_digest} and this parent CANNOT CHECK IT — the "
+                f"install is missing {_CONTRACT_MISSING}, which "
                 f"`_CONTRACT_MODULES` names as part of the parent/child "
-                f"contract. That is a BROKEN INSTALL, not the frozen case, so "
-                f"it refuses instead of skipping: pgw#840 exists because an "
+                f"contract. A BROKEN INSTALL, not the frozen case, so it "
+                f"refuses instead of skipping: pgw#840 exists because an "
                 f"artifact compiled by unknown code must not be packed into a "
                 f"compiled graph whose identity claims this parent's.")
         if not CODE_DIGEST:

--- a/tests/test_child_code_identity_pgw840.py
+++ b/tests/test_child_code_identity_pgw840.py
@@ -176,3 +176,61 @@ def test_the_reports_identity_survives_the_wire(tmp_path: Path) -> None:
         b'{"entry":"share-000","status":"compiled"}',
         type=pool.EntryReport)
     assert old.code_digest == "" and old.spans == {}
+
+
+# --- pgw#1446: the missing-contract refusal, and what it must NOT do --------
+
+
+def _guard_row() -> Any:
+    """The minimum `_Running` the guard reads: it only uses `row.entry`."""
+    return type("_Row", (), {"entry": "share-000"})()
+
+
+def test_an_unverifiable_child_report_is_refused_when_the_contract_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#840's hazard, reached through pgw#1444's recorded cause.
+
+    A child REPORTED code the parent cannot check, because a module
+    `_CONTRACT_MODULES` names is absent. That is a broken install, not the
+    frozen case, and the artifact must not be packed.
+    """
+    monkeypatch.setattr(pool, "_CONTRACT_MISSING", ["aot_compile_child.py"])
+    box = object.__new__(pool.EntryCompilePool)
+    report = pool.EntryReport(entry="share-000", code_digest="deadbeefdeadbeef")
+
+    with pytest.raises(pool.EntryCompileFailed, match="CANNOT CHECK IT"):
+        pool.EntryCompilePool._verify_child_code(box, _guard_row(), report)
+
+
+def test_a_missing_contract_alone_does_not_refuse_a_child_that_reported_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE pgw#1446 REGRESSION, and it is about measurements.
+
+    pgw#1444 refused on `_CONTRACT_MISSING` unconditionally. `entry_phases` is
+    banked AFTER this gate, so that raise emptied it and broke pgw#1189's law
+    — the attempt that FAILED is exactly the attempt whose measurement the
+    next one sizes against (pgw#877 states it three lines above the call
+    site). It also fired on a tier Paul PARKED on pgw#1371/#1372 (`c4f2caaa`),
+    which cannot run at all, so it protected nothing while breaking staged
+    tests.
+
+    No reported digest means no artifact of unknown origin — nothing to
+    refuse, and the measurements survive.
+    """
+    monkeypatch.setattr(pool, "_CONTRACT_MISSING", ["aot_compile_child.py"])
+    monkeypatch.setattr(pool, "CODE_DIGEST", "")
+    box = object.__new__(pool.EntryCompilePool)
+    report = pool.EntryReport(entry="share-000", code_digest="")
+
+    pool.EntryCompilePool._verify_child_code(box, _guard_row(), report)  # no raise
+
+
+def test_the_missing_contract_cause_is_recorded_rather_than_silent() -> None:
+    """The half of pgw#1444 that was right and stays: an empty digest whose
+    cause is a DELETED module is inspectable, where before it was
+    indistinguishable from zipimport."""
+    assert pool.CODE_DIGEST == "" and pool._CONTRACT_MISSING == [
+        "aot_compile_child.py"
+    ], (pool.CODE_DIGEST, pool._CONTRACT_MISSING)


### PR DESCRIPTION
**I was asked to delete the orphaned v1 compile pool to clear this red. I did not, and this PR is the smaller thing instead.** The reason is in the tree.

## What the red actually is

Reproduced rather than taken from the report: it is **not** `EntryCompilePool` construction raising. It is `entry_phases == {}`.

`_verify_child_code` is called at `aot_compile_pool.py:2064`. `entry_phases[row.entry]` is banked at `:2097` — **after** it. pgw#1444 made that gate refuse unconditionally whenever `_CONTRACT_MISSING` is non-empty, which is *always* on this tree, so every reap raised before the fold.

That breaks pgw#1189's law, and pgw#877 states it three lines above the call site:

> banked BEFORE any gate can raise ... the attempt that FAILED is exactly the attempt whose measurement the next one has to size against.

## Why not delete the tier

Paul PARKED it, three hours before this PR, in `c4f2caaa` (pgw#1438):

> The three new rows are **STAGED, not CI-SKIPPED**: the compile/mint tier is **PARKED on pgw#1371/#1372, not retired**, and the skip is conditioned on `find_spec(ENTRY_CHILD_MODULE)` so they return by themselves the day the wiring lands.

The deletion was written and staged before I found this — the rebase surfaced it as a **modify/delete conflict on the exact two files he had just staged**. Deleting would have discarded a deliberate, current decision by the person who owns it, to fix a defect that is mine and one line wide.

## The fix

Refuse only when a child **actually reported a digest** this parent cannot check. That is the pgw#840 hazard — real work of unknown provenance. No reported digest means no artifact of unknown origin, so there is nothing to refuse and the measurements survive.

**The half of pgw#1444 that was right stays.** The original defect was *silence*: `cd46c957` deleted `aot_compile_child.py`, `_code_digest()` returned `""` through a branch written for zipimport, and the guard skipped while still reading as a guard. `_CONTRACT_MISSING` still records the cause, so a guard disabled by an upstream deletion is inspectable rather than indistinguishable from zipimport. Only the blanket raise is withdrawn.

## Red-verified both directions

| mutation | result |
|---|---|
| restore the unconditional raise (pgw#1444's bug) | reproduces **exactly the three reported failures**, plus the new regression test |
| drop the refusal entirely (fail-open again) | loses the real hazard — `test_an_unverifiable_child_report_is_refused_when_the_contract_is_missing` fails |

Three new tests pin the corrected condition, the measurement-preservation regression, and the recorded cause.

## Green

**32 passed / 3 skipped** across the five v1-pool suites — the skips are Paul's staging working as designed. `ruff` clean; `mypy` clean on both changed files; `lint_unreached_surface`, `lint_serving_process_compiles`, `lint_config_reads`, `lint_mypy_ratchet` green.

**Two pre-existing reds I did not touch and did not cause:** `test_eager_bridge_dtype_pgw1447.py` trips `lint_incident_test_names` and carries 6 mypy errors — pgw#1447's file, landed while this was in flight. Flagging for that lane.

## If the tier should still go

The deletion is ready and measured — 3,692 lines, five test modules, every fence and ratchet turned (`MINT_MACHINERY`, `SUPERVISED`, mypy overrides, `config_reads_allowlist`, `incident_named_tests`, both mypy high-waters), and two stranded symbols (`compile_posture.rss_reserve_bytes`, `env_seal.write_library_memo`) baselined with an owner and expiry rather than chased into a live module. It needs **Paul's word**, not mine, because it reverses his.