### PR TITLE
pgw#1421: the engine-hosted runtime can BOOT again — ctx.engine(LlamaServer(...))

### DIFF
--- a/changelog.d/pgw1421-engine-runtime.md
+++ b/changelog.d/pgw1421-engine-runtime.md
@@ -1,0 +1,79 @@
+- **pgw#1421: an endpoint whose model is served by an external binary can BOOT
+  it again.** The pgw#1373 hardcut deleted `gen_worker.runtimes.{server,llama}`
+  — 747 lines of `ServerHandle` / `vllm_server` / `llama_server` /
+  `DegradingBoot` — with no v2 successor, while the platform kept ratifying the
+  tier around the hole: `Model.unload`'s docstring names *"external server
+  processes"* as its reason to exist, `models/materialized_view.py` calls
+  `llama-server -m` PERMANENT tier 3, and `serving/streaming/engine.py` refuses
+  block-quantized containers into the pytorch path BY DESIGN. Teardown
+  survived, the loader deferred to it, and boot was gone. `gen_worker.serving.
+  engine_runtime` is the successor, on the post-hardcut surface:
+  `ctx.engine(LlamaServer(...))` / `ctx.engine(VllmServer(...))` is the one
+  spelling and the sibling of `ctx.load(...)`. Only fleet consumers:
+  `qwen3.6-27b-mtp-gguf` and `qwen3.6-35b-a3b` (se#773).
+
+- **pgw#1421: the spec DECLARES, the platform SUPERVISES.** An `EngineSpec` is
+  frozen and knows only the engine and its flags — no path, no port, no
+  process. `ctx.engine(spec)` supplies the checkpoint tree from the deploy
+  binding, allocates the port, walks the boot ladder, waits on real liveness,
+  and REGISTERS the handle. `boot_timeout_s` does not exist and will not: a
+  boot is bounded by SILENCE on the engine's own output
+  (`stall.SilenceWindow`), never by a clock, because a flat deadline whose only
+  liveness check is `proc.poll()` cannot tell a healthy 35B cold load from a
+  wedge. The red/green pair is in the suite — the SAME 3-second boot under a
+  1.5-second window dies when the child goes quiet and succeeds when it keeps
+  talking.
+
+- **pgw#1421: engine teardown is STRUCTURAL, not remembered.**
+  `EndpointHost.evict` stops every engine the load context started AFTER the
+  author's `unload`, whatever that did — the suite's arm has an `unload` that
+  RAISES and the process is still reaped. An engine subprocess is invisible to
+  torch's allocator, so a stranded one is VRAM the next residency admit can
+  neither see nor reclaim. `stop` signals the process GROUP (vLLM's workers
+  survive a bare SIGTERM to the parent and keep the card pinned) and is
+  idempotent, so an author who stops it anyway pays nothing.
+
+- **pgw#1421: every phase of a boot is a typed, countable row.** New activity
+  kind `engine_boot` with a CLOSED phase vocabulary — `engine_planned`
+  (the ladder and its rungs), `engine_started` (argv + port), `engine_healthy`
+  (with the measured boot wall in the numeric `duration_ms` column),
+  `engine_boot_failed`, `engine_stopped` — so "where did this pod's engine boot
+  go" groups on `(kind, phase)` with no join and no regex over a sentence.
+  `boot_stages` cannot answer it: it decomposes THIS process's cold start and
+  an engine subprocess is invisible to every one of its spans. A DEGRADED rung
+  additionally confesses on `serve_degrade`, the countable quality channel —
+  two questions, two rows, deliberately (the z-image finding that `report_*`
+  does not subsume `emit_event`).
+
+- **pgw#1421: llama.cpp degrades instead of dying.** `LlamaServer` resolves the
+  checkpoint tree to its single logical GGUF model (split shards count as one;
+  several distinct quants fail closed), reads the header, sizes `-ngl` and the
+  context to the free-VRAM budget, and steps down through half the GPU layers
+  to CPU-only rather than failing the boot. `VllmServer` states ONE rung
+  because vLLM sizes itself and refuses rather than degrades — a ladder whose
+  lower rungs cannot fire would read as resilience the endpoint does not have.
+
+- **pgw#1421: the endpoint.lock names the engine, read STATICALLY.** Discovery
+  parses `ctx.engine(LlamaServer(...))` off the AST — importing nothing, the
+  same promise `_pipeline_class` makes — and lifts the answer into a third
+  derived census beside `execution_lanes` and `decode_set`:
+  `engine_runtimes[] = {entrypoint, slot, model_class, runtime}`. Omitted
+  entirely when nothing hosts an engine, so a lock carrying the block IS an
+  engine-hosted endpoint, and `entrypoints[]` stays byte-identical to what the
+  hub already decodes. The pytorch CONTROL arm asserts the absence.
+
+- **pgw#1421: an engine-hosted model is SELF-LOADING by construction, and adds
+  no second surface for saying so.** `self_loading=` landed as pgw#1431 fix (b)
+  (`2449c6b1`), and the two engine specs inherit the whole discovery/publish
+  path through it unchanged: a marked slot emits `self_loading` instead of
+  `pipeline_class` and clears the publish gate. What this lane adds is the
+  refusal an UNMARKED one gets. It used to be *"could not read the pipeline
+  class … write `ctx.load(StableDiffusionXLPipeline)`"* — a false sentence
+  (discovery knows exactly what the slot boots) carrying unfollowable advice
+  (the streaming engine refuses a block-quantized container into the pytorch
+  path BY DESIGN). It now names the engine and hands over the line to write:
+  *"slot 'model' is ENGINE-HOSTED (llama-server) … declare
+  `self_loading="served by llama-server; ctx.load drives no part of it"`"*.
+  `docs/endpoint-authoring.md` stops teaching the deleted
+  `@endpoint(runtime="vllm")` API, and `subproc.py`'s dangling reference to
+  `runtimes.server` names its successor.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -808,55 +808,82 @@ retrieves the result. Token endpoints should yield one
 tokens_per_second=)` at the end of the stream — billing reads it from the
 terminal `StreamResult.usage`.
 
-## Engine-hosted runtimes
+## Engine-hosted runtimes (external binaries)
 
-`@endpoint(runtime="vllm")` (or `"llama-server"`) makes the worker boot the
-engine server around `setup()`: download the bound model, start the
-subprocess, wait for `/health`, and inject a `ServerHandle` (base_url +
-process control) into any setup parameter annotated with it:
+Some models are not served by a Python pipeline at all: `llama-server` reads
+a GGUF, `vllm serve` reads a directory, and both speak HTTP. That tier is
+PERMANENT (Paul, 2026-08-19 — the #1303 file-access ladder's tier 3 narrows
+to external binaries and AOT `.so` delivery, and stays there), and it is the
+only tier that gets real files out of the store.
+
+Declare the engine and let the platform run it. `ctx.engine(...)` is the
+sibling of `ctx.load(...)`:
 
 ```python
-from gen_worker.runtimes.server import ServerHandle
+from gen_worker import LlamaServer, LoadContext, Model, entrypoint
 
-@endpoint(model=HF("org/llm"), resources=Resources(gpu=True), runtime="vllm")
-class Chat:
-    def setup(self, model: str, server: ServerHandle) -> None:
-        self.base_url = server.base_url
+class QwenMtpModel(Model[Qwen36MtpGguf], lanes=()):
+    def load(self, ctx: LoadContext[Qwen36MtpGguf]) -> None:
+        self.engine = ctx.engine(LlamaServer(
+            n_ctx=32768,
+            extra_args=["--alias", "qwen3.6-27b-mtp-gguf", "-fa", "on"],
+        ))
+
+@entrypoint
+async def chat(ctx, payload: ChatIn, model: QwenMtpModel) -> AsyncIterator[...]:
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "POST", f"{model.engine.base_url}/v1/chat/completions", json=...,
+        ) as response:
+            ...
 ```
 
-The worker aborts the boot on failure and stops the server at teardown.
+`lanes=()` is the honest declaration here: an engine-hosted model performs no
+pytorch streaming load, so `ctx.lane` has nothing to answer and raises by
+design.
+
+The spec is a DECLARATION — engine + flags, and nothing else. The checkpoint
+tree, the port, the environment and the supervision are the platform's half:
+
+* the checkpoint tree comes from the deploy binding, materialized to real
+  files for the binary that cannot read our store;
+* the port is allocated free unless you pin one;
+* **boot is bounded by SILENCE, never by a clock.** There is no
+  `boot_timeout_s` and there will not be one: every line the engine prints is
+  proof it is still loading, so a 35B cold load takes as long as it takes and
+  an engine that says nothing for 15 minutes is called wedged. Raise
+  `stall_window_s` only for an engine with a known-silent phase longer than
+  that — never to "fix" a boot that failed;
+* the boot ABORTS on engine death, and the whole ladder failing raises
+  `EngineBootError`;
+* **teardown is structural.** The host stops every engine the load context
+  started after your `unload`, whether or not you wrote one. `stop` signals
+  the process GROUP (vLLM's workers survive a bare SIGTERM to the parent and
+  keep the card pinned) and is idempotent, so stopping it yourself is fine.
+
+Every phase is a typed event on `engine_boot`: `engine_planned` (the ladder),
+`engine_started` (argv + port), `engine_healthy` (with the measured boot wall
+in `duration_ms`), `engine_boot_failed`, `engine_stopped` — and a degraded
+rung additionally confesses on `serve_degrade`, which is the countable
+quality channel.
 
 ### llama.cpp / GGUF
 
-For `runtime="llama-server"` the bound snapshot may be the `.gguf` file or
-a dir holding exactly one GGUF model (split shards count as one; several
-quants fail closed — pin the flavor). Unless `-ngl`/`-c` are pinned in
-`extra_args`, the worker reads the GGUF header and sizes `-ngl` + context
-to the free-VRAM budget, degrading through fewer GPU layers (down to
-CPU-only) instead of failing the boot. The serve image provides the
-`llama-server` binary (native-build image class); gen-worker adds no
-Python binding dependency.
+`LlamaServer` resolves the checkpoint tree to its single logical GGUF model
+(split shards count as one; several distinct quants fail closed — pin the
+flavor). Unless you pin `-ngl`/`-c` in `extra_args`, it reads the GGUF header
+and sizes `-ngl` + context to the free-VRAM budget, then degrades through
+half the GPU layers and finally CPU-only rather than failing the boot. The
+serve image provides the `llama-server` binary; gen-worker adds no Python
+binding dependency.
 
-`gen_worker.runtimes.llama` has the streaming client half —
-`chat_deltas(server, messages, ...)` / `completion_deltas(server, prompt,
-...)` are sync generators yielding `IncrementalTokenDelta` then one
-`TokenUsage`, so a handler is one `yield from`:
+### vLLM
 
-```python
-from gen_worker.runtimes.llama import chat_deltas
-from gen_worker.runtimes.server import ServerHandle
-
-@endpoint(model=Hub("org/llm-gguf"), resources=Resources(gpu=True),
-          runtime="llama-server")
-class Chat:
-    def setup(self, model: str, server: ServerHandle) -> None:
-        self.server = server
-
-    def chat(self, ctx, p: ChatIn) -> Iterator[IncrementalTokenDelta]:
-        yield from chat_deltas(self.server, p.messages,
-                               max_tokens=p.max_tokens,
-                               cancelled=lambda: ctx.cancelled)
-```
+`VllmServer` runs `vllm serve <checkpoint>` with the OpenAI-compatible API
+and `/health`. It has ONE rung: vLLM sizes itself from
+`--gpu-memory-utilization` and refuses rather than degrades, and a ladder
+whose lower rungs cannot work would read as resilience the endpoint does not
+have.
 
 ## RequestContext
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,7 +250,6 @@ module = [
   "gen_worker.procsplit.broker",
   "gen_worker.procsplit.child",
   "gen_worker.procsplit.parent",
-  "gen_worker.runtimes.server",
   "gen_worker.sparse_attention",
   "gen_worker.stage_timing",
   "gen_worker.supervisor",
@@ -288,7 +287,6 @@ module = [
   "gen_worker.models.w8a8",
   "gen_worker.procsplit.parent",
   "gen_worker.rigboot",
-  "gen_worker.runtimes.llama",
   "gen_worker.testing",
   "gen_worker.transport",
 ]
@@ -528,7 +526,6 @@ module = [
   "tests.test_latent_basis_pgw1167",
   "tests.test_layout_converter_registry_pgw1143",
   "tests.test_limits_census_wave3_pgw973",
-  "tests.test_llama_runtime",
   "tests.test_load_telemetry_pgw1041",
   "tests.test_local_serve_no_publisher_pgw1127",
   "tests.test_lora_compiled_graphs",

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -128,6 +128,13 @@ if TYPE_CHECKING:  # pragma: no cover - the eager spelling, for type checkers on
         LoadContext,
         RequestContext,
     )
+    from .serving.engine_runtime import (
+        EngineBootError,
+        EngineHandle,
+        EngineSpec,
+        LlamaServer,
+        VllmServer,
+    )
     from .serving.entrypoints import entrypoint
     from .api.resources import Resources
     from .serving.model import Model
@@ -172,6 +179,15 @@ _EXPORTS: Final[dict[str, str]] = {
     # ctx splits into LoadContext (load moment) + RequestContext (request
     # moment); Adapter slots are explicit entrypoint parameters.
     "Adapter": "serving.context",
+    # pgw#1421: the ENGINE-HOSTED tier's author surface. A spec DECLARES the
+    # engine (`LlamaServer`/`VllmServer`); `ctx.engine(spec)` boots and
+    # supervises it and hands back an `EngineHandle` with a `base_url`. This
+    # is F3's eager-permanent world — external binaries only.
+    "EngineBootError": "serving.engine_runtime",
+    "EngineHandle": "serving.engine_runtime",
+    "EngineSpec": "serving.engine_runtime",
+    "LlamaServer": "serving.engine_runtime",
+    "VllmServer": "serving.engine_runtime",
     "Resources": "api.resources",
     "DistillationAdapter": "serving.context",
     "ExpectedOutput": "api.types",
@@ -263,6 +279,12 @@ __all__ = [
     "Model",
     "Resources",
     "entrypoint",
+    # pgw#1421: the engine-hosted tier (external binaries only).
+    "EngineBootError",
+    "EngineHandle",
+    "EngineSpec",
+    "LlamaServer",
+    "VllmServer",
     # The decorators + bindings.
     # pgw#1294: run-once submitted functions. Same (ctx, payload) -> Struct
     # contract as @endpoint, so one body promotes between them unchanged.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -267,6 +267,19 @@ KIND_SNAPSHOT_PULL = "snapshot_pull"
 # needs no hub schema change. See `boot_stages.py` for why the total is a UNION
 # and never a sum.
 KIND_BOOT_STAGES = "boot_stages"
+# pgw#1421: the ENGINE-HOSTED tier's boot — an external engine binary
+# (`llama-server`, `vllm serve`) started, health-waited and stopped by the
+# worker. Its own KIND because nothing else on the pod can answer "why is this
+# endpoint not serving yet" for a tier whose work happens in another PROCESS:
+# `boot_stages` decomposes THIS process's cold start and an engine subprocess
+# is invisible to every one of its spans, exactly as it is invisible to torch's
+# allocator. The phase vocabulary is CLOSED (`serving.engine_runtime`
+# ENGINE_PHASES) so a reader can group on (kind, phase) rather than regex a
+# sentence; `duration_ms` on the `engine_healthy` row is the measured boot wall.
+# A DEGRADED rung is deliberately NOT reported here — it rides
+# KIND_SERVE_DEGRADE, which is the countable quality-confession channel
+# (th#2075's ingest), so the two questions stay two rows.
+KIND_ENGINE_BOOT = "engine_boot"
 # th#1322: the roll-up phase both mint routes report their TOTAL under. A
 # reader groups on (kind, phase) and must never sum a roll-up together with
 # its own children.

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -30,6 +30,7 @@ from gen_worker.discovery.entrypoints_v2 import (
     assert_manifest_advertises_something,
     discover_entrypoints,
     entrypoints_block,
+    lift_engine_runtimes,
 )
 from gen_worker.discovery.execution_lanes import (
     derive_execution_lanes,
@@ -202,9 +203,10 @@ def prime_sys_path(root: Path) -> None:
 def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
     """The complete endpoint.lock manifest for the project at ``root``.
 
-    ``entrypoints[]`` + the two DERIVED censuses this image can prove about
-    itself (``execution_lanes``, ``decode_set``). No hand-maintained lists,
-    and no second declaration vocabulary.
+    ``entrypoints[]`` + the DERIVED censuses this image can prove about itself
+    (``execution_lanes``, ``decode_set``, and ``engine_runtimes`` when
+    anything hosts an external engine). No hand-maintained lists, and no
+    second declaration vocabulary.
     """
     if root is None:
         root = Path.cwd()
@@ -239,10 +241,18 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
                 for e in exclusions
             ]
 
+    # pgw#1421: the THIRD derived census — which external engine binaries
+    # this image's models boot. Lifted off the slots (which is where the
+    # static read lands them) so `entrypoints[]` keeps exactly the fields the
+    # hub decodes. Omitted entirely when nothing hosts an engine, so a lock
+    # carrying this block IS an engine-hosted endpoint.
+    engine_runtimes = lift_engine_runtimes(entrypoints)
+
     manifest: Dict[str, Any] = {
         "entrypoints": entrypoints_block(entrypoints),
         "execution_lanes": manifest_block(derived),
         "decode_set": decode_set_manifest_block(decode_set),
+        **({"engine_runtimes": engine_runtimes} if engine_runtimes else {}),
     }
     # A manifest that advertises nothing is a BUILD failure, never a warning
     # the bake outlives (pgw#1387).

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -194,6 +194,111 @@ def _pipeline_class(model_cls: type) -> str:
     return ""
 
 
+def _engine_runtime(model_cls: type) -> str:
+    """The EXTERNAL ENGINE ``load()`` boots, read STATICALLY (pgw#1421).
+
+    ``ctx.engine(LlamaServer(...))`` is the engine-hosted tier's one spelling,
+    and this is the parse that turns it into a word the endpoint.lock can
+    state: ``"llama-server"``, ``"vllm"``, or ``""`` for a model that boots no
+    engine (every pytorch endpoint in the fleet).
+
+    Same promise as :func:`_pipeline_class` — no author code runs beyond the
+    import that already happened. Two resolutions, in order of authority:
+
+    1. the spec class bound on the endpoint's MODULE, whose ``runtime`` class
+       constant is the authority;
+    2. failing that, a ``from gen_worker… import LlamaServer`` resolved off the
+       AST, matched against ``ENGINE_SPEC_RUNTIMES``.
+
+    (2) exists for the same reason the pipeline-class fallback does: a stubbed
+    heavy dep can bind a MODULE where a class was expected. It is deliberately
+    keyed on the import RESOLVING INTO gen_worker, so an author's own class
+    that happens to be called ``LlamaServer`` is never read as this one.
+    """
+    from ..serving.engine_runtime import ENGINE_SPEC_RUNTIMES, EngineSpec
+
+    load = getattr(model_cls, "load", None)
+    if load is None:
+        return ""
+    try:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(load)))
+    except (OSError, TypeError, SyntaxError):
+        return ""
+    module = inspect.getmodule(model_cls)
+    static: Dict[str, str] = {}
+    try:
+        module_source = inspect.getsource(module) if module is not None else ""
+    except (OSError, TypeError):
+        module_source = ""
+    if module_source:
+        try:
+            static.update(_import_sites(ast.parse(module_source)))
+        except SyntaxError:
+            pass
+    static.update(_import_sites(tree))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if not (isinstance(fn, ast.Attribute) and fn.attr == "engine"):
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Call):
+            continue
+        spec_fn = node.args[0].func
+        if not isinstance(spec_fn, ast.Name):
+            continue
+        target = getattr(module, spec_fn.id, None)
+        if isinstance(target, type) and issubclass(target, EngineSpec):
+            runtime = str(getattr(target, "runtime", "") or "")
+            if runtime:
+                return runtime
+        dotted = static.get(spec_fn.id, "")
+        if dotted.startswith("gen_worker."):
+            runtime = ENGINE_SPEC_RUNTIMES.get(dotted.rsplit(".", 1)[-1], "")
+            if runtime:
+                return runtime
+    return ""
+
+
+def lift_engine_runtimes(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """The ``engine_runtimes`` census: every external engine binary this image
+    will BOOT, and which declaration asked for it.
+
+    A DERIVED census in the shape of ``execution_lanes`` and ``decode_set`` —
+    what the image can prove about itself, never a hand-maintained list. It
+    exists because "which engine does this endpoint start" was answerable in
+    v1 only by reading ``@endpoint(runtime=...)``, which the hardcut deleted,
+    and an operator staring at a pod that is not serving needs the answer
+    without the source.
+
+    Empty for every pytorch endpoint, and omitted from the manifest then, so a
+    lock that carries this block is exactly a lock whose endpoint hosts an
+    engine.
+
+    It LIFTS: the two keys `_model_slot` parked on the slot are POPPED here,
+    so the `entrypoints[]` block the hub decodes carries exactly the fields it
+    decoded before this landed. A derived fact with no hub reader belongs in
+    the lock's own census, never as a `functions[].slots[]` field — a mirror
+    with no reader is the th#2087 shape, and this one would additionally be a
+    field the hub's slot normalizer would have to learn to ignore.
+    """
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        for slot in row.get("slots", []):
+            runtime = slot.pop("engine_runtime", "") or ""
+            model_class = slot.pop("model_class", "") or ""
+            if not runtime:
+                continue
+            out.append({
+                "entrypoint": row["name"],
+                "slot": slot["name"],
+                "model_class": model_class,
+                "runtime": runtime,
+            })
+    out.sort(key=lambda r: (str(r["entrypoint"]), str(r["slot"])))
+    return out
+
+
 def _model_slot(slot: Any) -> Dict[str, Any]:
     """A model slot in the hub's `functions[].slots[]` vocabulary.
 
@@ -253,6 +358,16 @@ def _model_slot(slot: Any) -> Dict[str, Any]:
     family = getattr(declared, "name", "") or ""
     if family:
         out["family"] = family
+    # pgw#1421. Both keys are OMITTED unless this slot hosts an engine, so
+    # every pytorch row is byte-identical to what it was. They do not travel
+    # to the hub as slot fields — `lift_engine_runtimes` lifts them into the
+    # lock's own `engine_runtimes` census, which is where a DERIVED fact about
+    # the image belongs (`execution_lanes`' shape), rather than inventing a
+    # `functions[].slots[]` field no hub reader decodes.
+    runtime = _engine_runtime(model_cls)
+    if runtime:
+        out["engine_runtime"] = runtime
+        out["model_class"] = f"{model_cls.__module__}.{model_cls.__qualname__}"
     return out
 
 
@@ -494,6 +609,26 @@ def _pipeline_class_or_refuse(rows: List[Dict[str, Any]]) -> None:
             # fix (c) becoming the green path — for MARKED slots only.
             if slot.get("self_loading"):
                 continue
+            runtime = slot.get("engine_runtime") or ""
+            if runtime:
+                # pgw#1421: engine-hosted and UNMARKED. Discovery knows exactly
+                # what this slot boots, so the generic "could not read the
+                # pipeline class" below would be false AND its advice
+                # unfollowable — `ctx.load(SomePipeline)` is a load the
+                # streaming engine refuses BY DESIGN for this class of
+                # container (`serving/streaming/engine.py`: block-quantized
+                # containers are the external-binary class, not the pytorch
+                # path). An engine-hosted model is self-loading BY
+                # CONSTRUCTION; the fix is the marker, and this says so.
+                raise EntrypointDiscoveryError(
+                    f"@entrypoint {row['name']!r} slot {slot['name']!r} is "
+                    f"ENGINE-HOSTED ({runtime}): its load() boots an external "
+                    "engine, so there is no Python pipeline class to name. "
+                    "Declare it — class YourModel(Model[X], lanes=(), "
+                    f'self_loading="served by {runtime}; ctx.load drives no '
+                    'part of it") — rather than inventing a class name to get '
+                    "past this."
+                )
             raise EntrypointDiscoveryError(
                 f"@entrypoint {row['name']!r} slot {slot['name']!r}: could not "
                 "read the pipeline class from the model's load(). Publish "
@@ -589,5 +724,6 @@ __all__ = [
     "EntrypointDiscoveryError",
     "assert_manifest_advertises_something",
     "discover_entrypoints",
+    "lift_engine_runtimes",
     "entrypoints_block",
 ]

--- a/src/gen_worker/serving/__init__.py
+++ b/src/gen_worker/serving/__init__.py
@@ -30,6 +30,15 @@ from .context import (
     LoaderEngine,
     RequestContext,
 )
+from .engine_runtime import (
+    EngineBootError,
+    EngineCommand,
+    EngineHandle,
+    EngineSpec,
+    LlamaServer,
+    VllmServer,
+    boot_engine,
+)
 from .envelope import (
     AdapterRow,
     DecodedRequest,
@@ -88,6 +97,13 @@ from .model import (
 from .placement import DeviceFacts, Shortfall, device_facts, shortfalls, warn_if_degraded
 
 __all__ = [
+    "boot_engine",
+    "VllmServer",
+    "LlamaServer",
+    "EngineSpec",
+    "EngineHandle",
+    "EngineCommand",
+    "EngineBootError",
     "DeviceFacts",
     "Shortfall",
     "device_facts",

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -179,6 +179,7 @@ class LoadContext(Generic[MT_co]):
         self._lane = lane
         self._engine = engine
         self._compile_sink = compile_sink
+        self._engines: list[Any] = []
 
     @property
     def checkpoint_dir(self) -> Path:
@@ -291,6 +292,72 @@ class LoadContext(Generic[MT_co]):
                 "takes the checkpoint's own", self._lane,
             )
             return None
+
+    def engine(self, spec: Any) -> Any:
+        """Boot the EXTERNAL engine that serves this checkpoint — the one
+        spelling for the engine-hosted tier (pgw#1421)::
+
+            self.engine = ctx.engine(LlamaServer(extra_args=["-ngl", "99"]))
+
+        The sibling of :meth:`load`, and the same division of labour: the
+        author declares (which engine, which flags), the platform supplies
+        (which checkpoint tree, which port, which environment) and supervises
+        (boot ladder, real-liveness health wait, typed events, teardown).
+
+        Returns an ``EngineHandle`` whose ``base_url`` an entrypoint POSTs to.
+
+        THE HANDLE IS REGISTERED HERE, which is what makes teardown
+        structural: ``EndpointHost.evict`` stops every engine this context
+        started AFTER the author's ``unload``, whether or not ``unload`` was
+        written. An engine subprocess is invisible to torch's allocator, so a
+        forgotten stop is not a tidy-up debt — it is VRAM the next residency
+        admit cannot see and cannot reclaim. ``EngineHandle.stop`` is
+        idempotent, so an author who stops it in ``unload`` anyway is right
+        and costs nothing.
+
+        This is the ONLY tier that gets a real file out of the store: Paul's
+        2026-08-19 ruling narrowed the #1303 ladder's tier 3 to external
+        binaries and AOT ``.so`` delivery, and made it permanent there. A
+        serving pytorch endpoint that reaches a materialized view is a defect
+        signal; ``llama-server -m`` reaching one is the design.
+        """
+        from .engine_runtime import EngineSpec, boot_engine
+
+        if not isinstance(spec, EngineSpec):
+            raise TypeError(
+                f"ctx.engine({spec!r}): expected an EngineSpec declaration "
+                "(gen_worker.LlamaServer / gen_worker.VllmServer), not a "
+                "command or a base URL. The spec states WHAT engine and WHICH "
+                "flags; the checkpoint tree, the port and the supervision are "
+                "the platform's half."
+            )
+        handle = boot_engine(spec, self.checkpoint_dir)
+        self._engines.append(handle)
+        return handle
+
+    @property
+    def engines(self) -> tuple[Any, ...]:
+        """Every engine this context started, in boot order."""
+        return tuple(self._engines)
+
+    def stop_engines(self) -> None:
+        """Stop every engine this context started, newest first.
+
+        BEST-EFFORT AND UNCONDITIONAL: called by the host after the author's
+        ``unload``, so an author who never wrote one still gets the process
+        reaped. Each stop is idempotent and a raising stop cannot prevent the
+        next one — the whole point is that no single failure strands a
+        VRAM-holding subprocess.
+        """
+        while self._engines:
+            handle = self._engines.pop()
+            try:
+                handle.stop()
+            except Exception:
+                logger.exception(
+                    "stopping engine %r raised; continuing with the rest",
+                    getattr(handle, "runtime", handle),
+                )
 
     def compile(self, target: Any) -> Any:
         """Imperative module marking, the torch.compile idiom (Paul ruling)::

--- a/src/gen_worker/serving/engine_runtime.py
+++ b/src/gen_worker/serving/engine_runtime.py
@@ -1,0 +1,526 @@
+"""Engine-hosted runtimes: boot / health-wait / abort / stop for an EXTERNAL
+engine binary (``llama-server``, ``vllm serve``).
+
+pgw#1421 — the v2 successor to the deleted ``gen_worker.runtimes.server``.
+The #1373 hardcut removed the boot half of this tier and left the teardown
+half standing (``Model.unload``'s docstring names *"external server
+processes"* as its reason to exist), while Paul's 2026-08-19 ruling narrowed
+the #1303 ladder's tier 3 to exactly this class and made it PERMANENT
+("the fill rung narrows to external binaries"). So this is not a restoration
+of v1 machinery: it is the boot half of a ratified, permanent tier, rewritten
+on the post-hardcut surface.
+
+**The one spelling**, and it is the sibling of ``ctx.load``::
+
+    class QwenMtpModel(Model[Qwen36MtpGguf], lanes=()):
+        def load(self, ctx: LoadContext[Qwen36MtpGguf]) -> None:
+            self.engine = ctx.engine(LlamaServer(extra_args=["-ngl", "99"]))
+
+        async def chat(...):
+            ... POST f"{self.engine.base_url}/v1/chat/completions" ...
+
+An :class:`EngineSpec` is a DECLARATION — no path, no process, no port. It is
+frozen, constructible at import, and carries only what the author knows.
+``ctx.engine(spec)`` is what turns it into a running process: it supplies the
+checkpoint tree from the deploy binding, plans the boot ladder, starts the
+process, waits on real liveness, and REGISTERS the handle so teardown is
+structural rather than remembered (``EndpointHost.evict`` stops every engine
+after the author's ``unload``, whether or not ``unload`` was written).
+
+Two properties this module refuses to compromise on:
+
+* **A boot is bounded by SILENCE, never by a clock.** A flat deadline whose
+  only liveness check is ``proc.poll()`` says nothing about progress, and a
+  35B cold load routinely outlives ten minutes — raising the number is the
+  same mistake made bigger. Every line the engine prints is proof it is still
+  loading (pgw#1243's doctrine, and :class:`gen_worker.stall.SilenceWindow`
+  is the one implementation of it). There is deliberately no ``timeout=``
+  argument anywhere in this file.
+* **Degrade, never OOM.** A tight card gets fewer GPU layers, not a dead
+  boot, and the degraded rung is a COUNTABLE typed event rather than a log
+  line an operator has to go find.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import signal
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar, Mapping, Optional, Sequence
+
+import msgspec
+
+from .. import activity as activity_mod
+from ..subproc import LineTail
+
+logger = logging.getLogger(__name__)
+
+#: Silence window over the engine's own output. NOT a boot budget: an engine
+#: that keeps talking boots for as long as it needs, and one that says nothing
+#: for 15 minutes is wedged. Orders of magnitude past any real silent phase
+#: (CUDA graph capture, torch.compile) and matches the window the llama.cpp
+#: toolchain gets.
+BOOT_STALL_WINDOW_S = 900.0
+TERM_GRACE_S = 10.0
+
+__all__ = [
+    "BOOT_STALL_WINDOW_S",
+    "ENGINE_SPEC_RUNTIMES",
+    "EngineBootError",
+    "EngineCommand",
+    "EngineHandle",
+    "EngineSpec",
+    "LlamaServer",
+    "TERM_GRACE_S",
+    "VllmServer",
+    "boot_engine",
+    "free_port",
+    "process_vram_bytes",
+]
+
+
+class EngineBootError(RuntimeError):
+    """The engine exited, or went silent, during boot.
+
+    The degrade ladder keys on this — so it is raised only on real evidence
+    (the process died, or it produced no output for its stall window), never
+    because a stopwatch expired.
+    """
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@dataclass(frozen=True)
+class EngineCommand:
+    """One rung of a boot ladder: the argv to run and the port it serves on.
+
+    ``label`` is what a typed event calls this rung — "planned", "half-gpu",
+    "cpu-only" — so a degrade is readable without diffing two argv lists.
+    """
+
+    argv: tuple[str, ...]
+    port: int
+    label: str = "planned"
+
+
+@dataclass
+class EngineHandle:
+    """A running engine: base URL + process control.
+
+    ``base_url`` is what an entrypoint POSTs to. ``stop`` is idempotent, so
+    an author who stops the engine in ``unload`` and the host's structural
+    stop cannot double-kill.
+    """
+
+    runtime: str
+    base_url: str
+    process: "subprocess.Popen[str]" = field(repr=False)
+    rung: str = "planned"
+
+    @property
+    def alive(self) -> bool:
+        return self.process.poll() is None
+
+    def stop(self, *, grace_s: float = TERM_GRACE_S) -> None:
+        """SIGTERM the process GROUP, wait ``grace_s``, then SIGKILL.
+
+        The group, not the process: vLLM forks worker processes that survive
+        a bare SIGTERM to the parent and keep the card's VRAM pinned, which
+        is a leak the next residency admit pays for.
+        """
+        proc = self.process
+        if proc.poll() is not None:
+            return
+        pgid: Optional[int] = None
+        try:
+            pgid = os.getpgid(proc.pid)
+        except (ProcessLookupError, PermissionError, OSError):
+            pgid = None
+        # HOW it stopped is the interesting half. An engine that had to be
+        # SIGKILLed is the one an operator wants to know about — it is the
+        # shape that strands VRAM when anything upstream is less careful than
+        # this — so the manner is recorded and the row is emitted on EVERY
+        # path, not only the clean one.
+        manner = "term"
+        try:
+            if pgid is not None:
+                os.killpg(pgid, signal.SIGTERM)
+            else:
+                proc.send_signal(signal.SIGTERM)
+            proc.wait(timeout=grace_s)
+        except subprocess.TimeoutExpired:
+            manner = "kill"
+            logger.warning("%s ignored SIGTERM for %.0fs; killing",
+                           self.runtime, grace_s)
+            try:
+                if pgid is not None:
+                    os.killpg(pgid, signal.SIGKILL)
+                else:
+                    proc.kill()
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+            try:
+                proc.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:  # pragma: no cover - kernel wedge
+                manner = "survived_kill"
+                logger.error("%s survived SIGKILL", self.runtime)
+        except Exception:  # pragma: no cover - best-effort tidiness
+            manner = "error"
+            logger.exception("%s stop failed", self.runtime)
+        activity_mod.emit_event(
+            activity_mod.KIND_ENGINE_BOOT,
+            f"runtime={self.runtime} base_url={self.base_url} "
+            f"rung={self.rung} manner={manner}",
+            phase=PHASE_STOPPED,
+        )
+
+
+# -- the typed phase vocabulary -------------------------------------------
+#
+# CLOSED, and every phase of a boot lands on exactly one of them, so
+# "where did this engine's boot go" is answerable by grouping on
+# (kind, phase) with no join and no regex over a sentence.
+PHASE_PLANNED = "engine_planned"
+PHASE_STARTED = "engine_started"
+PHASE_HEALTHY = "engine_healthy"
+PHASE_DEGRADED = "engine_degraded"
+PHASE_FAILED = "engine_boot_failed"
+PHASE_STOPPED = "engine_stopped"
+
+ENGINE_PHASES: tuple[str, ...] = (
+    PHASE_PLANNED, PHASE_STARTED, PHASE_HEALTHY,
+    PHASE_DEGRADED, PHASE_FAILED, PHASE_STOPPED,
+)
+
+
+class EngineSpec(msgspec.Struct, frozen=True, kw_only=True):
+    """What an author DECLARES about the engine that serves this model.
+
+    No checkpoint path and no port: both are the platform's to supply, and an
+    author who could write them would be writing deploy config into code.
+    Subclasses state their binary and their health route as class constants
+    and build the boot ladder in :meth:`ladder`.
+    """
+
+    #: Extra engine flags, verbatim. The author's tuning surface.
+    extra_args: Sequence[str] = ()
+    #: Pin the port. Default: allocate a free one.
+    port: Optional[int] = None
+    #: Environment overlay for the child.
+    env: Optional[Mapping[str, str]] = None
+    #: Silence window for THIS engine's boot. Raise it only for an engine
+    #: with a known-silent phase longer than the default; never as a fix for
+    #: a boot that failed.
+    stall_window_s: float = BOOT_STALL_WINDOW_S
+
+    #: The engine's stable runtime handle — the word discovery puts in
+    #: endpoint.lock and an operator reads in an event.
+    runtime: ClassVar[str] = ""
+    #: Path appended to the base URL for the readiness probe.
+    health_path: ClassVar[str] = "/health"
+
+    def ladder(self, checkpoint_dir: Path) -> list[EngineCommand]:
+        """The boot ladder for this checkpoint, best rung FIRST.
+
+        A single-element list is a boot with no degrade path, which is the
+        honest answer for an engine that sizes itself.
+        """
+        raise NotImplementedError
+
+    # -- helpers subclasses share ------------------------------------------
+
+    def _args(self) -> list[str]:
+        return [str(a) for a in self.extra_args]
+
+    def _port(self) -> int:
+        return int(self.port) if self.port else free_port()
+
+
+class VllmServer(EngineSpec, frozen=True, kw_only=True):
+    """``vllm serve <checkpoint>`` — OpenAI-compatible API + ``/health``.
+
+    vLLM sizes itself from ``--gpu-memory-utilization`` and refuses rather
+    than degrades, so there is ONE rung. That is stated here rather than
+    faked with a ladder whose lower rungs cannot work: a degrade path that
+    cannot fire reads as resilience the endpoint does not have.
+    """
+
+    runtime: ClassVar[str] = "vllm"
+
+    def ladder(self, checkpoint_dir: Path) -> list[EngineCommand]:
+        port = self._port()
+        return [EngineCommand(
+            argv=("vllm", "serve", str(checkpoint_dir),
+                  "--host", "127.0.0.1", "--port", str(port), *self._args()),
+            port=port,
+        )]
+
+
+#: Flags whose presence in ``extra_args`` means the AUTHOR sized the fit and
+#: this module must not second-guess it.
+_NGL_FLAGS = frozenset({"-ngl", "--n-gpu-layers", "--gpu-layers"})
+_CTX_FLAGS = frozenset({"-c", "--ctx-size"})
+
+
+class LlamaServer(EngineSpec, frozen=True, kw_only=True):
+    """``llama-server -m <gguf>`` — llama.cpp's built-in ``/health``.
+
+    The checkpoint tree resolves to its single logical GGUF model (split
+    shards count as one). Unless the author pins ``-ngl``/``-c``, the GGUF
+    header sizes ``-ngl`` and the context to the free-VRAM budget and the
+    ladder degrades through fewer GPU layers — down to CPU-only — rather
+    than failing the boot.
+    """
+
+    runtime: ClassVar[str] = "llama-server"
+
+    #: Serving context. ``None`` = the header's training context.
+    n_ctx: Optional[int] = None
+    #: Override the measured free-VRAM budget (a test seam, and the escape
+    #: hatch for a card shared with something this process cannot see).
+    vram_budget_gb: Optional[float] = None
+
+    def ladder(self, checkpoint_dir: Path) -> list[EngineCommand]:
+        from .gguf_fit import plan_for, resolve_gguf
+
+        gguf_path = str(resolve_gguf(checkpoint_dir))
+        args = self._args()
+
+        def rung(fit_args: Sequence[str], label: str) -> EngineCommand:
+            port = self._port()
+            return EngineCommand(
+                argv=("llama-server", "-m", gguf_path,
+                      "--host", "127.0.0.1", "--port", str(port),
+                      *fit_args, *args),
+                port=port,
+                label=label,
+            )
+
+        if any(a in _NGL_FLAGS for a in args):
+            return [rung((), "author-pinned")]
+        plan = plan_for(
+            gguf_path, vram_budget_gb=self.vram_budget_gb, n_ctx=self.n_ctx
+        )
+        if plan is None:
+            # Header unreadable: llama.cpp's own defaults beat a guess.
+            return [rung((), "engine-default")]
+        ctx_args = (
+            [] if any(a in _CTX_FLAGS for a in args)
+            else ["-c", str(plan.n_ctx)]
+        )
+        rungs: list[tuple[int, str]] = [(plan.n_gpu_layers, "planned")]
+        if plan.n_gpu_layers > 1:
+            rungs.append((plan.n_gpu_layers // 2, "half-gpu"))
+        if plan.n_gpu_layers > 0:
+            rungs.append((0, "cpu-only"))
+        return [
+            rung(["-ngl", str(n), *ctx_args], label) for n, label in rungs
+        ]
+
+
+#: Spec CLASS NAME -> runtime handle. Discovery reads an author's
+#: ``ctx.engine(LlamaServer(...))`` STATICALLY off the AST and needs the
+#: handle without importing anything the author wrote, so the mapping is a
+#: plain table rather than an attribute lookup on a resolved class.
+ENGINE_SPEC_RUNTIMES: dict[str, str] = {
+    "VllmServer": VllmServer.runtime,
+    "LlamaServer": LlamaServer.runtime,
+}
+
+
+# ---------------------------------------------------------------------------
+# The boot itself
+# ---------------------------------------------------------------------------
+
+
+def boot_engine(spec: EngineSpec, checkpoint_dir: Path) -> EngineHandle:
+    """Walk ``spec``'s ladder; the first rung that becomes healthy wins.
+
+    Raises :class:`EngineBootError` with the LAST rung's failure when every
+    rung fails — the boot is over, and a caller that swallowed it would serve
+    requests against a dead base URL.
+    """
+    ladder = spec.ladder(Path(checkpoint_dir))
+    if not ladder:  # pragma: no cover - a spec with no rungs is a bug
+        raise EngineBootError(
+            f"{spec.runtime}: the engine spec produced no boot command"
+        )
+    activity_mod.emit_event(
+        activity_mod.KIND_ENGINE_BOOT,
+        f"runtime={spec.runtime} rungs={len(ladder)} "
+        f"ladder={','.join(c.label for c in ladder)} "
+        f"checkpoint={Path(checkpoint_dir).name}",
+        phase=PHASE_PLANNED,
+        step=0, total_steps=len(ladder),
+    )
+
+    last: Optional[EngineBootError] = None
+    for index, command in enumerate(ladder):
+        try:
+            handle = _start(spec, command, rung_index=index, rungs=len(ladder))
+        except EngineBootError as exc:
+            last = exc
+            logger.warning(
+                "%s boot failed on rung %d/%d (%s): %s",
+                spec.runtime, index + 1, len(ladder), command.label, exc,
+            )
+            activity_mod.emit_event(
+                activity_mod.KIND_ENGINE_BOOT,
+                f"runtime={spec.runtime} rung={command.label} error={exc}",
+                phase=PHASE_FAILED,
+                step=index + 1, total_steps=len(ladder),
+            )
+            continue
+        if index > 0:
+            # Serving on a degraded rung (fewer GPU layers / CPU-only) is a
+            # QUALITY decision the planned rung's failure would otherwise
+            # hide. Two channels on purpose: this countable operator row, and
+            # the boot log the warning above wrote.
+            activity_mod.emit_event(
+                activity_mod.KIND_SERVE_DEGRADE,
+                f"runtime={spec.runtime} rung={command.label} "
+                f"({index} of {len(ladder) - 1} degrade steps): engine booted "
+                f"on a degraded rung after: {last}",
+                phase=PHASE_DEGRADED,
+                step=index, total_steps=len(ladder) - 1,
+            )
+        return handle
+    assert last is not None
+    raise last
+
+
+def _start(
+    spec: EngineSpec, command: EngineCommand, *, rung_index: int, rungs: int
+) -> EngineHandle:
+    argv = list(command.argv)
+    base_url = f"http://127.0.0.1:{command.port}"
+    logger.info("booting %s: %s", spec.runtime, shlex.join(argv))
+    env = dict(os.environ)
+    if spec.env:
+        env.update({str(k): str(v) for k, v in spec.env.items()})
+    started = time.monotonic()
+    activity_mod.emit_event(
+        activity_mod.KIND_ENGINE_BOOT,
+        f"runtime={spec.runtime} rung={command.label} port={command.port} "
+        f"argv={shlex.join(argv)}",
+        phase=PHASE_STARTED,
+        step=rung_index + 1, total_steps=rungs,
+    )
+    # Capture the engine's merged output instead of inheriting stdio: it is
+    # both the boot-PROGRESS signal and the log line an operator needs when a
+    # boot goes wrong. The tail thread keeps draining for the whole life of
+    # the process — a child whose pipe fills blocks mid-serving.
+    try:
+        proc = subprocess.Popen(
+            argv,
+            env=env,
+            start_new_session=True,  # own group -> group-wide signals
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except OSError as exc:
+        raise EngineBootError(
+            f"{spec.runtime}: could not exec {shlex.join(argv)}: {exc}"
+        ) from exc
+    tail = LineTail(
+        proc,
+        window_s=float(spec.stall_window_s),
+        on_line=lambda line: logger.info("[%s] %s", spec.runtime, line),
+        name=f"{spec.runtime}-tail",
+    ).start()
+    handle = EngineHandle(
+        runtime=spec.runtime,
+        base_url=base_url,
+        process=proc,
+        rung=command.label,
+    )
+    health_url = base_url + spec.health_path
+    try:
+        _wait_healthy(spec, proc, tail, health_url, argv)
+    except BaseException:
+        handle.stop()
+        raise
+    duration_ms = int((time.monotonic() - started) * 1000)
+    logger.info("%s healthy at %s after %dms", spec.runtime, base_url,
+                duration_ms)
+    activity_mod.emit_event(
+        activity_mod.KIND_ENGINE_BOOT,
+        f"runtime={spec.runtime} rung={command.label} base_url={base_url}",
+        phase=PHASE_HEALTHY,
+        duration_ms=duration_ms,
+        step=rung_index + 1, total_steps=rungs,
+    )
+    return handle
+
+
+def _wait_healthy(
+    spec: EngineSpec,
+    proc: "subprocess.Popen[str]",
+    tail: LineTail,
+    health_url: str,
+    argv: Sequence[str],
+) -> None:
+    """Boot is OVER when the health URL answers 2xx. It has FAILED only when
+    the process died, or stopped emitting output for its stall window."""
+    delay = 0.25
+    while True:
+        code = proc.poll()
+        if code is not None:
+            raise EngineBootError(
+                f"{spec.runtime} exited during boot (code {code}): "
+                f"{shlex.join(list(argv))}"
+            )
+        try:
+            with urllib.request.urlopen(health_url, timeout=5) as resp:
+                if 200 <= resp.status < 300:
+                    return
+        except (urllib.error.URLError, OSError, TimeoutError):
+            pass
+        if tail.stalled():
+            raise EngineBootError(
+                f"{spec.runtime} produced no output for "
+                f"{tail.silent_for():.0f}s (stall window {tail.window_s:.0f}s) "
+                f"and never became healthy at {health_url}: "
+                f"{shlex.join(list(argv))}"
+            )
+        time.sleep(delay)
+        delay = min(delay * 1.5, 2.0)
+
+
+def process_vram_bytes(pid: int) -> int:
+    """Measured VRAM of one process via nvidia-smi. 0 when unavailable.
+
+    An engine subprocess is invisible to torch's allocator, so residency
+    accounting for this tier books THIS number instead of asking torch.
+    """
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-compute-apps=pid,used_memory",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10, check=True,
+        ).stdout
+    except Exception:
+        return 0
+    total = 0
+    for line in out.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 2 and parts[0].isdigit() and int(parts[0]) == pid:
+            try:
+                total += int(parts[1]) * 1024 * 1024
+            except ValueError:
+                pass
+    return total

--- a/src/gen_worker/serving/gguf_fit.py
+++ b/src/gen_worker/serving/gguf_fit.py
@@ -1,0 +1,282 @@
+"""GGUF resolution and VRAM fit planning for the llama.cpp engine runtime.
+
+Torch-free on purpose: a llama-server serve image carries no torch, and this
+module is imported by :mod:`gen_worker.serving.engine_runtime` on that image.
+The ``gguf`` reader is imported lazily so discovery stays cheap.
+
+pgw#1421. This is the fit half of the deleted ``runtimes/llama.py``, carried
+forward unchanged in substance. The STREAMING-CLIENT half of that module
+(``chat_deltas``/``completion_deltas``) is deliberately NOT restored: both
+fleet consumers roll their own ``httpx`` streaming against the engine's
+OpenAI-compatible route, so restoring it would ship a surface with no caller.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import msgspec
+
+from ..api.errors import FatalError
+from ..models.materialized_view import third_party_dir
+
+logger = logging.getLogger(__name__)
+
+_GiB = 1024**3
+# Non-weight VRAM llama.cpp needs on top of layers + KV (compute graph,
+# scratch buffers, CUDA pool). Conservative; sized for 7B-class contexts.
+_OVERHEAD_GB = 1.0
+_SPLIT_RE = re.compile(r"-\d{5}-of-\d{5}\.gguf$")
+
+__all__ = [
+    "GGUFInfo",
+    "LlamaFitPlan",
+    "free_vram_gb",
+    "kv_bytes_per_token",
+    "plan_fit",
+    "plan_for",
+    "read_gguf_info",
+    "resolve_gguf",
+]
+
+
+# ---------------------------------------------------------------------------
+# GGUF resolution: checkpoint tree -> the .gguf file
+# ---------------------------------------------------------------------------
+
+
+def _split_stem(path: Path) -> str:
+    """Logical model stem: split shards of one model share a stem."""
+    return _SPLIT_RE.sub(".gguf", path.name)
+
+
+def resolve_gguf(source: Union[str, Path]) -> Path:
+    """Resolve a checkpoint tree to the single ``.gguf`` file to serve.
+
+    A ``.gguf`` file path passes through. A directory (``ctx.checkpoint_dir``)
+    must contain exactly one logical GGUF model; split shards
+    (``-00001-of-0000N.gguf``) count as one model and the first shard is
+    returned (llama.cpp discovers the rest). Multiple distinct models fail
+    closed — pin a flavor instead of guessing a quant.
+
+    **The returned path is always a REAL file.** This is tier 3 of Paul's
+    #1303 file-access ladder, narrowed by the 2026-08-19 ruling to exactly
+    this class and PERMANENT there: everything downstream is llama.cpp — the
+    ``llama-server -m`` argument, the ``gguf`` reader, and the ``st_size`` sum
+    that sizes the fit. None of them can read our store, and a pod has no FUSE
+    to give them file semantics.
+    """
+    p = Path(source)
+    if p.suffix == ".gguf":
+        return _real_shard_group(p)
+    if not p.is_dir():
+        raise FatalError(
+            f"checkpoint {str(p)!r} is neither a .gguf file nor a directory"
+        )
+    ggufs = sorted(q for q in p.rglob("*.gguf") if q.is_file())
+    if not ggufs:
+        raise FatalError(f"no .gguf file found under checkpoint tree {str(p)!r}")
+    stems = sorted({_split_stem(q) for q in ggufs})
+    if len(stems) > 1:
+        raise FatalError(
+            f"checkpoint tree {str(p)!r} holds {len(stems)} distinct GGUF "
+            f"models ({', '.join(stems)}); pin the flavor to exactly one quant"
+        )
+    return _real_shard_group(ggufs[0])
+
+
+def _real_shard_group(gguf: Path) -> Path:
+    """``gguf`` as a real file, with its shard siblings made real too.
+
+    Materializes the CONTAINING DIRECTORY rather than the one file: llama.cpp
+    opens ``-00002-of-0000N`` itself, having been told only about the first
+    shard, so a per-file copy would hand it one real shard and N-1 stubs. On a
+    tree that is not projected this returns ``gguf`` unchanged, so the
+    non-projected paths (a bare download, a test fixture) are untouched.
+    """
+    return third_party_dir(
+        gguf.parent, why="llama.cpp wants real GGUF files"
+    ) / gguf.name
+
+
+def _shard_group(gguf: Path) -> list[Path]:
+    """All shards belonging to the same logical model as ``gguf``."""
+    stem = _split_stem(gguf)
+    siblings = [q for q in gguf.parent.glob("*.gguf") if _split_stem(q) == stem]
+    return sorted(siblings) or [gguf]
+
+
+# ---------------------------------------------------------------------------
+# Header introspection (lazy `gguf` import)
+# ---------------------------------------------------------------------------
+
+
+class GGUFInfo(msgspec.Struct, frozen=True, kw_only=True):
+    """Fit-relevant facts from a GGUF header (weights never read)."""
+
+    architecture: str = ""
+    n_layers: int = 0
+    n_ctx_train: int = 0
+    n_embd: int = 0
+    n_head: int = 0
+    n_head_kv: int = 0
+    size_bytes: int = 0
+
+
+def _field_int(reader: Any, key: str) -> int:
+    field = reader.get_field(key)
+    if field is None:
+        return 0
+    try:
+        return int(field.contents())
+    except Exception:
+        return 0
+
+
+def read_gguf_info(path: Union[str, Path]) -> GGUFInfo:
+    """Read fit metadata from a GGUF header. ``size_bytes`` sums all shards.
+
+    ``size_bytes`` is what decides ``-ngl``, and it comes from ``st_size``.
+    Over a projected tree a stub's ``st_size`` is ~128 bytes REGARDLESS of the
+    model behind it, so the fit would conclude "everything fits" for a 30 GiB
+    model and never degrade — silently, since nothing fails. The whole shard
+    group is therefore made real first, and every stat below is taken on the
+    real files.
+    """
+    try:
+        from gguf import GGUFReader
+    except ImportError as exc:  # pragma: no cover - gguf is a core dep
+        raise FatalError(
+            "the 'gguf' package is required for the llama.cpp engine runtime; "
+            "install with 'pip install gen-worker'"
+        ) from exc
+
+    gguf_path = _real_shard_group(Path(path))
+    reader = GGUFReader(str(gguf_path), "r")
+    arch_field = reader.get_field("general.architecture")
+    arch = str(arch_field.contents()) if arch_field is not None else ""
+    n_head = _field_int(reader, f"{arch}.attention.head_count")
+    n_head_kv = _field_int(reader, f"{arch}.attention.head_count_kv") or n_head
+    return GGUFInfo(
+        architecture=arch,
+        n_layers=_field_int(reader, f"{arch}.block_count"),
+        n_ctx_train=_field_int(reader, f"{arch}.context_length"),
+        n_embd=_field_int(reader, f"{arch}.embedding_length"),
+        n_head=n_head,
+        n_head_kv=n_head_kv,
+        size_bytes=sum(q.stat().st_size for q in _shard_group(gguf_path)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fit planning: free VRAM -> n_gpu_layers / n_ctx. Never raises.
+# ---------------------------------------------------------------------------
+
+
+class LlamaFitPlan(msgspec.Struct, frozen=True, kw_only=True):
+    n_gpu_layers: int = 0
+    n_ctx: int = 0
+    degraded: bool = False
+    reason: str = ""
+
+
+def kv_bytes_per_token(info: GGUFInfo, *, bytes_per_elem: float = 2.0) -> int:
+    """K+V cache bytes per context token (f16 default; q8_0 ~= 1.06)."""
+    if not (info.n_layers and info.n_head and info.n_head_kv and info.n_embd):
+        return 0
+    head_dim = info.n_embd / info.n_head
+    return int(info.n_layers * info.n_head_kv * head_dim * 2 * bytes_per_elem)
+
+
+def plan_fit(
+    info: GGUFInfo,
+    *,
+    free_vram_gb: float,
+    n_ctx: Optional[int] = None,
+    kv_bytes_per_elem: float = 2.0,
+    overhead_gb: float = _OVERHEAD_GB,
+) -> LlamaFitPlan:
+    """Size ``-ngl`` / ``-c`` to the VRAM budget.
+
+    Full offload when everything fits; otherwise as many layers as fit with
+    their share of the KV cache (the rest runs on CPU). Floor is 0 GPU layers
+    — a plan is always returned, never an exception (degrade-never-OOM: a
+    tight card serves slowly and says so, it does not refuse).
+    """
+    ctx = int(n_ctx or info.n_ctx_train or 4096)
+    if info.n_ctx_train:
+        ctx = min(ctx, info.n_ctx_train)
+    total_layers = info.n_layers + 1  # +1: output/embedding layer
+    budget = free_vram_gb * _GiB - overhead_gb * _GiB
+    if budget <= 0 or not info.n_layers or not info.size_bytes:
+        why = "no VRAM budget" if budget <= 0 else "unknown model geometry"
+        return LlamaFitPlan(
+            n_gpu_layers=0, n_ctx=ctx, degraded=free_vram_gb > 0,
+            reason=f"{why}; running all layers on CPU",
+        )
+    kv_total = kv_bytes_per_token(info, bytes_per_elem=kv_bytes_per_elem) * ctx
+    if budget >= info.size_bytes + kv_total:
+        return LlamaFitPlan(
+            n_gpu_layers=total_layers, n_ctx=ctx, degraded=False,
+            reason=(
+                f"full offload: {total_layers} layers + "
+                f"{kv_total // _GiB}GiB KV fit"
+            ),
+        )
+    layer_bytes = info.size_bytes / total_layers
+    kv_per_layer = kv_total / info.n_layers if info.n_layers else 0
+    n = int(budget // (layer_bytes + kv_per_layer))
+    n = max(0, min(n, total_layers))
+    return LlamaFitPlan(
+        n_gpu_layers=n, n_ctx=ctx, degraded=True,
+        reason=(
+            f"partial offload: {n}/{total_layers} layers fit in "
+            f"{free_vram_gb:.1f}GiB free VRAM (ctx={ctx})"
+        ),
+    )
+
+
+def free_vram_gb() -> float:
+    """Free VRAM on device 0. Torch-free fallback: nvidia-smi (llama-server
+    serve images carry no torch)."""
+    try:
+        from ..models.memory import get_available_vram_gb
+
+        via_torch = get_available_vram_gb()
+    except Exception:
+        via_torch = 0.0
+    if via_torch > 0:
+        return via_torch
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.free",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10, check=True,
+        ).stdout.strip().splitlines()
+        return float(out[0]) / 1024.0 if out else 0.0
+    except Exception:
+        return 0.0
+
+
+def plan_for(
+    gguf_path: Union[str, Path],
+    *,
+    vram_budget_gb: Optional[float] = None,
+    n_ctx: Optional[int] = None,
+) -> Optional[LlamaFitPlan]:
+    """Best-effort plan for a checkpoint: ``None`` when the header is
+    unreadable (the caller then falls back to llama.cpp's own defaults rather
+    than failing the boot)."""
+    try:
+        info = read_gguf_info(gguf_path)
+    except Exception as exc:
+        logger.debug("gguf header unreadable for %s: %s", gguf_path, exc)
+        return None
+    budget = free_vram_gb() if vram_budget_gb is None else vram_budget_gb
+    plan = plan_fit(info, free_vram_gb=budget, n_ctx=n_ctx)
+    logger.info("llama fit plan for %s: %s", Path(gguf_path).name, plan.reason)
+    return plan

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -305,6 +305,14 @@ class EndpointHost:
                     "unload(%s) raised; eviction proceeds (best-effort, "
                     "never correctness)", model_cls.__name__,
                 )
+            # pgw#1421: engine-hosted teardown is STRUCTURAL, not remembered.
+            # An external engine subprocess (`llama-server`, `vllm serve`) is
+            # invisible to torch's allocator, so an unload that forgot to stop
+            # it — or raised before reaching the stop — leaves VRAM the next
+            # admit can neither see nor reclaim. This runs whatever `unload`
+            # did, and `EngineHandle.stop` is idempotent so an author who did
+            # stop it pays nothing.
+            instance.load_context.stop_engines()
             del self.instances[model_cls]
 
     def teardown(self) -> None:

--- a/src/gen_worker/subproc.py
+++ b/src/gen_worker/subproc.py
@@ -38,8 +38,9 @@ class LineTail:
     captures output must keep reading for the process's whole life.
 
     ``run_process`` uses it to bound a run-to-completion tool;
-    ``runtimes.server`` uses it to bound an engine BOOT while keeping the
-    child alive afterwards.
+    ``serving.engine_runtime`` uses it to bound an engine BOOT while keeping
+    the child alive afterwards (pgw#1421 — the v1 ``runtimes.server`` this
+    line used to name was deleted by the pgw#1373 hardcut).
     """
 
     __slots__ = ("_proc", "_on_line", "_window", "_thread")

--- a/tests/fixtures/serving_engine_endpoint/endpoint.toml
+++ b/tests/fixtures/serving_engine_endpoint/endpoint.toml
@@ -1,0 +1,1 @@
+main = "serving_engine_fixture.main"

--- a/tests/fixtures/serving_engine_endpoint/src/serving_engine_fixture/main.py
+++ b/tests/fixtures/serving_engine_endpoint/src/serving_engine_fixture/main.py
@@ -1,0 +1,115 @@
+"""pgw#1421 fixture: an ENGINE-HOSTED endpoint, written the way the two real
+consumers (`qwen3.6-27b-mtp-gguf`, `qwen3.6-35b-a3b`) will be after the wave.
+
+The v1 shape this replaces, verbatim from the shipped endpoints::
+
+    from gen_worker.runtimes.server import ServerHandle, llama_server
+    @endpoint(model=Slot(str, layouts_undeclarable="GGUF: ..."), ...)
+    class QwenMTPCompletion:
+        def setup(self, model: str) -> None:
+            self._handle = llama_server(model, extra_args=[...]).start()
+        def shutdown(self) -> None:
+            self._handle.stop()
+
+The v2 shape below states the same facts in the wave's vocabulary: the model
+class is the stateful half, `lanes=()` is eager-permanent (a self-loading
+external binary performs no pytorch lane load), `ctx.engine` is the boot seam,
+and there is no `shutdown` at all — the host stops the engine structurally.
+
+Two engine arms and a CONTROL: llama.cpp, vLLM, and a plain pytorch model
+that must read as hosting NO engine. The arm that actually BOOTS an engine
+lives in `serving_engine_host_endpoint` — `EndpointHost.setup()` loads every
+referenced model class, so declaring all four here would exec `llama-server`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+
+from gen_worker import (
+    LlamaServer,
+    LoadContext,
+    Model,
+    RequestContext,
+    VllmServer,
+    entrypoint,
+)
+from gen_worker.models import SDXL
+
+
+class In(msgspec.Struct):
+    prompt: str = ""
+
+
+class Out(msgspec.Struct):
+    text: str
+
+
+class FakePipeline:
+    """A module-level pipeline class, so the CONTROL arm resolves the way
+    every pytorch endpoint in the fleet does."""
+
+    @classmethod
+    def from_pretrained(cls, *args: Any, **kwargs: Any) -> "FakePipeline":
+        return cls()
+
+
+class GgufModel(
+    Model[SDXL],
+    lanes=(),
+    self_loading="served by llama-server, which self-loads a GGUF; the "
+                 "block-quantized container is the external-binary class "
+                 "the streaming engine refuses by design",
+):
+    """llama.cpp / GGUF — `qwen3.6-27b-mtp-gguf`'s shape.
+
+    `self_loading=` (pgw#1431 fix (b)) is not a second declaration beside
+    `ctx.engine`: an engine-hosted model is self-loading BY CONSTRUCTION, and
+    the marker is where that fact reaches the publish path.
+    """
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.engine = ctx.engine(LlamaServer(
+            n_ctx=32768,
+            extra_args=["--alias", "qwen3.6-27b-mtp-gguf", "-ngl", "99",
+                        "--cache-type-k", "q8_0", "-fa", "on"],
+        ))
+
+
+class VllmModel(
+    Model[SDXL],
+    lanes=(),
+    self_loading="served by vLLM, which self-loads the checkpoint directory; "
+                 "ctx.load is never called",
+):
+    """vLLM / fp8 — `qwen3.6-35b-a3b`'s shape."""
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.engine = ctx.engine(VllmServer(
+            extra_args=["--max-model-len", "16384",
+                        "--gpu-memory-utilization", "0.94"],
+        ))
+
+
+class PytorchModel(Model[SDXL], lanes=()):
+    """THE CONTROL: boots no engine, so the census must not name it."""
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(FakePipeline)
+
+
+@entrypoint
+def chat(ctx: RequestContext, payload: In, model: GgufModel) -> Out:
+    return Out(text=model.engine.base_url)
+
+
+@entrypoint
+def complete(ctx: RequestContext, payload: In, model: VllmModel) -> Out:
+    return Out(text=model.engine.base_url)
+
+
+@entrypoint
+def draw(ctx: RequestContext, payload: In, model: PytorchModel) -> Out:
+    return Out(text=type(model.pipe).__name__)

--- a/tests/fixtures/serving_engine_host_endpoint/endpoint.toml
+++ b/tests/fixtures/serving_engine_host_endpoint/endpoint.toml
@@ -1,0 +1,1 @@
+main = "serving_engine_host_fixture.main"

--- a/tests/fixtures/serving_engine_host_endpoint/src/serving_engine_host_fixture/main.py
+++ b/tests/fixtures/serving_engine_host_endpoint/src/serving_engine_host_fixture/main.py
@@ -1,0 +1,67 @@
+"""pgw#1421 host fixture: ONE engine-hosted model, whose engine really boots.
+
+Separate from `serving_engine_endpoint` on purpose. `EndpointHost.setup()`
+loads EVERY model class the endpoint references, so a fixture that also
+declared the llama.cpp and vLLM arms would try to exec `llama-server` and
+`vllm` on this box — the declaration arms and the supervision arm cannot
+share a package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+import msgspec
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+from gen_worker.models import SDXL
+from gen_worker.serving.engine_runtime import EngineCommand, EngineSpec
+
+#: Set by the test before boot — the stand-in engine script.
+STAND_IN_SCRIPT = ""
+#: Appended by `unload`, so ordering (author unload FIRST, then the
+#: structural engine stop) is observable.
+ORDER: List[str] = []
+
+
+class In(msgspec.Struct):
+    prompt: str = ""
+
+
+class Out(msgspec.Struct):
+    text: str
+
+
+class StandInSpec(EngineSpec, frozen=True, kw_only=True):
+    """A spec whose engine really runs, so the host supervises a real process
+    rather than a stub of one."""
+
+    runtime = "stand-in"
+
+    def ladder(self, checkpoint_dir: Path) -> List[EngineCommand]:
+        port = self._port()
+        return [EngineCommand(
+            argv=(sys.executable, STAND_IN_SCRIPT, str(port), "0", "0.1", "-1"),
+            port=port,
+        )]
+
+
+class StandInModel(
+    Model[SDXL],
+    lanes=(),
+    self_loading="served by an external engine process over HTTP",
+):
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.engine = ctx.engine(StandInSpec())
+
+    def unload(self, ctx: LoadContext[SDXL]) -> None:
+        ORDER.append("author_unload")
+        # An author bug, deliberately: the engine must be reaped anyway.
+        raise RuntimeError("author unload bug — must not strand the engine")
+
+
+@entrypoint
+def probe(ctx: RequestContext, payload: In, model: StandInModel) -> Out:
+    return Out(text=model.engine.base_url)

--- a/tests/test_engine_runtime_binding_pgw1421.py
+++ b/tests/test_engine_runtime_binding_pgw1421.py
@@ -1,0 +1,294 @@
+"""pgw#1421, the WIDENING: the declaration binds to the runtime.
+
+The isolated arms (`test_engine_runtime_pgw1421.py`) prove the supervisor.
+These prove the two boundaries it has to cross for a real endpoint:
+
+* **DISCOVERY** reads an author's `ctx.engine(LlamaServer(...))` statically —
+  no author code runs — and the endpoint.lock states the engine BY NAME. That
+  is what makes "which binary does this pod start" answerable from the release
+  instead of from the source.
+* **THE HOST** stops every engine a load context started, after the author's
+  `unload` and regardless of what it did. An external engine is invisible to
+  torch's allocator, so a stranded one is VRAM nothing can see or reclaim.
+
+The fixture is written as the qwen3.6 pair will be, so what these arms bind
+to is the real migration shape rather than a shape invented for a test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, cast
+
+import pytest
+
+from gen_worker.discovery.entrypoints_v2 import (
+    EntrypointDiscoveryError,
+    _engine_runtime,
+    _model_slot,
+    discover_entrypoints,
+    lift_engine_runtimes,
+)
+from gen_worker import LlamaServer
+from gen_worker.models import SDXL
+from gen_worker.serving import (
+    DeployBinding,
+    EndpointHost,
+    LoadContext,
+    Model,
+    load_endpoint,
+)
+from gen_worker.serving.engine_runtime import ENGINE_SPEC_RUNTIMES
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "serving_engine_endpoint"
+HOST_FIXTURE_DIR = (
+    Path(__file__).parent / "fixtures" / "serving_engine_host_endpoint"
+)
+
+# Same stand-in as the isolated file; duplicated rather than imported so this
+# file states its own substrate (a stand-in that drifts silently is worse than
+# one written twice).
+_STAND_IN = textwrap.dedent(
+    '''
+    import http.server, sys, threading, time
+    port, warmup, chatter, die = (int(sys.argv[1]), float(sys.argv[2]),
+                                  float(sys.argv[3]), int(sys.argv[4]))
+    if die >= 0:
+        sys.exit(die)
+    class H(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = b"READY"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        def log_message(self, *a):
+            pass
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", port), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    print("stand-in: ready", flush=True)
+    while True:
+        time.sleep(3600)
+    '''
+)
+
+
+@pytest.fixture
+def declarations() -> Any:
+    """The DECLARATION fixture: three model classes, no process ever started
+    (discovery reads the AST — it runs no author code)."""
+    load_endpoint(FIXTURE_DIR)
+    import serving_engine_fixture.main as main
+
+    return main
+
+
+@pytest.fixture
+def host_fixture(tmp_path: Path) -> Any:
+    """The SUPERVISION fixture: one model whose engine really boots."""
+    script = tmp_path / "stand_in.py"
+    script.write_text(_STAND_IN)
+    loaded = load_endpoint(HOST_FIXTURE_DIR)
+    import serving_engine_host_fixture.main as main
+
+    main.STAND_IN_SCRIPT = str(script)
+    main.ORDER.clear()
+    return loaded, main
+
+
+# --------------------------------------------------------------------------
+# 1. the static read: a declaration -> an engine NAME, importing nothing
+# --------------------------------------------------------------------------
+
+
+def test_the_declaration_names_its_engine(declarations: Any) -> None:
+    main = declarations
+    assert _engine_runtime(main.GgufModel) == "llama-server"
+    assert _engine_runtime(main.VllmModel) == "vllm"
+    # THE CONTROL, and it is the load-bearing half: a plain pytorch model
+    # must read as hosting NO engine. Without this arm a `_engine_runtime`
+    # that returned a constant would pass every assertion above.
+    assert _engine_runtime(main.PytorchModel) == ""
+
+
+def test_the_registry_and_the_classes_cannot_drift() -> None:
+    """The static fallback resolves a name off the AST when the class object
+    is not there to ask, so its table has to agree with the classes. Two
+    producers of one fact is how they stop agreeing."""
+    from gen_worker.serving.engine_runtime import LlamaServer, VllmServer
+
+    assert ENGINE_SPEC_RUNTIMES == {
+        "VllmServer": VllmServer.runtime,
+        "LlamaServer": LlamaServer.runtime,
+    }
+    assert sorted(ENGINE_SPEC_RUNTIMES.values()) == ["llama-server", "vllm"]
+
+
+# --------------------------------------------------------------------------
+# 2. the lock: the census names the engine, and the CONTROL is absent from it
+# --------------------------------------------------------------------------
+
+
+def test_the_lock_census_names_the_engine_runtime(declarations: Any) -> None:
+    # The REAL discovery walk, end to end — the marker landing (pgw#1431) is
+    # what lets this run to completion instead of refusing at the first
+    # engine-hosted slot.
+    rows = discover_entrypoints("serving_engine_fixture.main")
+    census = lift_engine_runtimes(rows)
+
+    assert [(r["entrypoint"], r["runtime"]) for r in census] == [
+        ("chat", "llama-server"),
+        ("complete", "vllm"),
+    ]
+    gguf = census[0]
+    assert gguf["slot"] == "model"
+    assert gguf["model_class"].endswith("main.GgufModel")
+    # `draw` is the pytorch CONTROL: no row, so a lock that carries this block
+    # at all IS an engine-hosted endpoint.
+    assert all(r["entrypoint"] != "draw" for r in census)
+
+    # LIFTED, not copied: the two keys are gone from the slot rows, so the
+    # `entrypoints[]` block the hub decodes is byte-identical to what it was
+    # before this landed.
+    for row in rows:
+        for slot in row["slots"]:
+            assert "engine_runtime" not in slot
+            assert "model_class" not in slot
+
+
+# --------------------------------------------------------------------------
+# 3. the SEAM with pgw#1431: an UNMARKED engine-hosted slot is told what to
+#    write, in words it can follow
+# --------------------------------------------------------------------------
+
+
+class UnmarkedGgufModel(Model[SDXL], lanes=()):
+    """Engine-hosted and NOT marked — the mistake a migrating author makes.
+
+    An engine-hosted model is self-loading by construction, so this class is
+    a contradiction the author has not noticed yet. What it must not get is
+    the generic refusal's advice: `ctx.load(StableDiffusionXLPipeline)` is a
+    load the streaming engine refuses BY DESIGN for a block-quantized
+    container, so telling this author to write one sends them into a wall.
+    """
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.engine = ctx.engine(LlamaServer(extra_args=["-ngl", "99"]))
+
+
+def test_an_unmarked_engine_hosted_slot_is_told_what_to_write() -> None:
+    from gen_worker.discovery.entrypoints_v2 import _pipeline_class_or_refuse
+    from gen_worker.serving.entrypoints import SlotSpec
+
+    slot = SlotSpec(name="model", kind="model", annotation=UnmarkedGgufModel)
+    emitted = _model_slot(slot)
+    row: Dict[str, Any] = {"name": "chat", "slots": [emitted]}
+    # The static read still worked — discovery KNOWS what this boots, which is
+    # exactly why "could not read the pipeline class" would be a false
+    # sentence here.
+    assert emitted["engine_runtime"] == "llama-server"
+    assert emitted["pipeline_class"] == ""
+
+    with pytest.raises(EntrypointDiscoveryError) as excinfo:
+        _pipeline_class_or_refuse([row])
+    message = str(excinfo.value)
+    assert "ENGINE-HOSTED (llama-server)" in message
+    assert "self_loading=" in message
+    # And it must NOT hand out the advice that cannot work here.
+    assert "ctx.load(StableDiffusionXLPipeline)" not in message
+
+
+def test_a_marked_engine_hosted_slot_publishes(declarations: Any) -> None:
+    """The green path: `self_loading=` (pgw#1431, landed) is what carries an
+    engine-hosted slot through the gate the hub requires — this lane adds no
+    surface of its own for it, and the fixture proves the inheritance."""
+    rows = discover_entrypoints("serving_engine_fixture.main")
+    by_name = {row["name"]: row for row in rows}
+    gguf_slot = by_name["chat"]["slots"][0]
+    assert "pipeline_class" not in gguf_slot
+    assert "llama-server" in gguf_slot["self_loading"]
+
+
+# --------------------------------------------------------------------------
+# 4. the host: teardown is STRUCTURAL, even when the author's unload explodes
+# --------------------------------------------------------------------------
+
+
+def _dead(proc: subprocess.Popen, *, within_s: float = 10.0) -> bool:
+    deadline = time.monotonic() + within_s
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def test_the_host_reaps_the_engine_after_a_raising_unload(
+    host_fixture: Any, tmp_path: Path
+) -> None:
+    loaded, main = host_fixture
+    host = EndpointHost(
+        loaded,
+        DeployBinding(checkpoint_ref="ckpt:qwen@1", checkpoint_dir=tmp_path),
+        output_dir=tmp_path / "out",
+    )
+    host.setup()
+    instance = host.instances[main.StandInModel]
+    # The author's own attribute — `Model` is a typed skeleton, so the engine
+    # handle lives on the author's class, not on the base.
+    handle = cast(Any, instance.model).engine
+    assert handle.alive
+    # The engine really serves: the entrypoint's dispatch target answers.
+    with urllib.request.urlopen(handle.base_url + "/health", timeout=5) as r:
+        assert r.status == 200
+    # The load context tracks it, which is what makes the stop structural
+    # rather than a thing `unload` has to remember.
+    assert instance.load_context.engines == (handle,)
+
+    host.evict(main.StandInModel)
+
+    assert main.ORDER == ["author_unload"]  # the author's unload DID run
+    assert not handle.alive
+    assert _dead(handle.process)
+    assert len(instance.load_context.engines) == 0
+    assert main.StandInModel not in host.instances
+
+
+def test_stop_engines_is_idempotent_and_survives_a_raising_stop(
+    tmp_path: Path,
+) -> None:
+    """The host calls `stop_engines` unconditionally, so one bad handle must
+    not strand the ones behind it — that is the whole reason the loop
+    swallows."""
+
+    class Boom:
+        runtime = "boom"
+
+        def stop(self) -> None:
+            raise RuntimeError("stop exploded")
+
+    class Counted:
+        runtime = "counted"
+
+        def __init__(self) -> None:
+            self.stops = 0
+
+        def stop(self) -> None:
+            self.stops += 1
+
+    ctx: LoadContext[Any] = LoadContext(
+        binding=DeployBinding(checkpoint_ref="c", checkpoint_dir=tmp_path)
+    )
+    counted = Counted()
+    ctx._engines.extend([counted, Boom()])
+    ctx.stop_engines()
+    # Newest-first: Boom raised, and the one behind it was still stopped.
+    assert counted.stops == 1
+    assert len(ctx.engines) == 0
+    ctx.stop_engines()  # idempotent: nothing left, nothing raised
+    assert counted.stops == 1

--- a/tests/test_engine_runtime_pgw1421.py
+++ b/tests/test_engine_runtime_pgw1421.py
@@ -1,0 +1,334 @@
+"""pgw#1421 — the engine-hosted (external-binary) runtime, ISOLATED.
+
+Paul's 2026-08-19 working loop: isolate the unit, RUN it, introspect deeply,
+then widen. The unit here is process supervision, and the thing it supervises
+is deliberately NOT llama.cpp or vLLM: it is a trivial stand-in HTTP server
+whose behaviour each arm dictates — serves, dies on exec, dies after N
+seconds, goes silent, or talks slowly. That isolation is legitimate because
+the boundary is strict and side-effect-free: ``EngineSpec`` hands
+:func:`boot_engine` an argv and a health route and learns nothing else about
+the engine, so an arm that proves the supervisor against a stand-in proves it
+against llama-server.
+
+$0, no GPU, no weights, no network beyond loopback. What it does NOT prove —
+and this is the widening a real pod owes — is that ``vllm serve`` and
+``llama-server`` accept the argv these specs build. Those are their
+CONTRACTS, not this code's behaviour, and the qwen3.6 activation lane owns
+that leg.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterator, List
+
+import pytest
+
+from gen_worker import activity
+from gen_worker.serving.engine_runtime import (
+    EngineBootError,
+    EngineCommand,
+    EngineHandle,
+    EngineSpec,
+    LlamaServer,
+    VllmServer,
+    boot_engine,
+    free_port,
+)
+
+# --------------------------------------------------------------------------
+# The stand-in engine: an HTTP server whose boot behaviour the arm dictates.
+# --------------------------------------------------------------------------
+
+_STAND_IN = textwrap.dedent(
+    '''
+    import http.server, sys, threading, time
+
+    port = int(sys.argv[1])
+    # seconds of "loading" before /health starts answering
+    warmup = float(sys.argv[2])
+    # seconds between progress lines; 0 = say NOTHING at all
+    chatter = float(sys.argv[3])
+    # exit with this code instead of serving; -1 = serve
+    die = int(sys.argv[4])
+
+    if die >= 0:
+        print("stand-in: refusing to serve", flush=True)
+        sys.exit(die)
+
+    ready = threading.Event()
+
+    class H(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health" and not ready.is_set():
+                self.send_error(503)
+                return
+            body = ("READY " + self.path).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):
+            pass
+
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", port), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+    deadline = time.monotonic() + warmup
+    while time.monotonic() < deadline:
+        if chatter > 0:
+            print("stand-in: loading...", flush=True)
+            time.sleep(min(chatter, max(0.0, deadline - time.monotonic())))
+        else:
+            time.sleep(0.05)
+    ready.set()
+    print("stand-in: ready", flush=True)
+    while True:
+        time.sleep(3600)
+    '''
+)
+
+
+@pytest.fixture(scope="module")
+def stand_in(tmp_path_factory: Any) -> Path:
+    path = tmp_path_factory.mktemp("engine") / "stand_in.py"
+    path.write_text(_STAND_IN)
+    return path
+
+
+class StandIn(EngineSpec, frozen=True, kw_only=True):
+    """A one-rung spec around the stand-in. ``script`` is the only thing this
+    spec knows that a real one gets from the platform."""
+
+    runtime = "stand-in"
+    health_path = "/health"
+
+    script: str = ""
+    warmup_s: float = 0.0
+    chatter_s: float = 0.1
+    die_code: int = -1
+
+    def ladder(self, checkpoint_dir: Path) -> List[EngineCommand]:
+        port = self._port()
+        return [EngineCommand(
+            argv=(sys.executable, self.script, str(port), str(self.warmup_s),
+                  str(self.chatter_s), str(self.die_code)),
+            port=port,
+        )]
+
+
+class StandInLadder(StandIn, frozen=True, kw_only=True):
+    """Two rungs: the first dies, the second serves — the degrade shape."""
+
+    def ladder(self, checkpoint_dir: Path) -> List[EngineCommand]:
+        bad, good = free_port(), free_port()
+        return [
+            EngineCommand(
+                argv=(sys.executable, self.script, str(bad), "0", "0.1", "3"),
+                port=bad, label="planned",
+            ),
+            EngineCommand(
+                argv=(sys.executable, self.script, str(good), "0", "0.1", "-1"),
+                port=good, label="cpu-only",
+            ),
+        ]
+
+
+@pytest.fixture
+def events(monkeypatch: pytest.MonkeyPatch) -> Iterator[List[Any]]:
+    """Every typed event this test's code emits, in order.
+
+    Introspection is the point: a boot that "worked" but reported nothing is
+    a boot no operator can read, so the arms assert the PHASES as hard as
+    they assert the process.
+    """
+    captured: List[Any] = []
+    monkeypatch.setattr(activity, "_sink", captured.append)
+    yield captured
+    monkeypatch.setattr(activity, "_sink", None)
+
+
+def _phases(events: List[Any], kind: str) -> List[str]:
+    return [e.phase for e in events if e.kind == kind]
+
+
+def _dead(proc: subprocess.Popen, *, within_s: float = 10.0) -> bool:
+    deadline = time.monotonic() + within_s
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+# --------------------------------------------------------------------------
+# 1. start -> health -> dispatch -> terminate, with the typed events
+# --------------------------------------------------------------------------
+
+
+def test_boot_health_dispatch_terminate(
+    stand_in: Path, tmp_path: Path, events: List[Any]
+) -> None:
+    handle = boot_engine(
+        StandIn(script=str(stand_in), warmup_s=0.5), tmp_path
+    )
+    try:
+        assert isinstance(handle, EngineHandle)
+        assert handle.alive
+        # HEALTH: boot_engine returned only because /health answered 2xx.
+        with urllib.request.urlopen(handle.base_url + "/health", timeout=5) as r:
+            assert r.status == 200
+        # DISPATCH: an entrypoint's POST target is reachable on base_url.
+        with urllib.request.urlopen(handle.base_url + "/v1/chat", timeout=5) as r:
+            assert r.read() == b"READY /v1/chat"
+    finally:
+        handle.stop()
+
+    # TERMINATE, and the process is genuinely reaped rather than orphaned.
+    assert not handle.alive
+    assert _dead(handle.process)
+    handle.stop()  # idempotent: the host's structural stop cannot double-kill
+
+    phases = _phases(events, activity.KIND_ENGINE_BOOT)
+    assert phases == [
+        "engine_planned", "engine_started", "engine_healthy", "engine_stopped",
+    ], phases
+    stopped = [
+        e for e in events
+        if e.kind == activity.KIND_ENGINE_BOOT and e.phase == "engine_stopped"
+    ]
+    # HOW it stopped, not just that it did: `manner=kill` is the row an
+    # operator needs, because an engine that had to be SIGKILLed is the shape
+    # that strands VRAM anywhere less careful than here.
+    assert "manner=term" in stopped[0].detail
+    healthy = [
+        e for e in events
+        if e.kind == activity.KIND_ENGINE_BOOT and e.phase == "engine_healthy"
+    ]
+    # The boot wall is a NUMBER in the duration column, not a sentence: a
+    # reader can percentile it. The stand-in warms for 0.5s, so a zero here
+    # would mean the span was never measured.
+    assert healthy[0].duration_ms >= 400, healthy[0].duration_ms
+    assert handle.base_url in healthy[0].detail
+
+
+# --------------------------------------------------------------------------
+# 2. the boot ABORTS on engine death — and leaves nothing running
+# --------------------------------------------------------------------------
+
+
+def test_boot_aborts_when_the_engine_exits(
+    stand_in: Path, tmp_path: Path, events: List[Any]
+) -> None:
+    with pytest.raises(EngineBootError) as excinfo:
+        boot_engine(StandIn(script=str(stand_in), die_code=3), tmp_path)
+    assert "exited during boot (code 3)" in str(excinfo.value)
+    assert "engine_boot_failed" in _phases(events, activity.KIND_ENGINE_BOOT)
+    # The failure is not a HEALTHY row with a sad detail — nothing claimed
+    # readiness.
+    assert "engine_healthy" not in _phases(events, activity.KIND_ENGINE_BOOT)
+
+
+def test_boot_refuses_an_engine_that_cannot_exec(tmp_path: Path) -> None:
+    class Missing(StandIn, frozen=True, kw_only=True):
+        def ladder(self, checkpoint_dir: Path) -> List[EngineCommand]:
+            port = free_port()
+            return [EngineCommand(
+                argv=("cozy-no-such-engine-binary",), port=port
+            )]
+
+    with pytest.raises(EngineBootError) as excinfo:
+        boot_engine(Missing(script=""), tmp_path)
+    assert "could not exec" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# 3. THE DOCTRINE ARM: a boot is bounded by SILENCE, not by a clock.
+#    Red and green differ ONLY in whether the child keeps talking.
+# --------------------------------------------------------------------------
+
+
+def test_a_silent_engine_is_wedged(stand_in: Path, tmp_path: Path) -> None:
+    started = time.monotonic()
+    with pytest.raises(EngineBootError) as excinfo:
+        boot_engine(
+            StandIn(script=str(stand_in), warmup_s=60.0, chatter_s=0.0,
+                    stall_window_s=1.5),
+            tmp_path,
+        )
+    assert "produced no output" in str(excinfo.value)
+    # It gave up on SILENCE, long before the 60s the engine claimed to need.
+    assert time.monotonic() - started < 20.0
+
+
+def test_a_talking_engine_outlives_the_window(
+    stand_in: Path, tmp_path: Path
+) -> None:
+    """The control for the arm above, and the whole point of the design: this
+    boot takes 3s with a 1.5s window and SUCCEEDS, because every line the
+    engine prints is proof it is still loading. A wall-clock budget would
+    have killed it; that is the mistake this module refuses to make."""
+    handle = boot_engine(
+        StandIn(script=str(stand_in), warmup_s=3.0, chatter_s=0.25,
+                stall_window_s=1.5),
+        tmp_path,
+    )
+    try:
+        assert handle.alive
+    finally:
+        handle.stop()
+
+
+# --------------------------------------------------------------------------
+# 4. degrade, never OOM — and the degraded rung CONFESSES
+# --------------------------------------------------------------------------
+
+
+def test_the_ladder_degrades_and_says_so(
+    stand_in: Path, tmp_path: Path, events: List[Any]
+) -> None:
+    handle = boot_engine(StandInLadder(script=str(stand_in)), tmp_path)
+    try:
+        assert handle.alive
+        assert handle.rung == "cpu-only"
+    finally:
+        handle.stop()
+
+    boot = _phases(events, activity.KIND_ENGINE_BOOT)
+    assert boot.count("engine_boot_failed") == 1
+    assert boot.count("engine_healthy") == 1
+    # Two channels on purpose (the z-image finding: report_* does not subsume
+    # emit_event). The degrade is a COUNTABLE row on the quality channel, not
+    # only a phase inside the boot's own story.
+    degrades = [e for e in events if e.kind == activity.KIND_SERVE_DEGRADE]
+    assert len(degrades) == 1
+    assert degrades[0].phase == "engine_degraded"
+    assert "rung=cpu-only" in degrades[0].detail
+
+
+def test_every_rung_failing_raises_the_last_failure(
+    stand_in: Path, tmp_path: Path
+) -> None:
+    class AllBad(StandInLadder, frozen=True, kw_only=True):
+        def ladder(self, checkpoint_dir: Path) -> List[EngineCommand]:
+            rungs = []
+            for code, label in ((3, "planned"), (7, "cpu-only")):
+                port = free_port()
+                rungs.append(EngineCommand(
+                    argv=(sys.executable, self.script, str(port),
+                          "0", "0.1", str(code)),
+                    port=port, label=label,
+                ))
+            return rungs
+
+    with pytest.raises(EngineBootError) as excinfo:
+        boot_engine(AllBad(script=str(stand_in)), tmp_path)
+    # The LAST rung's failure, not the first: a caller that swallowed this
+    # would serve requests against a base URL nothing is listening on.
+    assert "code 7" in str(excinfo.value)


### PR DESCRIPTION
**Closes the P1 gap filed by se#773.** The pgw#1373 hardcut deleted
`gen_worker.runtimes.{server,llama}` — 747 lines of `ServerHandle` /
`vllm_server` / `llama_server` / `DegradingBoot` — with **no v2 successor**,
while the platform went on ratifying the tier around the hole:

- `serving/model.py` — `Model.unload`'s docstring names *"external server
  processes"* as its reason to exist;
- `models/materialized_view.py` — `llama-server -m` is PERMANENT tier 3
  (Paul, 2026-08-19: *the fill rung narrows to external binaries*);
- `serving/streaming/engine.py:130-136` — block-quantized containers are
  REFUSED into the pytorch path by design.

Teardown survived, the loader deferred to it, and boot was gone. Only fleet
consumers: `qwen3.6-27b-mtp-gguf` and `qwen3.6-35b-a3b`.

## The shape

`ctx.engine(...)` is the sibling of `ctx.load(...)`:

```python
class QwenMtpModel(Model[Qwen36MtpGguf], lanes=(),
                   self_loading="served by llama-server; ctx.load drives no part of it"):
    def load(self, ctx):
        self.engine = ctx.engine(LlamaServer(n_ctx=32768, extra_args=[...]))
```

An `EngineSpec` is a frozen **declaration** — engine + flags, no path, no
port, no process. `ctx.engine(spec)` is the platform half: checkpoint tree
from the deploy binding, free port, boot ladder, real-liveness health wait,
typed events, registration for teardown.

## Properties it refuses to compromise on

- **Boot is bounded by SILENCE, never by a clock.** No `boot_timeout_s`, ever.
  The red/green pair is the doctrine as a test: the SAME 3-second boot under a
  1.5-second window dies when the child goes quiet and succeeds when it keeps
  talking.
- **Teardown is structural.** `EndpointHost.evict` stops every engine the load
  context started *after* the author's `unload`, whatever that did — the suite
  has an `unload` that RAISES and the process is still reaped. `stop` signals
  the process GROUP (vLLM workers survive a bare SIGTERM to the parent and keep
  the card pinned) and is idempotent.
- **Degrade, never OOM.** llama.cpp steps down through half the GPU layers to
  CPU-only; vLLM states ONE rung because it sizes itself and refuses rather
  than degrades.
- **Every phase introspectable.** New `engine_boot` kind, closed phase
  vocabulary, measured boot wall in the numeric `duration_ms` column, degraded
  rung confessing separately on `serve_degrade`.
- **The lock names the engine.** Discovery parses `ctx.engine(LlamaServer(...))`
  statically and lifts it into a third derived census beside `execution_lanes`
  and `decode_set`. `entrypoints[]` stays byte-identical for the hub.

## Not restored, on purpose

`chat_deltas`/`completion_deltas` (v1's streaming-client half): both real
consumers roll their own httpx streaming, so restoring it would ship a surface
with no caller.

## No new declaration surface

An engine-hosted model is self-loading **by construction**, so it inherits
pgw#1431's `self_loading=` marker (`2449c6b1`) unchanged. This PR adds only the
refusal an *unmarked* one gets — which used to be false ("could not read the
pipeline class") and unfollowable ("write `ctx.load(SomePipeline)`", a load the
streaming engine refuses by design for this container class).

## Evidence

$0, no GPU, no weights. Isolate → run → introspect → widen: the supervisor runs
against a trivial stand-in HTTP server whose behaviour each arm dictates
(serves / cannot exec / dies on boot / goes silent / talks slowly / fails one
rung then serves), then the widening — the real `load_endpoint` + `EndpointHost`
boot/serve/evict cycle, and the real `discover_entrypoints` walk over a fixture
written the way the qwen3.6 pair will be, with a pytorch CONTROL arm asserting
the census stays empty for it.

**Not proven here, and owned by the qwen3.6 activation lane:** that
`vllm serve` and `llama-server` accept the argv these specs build. That is
their contract, not this code's behaviour, and it needs a rented pod.

Refs: pgw#1421, se#773, pgw#1373, pgw#1431.