### PR TITLE
pgw#1431 fix (b): `self_loading=` — the v2 successor to v1's Slot(str) escape hatch

### DIFF
--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -219,13 +219,36 @@ def _model_slot(slot: Any) -> Dict[str, Any]:
     """
     from ..serving import model_type
 
+    from ..serving.model import SELF_LOADING_ATTR
+
     model_cls = slot.annotation
     out: Dict[str, Any] = {
         "name": slot.name,
         # `kind` is omitted rather than spelled "model": empty IS model on the
         # hub side (th#2140 5c) and every pre-5c manifest means exactly that.
-        "pipeline_class": _pipeline_class(model_cls),
     }
+    self_loading = str(getattr(model_cls, SELF_LOADING_ATTR, "") or "").strip()
+    readable = _pipeline_class(model_cls)
+    if self_loading:
+        # pgw#1431 fix (b). A marked slot states WHY it has no class instead of
+        # naming one, exactly as `layouts_undeclarable` does one level down for
+        # the bytes. `pipeline_class` and `self_loading` are mutually exclusive
+        # in the manifest: a slot either names its class or says why it has none.
+        if readable:
+            # Both would be true at once, and they contradict. Refuse naming
+            # BOTH sites — otherwise the marker becomes a way to silence a
+            # perfectly readable class, which is the se#757 silent-lie shape
+            # wearing a new hat.
+            raise EntrypointDiscoveryError(
+                f"{model_cls.__qualname__}: declares self_loading= "
+                f"({self_loading!r}) AND its load() calls "
+                f"ctx.load({readable.rsplit('.', 1)[-1]}) — those contradict. "
+                "self_loading= is for a pipeline ctx.load CANNOT drive; drop "
+                "the marker if it can, or drop the ctx.load call if it cannot."
+            )
+        out["self_loading"] = self_loading
+    else:
+        out["pipeline_class"] = readable
     declared = model_type(model_cls)
     family = getattr(declared, "name", "") or ""
     if family:
@@ -465,6 +488,11 @@ def _pipeline_class_or_refuse(rows: List[Dict[str, Any]]) -> None:
     for row in rows:
         for slot in row["slots"]:
             if slot.get("kind") == "adapter" or slot.get("pipeline_class"):
+                continue
+            # pgw#1431 fix (b): a slot that DECLARED why it has no class is
+            # answered, not silent. This is the ArmSelfLoading boundary from
+            # fix (c) becoming the green path — for MARKED slots only.
+            if slot.get("self_loading"):
                 continue
             raise EntrypointDiscoveryError(
                 f"@entrypoint {row['name']!r} slot {slot['name']!r}: could not "

--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -38,6 +38,11 @@ MT = TypeVar("MT")
 MODEL_TYPE_ATTR = "__cozy_model_type__"
 LANES_ATTR = "__cozy_lanes__"
 REQUIRES_ATTR = "__cozy_requires__"
+#: pgw#1431 fix (b). The author's REASON that this model's pipeline has no
+#: class `ctx.load` can drive — the v2 successor to v1's `Slot(str)` escape
+#: hatch, and the pipeline-level twin of `Slot(layouts_undeclarable=)`, which
+#: says the same thing one level down about the BYTES.
+SELF_LOADING_ATTR = "__cozy_self_loading__"
 
 
 class ModelDeclarationError(TypeError):
@@ -360,11 +365,13 @@ class Model(Generic[MT]):
     __cozy_model_type__: ClassVar[Any] = None
     __cozy_lanes__: ClassVar[tuple[Any, ...] | None] = None
     __cozy_requires__: ClassVar[dict[str, Any]] = {}
+    __cozy_self_loading__: ClassVar[str] = ""
 
     def __init_subclass__(
         cls,
         *,
         lanes: tuple[Any, ...] | Mapping[Any, Any] | None = None,
+        self_loading: str | None = None,
         **kwargs: Any,
     ) -> None:
         if "requires" in kwargs:
@@ -376,6 +383,27 @@ class Model(Generic[MT]):
                 "mapping value is the lane's VRAM floor (None/\"\" for none); "
                 "the sm floor is derived from the contract, not written."
             )
+        if self_loading is not None:
+            # pgw#1431 fix (b). A REASON IS MANDATORY, verbatim the rule
+            # `Slot(layouts_undeclarable=)` already enforces one level down: an
+            # escape hatch with no stated reason is the silence the rung exists
+            # to replace, and it is the only thing standing between this marker
+            # and a way to quietly silence a class discovery could have read.
+            if not isinstance(self_loading, str):
+                raise ModelDeclarationError(
+                    f"{cls.__qualname__}: self_loading= must be a string "
+                    f"reason, got {type(self_loading).__name__}"
+                )
+            reason = self_loading.strip()
+            if not reason:
+                raise ModelDeclarationError(
+                    f"{cls.__qualname__}: self_loading= needs a REASON. Say "
+                    "why `ctx.load` cannot drive this pipeline — a bespoke "
+                    "loader, an external server, pipeline code that ships "
+                    "inside the checkpoint. A blank escape is the silence "
+                    "this declaration replaces."
+                )
+            cls.__cozy_self_loading__ = reason
         super().__init_subclass__(**kwargs)
         if Model in cls.__bases__ and _declared_model_type(cls) is None and not any(
             isinstance(parameter, TypeVar)

--- a/tests/test_endpoint_discovery.py
+++ b/tests/test_endpoint_discovery.py
@@ -176,3 +176,132 @@ def test_an_absent_pipeline_class_still_refuses_at_publish() -> None:
 def test_an_adapter_slot_is_still_exempt() -> None:
     rows = [{"name": "generate", "slots": [{"name": "loras", "kind": "adapter"}]}]
     _pipeline_class_or_refuse(rows)  # does not raise
+
+
+# --------------------------------------------------------------------------- #
+# pgw#1431 fix (b): the `self_loading=` marker — the v2 successor to v1's       #
+# `Slot(str)` escape hatch, for pipelines `ctx.load` structurally cannot drive. #
+# --------------------------------------------------------------------------- #
+
+
+from gen_worker.models import Trellis2  # noqa: E402
+from gen_worker.serving.model import Model  # noqa: E402
+
+
+class PlainWithLoad(Model[Trellis2]):
+    """Unmarked, with a readable ctx.load — the control for the marker."""
+
+    def load(self, ctx):  # type: ignore[no-untyped-def]
+        self.pipe = ctx.load(RealPipeline)
+
+
+class MarkedAndReadable(
+    Model[Trellis2],
+    self_loading="claims ctx.load cannot drive it",
+):
+    """Declares the marker AND calls ctx.load — a contradiction, and the thing
+    `_model_slot` must refuse rather than silently prefer one of."""
+
+    def load(self, ctx):  # type: ignore[no-untyped-def]
+        self.pipe = ctx.load(RealPipeline)
+
+
+class _Slot:
+    """Only what `_model_slot` reads off a discovered parameter."""
+
+    def __init__(self, name, annotation):  # type: ignore[no-untyped-def]
+        self.name = name
+        self.annotation = annotation
+
+
+def _marked_model(reason="bespoke pipeline.json loader; ctx.load drives neither path"):  # type: ignore[no-untyped-def]
+    from gen_worker.models import Trellis2
+    from gen_worker.serving.model import Model
+
+    namespace = {"Model": Model, "Trellis2": Trellis2}
+    exec(  # noqa: S102 - the class header IS the thing under test
+        "class Marked(Model[Trellis2], self_loading=%r):\n"
+        "    def load(self, ctx):\n"
+        "        self.pipe = object()\n" % reason,
+        namespace,
+    )
+    return namespace["Marked"]
+
+
+def test_a_marked_slot_states_its_reason_instead_of_a_pipeline_class() -> None:
+    """The two keys are mutually exclusive in the manifest, exactly as
+    `layouts`/`layouts_undeclarable` are one level down: a slot either names
+    its class or says why it has none."""
+    from gen_worker.discovery.entrypoints_v2 import _model_slot
+
+    emitted = _model_slot(_Slot("model", _marked_model()))
+    assert emitted["self_loading"].startswith("bespoke pipeline.json loader")
+    assert "pipeline_class" not in emitted
+
+
+def test_an_unmarked_slot_still_emits_a_pipeline_class() -> None:
+    from gen_worker.discovery.entrypoints_v2 import _model_slot
+
+    emitted = _model_slot(_Slot("model", PlainWithLoad))
+    assert emitted["pipeline_class"].endswith(".RealPipeline")
+    assert "self_loading" not in emitted
+
+
+def test_declaring_the_marker_AND_a_readable_ctx_load_is_a_refusal() -> None:
+    """Both cannot be true at once. Without this refusal the marker is a way to
+    silence a class discovery could have read perfectly well — the se#757
+    silent-lie shape wearing a new hat."""
+    from gen_worker.discovery.entrypoints_v2 import _model_slot
+
+    with pytest.raises(EntrypointDiscoveryError, match="those contradict"):
+        _model_slot(_Slot("model", MarkedAndReadable))
+
+
+def test_a_marked_slot_passes_the_publish_gate_and_an_unmarked_one_does_not() -> None:
+    """The ArmSelfLoading boundary becomes the green path FOR MARKED SLOTS
+    ONLY. Widening the marker must not disarm the gate for everyone else."""
+    from gen_worker.discovery.entrypoints_v2 import _pipeline_class_or_refuse
+
+    marked = [{"name": "generate", "slots": [{"name": "model", "kind": "model", "self_loading": "bespoke loader"}]}]
+    _pipeline_class_or_refuse(marked)  # does not raise
+
+    unmarked = [{"name": "generate", "slots": [{"name": "model", "kind": "model", "pipeline_class": ""}]}]
+    with pytest.raises(EntrypointDiscoveryError, match="could not read the pipeline class"):
+        _pipeline_class_or_refuse(unmarked)
+
+
+def test_the_marker_demands_a_reason() -> None:
+    """Verbatim the rule `Slot(layouts_undeclarable=)` enforces one level down:
+    an escape hatch with no stated reason is the silence the rung replaces."""
+    from gen_worker.models import Trellis2
+    from gen_worker.serving.model import Model, ModelDeclarationError
+
+    namespace = {"Model": Model, "Trellis2": Trellis2}
+    for bad in ("", "   ", 123):
+        with pytest.raises(ModelDeclarationError):
+            exec(  # noqa: S102
+                "class B(Model[Trellis2], self_loading=%r):\n    pass" % (bad,),
+                dict(namespace),
+            )
+
+
+def test_the_marker_is_ORTHOGONAL_to_lanes() -> None:
+    """A self-loading model still has weights, still has a lane, still needs a
+    VRAM floor. `trellis-3d` declares both; coupling them would strand its
+    floor the way pgw#1423 strands hunyuan's."""
+    from tensorfs import contracts
+
+    from gen_worker.models import Trellis2
+    from gen_worker.serving.model import LANES_ATTR, REQUIRES_ATTR, Model
+
+    namespace = {"Model": Model, "Trellis2": Trellis2, "contracts": contracts}
+    exec(  # noqa: S102
+        "class Both(Model[Trellis2],\n"
+        "           lanes={contracts.TRELLIS2_DIT_BF16: 'vram24g'},\n"
+        "           self_loading='bespoke loader'):\n"
+        "    pass",
+        namespace,
+    )
+    both = namespace["Both"]
+    assert [c.stamp for c in getattr(both, LANES_ATTR)] == ["trellis2.dit-bf16@1"]
+    assert "min_vram_gb=24.0" in repr(getattr(both, REQUIRES_ATTR))


### PR DESCRIPTION
pgw#1431 fix (b): `self_loading=` — the v2 successor to v1's `Slot(str)` escape hatch

Authorized by Paul's fix-all order (2026-08-19). Shape derived under
minimum-hand-specification and WRITTEN INTO HUMAN_MUST_DO BEFORE THIS CODE, so
the pgw#1421 server-runtime lane builds against a fixed surface rather than
past it.

WHY THIS SHAPE. `Slot(layouts_undeclarable=)` — A20's third rung — already
exists on both sides for the same question one level down: *the bytes have no
declarable layout*. `self_loading=` is that question one level up: *the
pipeline has no declarable class*. Mirroring it means the hub's tri-state, its
mutual-exclusion rule and its non-empty-reason rule all transfer unchanged, and
the fleet learns one idiom instead of two. It adds ONE field and invents no
vocabulary.

    class Trellis3dModel(Model[Trellis2],
                         lanes={contracts.TRELLIS2_DIT_BF16: "vram24g"},
                         self_loading="bespoke pipeline.json loader; "
                                      "ctx.load drives neither path"):

THE REASON IS MANDATORY, verbatim the rule `layouts_undeclarable=` enforces at
`tensor_layout_contract.py:672`. An escape hatch with no stated reason is the
silence the rung exists to replace, and it is the only thing standing between
this marker and a way to quietly silence a class discovery could have read.

ORTHOGONAL TO `lanes=`, and that is load-bearing rather than incidental. A
self-loading model still has weights, still has a lane, still needs its VRAM
floor — `trellis-3d` declares BOTH. Coupling them would strand its floor the
way pgw#1423 strands hunyuan's, which is a defect this lane is already holding
an issue open about.

DISCOVERY. `_model_slot` emits `self_loading` and OMITS `pipeline_class` — the
two are mutually exclusive in the manifest, exactly as `layouts` and
`layouts_undeclarable` are. `_pipeline_class_or_refuse` admits a marked slot:
this is the `ArmSelfLoading` boundary from fix (c) becoming the green path, FOR
MARKED SLOTS ONLY.

AND IT REFUSES THE CONTRADICTION. A class declaring `self_loading=` whose
`load()` also contains a readable `ctx.load(<Name>)` is stating two
incompatible things; discovery refuses naming both sites. Without that, the
marker is a way to silence a perfectly readable class — the se#757 silent-lie
shape wearing a new hat, which is precisely what fix (c)'s boundary test was
protecting against.

RED/GREEN VERIFIED, each arm against the defect it exists to catch:
  * disarm the contradiction check  -> the contradiction test fails, alone;
  * let the publish gate skip EVERY slot rather than marked ones -> TWO tests
    fail, including fix (c)'s original `..._still_refuses_at_publish`, proving
    the gate stays armed for everyone else;
  * both restored green.
The first red attempt cut the file syntactically and failed at COLLECTION,
which proves nothing about behaviour — redone as a condition flip so the
failure is the assertion, not the parser.

180 passed / 1 skipped across the discovery, staffing, weightless, producer,
model-defaults and lane-contract suites. `test_model_authoring` and
`test_serving_adopt_first` are unchanged against master (no local torch) —
diffed rather than assumed.

The hub half is the same change in `tensorhub/internal/builder/manifest_contract.go`,
where `pipeline_class is required` (`:565-566`) must learn the marker. It rides
separately because it is a different repo, not because it is optional.