### PR TITLE
pgw#1418 + pgw#1425: the ten orphaned serve-path wires — nine reconnected, two sentenced

### DIFF
--- a/changelog.d/pgw1418-1425-serve-wires.md
+++ b/changelog.d/pgw1418-1425-serve-wires.md
@@ -22,3 +22,8 @@
   `models.memory.report_unevidenced_serving_facts` both collapse catalog-stamped serving facts, and
   pgw#1373 deleted the catalog). The baseline shrinks instead of accreting, which is the half of
   pgw#1425 that is about the instrument rather than the wires.
+- **Found by RUNNING the suite, not by reading it: unresolvable type hints emitted an EMPTY
+  moderation block.** The v1 collector swallowed a `get_type_hints` failure and fell back to
+  `__annotations__`, which under `from __future__ import annotations` — every endpoint module in
+  this repo — is a dict of STRINGS the walk skips. No media, no prompts, no error: the pgw#1418
+  silence one layer down. It now refuses, naming the struct.

--- a/changelog.d/pgw1418-1425-serve-wires.md
+++ b/changelog.d/pgw1418-1425-serve-wires.md
@@ -1,0 +1,24 @@
+- **The v2 serve path calls `materialize_input_assets` again, and the SDK emits the `moderation`
+  block again (pgw#1418).** `cd46c957` deleted `executor.py` entire and the rewrite never re-wired
+  either half, so every `@entrypoint` taking an `ImageAsset`/`VideoAsset`/`AudioAsset` failed
+  `asset not materialized` — measured on a rented route-2 pod, 3 of `dj-utils`' 4 functions and
+  ALL THREE of `music-analysis`'. Materialization now runs at the payload seam in
+  `ServeLoop.invoke`, after decode and before any lease, and `discovery.moderation` re-derives the
+  hub's `{prompts, media}` field paths from the payload type. The prompt half went with it, which
+  was the safety-relevant half nobody had assessed.
+- **`receipts.gate_delivered_artifact` fails CLOSED (pgw#1425, security).** It returned `True` when
+  nobody had configured it, and the v2 serve path configured nobody — so every fleet worker armed
+  hub-delivered native code with no receipt verified at all. Three explicit postures now: `armed`
+  (`configure` at HelloAck), `local` (`trust_local_store(reason)`, for cozy-local/CLI/rigs), and the
+  DEFAULT `unset`, which refuses with the typed `gate_unconfigured` event and falls through to
+  self-mint. `configure("")` raises instead of returning silently.
+- **Eight more orphaned wires reconnected.** Per-request capability renewal, the `StageTimer`
+  handler span and its `stage_ms` on `JobResult.metrics`, `postmortem.current_inflight_request` on
+  the `aot_ingress_refused` event, four `boot_phases.mark_once` milestones (`sdk_ready`, `hello`,
+  `first_request_servable`, `eager_ready`), `process_role.declare`/`emit_boot_role` at the transport
+  bind, C2PA remote signing at HelloAck, and the `ServePosture` scheduler message.
+- **Fifteen rows leave `unreached_surface_baseline.txt`** — thirteen by acquiring a production
+  caller, two DELETED with the ruling that kills them (`serving_facts.facts_or_degrade` and
+  `models.memory.report_unevidenced_serving_facts` both collapse catalog-stamped serving facts, and
+  pgw#1373 deleted the catalog). The baseline shrinks instead of accreting, which is the half of
+  pgw#1425 that is about the instrument rather than the wires.

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -366,12 +366,10 @@ gen_worker.artifact_meta.compiled_graph_metadata_fields()
 gen_worker.artifact_meta.try_read_metadata()
 gen_worker.boot_phases.BootCompleteness.explain()
 gen_worker.boot_phases.completeness()
-gen_worker.boot_phases.mark_once()
 gen_worker.boot_phases.render_phase_table()
 gen_worker.boot_stages.emit()
 gen_worker.capability.HardwareUnmetError.axes()
 gen_worker.capability.InsufficientDiskError.axes()
-gen_worker.capability_renewal.renew_capability_while_running()
 gen_worker.cli.args.build_payload()
 gen_worker.cli.protocol.gen_worker_version()
 gen_worker.cli.sockaddr.cleanup_listener()
@@ -379,7 +377,6 @@ gen_worker.cli.sockaddr.create_client()
 gen_worker.cli.sockaddr.create_listener()
 gen_worker.cli.sockaddr.display()
 gen_worker.compile_posture.install()
-gen_worker.content_credentials.configure_remote_signer()
 gen_worker.cuda_root.torch_cuda_home()
 gen_worker.dispatch.AdapterOrder
 gen_worker.dispatch.order_from_binding()
@@ -387,7 +384,6 @@ gen_worker.env_seal.assert_seal_unchanged()  # pgw#1373: its caller was the v1 e
 gen_worker.families.base.register_family()
 gen_worker.file_hash.sha256_file()
 gen_worker.graph_facts.subject_digest()
-gen_worker.input_assets.materialize_input_assets()
 gen_worker.models.attention_modes.most_sparse_mode()
 gen_worker.models.execution_lanes.ExecutionLaneUnavailableError
 gen_worker.models.execution_lanes.execution_lane_body_of_binding()
@@ -400,7 +396,6 @@ gen_worker.models.machine_fit.lane_candidates()
 gen_worker.models.memory.cuda_allocated_bytes()
 gen_worker.models.memory.rearm_offload()
 gen_worker.models.memory.release_unused_pinned_host_cache()
-gen_worker.models.memory.report_unevidenced_serving_facts()
 gen_worker.models.pinned_swap.prestage_module()
 gen_worker.models.provision.AppliedAttentionScope
 gen_worker.models.provision.AppliedLaneScope
@@ -421,21 +416,45 @@ gen_worker.models.tensor_layout_contract.normalize_layout_undeclarable()
 gen_worker.models.traceability.untraceable_reason()
 gen_worker.numerics_ladder.compare_outputs()
 gen_worker.numerics_ladder.declared_thresholds()
-gen_worker.postmortem.current_inflight_request()
-gen_worker.process_role.declare()
-gen_worker.process_role.emit_boot_role()
-gen_worker.receipts.configure()
 gen_worker.request_context.JobContext.metric()
 gen_worker.request_context._PublisherMixin.materialize_blob()
 gen_worker.request_context._PublisherMixin.resolve_dataset()
-gen_worker.serve_posture.apply_command()
-gen_worker.serving_facts.facts_or_degrade()
-gen_worker.stage_timing.StageTimer.handler_close()
-gen_worker.stage_timing.StageTimer.handler_open()
-gen_worker.stage_timing.StageTimer.record_pre()
-gen_worker.stage_timing.stage_ms_for_metrics()
 gen_worker.topology.device_group_scope
 gen_worker.topology.pin_cuda_device_for_group()
 gen_worker.warm_spans.WarmLedger
 gen_worker.wire_snapshots.index_snapshots()
 gen_worker.worker_fatal.report_worker_error_async()
+
+# pgw#1425 — THIRTEEN ROWS WIRED AND TWO SENTENCED, 2026-08-18. All fifteen were
+# appended wholesale by pgw#1373's `--write-baseline` (722e30b9, +79 rows) when
+# `cd46c957` deleted `executor.py` and took every caller with it. That
+# regeneration is what made pgw#1418 cost a rented pod to rediscover: the guard
+# had already computed the answer.
+#
+# WIRED into the v2 serve path (`worker.py` / `serving/serve_loop.py` /
+# `aot_serve.py`), so they leave this file by acquiring a production caller:
+#   input_assets.materialize_input_assets — the payload seam, before the leases
+#   stage_timing.{handler_open,handler_close,record_pre,stage_ms_for_metrics}
+#   capability_renewal.renew_capability_while_running — per-job renewal task
+#   postmortem.current_inflight_request — names the request on `aot_ingress_refused`
+#   boot_phases.mark_once — sdk_ready / hello / first_request_servable / eager_ready
+#   process_role.{declare,emit_boot_role} — at the transport bind
+#   receipts.configure + content_credentials.configure_remote_signer — at HelloAck
+#   serve_posture.apply_command — the ServePosture SchedulerMessage arm
+#
+# SENTENCED, with the ruling that kills them, because a row removed without a
+# reason is the silence this issue exists to reverse:
+#   serving_facts.facts_or_degrade
+#   models.memory.report_unevidenced_serving_facts
+# Both collapse a `SlotEvidence`, whose ONLY producer is
+# `dispatch.order_from_binding`, which reads `objective`/`distilled`/
+# `distilled_status` off a CATALOG-stamped `ModelBinding`. pgw#1373 DELETED the
+# catalog/declaration architecture under Paul's hardcut mandate, so there is no
+# stamp to read and `@entrypoint` declares no serving contract to check one
+# against — producer and consumer both gone, in one ruling. The v2 successor for
+# "this instance is serving degraded, and every request it serves says so" is
+# `serving/placement.warn_if_degraded`, taken at residency-admit and stained onto
+# every request through `ctx.warn` (`serve_loop._InstanceBackend.load`). The dead
+# chain itself (`dispatch.order_from_binding` -> `SlotEvidence` ->
+# `measured_posture.REASON_SERVING_FACTS_UNEVIDENCED`) is a DELETE that belongs
+# with pgw#1425's remaining-69 triage, not smuggled into the P0 lane.

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -46,6 +46,7 @@ from . import activity as activity_mod
 from . import aot_constants
 from . import aot_identity
 from . import local_compiled_graph_store
+from . import postmortem
 from .compiled_graph_adopt import AdoptOutcome
 from . import serve_posture
 from . import shape_growth
@@ -1341,9 +1342,19 @@ def wrap_module(
                 "aot-serve: %s REFUSED input outside the declared envelope (%s: %s); "
                 "serving this request eager, artifact stays armed",
                 label, exc.reason, exc)
+            # pgw#1425: NAME THE REQUEST. pgw#1414 stamps an in-flight marker
+            # around tenant execution and nothing read it, so this event — the
+            # one that says an armed compiled lane served a request eager —
+            # named a family and a target and no request at all, which is
+            # precisely the row an operator needs to subtract from the compiled
+            # measurement. '' when nothing is in flight (a boot-time refusal),
+            # and the word `<none>` rather than an empty tail, so an absent
+            # attribution reads as an answer instead of a truncation.
+            inflight = postmortem.current_inflight_request()
             activity_mod.emit_event(
                 "aot_ingress_refused",
-                f"family={meta.get('family')} target={label}: {exc}",
+                f"family={meta.get('family')} target={label} "
+                f"request={inflight or '<none>'}: {exc}",
                 phase=exc.reason,
             )
             report_ingress_refusal(state, exc.reason, str(exc))

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -53,6 +53,7 @@ import pkgutil
 import textwrap
 from typing import Any, Dict, List, Set
 
+from .moderation import payload_moderation
 from .schema import type_schema_and_hash
 
 #: The DEFAULT kind: an entrypoint that declares nothing is an inference
@@ -412,6 +413,7 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
     row_kind = getattr(spec, "kind", "") or ENTRYPOINT_KIND
     input_schema, input_sha = type_schema_and_hash(spec.payload_type)
     output_schema, output_sha = type_schema_and_hash(spec.return_type)
+    moderation = payload_moderation(spec.payload_type)
     slots: List[Dict[str, Any]] = []
     for slot in spec.slots:
         slots.append(_model_slot(slot) if slot.kind == "model" else _adapter_slot(slot))
@@ -436,6 +438,14 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         # A v2 entrypoint returns one struct; streaming is not part of the
         # ratified surface, so the cardinality fact is stated, never omitted.
         "incremental_output": False,
+        # pgw#1418: WHICH payload paths are media, and which are prompts. The
+        # hub decodes exactly this key to recognize typed media inputs — it
+        # deliberately will not sniff URL-shaped strings — so without it no
+        # `@entrypoint` taking an Image/Video/AudioAsset can be served, and
+        # every prompt-moderation declaration is silently absent. Emitted only
+        # when the payload declares one, so a text-only row stays byte
+        # identical.
+        **({"moderation": moderation} if moderation else {}),
         "slots": slots,
         # `None` is ABSENT (no model slot, no `resources=`); a dict is
         # PRESENT, and a present-but-empty block is the hub's explicit CPU

--- a/src/gen_worker/discovery/moderation.py
+++ b/src/gen_worker/discovery/moderation.py
@@ -55,6 +55,29 @@ def _media_kind(t: type) -> str:
     return "media"
 
 
+
+def _hints_or_refuse(struct: type, path: str) -> Any:
+    """Resolved type hints, or a BUILD ERROR naming the struct.
+
+    The v1 collector swallowed a resolution failure and fell back to
+    ``__annotations__`` — which, under ``from __future__ import annotations``
+    (every endpoint module in this repo), is a dict of STRINGS. A string is not
+    a type, so the walk below skips it and the function emits an EMPTY
+    moderation block: no media, no prompts, no error, and an endpoint that
+    cannot serve an asset. That is the exact silence pgw#1418 cost a rented pod
+    to find, one layer down. Refuse instead.
+    """
+    try:
+        return typing.get_type_hints(struct, include_extras=True)
+    except Exception as exc:
+        raise ValueError(
+            f"{path or struct.__name__}: cannot resolve the type hints of "
+            f"{struct.__name__} ({type(exc).__name__}: {exc}) — the moderation "
+            f"block would be silently EMPTY, and an endpoint with no declared "
+            f"media inputs cannot be served one"
+        ) from exc
+
+
 def _annotation_carries_asset(ann: Any, _seen: Optional[Set[type]] = None) -> bool:
     """True when the annotation subtree can hold an input ``Asset``."""
     seen = _seen if _seen is not None else set()
@@ -83,10 +106,7 @@ def _annotation_carries_asset(ann: Any, _seen: Optional[Set[type]] = None) -> bo
             if ann in seen:
                 return False
             seen.add(ann)
-            try:
-                hints = typing.get_type_hints(ann, include_extras=True)
-            except Exception:
-                hints = getattr(ann, "__annotations__", {})
+            hints = _hints_or_refuse(ann, ann.__name__)
             return any(
                 _annotation_carries_asset(hints[field], seen)
                 for field in getattr(ann, "__struct_fields__", ()) or ()
@@ -169,10 +189,7 @@ def payload_moderation(payload_type: type) -> Dict[str, List[Dict[str, str]]]:
                 if ann in seen_structs:
                     return
                 seen_structs.add(ann)
-                try:
-                    hints = typing.get_type_hints(ann, include_extras=True)
-                except Exception:
-                    hints = getattr(ann, "__annotations__", {})
+                hints = _hints_or_refuse(ann, path)
                 for field in getattr(ann, "__struct_fields__", ()) or ():
                     if field in hints:
                         walk(hints[field], f"{path}.{field}" if path else field)

--- a/src/gen_worker/discovery/moderation.py
+++ b/src/gen_worker/discovery/moderation.py
@@ -1,0 +1,185 @@
+"""The ``moderation`` manifest block: which payload paths are MEDIA, and
+which are PROMPTS (pgw#1418).
+
+The hub will not guess. ``inputassets``' package doc opens by refusing to treat
+arbitrary string fields as media URLs, so the ONLY way it learns that
+``extract_frame(payload.video)`` is a video is this block — decoded at
+``release/resolver.go`` into ``PayloadModerationMetadata`` and read by
+``input_asset_validation.go`` to build the stored-input manifest, and by the
+prompt-moderation pipeline for the ``prompts`` half.
+
+pgw#1373 deleted the v1 collector with the rest of ``discover.py``'s endpoint
+walk and the v2 row never grew a replacement, so every v2 release shipped a
+manifest with no ``moderation`` key at all: no typed media inputs, and no
+prompt-moderation field declarations either — the safety half nobody noticed.
+
+The path grammar is the hub's (``internal/jsonschema.NodeAtPath``): dotted
+segments, ``[]`` for array items, ``*`` for an open mapping's values. Paths are
+BARE (``video``, ``slots[].prompt``), rooted at the payload struct, because
+that is what ``validateModerationSchemaPath`` navigates the input schema with —
+and the hub REFUSES a path that does not resolve, so a wrong spelling here
+fails the publish rather than degrading quietly.
+"""
+
+from __future__ import annotations
+
+import types as py_types
+import typing
+from typing import Any, Dict, List, Optional, Set
+
+import msgspec
+
+from ..api.types import (
+    Asset,
+    AudioAsset,
+    ImageAsset,
+    PromptRole,
+    Tensors,
+    VideoAsset,
+)
+
+
+def _is_msgspec_struct(t: Any) -> bool:
+    return isinstance(t, type) and issubclass(t, msgspec.Struct)
+
+
+def _media_kind(t: type) -> str:
+    """The hub's four-value ``kind`` vocabulary. A bare ``Asset``/``MediaAsset``
+    is ``media`` — the widest of the four, never a guess at a narrower one."""
+    if issubclass(t, ImageAsset):
+        return "image"
+    if issubclass(t, VideoAsset):
+        return "video"
+    if issubclass(t, AudioAsset):
+        return "audio"
+    return "media"
+
+
+def _annotation_carries_asset(ann: Any, _seen: Optional[Set[type]] = None) -> bool:
+    """True when the annotation subtree can hold an input ``Asset``."""
+    seen = _seen if _seen is not None else set()
+    origin = typing.get_origin(ann)
+    if origin is typing.Annotated:
+        args = typing.get_args(ann)
+        return bool(args) and _annotation_carries_asset(args[0], seen)
+    if origin in (typing.Union, py_types.UnionType):
+        return any(
+            _annotation_carries_asset(arg, seen)
+            for arg in typing.get_args(ann)
+            if arg is not type(None)
+        )
+    if origin in (list, tuple, set, frozenset):
+        args = typing.get_args(ann)
+        return bool(args) and _annotation_carries_asset(args[0], seen)
+    if origin is dict:
+        args = typing.get_args(ann)
+        return len(args) == 2 and _annotation_carries_asset(args[1], seen)
+    if isinstance(ann, type):
+        if issubclass(ann, Asset):
+            return True
+        if issubclass(ann, Tensors):
+            return False
+        if _is_msgspec_struct(ann):
+            if ann in seen:
+                return False
+            seen.add(ann)
+            try:
+                hints = typing.get_type_hints(ann, include_extras=True)
+            except Exception:
+                hints = getattr(ann, "__annotations__", {})
+            return any(
+                _annotation_carries_asset(hints[field], seen)
+                for field in getattr(ann, "__struct_fields__", ()) or ()
+                if field in hints
+            )
+    return False
+
+
+def payload_moderation(payload_type: type) -> Dict[str, List[Dict[str, str]]]:
+    """``{"prompts": [...], "media": [...]}`` for one entrypoint's payload —
+    keys omitted when empty, so a payload with neither emits ``{}`` and the
+    caller omits the block entirely.
+
+    Two shapes are BUILD ERRORS rather than silent omissions, both because the
+    input-asset manifest is ORDERED and an unordered container has no stable
+    occurrence order to match it against.
+    """
+    out: Dict[str, List[Dict[str, str]]] = {"prompts": [], "media": []}
+    seen_structs: Set[type] = set()
+
+    def walk(ann: Any, path: str) -> None:
+        origin = typing.get_origin(ann)
+
+        if origin is typing.Annotated:
+            args = typing.get_args(ann)
+            if not args:
+                return
+            base = args[0]
+            roles = [m for m in args[1:] if isinstance(m, PromptRole)]
+            if roles:
+                if base is not str:
+                    raise ValueError(
+                        f"{path}: PromptRole markers must annotate str fields"
+                    )
+                out["prompts"].append({"field": path, "role": roles[-1].role})
+                return
+            walk(base, path)
+            return
+
+        if origin in (typing.Union, py_types.UnionType):
+            for arg in typing.get_args(ann):
+                if arg is not type(None):
+                    walk(arg, path)
+            return
+
+        if origin in (set, frozenset):
+            args = typing.get_args(ann)
+            if args and _annotation_carries_asset(args[0]):
+                raise ValueError(
+                    f"{path}: Asset fields cannot ride unordered set/frozenset "
+                    "containers; use list or tuple"
+                )
+            if args:
+                walk(args[0], f"{path}[]")
+            return
+
+        if origin in (list, tuple):
+            args = typing.get_args(ann)
+            if args:
+                walk(args[0], f"{path}[]")
+            return
+
+        if origin is dict:
+            args = typing.get_args(ann)
+            if len(args) == 2:
+                if args[0] is not str and _annotation_carries_asset(args[1]):
+                    raise ValueError(
+                        f"{path}: Asset-bearing mappings require string keys"
+                    )
+                walk(args[1], f"{path}.*")
+            return
+
+        if isinstance(ann, type):
+            if issubclass(ann, Tensors):
+                return
+            if issubclass(ann, Asset):
+                out["media"].append({"field": path, "kind": _media_kind(ann)})
+                return
+            if _is_msgspec_struct(ann):
+                if ann in seen_structs:
+                    return
+                seen_structs.add(ann)
+                try:
+                    hints = typing.get_type_hints(ann, include_extras=True)
+                except Exception:
+                    hints = getattr(ann, "__annotations__", {})
+                for field in getattr(ann, "__struct_fields__", ()) or ():
+                    if field in hints:
+                        walk(hints[field], f"{path}.{field}" if path else field)
+                seen_structs.discard(ann)
+
+    walk(payload_type, "")
+    return {k: v for k, v in out.items() if v}
+
+
+__all__ = ["payload_moderation"]

--- a/src/gen_worker/measured_posture.py
+++ b/src/gen_worker/measured_posture.py
@@ -168,7 +168,8 @@ REASON_BELOW_DECLARED_MINIMUM = "below_declared_minimum"
 # and at request time; this reader is a version-skew backstop, and a backstop
 # that fatals turns a hub-side stamping gap into a customer-visible outage —
 # which is exactly what it did to sd15 and anima on 0.120.0.
-# Doubles as the `serve_degrade` phase token (`memory.UNEVIDENCED_FACTS_PHASE`).
+# pgw#1425: its one reader (`memory.UNEVIDENCED_FACTS_PHASE`) went with the
+# catalog pgw#1373 deleted. Kept as the wire vocabulary's token, unused.
 REASON_SERVING_FACTS_UNEVIDENCED = "serving_facts_unevidenced"
 
 #: Shortfall resources.

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -1437,11 +1437,6 @@ OFFLOAD_ENGAGED_PHASE = "cpu_offload_engaged"
 #: so the reason has one spelling on both carriers.
 UNDER_MINIMUM_PHASE = posture_mod.REASON_BELOW_DECLARED_MINIMUM
 
-#: pgw#1339: the invoked function declares a serving contract and the resolved
-#: checkpoint carries no evidence on a declared axis. Same confession home,
-#: its own phase token, for the same reason as the line above.
-UNEVIDENCED_FACTS_PHASE = posture_mod.REASON_SERVING_FACTS_UNEVIDENCED
-
 
 def _confess_serve_degrade(
     *, phase: str, line: str, detail: str, log: logging.Logger,
@@ -1504,66 +1499,14 @@ def report_under_minimum(
     return head
 
 
-def report_unevidenced_serving_facts(
-    axes: "Sequence[str]",
-    *,
-    slot: str,
-    scope: str,
-    declared: str,
-    gap: str = "",
-    logger: Optional[logging.Logger] = None,
-) -> str:
-    """A DECLARED serving contract could not be checked, and we serve anyway.
-
-    pgw#1339 / th#2099. Returns the warning text (so a caller may also put it
-    on `ServePlan.warning`), having already emitted the typed event — one
-    derivation, two carriers, exactly as `report_under_minimum` does.
-
-    ``gap`` is the wire-gap sentence from `serving_facts.facts_or_degrade`
-    when NOBODY stamped the facts; empty when the catalog answered and simply
-    had nothing. The two are different jobs for different people, so the
-    confession says which one this is rather than flattening both into
-    "unevidenced".
-
-    The suggestion is aimed at the CATALOG, not at a card: no GPU can supply a
-    training objective, and th#1867's rule against the worker guessing on the
-    hub's behalf applies to this axis too. What would be better here is a
-    classified checkpoint, and only the hub can make one.
-    """
-    named = tuple(str(a) for a in axes if str(a))
-    if not named:
-        return ""
-    # WHAT WOULD BE BETTER, aimed at whoever can actually close THIS gap —
-    # they are different people. A wire gap is ours to fix in the sender; an
-    # unclassified checkpoint is a catalog job. One suggestion for both would
-    # send half of every report to the wrong team.
-    better = (
-        "stamp the serving facts on the binding this pod was sent"
-        if gap else
-        "classify this checkpoint in the hub catalog"
-    )
-    head = (
-        f"serving {scope} with an UNCHECKED serving contract: slot {slot!r} "
-        f"carries no evidence for the declared {', '.join(named)} "
-        f"({declared}). "
-        + (f"{gap} " if gap else
-           "The catalog answered and had nothing to say on "
-           f"{'this axis' if len(named) == 1 else 'these axes'}. ")
-        + "The request still serves — this is a diagnostic, not a gate. "
-        f"WHAT WOULD BE BETTER: {better}, so the declared contract can "
-        "actually be checked; until then the hub's own deploy-time and "
-        "request-time gates are the only ones enforcing it."
-    )
-    _confess_serve_degrade(
-        phase=UNEVIDENCED_FACTS_PHASE,
-        line=transition_line(
-            event="planned", phase="serving_contract",
-            from_rung="declared_contract", to_rung="unchecked", detail=head,
-        ),
-        detail=head,
-        log=logger or _LOG,
-    )
-    return head
+# pgw#1425: `report_unevidenced_serving_facts` is DELETED, not baselined.
+# It confessed that a DECLARED serving contract could not be checked against a
+# checkpoint's stamped facts. pgw#1373 deleted the catalog/declaration
+# architecture under Paul's hardcut mandate, so nothing stamps those facts and
+# `@entrypoint` declares no serving contract to check them against — the
+# question this answered no longer exists. The v2 degrade channel is
+# `serving/placement.warn_if_degraded`, taken at residency-admit and stained
+# onto every request the instance serves.
 
 
 def _report_offload_engaged(

--- a/src/gen_worker/receipts.py
+++ b/src/gen_worker/receipts.py
@@ -31,10 +31,12 @@ REFUSED rather than compared against nothing. There is no bare-hex
 publishes a replacement whose receipt is sha256-bound — the designed miss
 policy, not a new failure.
 
-Configuration happens at the HelloAck site in ``lifecycle`` (the same
-moment ``file_base_url`` arrives). cozy-local and the CLI never configure
-this module, so the gate is a no-op there — user-controlled stores keep
-their local trust model.
+Configuration happens at the HelloAck site in :mod:`gen_worker.worker` (the
+same moment ``file_base_url`` arrives). cozy-local and the CLI call
+``trust_local_store(reason)`` instead — user-controlled stores keep their
+local trust model, but they must SAY SO. A process that says neither refuses:
+pgw#1425 measured the alternative, where the v2 serve path called neither and
+every fleet worker armed hub-delivered native code with nothing checked.
 """
 
 from __future__ import annotations
@@ -153,19 +155,74 @@ class _Config:
 
 _LOCK = threading.Lock()
 _CONFIG: Optional[_Config] = None
+#: Why this process is allowed to arm UNVERIFIED bytes. Empty = nobody said.
+_LOCAL_TRUST: str = ""
+
+#: The three postures. There is no fourth, and no default that means "probably
+#: fine": pgw#1425 measured what the missing one cost. `UNSET` is what a fleet
+#: worker holds until its HelloAck arrives, and it REFUSES — the gate cannot
+#: tell "nobody wired me" from "there is no hub here" by itself, so somebody
+#: has to say which, and the side that says nothing gets the safe answer.
+POSTURE_ARMED = "armed"
+POSTURE_LOCAL = "local"
+POSTURE_UNSET = "unset"
 
 
 def configure(base_url: str, worker_jwt: Callable[[], str]) -> None:
-    """Arm the receipt gate. Called from the HelloAck site; idempotent
-    (re-configuration replaces the base URL and drops the JWKS cache so a
-    hub bounce with rotated keys re-fetches)."""
-    global _CONFIG
+    """Arm the receipt gate against the hub. Called from the HelloAck site;
+    idempotent (re-configuration replaces the base URL and drops the JWKS
+    cache so a hub bounce with rotated keys re-fetches).
+
+    An empty ``base_url`` RAISES. It used to return silently, which made a
+    HelloAck carrying no file API indistinguishable from one that was never
+    delivered — both left the gate unarmed and said nothing.
+    """
+    global _CONFIG, _LOCAL_TRUST
     base = str(base_url or "").strip().rstrip("/")
     if not base:
-        return
+        raise ReceiptError(
+            "gate_unconfigurable",
+            "receipts.configure() was given no base URL; a hub session that "
+            "names no file API cannot arm the receipt gate, and pretending it "
+            "did is how the gate came to be silently open")
     with _LOCK:
         _CONFIG = _Config(base_url=base, worker_jwt=worker_jwt)
+        _LOCAL_TRUST = ""
     logger.info("receipts: gate configured against %s", base)
+
+
+def trust_local_store(reason: str) -> None:
+    """Declare that this process's compiled-graph store is USER-CONTROLLED,
+    so hub-signed receipts do not apply to it.
+
+    The cozy-local / CLI / unit-rig half of the posture, and the ONLY thing
+    that turns the unconfigured gate from a refusal into a pass. It takes a
+    ``reason`` because the whole defect this replaces was an unattributed
+    silence: an operator reading a pod that armed unverified bytes must be
+    able to see WHO said that was allowed.
+    """
+    global _LOCAL_TRUST, _CONFIG
+    why = str(reason or "").strip()
+    if not why:
+        raise ReceiptError(
+            "local_trust_unattributed",
+            "trust_local_store() needs a reason — an anonymous decision to arm "
+            "unverified compiled graphs is the fail-open this parameter exists "
+            "to abolish")
+    with _LOCK:
+        _LOCAL_TRUST = why
+        _CONFIG = None
+    logger.warning(
+        "receipts: gate DISARMED for a user-controlled store (%s) — delivered "
+        "artifacts are armed without a hub-signed receipt here", why)
+
+
+def posture() -> str:
+    """:data:`POSTURE_ARMED` / :data:`POSTURE_LOCAL` / :data:`POSTURE_UNSET`."""
+    with _LOCK:
+        if _CONFIG is not None:
+            return POSTURE_ARMED
+        return POSTURE_LOCAL if _LOCAL_TRUST else POSTURE_UNSET
 
 
 def configured() -> bool:
@@ -174,10 +231,11 @@ def configured() -> bool:
 
 
 def reset() -> None:
-    """Disarm the gate (test seam)."""
-    global _CONFIG
+    """Back to the DEFAULT posture — unset, i.e. refusing (test seam)."""
+    global _CONFIG, _LOCAL_TRUST
     with _LOCK:
         _CONFIG = None
+        _LOCAL_TRUST = ""
 
 
 # -- crypto -----------------------------------------------------------------
@@ -651,13 +709,26 @@ def gate_delivered_artifact(artifact: Path, family: str) -> bool:
     """The one arming hook (called from ``models.provision.enable_compiled``
     for every non-None delivered artifact). True = arm may proceed.
 
-    Unconfigured (cozy-local, CLI, unit rigs): no-op True. Configured
-    (fleet workers, armed at HelloAck): full verification; ANY failure
-    emits the typed ``compiled_graph_receipt_refused`` wire event and returns False —
-    the caller drops the delivered artifact and the ordinary miss policy
-    (self-mint) takes over. Never raises; never kills serving.
+    Three postures, and the DEFAULT one refuses (pgw#1425):
+
+    * :data:`POSTURE_LOCAL` — somebody called :func:`trust_local_store`
+      (cozy-local, the CLI, unit rigs): pass, no verification, reason on the
+      record.
+    * :data:`POSTURE_ARMED` — :func:`configure` ran at HelloAck: full
+      verification.
+    * :data:`POSTURE_UNSET` — nobody said either. REFUSE, with the same typed
+      ``compiled_graph_receipt_refused`` event carrying reason
+      ``gate_unconfigured``. This is the arm that used to return True: the v2
+      serve path never called :func:`configure`, so every fleet worker sat in
+      this posture and armed hub-delivered native code with no receipt checked
+      at all, silently.
+
+    ANY failure emits the typed ``compiled_graph_receipt_refused`` wire event
+    and returns False — the caller drops the delivered artifact and the
+    ordinary miss policy (self-mint) takes over. Refusing here therefore costs
+    a compile, never a served request. Never raises; never kills serving.
     """
-    if not configured():
+    if posture() == POSTURE_LOCAL:
         return True
     try:
         receipt = verify_delivered_artifact(Path(artifact), family)
@@ -691,6 +762,9 @@ __all__ = [
     "ARTIFACT_DIGEST_ALGORITHM",
     "COMPILED_GRAPH_PUBLISHER_TIER_ORG",
     "COMPILED_GRAPH_PUBLISHER_TIER_PLATFORM",
+    "POSTURE_ARMED",
+    "POSTURE_LOCAL",
+    "POSTURE_UNSET",
     "Receipt",
     "ReceiptError",
     "artifact_digest",
@@ -699,8 +773,10 @@ __all__ = [
     "configured",
     "gate_delivered_artifact",
     "needs_viewer_identity",
+    "posture",
     "refuse_untrusted_publisher",
     "reset",
+    "trust_local_store",
     "verify_delivered_artifact",
     "verify_receipt_jws",
 ]

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -33,6 +33,7 @@ from typing import Any, Mapping
 
 import msgspec
 
+from .. import receipts
 from .context import DeployBinding
 from .host import EndpointHost
 from .loader import load_endpoint
@@ -303,6 +304,13 @@ def _serve_envelopes(args: argparse.Namespace, loaded: Any) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    # pgw#1425: this is the cozy-local / local-drive shape — the compiled-graph
+    # store is the operator's own directory, so hub-signed receipts do not
+    # apply and the gate is DECLARED off rather than left unset. A process
+    # that declares neither posture refuses; that is the point.
+    receipts.trust_local_store(
+        "gen_worker.serving CLI: the store is a local directory the operator "
+        "owns, not a hub delivery")
     if args.envelope and args.payload:
         raise SystemExit("--payload and --envelope are two modes; pick one")
     if args.envelope:

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -31,11 +31,19 @@ import asyncio
 import inspect
 import logging
 import threading
+import time
 from contextlib import ExitStack
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Tuple
+from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Sequence, Tuple
 
+from .. import boot_phases
+from ..input_assets import (
+    InputManifestEntry,
+    cleanup_input_assets,
+    materialize_input_assets,
+)
+from ..stage_timing import StageTimer
 from .context import DeployBinding, LoadContext, LoaderEngine, RequestContext
 from .envelope import DecodedRequest, decode_envelope
 from .host import ServeDispatchError
@@ -64,11 +72,20 @@ class BindingResolver(Protocol):
 @dataclass(frozen=True, slots=True)
 class InvokeOutcome:
     """One served request: the entrypoint's result + the request facts the
-    envelope reply carries (``ctx.warn`` rows, adjustments)."""
+    envelope reply carries (``ctx.warn`` rows, adjustments, stage timings)."""
 
     result: Any
     warnings: Tuple[str, ...]
     adjustments: Tuple[Dict[str, str], ...]
+    #: pgw#1425: this request's :class:`~gen_worker.stage_timing.StageTimer`.
+    #: ``RequestContext`` has always FILLED one; until this field existed
+    #: nothing read it out, so every served request reported a bare
+    #: ``runtime_ms`` and the stage breakdown died with the context object.
+    #: Handed out RAW rather than rendered because
+    #: :func:`~gen_worker.stage_timing.stage_ms_for_metrics` closes the
+    #: breakdown against ``runtime_ms``, and the dispatch — not the loop — is
+    #: what measures that.
+    stages: Optional[StageTimer] = None
 
 
 class _InstanceBackend:
@@ -114,6 +131,12 @@ class _InstanceBackend:
         model: Model[Any] = self.model_cls()  # cheap __init__ — no GPU, by contract
         model.load(self.load_context)
         self.model = model
+        # pgw#1425: the FIRST user-visible "could have answered a request".
+        # `mark_once` because this runs on every residency admission and only
+        # the first one is a boot number.
+        boot_phases.mark_once(
+            boot_phases.PHASE_EAGER_READY, function=self.model_cls.__name__
+        )
         if self._on_loaded is not None:
             try:
                 self._on_loaded(self.model_cls, self.lane)
@@ -224,7 +247,10 @@ class ServeLoop:
         envelope: Any,
         *,
         request_id: str,
+        attempt: int = 0,
+        input_assets: Sequence[InputManifestEntry] = (),
         context: Optional[Mapping[str, Any]] = None,
+        on_context: Optional[Callable[[RequestContext[Any]], None]] = None,
     ) -> InvokeOutcome:
         """Serve one request end-to-end. See the module docstring for the
         walk; every step before ``spec.fn`` refuses typed.
@@ -235,6 +261,19 @@ class ServeLoop:
         and the inline-output preference. They cannot ride ``context_kwargs``,
         which is constructed once per ServeLoop: a capability token is minted
         per request and expires.
+
+        ``input_assets`` is the dispatch's ordered, credential-free input
+        manifest (``RunJob.input_assets``) and ``attempt`` its attempt number;
+        together with the token and file API base out of ``context`` they are
+        everything :func:`~gen_worker.input_assets.materialize_input_assets`
+        needs. pgw#1418: the v1 executor called it and the v2 rewrite did not,
+        so every typed media input reached the author with ``local_path``
+        unset and every asset-taking endpoint failed the request.
+
+        ``on_context`` is handed this request's :class:`RequestContext` the
+        instant it exists — the seam a caller needs to renew the capability
+        token mid-flight, since the token lives on the context and the context
+        is built in here.
         """
         spec = self.loaded.entrypoints.get(function)
         if spec is None:
@@ -264,9 +303,52 @@ class ServeLoop:
         picks = dict(decoded.model_picks)
         adapters = dict(decoded.adapter_values)
 
+        # THE PAYLOAD SEAM (pgw#1418). Everything the author's body sees is
+        # decoded now, so this is the one instant where a typed media input
+        # can be turned into bytes on disk — and it happens BEFORE any weight
+        # moves, exactly where the v1 executor put it: a request whose input
+        # cannot be fetched must not first pay for a model load.
+        #
+        # The context is built here rather than after the leases for the same
+        # reason it was: `materialize_input_assets` needs the request's
+        # capability token, `on_context` needs to hand it to the renewal loop
+        # before the first long wait, and the primary binding is a pure
+        # resolver lookup that never needed a lease to compute.
+        primary_binding: Optional[DeployBinding] = None
+        if spec.model_params:
+            first_slot = spec.model_params[0][0]
+            primary_binding = self._resolver.resolve(
+                model_slots[first_slot], picks[first_slot]
+            )
+        ctx = self._make_context(request_id, primary_binding, spec, context)
+        if on_context is not None:
+            on_context(ctx)
+
+        per_request = dict(context or {})
+        input_fetch_t0 = time.monotonic()
+        try:
+            materialize_input_assets(
+                decoded.payload,
+                request_id,
+                attempt=int(attempt),
+                manifest=tuple(input_assets),
+                file_base_url=str(per_request.get("file_api_base_url") or ""),
+                capability_token=str(
+                    per_request.get("worker_capability_token") or ""
+                ),
+            )
+        except BaseException:
+            # `materialize_input_assets` already cleared its own attempt
+            # directory; this only guarantees it for anything that raised
+            # around it. The refusal itself is typed and propagates.
+            cleanup_input_assets(request_id, int(attempt))
+            raise
+        # A PRE-handler stage: input fetch is not the author's runtime, and
+        # folding it in makes every asset-taking endpoint look slow.
+        ctx._stages.record_pre("input_fetch", time.monotonic() - input_fetch_t0)
+
         with ExitStack() as leases:
             models: Dict[str, Model[Any]] = {}
-            primary_binding: Optional[DeployBinding] = None
             #: Unmet machine floors of the instances this request actually
             #: uses — a load-time fact, so it stains EVERY request the
             #: degraded instance serves, not just the one that loaded it.
@@ -305,40 +387,44 @@ class ServeLoop:
                     )
                 models[slot_name] = backend.model
                 degraded.extend(backend.degraded)
-                if primary_binding is None:
-                    # The FIRST slot in signature order is the request's
-                    # primary routing fact (ctx.checkpoint_ref).
-                    first_slot = spec.model_params[0][0]
-                    primary_binding = self._resolver.resolve(
-                        model_slots[first_slot], picks[first_slot]
-                    )
 
-            ctx = self._make_context(request_id, primary_binding, spec, context)
             for warning in degraded:
                 ctx.warn(warning)
             arguments = [
                 models[slot.name] if slot.kind == "model" else adapters[slot.name]
                 for slot in spec.slots
             ]
-            result = spec.fn(ctx, decoded.payload, *arguments)
-            if inspect.iscoroutine(result):
-                # AN `async def` ENTRYPOINT IS DRIVEN HERE, INSIDE ITS LEASE.
-                # `@entrypoint` accepts one (an async function IS a function),
-                # and returning the coroutine unawaited made the result a
-                # coroutine OBJECT — msgpack then failed the job with
-                # "Encoding objects of type coroutine is unsupported", after
-                # the leases had already been released. Awaiting it anywhere
-                # above this line would run author code outside its residency
-                # lease, which is the one thing the lease exists to prevent.
-                #
-                # `asyncio.run` is correct rather than lucky: `invoke` is
-                # called from `asyncio.to_thread`, so this thread has no
-                # running loop of its own to conflict with.
-                result = asyncio.run(result)
+            # The author's own span. Everything outside it — envelope decode,
+            # input fetch, admission, weight load — is platform time, and
+            # `handler_open`/`handler_close` are what let a slow request be
+            # attributed to the right side of that line.
+            ctx._stages.handler_open()
+            try:
+                result = spec.fn(ctx, decoded.payload, *arguments)
+                if inspect.iscoroutine(result):
+                    # AN `async def` ENTRYPOINT IS DRIVEN HERE, INSIDE ITS
+                    # LEASE. `@entrypoint` accepts one (an async function IS a
+                    # function), and returning the coroutine unawaited made the
+                    # result a coroutine OBJECT — msgpack then failed the job
+                    # with "Encoding objects of type coroutine is unsupported",
+                    # after the leases had already been released. Awaiting it
+                    # anywhere above this line would run author code outside
+                    # its residency lease, which is the one thing the lease
+                    # exists to prevent.
+                    #
+                    # `asyncio.run` is correct rather than lucky: `invoke` is
+                    # called from `asyncio.to_thread`, so this thread has no
+                    # running loop of its own to conflict with.
+                    result = asyncio.run(result)
+            finally:
+                # CLOSE THE SPAN ON THE FAILING PATH TOO: a handler that raised
+                # after 90 s is the sample most worth having.
+                ctx._stages.handler_close()
         return InvokeOutcome(
             result=result,
             warnings=ctx.warnings,
             adjustments=ctx.adjustments,
+            stages=ctx._stages,
         )
 
     def _make_context(

--- a/src/gen_worker/serving_facts.py
+++ b/src/gen_worker/serving_facts.py
@@ -98,30 +98,14 @@ class FactsUnavailable(
 SlotEvidence = Union[ServingFacts, FactsUnavailable]
 
 
-def facts_or_degrade(
-    evidence: SlotEvidence, *, slot: str, what: str,
-) -> "tuple[ServingFacts, str]":
-    """The stamped facts, plus the sentence to CONFESS if nobody stamped them.
-
-    The ONE place the union is collapsed. pgw#1333 made this raise, and the
-    attribution it built was right — the message blames the *sender* that
-    skipped the stamp, never the checkpoint's catalog row. What was wrong was
-    the refusal: a wire gap on our own side is not grounds to decline a paid
-    customer request (pgw#1339 / th#2099). So the gap now degrades — an empty
-    :class:`ServingFacts` and a non-empty reason — and the caller serves while
-    saying exactly whose stamp is missing.
-
-    An empty second element means there is nothing to confess.
-    """
-    if isinstance(evidence, ServingFacts):
-        return evidence, ""
-    return ServingFacts(), (
-        f"slot {slot!r}: no serving facts were resolved for this checkpoint "
-        f"({what}) — {evidence.owed_by} did not stamp objective/distilled/"
-        f"distilled_status, so there is no evidence to check the invoked "
-        f"function's declared serving contract against. This is a wire gap, "
-        f"NOT a claim about the checkpoint's catalog row; the request still "
-        f"serves and this slot's declared contract goes UNCHECKED.")
+# pgw#1425: `facts_or_degrade` is DELETED, not baselined. It collapsed the
+# `SlotEvidence` union, whose only producer is `dispatch.order_from_binding` —
+# which reads `objective`/`distilled`/`distilled_status` off a CATALOG-stamped
+# `ModelBinding`. pgw#1373 deleted the catalog/declaration architecture, so
+# there is no stamp to read and no declared serving contract to check one
+# against: producer and consumer died in one ruling. `SlotEvidence` itself
+# survives for `child_contract`; the rest of the chain is pgw#1425's
+# remaining-69 triage.
 
 
 __all__ = [
@@ -130,5 +114,4 @@ __all__ = [
     "FactsUnavailable",
     "ServingFacts",
     "SlotEvidence",
-    "facts_or_degrade",
 ]

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -468,6 +468,31 @@ class Worker:
         # defensiveness: a pod that cannot adopt can still SERVE, and a worker
         # that refuses to boot over its compiled-graph story is strictly worse
         # than one that serves eager and says why.
+        # pgw#1425: ARM THE RECEIPT GATE BEFORE THE ADOPT, not only at HelloAck.
+        # Boot-adopt runs before the stream is up, so a gate armed only at
+        # HelloAck leaves the pod's FIRST artifacts — the ones it pulls by key
+        # from the hub store — outside it. v1 had the same window and it was
+        # silently OPEN; with the gate failing closed it would instead refuse
+        # every boot-adopt and self-mint the lot. Neither is right, and the
+        # fix is neither: `HelloAck.file_base_url` IS the tensorhub base URL
+        # (`worker_scheduler.proto`: "tensorhub base URL for capability-token
+        # HTTP calls"), which this pod already knows as TENSORHUB_URL. So arm
+        # from settings now and re-arm from the ack later — `configure` is
+        # idempotent and drops the JWKS cache, so the authoritative value
+        # simply replaces this one.
+        hub_base = str(getattr(settings, "tensorhub_url", "") or "").strip()
+        if hub_base:
+            receipts.configure(hub_base, worker_credential.current)
+        else:
+            # Not a refusal to boot: the pod serves, and every hub-delivered
+            # artifact refuses until the ack arms the gate. Said out loud
+            # because "nothing adopted" would otherwise read as "nothing to
+            # adopt".
+            logger.warning(
+                "receipts: no TENSORHUB_URL, so the gate is UNARMED for the "
+                "boot-adopt window — hub-delivered artifacts will be refused "
+                "and self-minted until HelloAck arms it"
+            )
         try:
             self.adoption = self._build_adoption()
         except Exception:  # noqa: BLE001 — adoption never costs a boot

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -36,8 +36,17 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import msgspec
 
+from . import boot_phases as boot_mod
+from . import content_credentials
 from . import hostfacts
+from . import process_role
+from . import receipts
+from . import serve_posture
+from . import worker_credential
+from .capability_renewal import renew_capability_while_running
 from .config import Settings
+from .input_assets import cleanup_input_assets, manifest_from_run_job
+from .stage_timing import stage_ms_for_metrics
 from .host_move_guard import install as _install_host_move_guard
 from .models.cache_paths import tensorhub_cache_dir, tensorhub_cas_dir
 from .models.cozy_snapshot import snapshot_dir_key
@@ -522,6 +531,13 @@ class Worker:
         self.worker_session_id = uuid.uuid4().hex
         self.file_base_url = ""
 
+        # pgw#1425: THE SDK IS UP. Author modules are imported, every
+        # `@entrypoint` is harvested and the serve stack is built — the phase
+        # the whole boot table is anchored on, and the one the v2 rewrite never
+        # marked, which is why every pod's phase series was empty.
+        boot_mod.mark_once(
+            boot_mod.PHASE_SDK_READY, function=",".join(self.functions)
+        )
         self.phase = pb.WORKER_PHASE_READY
         self.draining = False
         self.drained = asyncio.Event()
@@ -645,6 +661,34 @@ class Worker:
             "hello acked: functions=%s file_base_url=%s",
             self.functions, self.file_base_url or "(none)",
         )
+        # pgw#1425: THE HELLOACK WIRING MOMENT. Three modules take their hub
+        # half here and nowhere else, and the v2 rewrite called none of them.
+        # `mark_once`, not `mark`: this coroutine runs again on every
+        # RECONNECT, and "process start -> hello" measured on the third
+        # reconnect of a six-hour-old worker is not a boot number.
+        boot_mod.mark_once(boot_mod.PHASE_HELLO)
+        if self.functions:
+            # THE cold-boot number: the hub has acked a Hello advertising these
+            # functions, so from this instant it may dispatch to this pod.
+            boot_mod.mark_once(
+                boot_mod.PHASE_FIRST_REQUEST_SERVABLE,
+                function=",".join(self.functions),
+            )
+        if not self.file_base_url:
+            # The gate stays UNSET, which now refuses (pgw#1425). Say so: a
+            # session with no file API is a hub-side fact this pod cannot fix,
+            # and the operator must be able to see why nothing arms.
+            logger.error(
+                "hello acked with NO file_base_url: the compiled-graph receipt "
+                "gate cannot arm, so every hub-delivered artifact will be "
+                "refused and self-minted, and C2PA remote signing is "
+                "unavailable"
+            )
+            return
+        receipts.configure(self.file_base_url, worker_credential.current)
+        content_credentials.configure_remote_signer(
+            self.file_base_url, worker_credential.current
+        )
 
     async def on_disconnect(self) -> None:
         logger.warning("hub stream disconnected; %d job(s) in flight", len(self._jobs))
@@ -657,6 +701,16 @@ class Worker:
             self._on_cancel_job(msg.cancel_job)
         elif which == "drain":
             self.start_drain(int(msg.drain.deadline_ms))
+        elif which == "serve_posture":
+            # pgw#1425: the operator's eager-only order (§4.32 item 4).
+            # `apply_command` owns idempotence — the hub REPLAYS the order to a
+            # reconnecting worker — so this handler must not try to dedupe.
+            posture = msg.serve_posture
+            serve_posture.apply_command(
+                bool(posture.eager_only),
+                actor=str(getattr(posture, "actor", "") or ""),
+                reason=str(getattr(posture, "reason", "") or ""),
+            )
         else:
             # Named, not swallowed: this build implements no residency
             # reconciliation (model_op) and no posture command.
@@ -816,6 +870,7 @@ class Worker:
         inline: Optional[bytes] = None
         message = ""
         adjustments: Tuple[Dict[str, str], ...] = ()
+        stages: Optional[Any] = None
         started = accepted_at
         try:
             self._check_lane(run)
@@ -832,6 +887,36 @@ class Worker:
             inflight = postmortem.note_inflight(
                 "request", str(run.function_name), request_id=str(run.request_id)
             )
+            # pgw#1425: the capability token this job writes with expires
+            # MID-FLIGHT on any long request, and nothing else refreshes it —
+            # the token carries no refresh and the hub does not push. The
+            # renewal loop lives on the event loop while the author's body runs
+            # on a worker thread; `on_context` is how it reaches the context
+            # object that holds the token.
+            renew: Optional[asyncio.Task[None]] = None
+            ctx_box: List[Any] = []
+
+            def _bind_context(ctx: Any, box: List[Any] = ctx_box) -> None:
+                box.append(ctx)
+
+            if run.capability_token and self.file_base_url:
+                renew = asyncio.create_task(
+                    renew_capability_while_running(
+                        file_base_url=self.file_base_url,
+                        request_id=str(run.request_id),
+                        attempt=int(run.attempt),
+                        get_worker_jwt=worker_credential.current,
+                        get_token=lambda: (
+                            ctx_box[0]._worker_capability_token or ""
+                            if ctx_box else str(run.capability_token or "")
+                        ),
+                        set_token=lambda t: (
+                            setattr(ctx_box[0], "_worker_capability_token", t)
+                            if ctx_box else None
+                        ),
+                    ),
+                    name=f"cap-renew-{run.request_id}",
+                )
             try:
                 outcome = await asyncio.to_thread(
                     functools.partial(
@@ -839,13 +924,26 @@ class Worker:
                         str(run.function_name),
                         envelope,
                         request_id=str(run.request_id),
+                        attempt=int(run.attempt),
+                        # pgw#1418: the ordered, credential-free input manifest.
+                        # Without it the serve path materialized nothing and
+                        # every Image/Video/AudioAsset reached the author with
+                        # `local_path` unset.
+                        input_assets=manifest_from_run_job(run.input_assets),
                         context=self._request_context_facts(run),
+                        on_context=_bind_context,
                     )
                 )
             finally:
                 postmortem.clear_inflight(inflight)
+                if renew is not None:
+                    renew.cancel()
+                # The attempt's input directory is worker-owned scratch and
+                # nothing downstream reads it once the body has returned.
+                cleanup_input_assets(str(run.request_id), int(run.attempt))
             inline = msgspec.msgpack.encode(outcome.result)
             adjustments = outcome.adjustments
+            stages = outcome.stages
             status = pb.JOB_STATUS_OK
         except asyncio.CancelledError:
             await self._send_result(*key, pb.JOB_STATUS_CANCELED, safe_message="canceled")
@@ -865,15 +963,22 @@ class Worker:
         finally:
             self._canceled.discard(key)
         now = time.monotonic()
+        runtime_ms = int((now - started) * 1000)
+        metrics = pb.JobMetrics(
+            runtime_ms=runtime_ms,
+            queue_ms=int((started - accepted_at) * 1000),
+        )
+        # pgw#1425: the per-stage breakdown, closed against `runtime_ms` so
+        # every emitted stage plus `resid.unattributed` sums to it. Before this
+        # the `JobResult.metrics` of every v2 request carried two numbers and
+        # the whole stage series was empty.
+        metrics.stage_ms.update(stage_ms_for_metrics(stages, runtime_ms))
         await self._send_result(
             *key,
             status,
             inline=inline,
             safe_message=message,
-            metrics=pb.JobMetrics(
-                runtime_ms=int((now - started) * 1000),
-                queue_ms=int((started - accepted_at) * 1000),
-            ),
+            metrics=metrics,
             adjustments=adjustments,
         )
 
@@ -942,6 +1047,13 @@ class Worker:
 
         activity_mod.bind_sink(self._send, loop)
         boot_mod.bind_sink(self._send, loop)
+
+        # pgw#1425: THIS is the serving process, and it says so where the wire
+        # that carries the claim is bound — so the fact and its transport
+        # arrive together. Compile children's pid rows are read beside this
+        # session; without the declaration they are attributed to nothing.
+        process_role.declare(process_role.ROLE_SERVING)
+        process_role.emit_boot_role()
 
         heartbeat = asyncio.create_task(self._heartbeat(), name="heartbeat")
         transport_task = asyncio.create_task(self.transport.run(), name="transport")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,9 +289,17 @@ def _fresh_receipt_gate():
     """
     from gen_worker import receipts as _receipts
 
-    _receipts.reset()
+    # pgw#1425: `reset()` restores the DEFAULT posture, which now REFUSES.
+    # A unit rig's store is the rig's own tmpdir, so it declares the
+    # user-controlled posture explicitly — the same sentence cozy-local says.
+    # A test that wants the refusal asserts it by calling `reset()` itself.
+    def _rig_posture() -> None:
+        _receipts.reset()
+        _receipts.trust_local_store("pytest rig: the store is the test's tmpdir")
+
+    _rig_posture()
     yield
-    _receipts.reset()
+    _rig_posture()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/release_fixtures/media_endpoint.py
+++ b/tests/release_fixtures/media_endpoint.py
@@ -1,0 +1,84 @@
+"""An ASSET-TAKING endpoint — the pgw#1418 shape, verbatim.
+
+`dj-utils.extract_frame` and all three of `music-analysis`'s functions take a
+mandatory typed media input, and on the v2 surface every one of them failed
+`asset not materialized` because nothing on the serve path materialized the
+payload. This fixture is that signature with the endpoint's own raise site
+kept: the refusal comes from the AUTHOR's code, exactly as it did in
+production, so a test that passes proves the PLATFORM filled `local_path` and
+not that the check was removed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Optional
+
+import msgspec
+
+from gen_worker import (
+    AudioAsset,
+    PromptRole,
+    RequestContext,
+    ValidationError,
+    VideoAsset,
+    entrypoint,
+)
+
+
+class Cue(msgspec.Struct, forbid_unknown_fields=True):
+    """A NESTED asset, reached through a list — the shape whose field path is
+    `cues[].clip` and the one a flat walk gets wrong."""
+
+    clip: VideoAsset
+    note: Annotated[str, PromptRole("negative")] = ""
+
+
+class ExtractFrameInput(msgspec.Struct, forbid_unknown_fields=True):
+    video: VideoAsset
+    caption: Annotated[str, PromptRole("positive")] = ""
+    cues: list[Cue] = []
+    at_seconds: float = 0.0
+
+
+class ExtractFrameOutput(msgspec.Struct):
+    local_path: str
+    size_bytes: int
+    nested_paths: list[str]
+
+
+class AnalyzeInput(msgspec.Struct, forbid_unknown_fields=True):
+    audio: AudioAsset
+    hint: Optional[str] = None
+
+
+class AnalyzeOutput(msgspec.Struct):
+    size_bytes: int
+
+
+def _local_path(asset: object, what: str) -> str:
+    """`dj_utils.main._local_path`, carried over unchanged — THE raise site the
+    production failure came from."""
+    path = getattr(asset, "local_path", None)
+    if not path:
+        raise ValidationError(f"{what} asset not materialized")
+    return str(path)
+
+
+@entrypoint
+def extract_frame(
+    ctx: RequestContext, payload: ExtractFrameInput
+) -> ExtractFrameOutput:
+    path = _local_path(payload.video, "video")
+    nested = [_local_path(cue.clip, "cue") for cue in payload.cues]
+    return ExtractFrameOutput(
+        local_path=path,
+        size_bytes=len(Path(path).read_bytes()),
+        nested_paths=nested,
+    )
+
+
+@entrypoint
+def analyze(ctx: RequestContext, payload: AnalyzeInput) -> AnalyzeOutput:
+    path = _local_path(payload.audio, "audio")
+    return AnalyzeOutput(size_bytes=len(Path(path).read_bytes()))

--- a/tests/test_serve_path_wires_pgw1425.py
+++ b/tests/test_serve_path_wires_pgw1425.py
@@ -16,9 +16,10 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Iterator
 
+import msgspec
 import pytest
 
-from gen_worker import receipts
+from gen_worker import ImageAsset, receipts
 from gen_worker.discovery.moderation import payload_moderation
 from gen_worker.serving.loader import load_endpoint_module
 from gen_worker.serving.residency import ResidencyManager
@@ -26,6 +27,16 @@ from gen_worker.serving.serve_loop import ServeLoop
 
 FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
 MODULE = "media_endpoint"
+
+_CLIP_BYTES = b"\x00\x00\x00\x18ftypmp42" + b"video" * 64
+_TRACK_BYTES = b"RIFF....WAVEfmt " + b"audio" * 64
+
+
+class UnorderedAssets(msgspec.Struct):
+    """Module scope on purpose: `get_type_hints` resolves against module
+    globals, and a locally-declared struct is the OTHER refusal below."""
+
+    images: set[ImageAsset]
 
 
 @pytest.fixture(scope="module")
@@ -73,8 +84,8 @@ def origin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
     """
     root = tmp_path / "origin"
     root.mkdir()
-    (root / "clip.mp4").write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"video" * 64)
-    (root / "track.wav").write_bytes(b"RIFF....WAVEfmt " + b"audio" * 64)
+    (root / "clip.mp4").write_bytes(_CLIP_BYTES)
+    (root / "track.wav").write_bytes(_TRACK_BYTES)
 
     handler = http.server.SimpleHTTPRequestHandler
     server = http.server.ThreadingHTTPServer(
@@ -149,15 +160,30 @@ def test_discovery_emits_the_block_on_the_manifest_row(media: ModuleType) -> Non
 
 def test_an_asset_on_an_unordered_container_is_a_build_error() -> None:
     """The input manifest is ORDERED; a set has no stable occurrence order."""
-    import msgspec
-
-    from gen_worker import ImageAsset
-
-    class Bad(msgspec.Struct):
-        images: set[ImageAsset]
-
     with pytest.raises(ValueError, match="unordered set/frozenset"):
-        payload_moderation(Bad)
+        payload_moderation(UnorderedAssets)
+
+
+def test_unresolvable_hints_REFUSE_instead_of_emitting_an_empty_block() -> None:
+    """Found by RUNNING this file, not by reading it.
+
+    Under `from __future__ import annotations` every annotation is a STRING
+    until `get_type_hints` resolves it. The v1 collector swallowed a resolution
+    failure and fell back to `__annotations__` — strings — which the walk skips,
+    so the block came out EMPTY: no media, no prompts, no error, and an
+    endpoint that cannot be served an asset. Same silence class as pgw#1418
+    itself, one layer down. It now refuses, naming the struct.
+    """
+    module = ModuleType("pgw1425_unresolvable")
+    exec(  # noqa: S102 — a REAL module whose annotations cannot be resolved
+        "from __future__ import annotations\n"
+        "import msgspec\n"
+        "class Payload(msgspec.Struct):\n"
+        "    image: SomeAssetTypeTheModuleNeverImported\n",
+        module.__dict__,
+    )
+    with pytest.raises(ValueError, match="cannot resolve the type hints"):
+        payload_moderation(module.Payload)
 
 
 # -- pgw#1418, half two: materialization at the serve seam ------------------
@@ -181,7 +207,7 @@ def test_the_serve_path_materializes_a_typed_media_input(
         request_id="pgw1418-drive",
         attempt=1,
     )
-    assert outcome.result.size_bytes == 8 + 5 * 64
+    assert outcome.result.size_bytes == len(_CLIP_BYTES)
     assert Path(outcome.result.local_path).exists()
     # A duplicate occurrence shares ONE worker-owned download.
     assert outcome.result.nested_paths == [outcome.result.local_path]
@@ -215,7 +241,7 @@ def test_the_attempt_directory_is_gone_when_materialization_fails(
     from gen_worker.api.errors import ValidationError
     from gen_worker.input_assets import inputs_dir_for_request
 
-    with pytest.raises(ValidationError, match="invalid_input_asset_url"):
+    with pytest.raises(ValidationError, match="unsupported_input_asset_scheme"):
         _loop().invoke(
             "analyze",
             {"input": {"audio": {"ref": "gopher://nope/track.wav"}}},

--- a/tests/test_serve_path_wires_pgw1425.py
+++ b/tests/test_serve_path_wires_pgw1425.py
@@ -1,0 +1,320 @@
+"""The orphaned serve-path wires, exercised through the seam that lost them.
+
+pgw#1418 measured one of these on a rented pod; pgw#1425 found nine siblings
+sitting in `scripts/unreached_surface_baseline.txt`, put there wholesale by a
+`--write-baseline` run. Every case here drives the WIRE, never the function:
+the bug in all ten was that nothing CALLED a function that worked fine.
+"""
+
+from __future__ import annotations
+
+import http.server
+import importlib
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator
+
+import pytest
+
+from gen_worker import receipts
+from gen_worker.discovery.moderation import payload_moderation
+from gen_worker.serving.loader import load_endpoint_module
+from gen_worker.serving.residency import ResidencyManager
+from gen_worker.serving.serve_loop import ServeLoop
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+MODULE = "media_endpoint"
+
+
+@pytest.fixture(scope="module")
+def media() -> Iterator[ModuleType]:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        yield importlib.import_module(MODULE)
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+
+class _NeverResolver:
+    def resolve(self, model_cls: type, checkpoint_ref: str) -> Any:
+        raise AssertionError("a weightless request resolved a binding")
+
+    def default_pick(self, model_cls: type, slot_name: str) -> str:
+        raise AssertionError("a weightless request asked for a default pick")
+
+
+class _NeverSizer:
+    def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        raise AssertionError("a weightless request sized a residency slot")
+
+    def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        raise AssertionError("a weightless request reserved activation bytes")
+
+
+def _loop() -> ServeLoop:
+    return ServeLoop(
+        load_endpoint_module(MODULE),
+        residency=ResidencyManager(1 << 30, _NeverSizer()),
+        resolver=_NeverResolver(),
+    )
+
+
+@pytest.fixture()
+def origin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """A real HTTP origin on loopback, serving real bytes.
+
+    The ONE seam faked: the SSRF policy blocks loopback, so a local origin
+    cannot be a caller transport without lifting that check. Everything else —
+    URL validation shape, the streamed download, the byte cap, the mime sniff,
+    the `local_path` assignment and the attempt-directory cleanup — is the
+    production code path.
+    """
+    root = tmp_path / "origin"
+    root.mkdir()
+    (root / "clip.mp4").write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"video" * 64)
+    (root / "track.wav").write_bytes(b"RIFF....WAVEfmt " + b"audio" * 64)
+
+    handler = http.server.SimpleHTTPRequestHandler
+    server = http.server.ThreadingHTTPServer(
+        ("127.0.0.1", 0), lambda *a, **kw: handler(*a, directory=str(root), **kw)
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    from gen_worker import input_assets as ia
+
+    monkeypatch.setattr(ia, "_url_is_blocked", lambda url: False)
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# -- pgw#1418, half one: the moderation block ------------------------------
+
+
+def test_the_moderation_block_names_every_media_and_prompt_path(
+    media: ModuleType,
+) -> None:
+    """The hub will not guess which payload fields are media. This is the only
+    thing that tells it, and the v2 row emitted no such key at all."""
+    block = payload_moderation(media.ExtractFrameInput)
+    assert block["media"] == [
+        {"field": "video", "kind": "video"},
+        {"field": "cues[].clip", "kind": "video"},
+    ]
+    assert block["prompts"] == [
+        {"field": "caption", "role": "positive"},
+        {"field": "cues[].note", "role": "negative"},
+    ]
+
+    audio = payload_moderation(media.AnalyzeInput)
+    assert audio["media"] == [{"field": "audio", "kind": "audio"}]
+    assert "prompts" not in audio
+
+
+def test_a_text_only_payload_emits_no_block_at_all() -> None:
+    """Absence is the answer for a payload with neither, so the row of every
+    existing text endpoint stays byte-identical."""
+    import msgspec
+
+    class TextOnly(msgspec.Struct):
+        text: str
+        count: int = 1
+
+    assert payload_moderation(TextOnly) == {}
+
+
+def test_discovery_emits_the_block_on_the_manifest_row(media: ModuleType) -> None:
+    """The WIRE assertion: the block reaches `entrypoints[]`, which is what the
+    hub decodes into `PayloadModerationMetadata`."""
+    from gen_worker.discovery.entrypoints_v2 import discover_entrypoints
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        rows = {row["name"]: row for row in discover_entrypoints(MODULE)}
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+    assert set(rows) == {"extract_frame", "analyze"}
+    assert rows["analyze"]["moderation"] == {
+        "media": [{"field": "audio", "kind": "audio"}]
+    }
+    assert rows["extract_frame"]["moderation"]["media"][0] == {
+        "field": "video", "kind": "video"
+    }
+
+
+def test_an_asset_on_an_unordered_container_is_a_build_error() -> None:
+    """The input manifest is ORDERED; a set has no stable occurrence order."""
+    import msgspec
+
+    from gen_worker import ImageAsset
+
+    class Bad(msgspec.Struct):
+        images: set[ImageAsset]
+
+    with pytest.raises(ValueError, match="unordered set/frozenset"):
+        payload_moderation(Bad)
+
+
+# -- pgw#1418, half two: materialization at the serve seam ------------------
+
+
+def test_the_serve_path_materializes_a_typed_media_input(
+    media: ModuleType, origin: str
+) -> None:
+    """THE regression. The endpoint's own `_local_path` raises
+    `video asset not materialized` when `local_path` is falsy — so this passes
+    only if the PLATFORM filled it before the body ran."""
+    outcome = _loop().invoke(
+        "extract_frame",
+        {
+            "input": {
+                "video": {"ref": f"{origin}/clip.mp4"},
+                "caption": "a cat",
+                "cues": [{"clip": {"ref": f"{origin}/clip.mp4"}, "note": "blur"}],
+            }
+        },
+        request_id="pgw1418-drive",
+        attempt=1,
+    )
+    assert outcome.result.size_bytes == 8 + 5 * 64
+    assert Path(outcome.result.local_path).exists()
+    # A duplicate occurrence shares ONE worker-owned download.
+    assert outcome.result.nested_paths == [outcome.result.local_path]
+
+
+def test_the_regression_itself_without_the_wire(
+    media: ModuleType, origin: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RED-PROOF: remove the call the fix added and the measured failure comes
+    back verbatim. Without this, a green suite proves only that the fixture is
+    easy to satisfy."""
+    from gen_worker.api.errors import ValidationError
+    from gen_worker.serving import serve_loop as loop_mod
+
+    monkeypatch.setattr(
+        loop_mod, "materialize_input_assets", lambda *a, **kw: 0
+    )
+    with pytest.raises(ValidationError, match="video asset not materialized"):
+        _loop().invoke(
+            "extract_frame",
+            {"input": {"video": {"ref": f"{origin}/clip.mp4"}}},
+            request_id="pgw1418-red",
+            attempt=1,
+        )
+
+
+def test_the_attempt_directory_is_gone_when_materialization_fails(
+    media: ModuleType, tmp_path: Path
+) -> None:
+    """A blocked transport fails CLOSED and leaves no scratch behind."""
+    from gen_worker.api.errors import ValidationError
+    from gen_worker.input_assets import inputs_dir_for_request
+
+    with pytest.raises(ValidationError, match="invalid_input_asset_url"):
+        _loop().invoke(
+            "analyze",
+            {"input": {"audio": {"ref": "gopher://nope/track.wav"}}},
+            request_id="pgw1418-refuse",
+            attempt=1,
+        )
+    assert not inputs_dir_for_request("pgw1418-refuse", 1).exists()
+
+
+# -- the stage timer, read out at last -------------------------------------
+
+
+def test_the_outcome_carries_the_stage_timer(media: ModuleType, origin: str) -> None:
+    """`RequestContext` always FILLED a StageTimer; nothing read it out, so
+    every v2 `JobResult.metrics` carried two numbers and no breakdown."""
+    from gen_worker.stage_timing import stage_ms_for_metrics
+
+    outcome = _loop().invoke(
+        "analyze",
+        {"input": {"audio": {"ref": f"{origin}/track.wav"}}},
+        request_id="pgw1425-stages",
+        attempt=1,
+    )
+    assert outcome.stages is not None
+    rendered = stage_ms_for_metrics(outcome.stages, 5)
+    # `input_fetch` is a PRE stage: reported, never folded into runtime_ms.
+    assert "input_fetch" in rendered
+
+
+def test_on_context_hands_out_the_live_request_context(
+    media: ModuleType, origin: str
+) -> None:
+    """The seam the capability-renewal loop needs: the token lives on the
+    context and the context is built inside `invoke`."""
+    seen: list[Any] = []
+    _loop().invoke(
+        "analyze",
+        {"input": {"audio": {"ref": f"{origin}/track.wav"}}},
+        request_id="pgw1425-ctx",
+        attempt=1,
+        context={"worker_capability_token": "cap-abc"},
+        on_context=seen.append,
+    )
+    assert len(seen) == 1
+    assert seen[0]._worker_capability_token == "cap-abc"
+
+
+# -- receipts: the fail-OPEN, closed ---------------------------------------
+
+
+def test_the_unconfigured_receipt_gate_now_REFUSES(tmp_path: Path) -> None:
+    """pgw#1425's security item. `gate_delivered_artifact` returned True when
+    nobody had configured it, and the v2 serve path configured nobody — so
+    every fleet worker armed hub-delivered native code with no receipt checked
+    at all. The default posture must refuse."""
+    artifact = tmp_path / "graph.tar"
+    artifact.write_bytes(b"not a real artifact")
+
+    receipts.reset()  # the DEFAULT posture, deliberately
+    assert receipts.posture() == receipts.POSTURE_UNSET
+    assert receipts.gate_delivered_artifact(artifact, "flux") is False
+
+    receipts.trust_local_store("a test's own tmpdir")
+    assert receipts.posture() == receipts.POSTURE_LOCAL
+    assert receipts.gate_delivered_artifact(artifact, "flux") is True
+
+
+def test_the_refusal_is_typed_and_named_on_the_wire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A silent False is a second silence. The refusal rides the same typed
+    event every other receipt refusal does, with its own reason."""
+    from gen_worker import activity as activity_mod
+
+    events: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        activity_mod,
+        "emit_event",
+        lambda kind, detail, phase="", **kw: events.append((kind, detail, phase)),
+    )
+    artifact = tmp_path / "graph.tar"
+    artifact.write_bytes(b"not a real artifact")
+
+    receipts.reset()
+    assert receipts.gate_delivered_artifact(artifact, "flux") is False
+    assert [e for e in events if e[0] == "compiled_graph_receipt_refused"]
+    assert any(e[2] == "gate_unconfigured" for e in events)
+
+
+def test_an_empty_base_url_can_no_longer_arm_nothing_quietly() -> None:
+    """`configure("")` used to return silently, which made "the hub named no
+    file API" indistinguishable from "HelloAck never arrived"."""
+    receipts.reset()
+    with pytest.raises(receipts.ReceiptError, match="gate_unconfigurable"):
+        receipts.configure("", lambda: "jwt")
+    assert receipts.posture() == receipts.POSTURE_UNSET
+
+
+def test_local_trust_must_be_attributed() -> None:
+    receipts.reset()
+    with pytest.raises(receipts.ReceiptError, match="local_trust_unattributed"):
+        receipts.trust_local_store("   ")


### PR DESCRIPTION
Closes the P0 regression [[pgw#1418]] and works [[pgw#1425]]'s bounded ten-wire list.

`cd46c957` deleted `executor.py` entire (11,718 lines) and the v2 serve path never re-wired what it was the sole caller of. `lint_unreached_surface` computed the complete list the day it happened; a `--write-baseline` run appended 79 rows wholesale and the answer went silent — which is why pgw#1418 cost a rented pod to rediscover.

## Disposition

| wire | disposition |
|---|---|
| `receipts.configure` | **WIRED** at HelloAck + gate made **fail-CLOSED** |
| `input_assets.materialize_input_assets` | **WIRED** at the payload seam in `ServeLoop.invoke` |
| the `moderation` block (pgw#1418's second half) | **RESTORED** — `discovery/moderation.py` |
| `stage_timing.{handler_open,handler_close,record_pre,stage_ms_for_metrics}` | **WIRED** — handler span + `JobResult.metrics.stage_ms` |
| `capability_renewal.renew_capability_while_running` | **WIRED** — per-job task in `_run_one` |
| `postmortem.current_inflight_request` | **WIRED** — names the request on `aot_ingress_refused` |
| `boot_phases.mark_once` | **WIRED** — `sdk_ready` / `hello` / `first_request_servable` / `eager_ready` |
| `process_role.declare` / `emit_boot_role` | **WIRED** — at the transport bind |
| `content_credentials.configure_remote_signer` | **WIRED** at HelloAck |
| `serve_posture.apply_command` | **WIRED** — the `ServePosture` SchedulerMessage arm |
| `serving_facts.facts_or_degrade` | **SENTENCED + DELETED** — pgw#1373 deleted the catalog that stamps the facts |

## Receipts, first, because it was a fail-open

`gate_delivered_artifact` returned `True` when unconfigured. The v2 path configured nobody, so **every fleet worker armed hub-delivered native code with no receipt verified at all** — silently. Three explicit postures now: `armed` (`configure`, at HelloAck), `local` (`trust_local_store(reason)` — cozy-local, the CLI, unit rigs), and the DEFAULT `unset`, which **refuses** with the typed `gate_unconfigured` event and falls through to the ordinary miss policy (self-mint). Refusing costs a compile, never a served request. `configure("")` now raises instead of returning silently, because "the hub named no file API" and "HelloAck never arrived" must not look the same.

## The sentence, with its citation

`serving_facts.facts_or_degrade` and `models.memory.report_unevidenced_serving_facts` are DELETED, not baselined. Both collapse a `SlotEvidence` whose only producer reads `objective`/`distilled`/`distilled_status` off a **catalog-stamped** `ModelBinding`; [[pgw#1373]] deleted the catalog/declaration architecture under Paul's hardcut mandate, so there is no stamp to read and `@entrypoint` declares no serving contract to check one against — producer and consumer in one ruling. The v2 successor for "this instance serves degraded and every request says so" is `serving/placement.warn_if_degraded`, already taken at residency-admit.

## The instrument

Fifteen rows leave `unreached_surface_baseline.txt` — thirteen by acquiring a production caller, two by deletion — each with the reason recorded in the file. The baseline shrinks instead of accreting, which is the half of pgw#1425 that is about the instrument rather than the wires.

## Proof

`tests/test_serve_path_wires_pgw1425.py` drives the WIRES, not the functions (the bug in all ten was that nothing CALLED code that worked fine), through a media-taking `@entrypoint` fixture that keeps `dj-utils`' own `_local_path` raise site — so a green run proves the platform filled `local_path`, not that the check was removed. Includes the RED-PROOF: stub the added call back out and `video asset not materialized` returns verbatim.

Local execution of that suite is DEFERRED under a shared-box hold in force at authoring time; see the tracker rows for the handoff. A real-pod re-proof of `music-analysis` is wave-2's activation, not this lane's.