### PR TITLE
pgw#1447/#1448 residue: the test module takes a SUBJECT name, per DESIGN-RULINGS 4.34b

### DIFF
--- a/tests/test_eager_bridge_dtype.py
+++ b/tests/test_eager_bridge_dtype.py
@@ -1,4 +1,8 @@
-"""pgw#1447: the eager `from_pretrained` bridge and `torch_dtype`.
+"""The eager `from_pretrained` bridge and `torch_dtype`.
+
+# pgw#1447: a kwargs-STRICT pipeline refuses the keyword.
+# pgw#1448: the lane handed it a STRING, so kwargs-ACCEPTING pipelines ran fp32.
+
 
 `ctx.load`'s docstring states the author contract as *"No ``torch_dtype=`` (the
 lane contract IS the dtype)"* — and twelve lines below it, the eager bridge


### PR DESCRIPTION
pgw#1447/#1448 residue: the test module takes a SUBJECT name, per DESIGN-RULINGS 4.34b

`tests/test_eager_bridge_dtype_pgw1447.py` was named for the incident that
produced it, which `lint_incident_test_names.py` refuses for new modules — and
it was tripping other lanes' gates, not mine.

Renamed to `tests/test_eager_bridge_dtype.py`. The lineage is not lost, it MOVES:
the two incidents are now a two-line comment at the top of the module

    # pgw#1447: a kwargs-STRICT pipeline refuses the keyword.
    # pgw#1448: the lane handed it a STRING, so kwargs-ACCEPTING pipelines ran fp32.

and the full story stays in the tracker issues. That is exactly the trade 4.34b
makes: the ledger keeps the narrative, the file name keeps the subject.

`lint_incident_test_names.py` now passes ("no NEW issue-named test module").
11 tests still pass. Baseline untouched — this file was never in it, and that
list only shrinks.

ON THE MYPY COUNT: the mint lane reports 6 errors on this file; I cleared 4 in
#1448 and cannot reproduce the remaining 2. Checked two ways, both clean:

    .venv/bin/python -m mypy tests/test_eager_bridge_dtype.py            -> Success
    .venv/bin/python -m mypy --python-executable <torch-bearing-python> \
        tests/test_eager_bridge_dtype.py src/gen_worker/serving/context.py \
        src/gen_worker/release/trace_context.py                          -> Success

The second run is the one that matters: my own env is torch-free, which is the
blind spot that let #1447 land with mypy debt in the first place, so this run
points mypy at an interpreter that HAS torch 2.13.0+cu130 and can resolve the
torch-typing seams. Still clean. If 2 errors survive in another env, the
difference is that env and I would like the exact output rather than guess at it.
