### PR TITLE
pgw#1425 follow-up: master's unreached-surface ratchet back to green

### DIFF
--- a/changelog.d/pgw1425-ratchet.md
+++ b/changelog.d/pgw1425-ratchet.md
@@ -1,0 +1,7 @@
+- **The unreached-surface ratchet caught pgw#1425's own fix within the hour, which is the
+  instrument working.** `receipts.configured()` lost its only caller when `posture()` replaced it,
+  so it is DELETED rather than baselined — two spellings of one state is how a caller ends up
+  asking a two-answer question about a three-state gate, and "not configured" collapsing `local`
+  into `unset` is exactly the fail-open pgw#1425 closed. pgw#1421's two new unreached callables
+  are added as rows WITH AN OWNER AND AN EXPIRY (the tool's own prescribed remedy for a row that
+  is not your commit) rather than guessed at.

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -458,3 +458,27 @@ gen_worker.worker_fatal.report_worker_error_async()
 # chain itself (`dispatch.order_from_binding` -> `SlotEvidence` ->
 # `measured_posture.REASON_SERVING_FACTS_UNEVIDENCED`) is a DELETE that belongs
 # with pgw#1425's remaining-69 triage, not smuggled into the P0 lane.
+
+# pgw#1421's engine-hosted boot (PR #1016, `86d0cef9`) landed two callables with
+# no production caller, an hour before pgw#1425 ran this ratchet. Rows added by
+# the pgw#1425 lane rather than deleted, because they are NOT that lane's
+# symbols and guessing another lane's intent is how a wire gets silenced — which
+# is the whole subject of pgw#1425. They are OWED, not accepted:
+#
+#     OWNER:  pgw#1421. `LoadContext.engine()` is the accessor the engine-hosted
+#             loader reads a slot's engine through, and `process_vram_bytes()`
+#             is its measured-residency reading; both look like the seam
+#             `serving/residency.py` is meant to size instances with. Wire them
+#             there, or say which successor already does it.
+#     EXPIRY: pgw#1421. If these outlive it, the engine-hosted boot shipped a
+#             loader whose engine handle and VRAM reading nothing on the pod
+#             ever asks for, and that is a finding rather than a lint row.
+gen_worker.serving.context.LoadContext.engine()
+gen_worker.serving.engine_runtime.process_vram_bytes()
+
+# pgw#1425 (same commit): `receipts.configured()` is DELETED, not listed. It was
+# the boolean `posture()` replaced, and it lost its caller in the fix itself —
+# the ratchet caught it within the hour, which is the instrument working. Two
+# spellings of one state is how a caller ends up asking a two-answer question
+# about a three-state gate, and "not configured" collapsing `local` into `unset`
+# is exactly the fail-open that issue closed.

--- a/src/gen_worker/receipts.py
+++ b/src/gen_worker/receipts.py
@@ -218,16 +218,18 @@ def trust_local_store(reason: str) -> None:
 
 
 def posture() -> str:
-    """:data:`POSTURE_ARMED` / :data:`POSTURE_LOCAL` / :data:`POSTURE_UNSET`."""
+    """:data:`POSTURE_ARMED` / :data:`POSTURE_LOCAL` / :data:`POSTURE_UNSET`.
+
+    THE question about this gate. It replaced the boolean ``configured()``,
+    which is deleted rather than kept beside it: two spellings of one state is
+    how a caller ends up asking the question that has only two answers when the
+    state has three — and "not configured" collapsing `local` into `unset` is
+    exactly the fail-open pgw#1425 closed.
+    """
     with _LOCK:
         if _CONFIG is not None:
             return POSTURE_ARMED
         return POSTURE_LOCAL if _LOCAL_TRUST else POSTURE_UNSET
-
-
-def configured() -> bool:
-    with _LOCK:
-        return _CONFIG is not None
 
 
 def reset() -> None:
@@ -770,7 +772,6 @@ __all__ = [
     "artifact_digest",
     "canonical_artifact_digest",
     "configure",
-    "configured",
     "gate_delivered_artifact",
     "needs_viewer_identity",
     "posture",


### PR DESCRIPTION
Running `scripts/lint_unreached_surface.py` after [#1014](https://github.com/cozy-creator/python-gen-worker/pull/1014) merged found three NEW unreached rows. The gate is red on master right now.

**One is mine.** `receipts.configured()` lost its only caller when `posture()` replaced it in #1014. **DELETED, not baselined** — the same rule that issue applies to everyone else, applied to its own fix. Keeping both is how a caller ends up asking a two-answer question about a three-state gate, and "not configured" collapsing `local` into `unset` is precisely the fail-open #1014 closed.

**Two are [[pgw#1421]]'s** (PR #1016, `86d0cef9`, landed an hour earlier): `LoadContext.engine()` and `engine_runtime.process_vram_bytes()`. Added as baseline rows **with an OWNER and an EXPIRY** — the tool's own prescribed remedy for a row that is not your commit. Guessing another lane's intent is the silencing pgw#1425 exists to reverse, so they are recorded as OWED rather than accepted or deleted.

`lint_unreached_surface.py` exits 0. `tests/test_serve_path_wires_pgw1425.py` still 14/14.