### PR TITLE
pgw#1447 second site: the DERIVE has its own eager bridge, and fixing only the serve-path copy left it broken

### DIFF
--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -19,6 +19,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from ..serving.context import _rejected_torch_dtype
+
 class TraceLoadContext:
     """What ``Model.load`` sees under ``gen-worker release derive``.
 
@@ -67,9 +69,24 @@ class TraceLoadContext:
                 f"ctx.load() needs a loader with from_pretrained "
                 f"(a diffusers/transformers class); got {loader!r}"
             )
-        loaded = from_pretrained(
-            self.checkpoint_dir, torch_dtype=getattr(self.lane, "dtype", None)
-        )
+        # pgw#1447, SECOND SITE. This is a separate implementation of the same
+        # eager bridge `serving/context.py` carries, and it had the identical
+        # defect: a `ModularPipeline` does not consume `torch_dtype` in
+        # `from_pretrained`, so `**kwargs` funnels it into the constructor and
+        # a strict pipeline refuses it. Fixing only the serve-path copy left
+        # the DERIVE — the one path that ALWAYS takes an eager bridge, because
+        # a trace has no streaming engine — still broken. Two bridges, one
+        # contract; the predicate is shared so they cannot drift.
+        dtype = getattr(self.lane, "dtype", None)
+        try:
+            loaded = from_pretrained(self.checkpoint_dir, torch_dtype=dtype)
+        except TypeError as exc:
+            if not _rejected_torch_dtype(exc):
+                raise
+            loaded = from_pretrained(self.checkpoint_dir)
+            to = getattr(loaded, "to", None)
+            if dtype is not None and callable(to):
+                to(dtype)
         # Adapter application mutates WEIGHTS (or injects adapter layers);
         # at trace every parameter is fake and no adapter bytes exist, so the
         # enumeration's fake-adapter arms must not hit real LoRA I/O. The

--- a/tests/test_eager_bridge_dtype_pgw1447.py
+++ b/tests/test_eager_bridge_dtype_pgw1447.py
@@ -171,3 +171,43 @@ def test_a_model_with_no_lane_never_mentions_dtype_at_all():
     ctx.load(NoLane)
     assert calls["kwargs"] == [], "an eager-permanent model has no dtype to pass"
     assert "to" not in calls
+
+
+# --------------------------------------------------------------------------
+# SECOND SITE — the DERIVE's own bridge (release/trace_context.py).
+#
+# Fixing only the serve-path copy left the derive broken, and the derive is the
+# one path that ALWAYS takes an eager bridge (a trace binds no streaming
+# engine). Two implementations of one contract; both are asserted here so they
+# cannot drift apart again.
+
+
+def test_the_derive_bridge_also_survives_a_loader_that_refuses_torch_dtype():
+    from gen_worker.release.trace_context import TraceLoadContext
+
+    calls = {"attempts": []}
+
+    class RefusesLikeModularPipeline:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            calls["attempts"].append(sorted(kwargs))
+            if "torch_dtype" in kwargs:
+                raise TypeError(
+                    "MiniMaxH3StreamingPipeline: ['torch_dtype'] are neither "
+                    "pipeline arguments nor components of this pipeline"
+                )
+            return cls()
+
+        def to(self, dtype):
+            calls["to"] = dtype
+            return self
+
+    ctx = TraceLoadContext(
+        checkpoint_dir=Path("/nonexistent/fixture"),
+        lane=_Lane("bfloat16"),
+    )
+    got = ctx.load(RefusesLikeModularPipeline)
+
+    assert isinstance(got, RefusesLikeModularPipeline)
+    assert calls["attempts"] == [["torch_dtype"], []]
+    assert calls["to"] == "bfloat16", "the derive must honour the lane dtype too"


### PR DESCRIPTION
pgw#1447 second site: the DERIVE has its own eager bridge, and fixing only the serve-path copy left it broken

`release/trace_context.py:TraceLoadContext.load` is a SEPARATE implementation of
the same eager `from_pretrained` bridge, with the identical defect — it passed
`torch_dtype=` unconditionally. The first commit fixed
`serving/context.py` and the derive still died on exactly the same error,
because it never goes through the serve path.

That is the sharper form of the lesson: the derive is the ONE path that ALWAYS
takes an eager bridge, since a trace binds no streaming engine. A bridge fix
that skips it fixes the case that rarely runs and misses the case that always
does.

Both sites now share `_rejected_torch_dtype`, so they cannot drift apart again,
and both are asserted in tests.

MEASURED ON THE REAL ENDPOINT, not just in a unit: with both sites fixed, the
minimax-h3 config-only derive gets PAST load for the first time. It now reaches
the next layer and fails there instead:

    minimax-h3 serve recipe: no DiT resolves on this pipeline -- arming nothing
    derive error: lane 'minimax.h3-dit-diffusers@1': load() marked nothing via
    ctx.compile()

which is a different, deeper finding (se#766's ModularPipeline component-
attachment seam under a hollow session) and is filed separately rather than
papered over here.

Import-cycle guard (tests/test_import_cycles_pgw981.py) green with the new
cross-package import; 7 tests pass in this file.
