### PR TITLE
pgw#1448: the lane dtype was a STRING, so every kwargs-accepting eager-bridge load silently ran fp32

### DIFF
--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -19,7 +19,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from ..serving.context import _rejected_torch_dtype
+from ..serving.context import _lane_torch_dtype, _rejected_torch_dtype
+
 
 class TraceLoadContext:
     """What ``Model.load`` sees under ``gen-worker release derive``.
@@ -77,7 +78,12 @@ class TraceLoadContext:
         # the DERIVE — the one path that ALWAYS takes an eager bridge, because
         # a trace has no streaming engine — still broken. Two bridges, one
         # contract; the predicate is shared so they cannot drift.
-        dtype = getattr(self.lane, "dtype", None)
+        # pgw#1448: the real `torch.dtype`, never the contract's SPELLING.
+        # `Contract.dtype` is `'bfloat16'` (str) and `Contract.torch_dtype` is
+        # `torch.bfloat16`; diffusers refuses the string with a warning and
+        # silently loads fp32, so this read decides the precision the whole
+        # trace runs at.
+        dtype = _lane_torch_dtype(self.lane)
         try:
             loaded = from_pretrained(self.checkpoint_dir, torch_dtype=dtype)
         except TypeError as exc:

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -65,6 +65,64 @@ logger = logging.getLogger(__name__)
 _DTYPE_REJECTIONS = ("torch_dtype", "'dtype'", '"dtype"')
 
 
+def _torch_dtype_from_name(name: str) -> Any:
+    """``'bfloat16'`` -> ``torch.bfloat16``, or None if it is not one.
+
+    Guarded with ``isinstance`` because ``getattr(torch, 'load')`` is a
+    perfectly good attribute that is not a dtype, and handing a FUNCTION to
+    ``torch_dtype=`` would be a worse failure than handing it a string.
+    """
+    try:
+        import torch
+    except Exception:  # pragma: no cover - torch-free serve role
+        return None
+    candidate = getattr(torch, name.replace("torch.", "", 1), None)
+    return candidate if isinstance(candidate, torch.dtype) else None
+
+
+def _lane_torch_dtype(lane: Any) -> Any:
+    """The lane's load dtype as a REAL ``torch.dtype``, or None.
+
+    Shared by both eager bridges (`serving/context.py` and
+    `release/trace_context.py`) so the two cannot drift — pgw#1447 already
+    proved they drift when they are two copies.
+
+    Prefers ``Contract.torch_dtype`` (the object) over ``Contract.dtype`` (the
+    spelling). Every non-AttributeError read is treated as "this contract
+    declares no top-level dtype", which is a LEGAL state tensorfs signals by
+    RAISING (``MissingDtype``) rather than answering None — the pgw#1386
+    protective arm, kept identical and applied to BOTH spellings, since a
+    dtype-less document raises the same way whichever attribute is asked for.
+    """
+    if lane is None:
+        return None
+    for attr in ("torch_dtype", "dtype"):
+        try:
+            value = getattr(lane, attr)
+        except AttributeError:
+            continue  # this contract object does not carry that spelling
+        except Exception:
+            logger.info(
+                "ctx.load: lane %r declares no load dtype; the eager bridge "
+                "takes the checkpoint's own", lane,
+            )
+            return None
+        if value is None:
+            continue
+        if isinstance(value, str):
+            resolved = _torch_dtype_from_name(value)
+            if resolved is not None:
+                return resolved
+            logger.warning(
+                "ctx.load: lane %r names dtype %r, which does not resolve to a "
+                "torch dtype; loading in the checkpoint's own precision "
+                "(pgw#1448)", lane, value,
+            )
+            return None
+        return value
+    return None
+
+
 def _rejected_torch_dtype(exc: TypeError) -> bool:
     """Did this ``TypeError`` come from passing ``torch_dtype``?
 
@@ -278,19 +336,27 @@ class LoadContext(Generic[MT_co]):
         kill the load before reaching it. ``getattr(lane, "dtype", None)`` does
         NOT swallow a non-AttributeError, which is why the plain read did.
         Any other error still propagates.
+
+        pgw#1448 — AND IT MUST RETURN A ``torch.dtype``, NOT A STRING. This
+        read used to answer ``Contract.dtype``, which is the contract's
+        SPELLING (``'bfloat16'``), while the sibling attribute
+        ``Contract.torch_dtype`` is the real object (``torch.bfloat16``)::
+
+            contracts.MINIMAX_H3_DIT_DIFFUSERS.dtype        -> 'bfloat16'  (str)
+            contracts.MINIMAX_H3_DIT_DIFFUSERS.torch_dtype  -> torch.bfloat16
+
+        diffusers REFUSES a string ``torch_dtype`` with a warning and falls
+        back to **fp32**, so every kwargs-accepting pipeline loaded through the
+        eager bridge was loading at the wrong precision — silently. Measured by
+        the local lane on a 4070: sd1.5 at **13 s/it**, ~20-40x off, because
+        fp32 doubles the weights on a 7.63 GiB card. **The precision bug IS the
+        performance bug**, and it is invisible: a scroll-past warning, then a
+        model that works and is slow.
+
+        FLEET CONSEQUENCE: any timing ever taken through this bridge was fp32
+        timing and must be re-baselined, not compared.
         """
-        if self._lane is None:
-            return None
-        try:
-            return self._lane.dtype
-        except AttributeError:
-            return None
-        except Exception:
-            logger.info(
-                "ctx.load: lane %r declares no load dtype; the eager bridge "
-                "takes the checkpoint's own", self._lane,
-            )
-            return None
+        return _lane_torch_dtype(self._lane)
 
     def compile(self, target: Any) -> Any:
         """Imperative module marking, the torch.compile idiom (Paul ruling)::

--- a/tests/test_eager_bridge_dtype_pgw1447.py
+++ b/tests/test_eager_bridge_dtype_pgw1447.py
@@ -21,38 +21,48 @@ would silently drop the dtype for the family that works.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 
-from gen_worker.serving.context import LoadContext, _rejected_torch_dtype
+from gen_worker.serving.context import (
+    DeployBinding, LoadContext, _rejected_torch_dtype,
+)
 
 
-class _Recorder:
-    """Base for the doubles: records what the loader was handed."""
-
-    seen_dtype: object = "<never called>"
-    to_calls: list = []
-
-
-def _ctx(lane) -> LoadContext:
+def _ctx(lane: Any) -> LoadContext[Any]:
     """A LoadContext with NO loader engine, which is what forces the bridge."""
     return LoadContext(
-        binding=_Binding(),
+        binding=DeployBinding(
+            checkpoint_ref="tensorhub/fixture@prod",
+            checkpoint_dir=Path("/nonexistent/fixture"),
+        ),
         lane=lane,
         engine=None,
     )
 
 
-class _Binding:
-    checkpoint_ref = "tensorhub/fixture@prod"
-    checkpoint_dir = Path("/nonexistent/fixture")
+class _FakeDtype:
+    """A stand-in for a real `torch.dtype` — deliberately NOT a str."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f"torch.{self.name}"
 
 
 class _Lane:
-    """A tensorfs-contract stand-in whose `.dtype` is the lane's load dtype."""
+    """A tensorfs-contract stand-in.
+
+    It carries BOTH spellings because the real `Contract` does, and pgw#1448
+    is precisely about which one the bridge reads: `.dtype` is the string
+    `'bfloat16'`, `.torch_dtype` is the object.
+    """
 
     def __init__(self, dtype):
         self.dtype = dtype
+        self.torch_dtype = _FakeDtype(dtype)
 
 
 # --------------------------------------------------------------------------
@@ -80,7 +90,7 @@ def test_a_typeerror_from_inside_the_model_is_NOT_swallowed():
 
 
 def test_a_loader_that_accepts_torch_dtype_still_receives_it():
-    calls = {}
+    calls: Dict[str, Any] = {}
 
     class Accepts:
         @classmethod
@@ -96,7 +106,7 @@ def test_a_loader_that_accepts_torch_dtype_still_receives_it():
     ctx = _ctx(_Lane("bfloat16"))
     ctx.load(Accepts)
 
-    assert calls["torch_dtype"] == "bfloat16", (
+    assert repr(calls["torch_dtype"]) == "torch.bfloat16", (
         "the accepting family must keep receiving torch_dtype at load time; "
         "applying it post-load instead would change when the cast happens"
     )
@@ -109,7 +119,7 @@ def test_a_loader_that_accepts_torch_dtype_still_receives_it():
 
 def test_a_modular_pipeline_that_refuses_torch_dtype_loads_and_is_cast_after():
     """se#780's exact production failure, reproduced as a unit."""
-    calls = {"attempts": []}
+    calls: Dict[str, Any] = {"attempts": []}
 
     class RefusesLikeModularPipeline:
         @classmethod
@@ -133,7 +143,7 @@ def test_a_modular_pipeline_that_refuses_torch_dtype_loads_and_is_cast_after():
     assert calls["attempts"] == [["torch_dtype"], []], (
         "expected one attempt WITH torch_dtype, then a retry without it"
     )
-    assert calls["to"] == "bfloat16", (
+    assert repr(calls["to"]) == "torch.bfloat16", (
         "THE LANE MUST STILL BE HONOURED. Dropping the dtype here would load a "
         "bf16 lane in the checkpoint's own dtype and serve different numerics "
         "with nothing raised — the silent-degradation shape this repo refuses."
@@ -155,7 +165,7 @@ def test_an_unrelated_typeerror_from_the_loader_propagates():
 
 
 def test_a_model_with_no_lane_never_mentions_dtype_at_all():
-    calls = {}
+    calls: Dict[str, Any] = {}
 
     class NoLane:
         @classmethod
@@ -185,7 +195,7 @@ def test_a_model_with_no_lane_never_mentions_dtype_at_all():
 def test_the_derive_bridge_also_survives_a_loader_that_refuses_torch_dtype():
     from gen_worker.release.trace_context import TraceLoadContext
 
-    calls = {"attempts": []}
+    calls: Dict[str, Any] = {"attempts": []}
 
     class RefusesLikeModularPipeline:
         @classmethod
@@ -210,4 +220,99 @@ def test_the_derive_bridge_also_survives_a_loader_that_refuses_torch_dtype():
 
     assert isinstance(got, RefusesLikeModularPipeline)
     assert calls["attempts"] == [["torch_dtype"], []]
-    assert calls["to"] == "bfloat16", "the derive must honour the lane dtype too"
+    assert repr(calls["to"]) == "torch.bfloat16", "the derive must honour the lane dtype too"
+
+
+# ==========================================================================
+# pgw#1448 — THE SECOND DEFECT IN THE SAME FUNCTION: the lane's dtype was a
+# STRING, and diffusers answers a string by WARNING and loading fp32.
+#
+# Found by the local lane's first real sd1.5 run on a 4070: 13 s/it, ~20-40x
+# off, because fp32 doubles the weights on a 7.63 GiB card. The precision bug
+# IS the performance bug, and it is invisible — a scroll-past warning, then a
+# model that works and is merely slow.
+#
+# THE ASSERTION HAS TO BE THE LOADED DTYPE. Asserting "we passed something"
+# would pass on the broken code too: the string WAS passed, and was ignored.
+
+from gen_worker.serving.context import _lane_torch_dtype, _torch_dtype_from_name
+
+
+class _ContractWithBoth:
+    """A tensorfs Contract as it really is: BOTH spellings, and they differ.
+
+        contracts.MINIMAX_H3_DIT_DIFFUSERS.dtype       -> 'bfloat16'  (str)
+        contracts.MINIMAX_H3_DIT_DIFFUSERS.torch_dtype -> torch.bfloat16
+    """
+
+    dtype = "bfloat16"
+    torch_dtype = _FakeDtype("bfloat16")
+
+
+class _DiffusersLike:
+    """Honours a real dtype object; a STRING falls back to fp32 with a warning
+    — which is exactly what diffusers does, and why this was silent."""
+
+    warned = False
+
+    @classmethod
+    def from_pretrained(cls, path, **kwargs):
+        got = kwargs.get("torch_dtype")
+        obj = cls()
+        if isinstance(got, str) or got is None:
+            cls.warned = True
+            obj.dtype = "float32"          # the silent fallback
+        else:
+            obj.dtype = got
+        return obj
+
+    def to(self, dtype):
+        self.dtype = dtype
+        return self
+
+
+def test_the_lane_dtype_read_prefers_the_OBJECT_over_the_spelling():
+    got = _lane_torch_dtype(_ContractWithBoth())
+    assert not isinstance(got, str), (
+        "returning Contract.dtype hands diffusers a string, which it refuses "
+        "with a warning before silently loading fp32"
+    )
+    assert repr(got) == "torch.bfloat16"
+
+
+def test_a_bf16_lane_ACTUALLY_LOADS_BF16_through_the_eager_bridge():
+    """The red arm the fp32 defect requires.
+
+    Reverting `_lane_torch_dtype` to `self._lane.dtype` leaves this failing
+    with `dtype == 'float32'` — the exact production symptom — while a test
+    that only asserted "torch_dtype was passed" would pass on the broken code,
+    because the string was passed and ignored.
+    """
+    _DiffusersLike.warned = False
+    ctx = _ctx(_ContractWithBoth())
+    loaded = ctx.load(_DiffusersLike)
+
+    assert repr(loaded.dtype) == "torch.bfloat16", (
+        f"a bf16 lane loaded as {loaded.dtype!r} — this is the fp32 silent "
+        f"fallback that made sd1.5 run at 13 s/it on a 4070"
+    )
+    assert not _DiffusersLike.warned, "the loader should never see a string dtype"
+
+
+def test_a_contract_carrying_only_the_spelling_is_still_resolved():
+    """Belt and braces: if some contract exposes only `.dtype`, turn the name
+    into the object rather than passing the string on."""
+
+    class SpellingOnly:
+        dtype = "bfloat16"
+
+    got = _lane_torch_dtype(SpellingOnly())
+    if got is not None:            # torch present in this env
+        assert not isinstance(got, str)
+
+
+def test_a_name_that_is_not_a_dtype_never_becomes_one():
+    """`getattr(torch, 'load')` is a real attribute and not a dtype; handing a
+    FUNCTION to torch_dtype= would be worse than handing it a string."""
+    assert _torch_dtype_from_name("load") is None
+    assert _torch_dtype_from_name("definitely_not_a_dtype") is None


### PR DESCRIPTION
pgw#1448: the lane dtype was a STRING, so every kwargs-accepting eager-bridge load silently ran fp32 — and the mypy debt from #1447

TWO defects lived in the same function. pgw#1447 fixed the first (a
kwargs-STRICT pipeline refusing `torch_dtype`). This is the second, and it hit
the OPPOSITE family — the kwargs-ACCEPTING pipelines #1447's retry never fires
for.

`_lane_dtype()` returned `Contract.dtype`, which is the contract's SPELLING,
while the sibling attribute is the object:

    contracts.MINIMAX_H3_DIT_DIFFUSERS.dtype        -> 'bfloat16'   (str)
    contracts.MINIMAX_H3_DIT_DIFFUSERS.torch_dtype  -> torch.bfloat16

diffusers REFUSES a string `torch_dtype` with a warning and falls back to
**fp32**. So sd15/sdxl/anima — every pipeline that takes the keyword happily —
loaded at the wrong precision, silently, forever.

FOUND BY THE LOCAL LANE (a546b5478b09f31ff) on the first real sd1.5 run on a
4070: **13 s/it, ~20-40x off**, because fp32 doubles the weights on a 7.63 GiB
card. THE PRECISION BUG IS THE PERFORMANCE BUG. Credit is theirs; without a
real card and a real model this is a warning nobody reads.

FLEET CONSEQUENCE, and it is not small: **any timing ever taken through the
eager bridge was fp32 timing.** Those numbers must be re-baselined, not
compared against.

THE FIX. `_lane_torch_dtype(lane)` prefers `torch_dtype` over `dtype`, and
converts a bare spelling to the object rather than passing a string on. It is
now a MODULE-LEVEL helper shared by both bridges (`serving/context.py` and
`release/trace_context.py`) — #1447's own lesson was that two copies of one
contract drift, so this one is not copied. pgw#1386's protective arm is kept
identical and applied to BOTH spellings: a dtype-less document is a legal state
tensorfs signals by RAISING, and the read must not kill the load before the
no-dtype arm. No dtype-less contract exists in the current library to test
against, so that symmetry is handled by construction rather than by example.

THE RED ARM ASSERTS THE LOADED DTYPE, not the passed argument. Reverting to the
spelling leaves `test_a_bf16_lane_ACTUALLY_LOADS_BF16_through_the_eager_bridge`
failing with `dtype == 'float32'` — the exact production symptom. A test that
asserted "torch_dtype was passed" would have PASSED on the broken code, because
the string was passed and ignored. That distinction is the whole defect.

Three of #1447's own tests needed updating: they used a string-only lane, which
the fixed code now correctly refuses to forward. They were written before this
defect was known; they now carry both spellings, like the real Contract.

ALSO FOLDED IN: the mypy debt #1447 left (4 strict errors in its test file —
missing annotations, a stand-in `_Binding` where a real `DeployBinding` belongs,
two unannotated dicts). `mypy` is clean on all three touched files.

This is my own `--admin`-without-the-full-suite caution materializing exactly as
predicted one checkpoint earlier, on my own commit, and caught by a sibling lane
rather than by me. The prediction and the fix came from the same discipline;
noting it because the acceleration order is worth keeping and the failure mode
is worth naming.
