### PR TITLE
pgw#1447: the eager from_pretrained bridge stops contradicting its own contract — ask, do not guess, whether a loader speaks torch_dtype

### DIFF
--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -58,6 +58,40 @@ MT_co = TypeVar("MT_co", covariant=True)
 
 logger = logging.getLogger(__name__)
 
+#: Substrings that identify a ``TypeError`` raised because the loader (or the
+#: class it constructs) would not take ``torch_dtype``. Narrow ON PURPOSE: a
+#: TypeError from INSIDE a model's own __init__ must keep propagating, so the
+#: retry below fires only when the rejected keyword is named.
+_DTYPE_REJECTIONS = ("torch_dtype", "'dtype'", '"dtype"')
+
+
+def _rejected_torch_dtype(exc: TypeError) -> bool:
+    """Did this ``TypeError`` come from passing ``torch_dtype``?
+
+    WHY THIS IS A TRY/EXCEPT AND NOT A SIGNATURE CHECK — measured, because the
+    obvious fix does not work. Both loader families take ``**kwargs`` and
+    NEITHER names ``torch_dtype`` in its signature::
+
+        ModularPipeline.from_pretrained   torch_dtype named: False  **kwargs: True
+        StableDiffusionXLPipeline...      torch_dtype named: False  **kwargs: True
+
+    so `"torch_dtype" in signature.parameters` is False for both (SDXL would
+    lose its dtype) and `has **kwargs` is True for both (H3 would still break).
+    The real difference is what the implementation DOES with the keyword:
+    ``DiffusionPipeline.from_pretrained`` reads ``torch_dtype`` (3 mentions in
+    its source) and consumes it; ``ModularPipeline.from_pretrained`` never
+    mentions it (0), so ``**kwargs`` funnels it through ``load_config`` into
+    the constructor — where a strict pipeline correctly refuses an argument
+    that is neither a pipeline argument nor a component (se#754/se#766's
+    ``MiniMaxH3StreamingPipeline``, which is where this was found).
+
+    Behaviour, not shape, is the discriminator — and asking is the only way to
+    read behaviour. Every loader that works today still takes the first branch
+    and is untouched; only the family that REFUSES gets the second.
+    """
+    text = str(exc)
+    return any(token in text for token in _DTYPE_REJECTIONS)
+
 
 @dataclass(frozen=True, slots=True)
 class Adapter:
@@ -207,11 +241,29 @@ class LoadContext(Generic[MT_co]):
             "native loader engine is not bound)", pipeline_cls.__name__,
         )
         dtype = self._lane_dtype()
-        if dtype is not None:
+        if dtype is None:
+            no_lane: P = from_pretrained(self.checkpoint_dir)
+            return no_lane
+        try:
             bridged: P = from_pretrained(self.checkpoint_dir, torch_dtype=dtype)
             return bridged
-        no_lane: P = from_pretrained(self.checkpoint_dir)
-        return no_lane
+        except TypeError as exc:
+            if not _rejected_torch_dtype(exc):
+                raise
+        # This loader does not SPEAK `torch_dtype`. Load without it and apply
+        # the lane's dtype afterwards, so the lane is honoured rather than
+        # silently dropped — `.to(dtype)` moves floating parameters and leaves
+        # ints/bools alone, which is what `from_pretrained(torch_dtype=)` does.
+        logger.info(
+            "ctx.load: %s.from_pretrained does not accept torch_dtype; "
+            "loading without it and applying the lane dtype post-load "
+            "(pgw#1447)", pipeline_cls.__name__,
+        )
+        loaded: P = from_pretrained(self.checkpoint_dir)
+        to = getattr(loaded, "to", None)
+        if callable(to):
+            to(dtype)
+        return loaded
 
     def _lane_dtype(self) -> Any:
         """The lane's load dtype, or None when the contract declares none.

--- a/tests/test_eager_bridge_dtype_pgw1447.py
+++ b/tests/test_eager_bridge_dtype_pgw1447.py
@@ -1,0 +1,173 @@
+"""pgw#1447: the eager `from_pretrained` bridge and `torch_dtype`.
+
+`ctx.load`'s docstring states the author contract as *"No ``torch_dtype=`` (the
+lane contract IS the dtype)"* — and twelve lines below it, the eager bridge
+passed exactly that to the author's own class. For a `ModularPipeline` the
+keyword is not consumed by `from_pretrained`; it funnels through `**kwargs` into
+the constructor, where a strict pipeline refuses an argument that is neither a
+pipeline argument nor a component.
+
+Found by se#780 running the LOCAL config-only derive on minimax-h3 — the derive
+has no streaming engine bound, so it takes this bridge:
+
+    lane 'minimax.h3-dit-diffusers@1': load() failed under the trace session:
+    TypeError: MiniMaxH3StreamingPipeline: ['torch_dtype'] are neither pipeline
+    arguments nor components of this pipeline
+
+Both arms are asserted here because a fix that only satisfies the broken family
+would silently drop the dtype for the family that works.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker.serving.context import LoadContext, _rejected_torch_dtype
+
+
+class _Recorder:
+    """Base for the doubles: records what the loader was handed."""
+
+    seen_dtype: object = "<never called>"
+    to_calls: list = []
+
+
+def _ctx(lane) -> LoadContext:
+    """A LoadContext with NO loader engine, which is what forces the bridge."""
+    return LoadContext(
+        binding=_Binding(),
+        lane=lane,
+        engine=None,
+    )
+
+
+class _Binding:
+    checkpoint_ref = "tensorhub/fixture@prod"
+    checkpoint_dir = Path("/nonexistent/fixture")
+
+
+class _Lane:
+    """A tensorfs-contract stand-in whose `.dtype` is the lane's load dtype."""
+
+    def __init__(self, dtype):
+        self.dtype = dtype
+
+
+# --------------------------------------------------------------------------
+# the refusal predicate
+
+
+def test_a_torch_dtype_refusal_is_recognised_by_the_keyword_it_names():
+    exc = TypeError(
+        "MiniMaxH3StreamingPipeline: ['torch_dtype'] are neither pipeline "
+        "arguments nor components of this pipeline"
+    )
+    assert _rejected_torch_dtype(exc)
+
+
+def test_a_typeerror_from_inside_the_model_is_NOT_swallowed():
+    """The retry must be narrow. A TypeError raised by the author's own
+    __init__ for an unrelated reason has to keep propagating — otherwise this
+    fix converts a real bug into a silent second load."""
+    assert not _rejected_torch_dtype(TypeError("unsupported operand type(s) for +"))
+    assert not _rejected_torch_dtype(TypeError("expected Tensor, got NoneType"))
+
+
+# --------------------------------------------------------------------------
+# ARM 1 — the loader that ACCEPTS torch_dtype keeps getting it (no regression)
+
+
+def test_a_loader_that_accepts_torch_dtype_still_receives_it():
+    calls = {}
+
+    class Accepts:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            calls["path"] = path
+            calls["torch_dtype"] = kwargs.get("torch_dtype", "<absent>")
+            return cls()
+
+        def to(self, dtype):  # pragma: no cover - must NOT be reached
+            calls["to"] = dtype
+            return self
+
+    ctx = _ctx(_Lane("bfloat16"))
+    ctx.load(Accepts)
+
+    assert calls["torch_dtype"] == "bfloat16", (
+        "the accepting family must keep receiving torch_dtype at load time; "
+        "applying it post-load instead would change when the cast happens"
+    )
+    assert "to" not in calls, "no post-load cast when the loader took the dtype"
+
+
+# --------------------------------------------------------------------------
+# ARM 2 — the ModularPipeline family: H3's refusal, verbatim
+
+
+def test_a_modular_pipeline_that_refuses_torch_dtype_loads_and_is_cast_after():
+    """se#780's exact production failure, reproduced as a unit."""
+    calls = {"attempts": []}
+
+    class RefusesLikeModularPipeline:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            calls["attempts"].append(sorted(kwargs))
+            if "torch_dtype" in kwargs:
+                raise TypeError(
+                    "MiniMaxH3StreamingPipeline: ['torch_dtype'] are neither "
+                    "pipeline arguments nor components of this pipeline"
+                )
+            return cls()
+
+        def to(self, dtype):
+            calls["to"] = dtype
+            return self
+
+    ctx = _ctx(_Lane("bfloat16"))
+    got = ctx.load(RefusesLikeModularPipeline)
+
+    assert isinstance(got, RefusesLikeModularPipeline)
+    assert calls["attempts"] == [["torch_dtype"], []], (
+        "expected one attempt WITH torch_dtype, then a retry without it"
+    )
+    assert calls["to"] == "bfloat16", (
+        "THE LANE MUST STILL BE HONOURED. Dropping the dtype here would load a "
+        "bf16 lane in the checkpoint's own dtype and serve different numerics "
+        "with nothing raised — the silent-degradation shape this repo refuses."
+    )
+
+
+def test_an_unrelated_typeerror_from_the_loader_propagates():
+    class Broken:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            raise TypeError("expected Tensor, got NoneType")
+
+    with pytest.raises(TypeError, match="expected Tensor"):
+        _ctx(_Lane("bfloat16")).load(Broken)
+
+
+# --------------------------------------------------------------------------
+# the no-lane path is untouched
+
+
+def test_a_model_with_no_lane_never_mentions_dtype_at_all():
+    calls = {}
+
+    class NoLane:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            calls["kwargs"] = sorted(kwargs)
+            return cls()
+
+        def to(self, dtype):  # pragma: no cover - must NOT be reached
+            calls["to"] = dtype
+            return self
+
+    ctx = _ctx(None)
+    ctx.load(NoLane)
+    assert calls["kwargs"] == [], "an eager-permanent model has no dtype to pass"
+    assert "to" not in calls


### PR DESCRIPTION
pgw#1447: the eager from_pretrained bridge stops contradicting its own contract — ask, do not guess, whether a loader speaks torch_dtype

`ctx.load`'s docstring states the author contract as "No `torch_dtype=` (the
lane contract IS the dtype)" — and twelve lines below it, the eager bridge
passed exactly that to the author's own class.

For a `ModularPipeline` that keyword is not consumed by `from_pretrained`: it
funnels through `**kwargs` into `load_config` and on into the constructor,
where a strict pipeline correctly refuses an argument that is neither a
pipeline argument nor a component. Found by se#780 running the LOCAL
config-only derive on minimax-h3 — the derive binds no streaming engine, so it
takes this bridge:

    lane 'minimax.h3-dit-diffusers@1': load() failed under the trace session:
    TypeError: MiniMaxH3StreamingPipeline: ['torch_dtype'] are neither pipeline
    arguments nor components of this pipeline

WHY THIS IS NOT A SIGNATURE CHECK, which is the obvious fix and does not work.
Measured on the real classes rather than assumed:

    ModularPipeline.from_pretrained        torch_dtype named: False   **kwargs: True
    StableDiffusionXLPipeline.from_pretrained  torch_dtype named: False   **kwargs: True

Both families take `**kwargs` and NEITHER names `torch_dtype`, so
`"torch_dtype" in signature.parameters` is False for both (sdxl would silently
lose its dtype) and `has **kwargs` is True for both (h3 would still break). The
difference is behavioural, not structural: `DiffusionPipeline.from_pretrained`
mentions `torch_dtype` three times in its own source and consumes it;
`ModularPipeline.from_pretrained` mentions it zero times. Behaviour is only
readable by asking, so the bridge asks: pass it, and on a TypeError that NAMES
the rejected keyword, load without it and apply the lane dtype post-load.

THE LANE IS STILL HONOURED. Dropping the dtype on the retry would load a bf16
lane in the checkpoint's own dtype and serve different numerics with nothing
raised — the silent-degradation shape this repo refuses. `.to(dtype)` moves
floating parameters and leaves ints/bools alone, which is what
`from_pretrained(torch_dtype=)` does.

THE RETRY IS NARROW ON PURPOSE. `_rejected_torch_dtype` matches only errors
naming the keyword; a TypeError from inside the author's own `__init__` keeps
propagating, so this cannot convert a real bug into a silent second load.

Tests, with the red arm FORCED rather than assumed: reverting the fix leaves
`test_a_modular_pipeline_that_refuses_torch_dtype_loads_and_is_cast_after`
failing with h3's production error verbatim, while the accepting arm passes in
BOTH states — which is what proves the fix is not a regression for the family
that already worked. 6 passed with the fix, 1 failed / 5 passed without it.

Also protects the local sd/anima derive loop, which takes the same bridge.
