### PR TITLE
pgw#1452: the eager bridge places weights where the WORKER said — every bare-tree boot was CPU inference

### DIFF
--- a/changelog.d/pgw1452.md
+++ b/changelog.d/pgw1452.md
@@ -1,0 +1,14 @@
+- **The eager `ctx.load` bridge places weights on the device the worker chose.** It built the
+  pipeline with `from_pretrained` and returned it unplaced, so every checkpoint tree with no chunk
+  store behind it — a bare download, a local run, a fixture, which is the whole cozy-local
+  substrate — ran on the CPU with an idle GPU beside it. Nothing failed: sd1.5 simply took 13 s per
+  step on a card that does it in well under one, and every timing anyone took through this bridge
+  was a CPU timing. The streaming arm always honoured the contract (`engine_for(..., device=)`);
+  only the fallback did not.
+
+- **The fix inherits the decision, it does not make one.** `EndpointHost` already picks the device
+  — "PLACEMENT is decided here, by the worker, never by author code" — and now hands it to
+  `LoadContext`, which applies it to a bridged pipeline. The bridge still names no device of its
+  own, so a bare `LoadContext(...)` and the derive path (which builds on `meta` precisely because
+  nothing should move) are unchanged. Both halves are asserted; the half that needs no GPU runs on
+  every runner.

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -260,3 +260,20 @@ STAGED tests/test_seal_lib_memo_pgw832.py|pgw#1371/#1372: gen_worker.aot_compile
 # developer box, which is where the drift they guard against is introduced.
 CI-SKIPPED tests/test_lane_contracts.py|no sibling tensorfs checkout
 CI-SKIPPED tests/test_weight_streaming_native_store.py|the installed tensorfs predates tensorfs#115 — it carries no tensorstreamreader, which is the whole subject of this suit
+
+# pgw#1452 — the placement row's CUDA arm. Skipped only on a host whose NVML
+# does not match its driver: raw CUDA still works there (a matmul and
+# `nn.Module.to("cuda")` both pass), but a diffusers `pipeline.to("cuda")`
+# walks torch's PeerToPeerAccess check, which calls `nvmlInit_v2_` and raises
+# INTERNAL ASSERT under some import orders. A HOST fault, not a placement
+# fault, and gated on a direct NVML probe rather than on the exception — so a
+# genuine placement regression on a healthy box still goes red.
+#
+# WHAT IS UNVERIFIED WHILE IT SKIPS: nothing on a healthy driver, and nothing
+# in CI either way — `ubuntu-latest` has no CUDA device, so this arm has never
+# run in CI and cannot (pgw#953). The property WAS verified by hand on the
+# authoring box, standalone, where the same load places every component on
+# `cuda:0`. The second row in that file — "the bridge names no device of its
+# own" — needs no GPU and runs everywhere, so the half of the contract that
+# says placement is the WORKER's decision is measured on every runner.
+CI-SKIPPED tests/test_bridge_placement.py|this host's nvml is version-mismatched; torch's p#p check raises inside pipeline.to(cuda)

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -231,6 +231,7 @@ class LoadContext(Generic[MT_co]):
         lane: Any = None,
         engine: Optional[LoaderEngine] = None,
         compile_sink: Optional[Callable[[Any], Any]] = None,
+        device: str = "",
     ) -> None:
         self._binding = binding
         self._model_type = model_type
@@ -238,6 +239,10 @@ class LoadContext(Generic[MT_co]):
         self._engine = engine
         self._compile_sink = compile_sink
         self._engines: list[Any] = []
+        #: The WORKER's placement decision, handed down (pgw#1452). Empty
+        #: means none was handed down — a bare `LoadContext(...)` places
+        #: nothing, exactly as before.
+        self._device = str(device or "")
 
     @property
     def checkpoint_dir(self) -> Path:
@@ -302,10 +307,10 @@ class LoadContext(Generic[MT_co]):
         dtype = self._lane_dtype()
         if dtype is None:
             no_lane: P = from_pretrained(self.checkpoint_dir)
-            return no_lane
+            return self._placed(no_lane)
         try:
             bridged: P = from_pretrained(self.checkpoint_dir, torch_dtype=dtype)
-            return bridged
+            return self._placed(bridged)
         except TypeError as exc:
             if not _rejected_torch_dtype(exc):
                 raise
@@ -322,7 +327,38 @@ class LoadContext(Generic[MT_co]):
         to = getattr(loaded, "to", None)
         if callable(to):
             to(dtype)
-        return loaded
+        return self._placed(loaded)
+
+    def _placed(self, pipeline: P) -> P:
+        """Apply the WORKER's placement decision to a bridged pipeline.
+
+        pgw#1452. The streaming arm streams weights ONTO the device
+        (`engine_for(..., device=device)`), and `host.py` says why in the same
+        breath: "PLACEMENT is decided here, by the worker, never by author
+        code". The eager arm built a pipeline and placed nothing — so every
+        tree with no chunk store behind it (a bare download, a local run, a
+        fixture: the entire cozy-local substrate) ran on the CPU, while
+        `ctx.load`'s own docstring four lines above promised "weights land on
+        device". Nothing failed. It was simply the wrong processor, which is
+        why every timing taken through this bridge was measuring a CPU.
+
+        This names NO device, which is the whole point — it applies the one it
+        was handed. An empty `_device` places nothing, so a bare
+        `LoadContext(...)` and any caller that never had a placement decision
+        behave exactly as before.
+        """
+        if not self._device:
+            return pipeline
+        to = getattr(pipeline, "to", None)
+        if not callable(to):
+            return pipeline
+        logger.info(
+            "ctx.load: placing the bridged pipeline on %s — the worker's "
+            "decision, inherited (pgw#1452)", self._device,
+        )
+        moved = to(self._device)
+        # diffusers returns self; some component-wise `.to` return None.
+        return pipeline if moved is None else moved
 
     def _lane_dtype(self) -> Any:
         """The lane's load dtype, or None when the contract declares none.

--- a/src/gen_worker/serving/engine_runtime.py
+++ b/src/gen_worker/serving/engine_runtime.py
@@ -54,7 +54,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar, Mapping, Optional, Sequence
+from typing import ClassVar, Mapping, Optional, Sequence
 
 import msgspec
 

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -112,6 +112,12 @@ class EndpointHost:
 
             engine = engine_for(binding.checkpoint_dir, device=device, io=io)
         self._engine = engine
+        #: pgw#1452: the SAME decision reaches the eager bridge. Handing it
+        #: only to `engine_for` meant a tree with no chunk store behind it
+        #: was built by `from_pretrained` and left wherever that put it —
+        #: the CPU — which is the substrate cozy-local, fixtures and every
+        #: local run use.
+        self._device = str(device or "")
         self._output_dir = output_dir
         self._context_kwargs = dict(context_kwargs or {})
 
@@ -150,6 +156,7 @@ class EndpointHost:
             lane=self.lanes[model_cls],
             engine=self._engine,
             compile_sink=compile_sink,
+            device=self._device,
         )
 
     # -- boot ---------------------------------------------------------------

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -33,7 +33,7 @@ import logging
 import threading
 import time
 from contextlib import ExitStack
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Sequence, Tuple
 

--- a/tests/test_bridge_placement.py
+++ b/tests/test_bridge_placement.py
@@ -1,0 +1,136 @@
+"""The eager bridge places weights where the WORKER said, or nowhere.
+
+pgw#1452, measured on a real CUDA box: `ctx.load`'s eager arm built a pipeline
+with `from_pretrained` and returned it unplaced, so every checkpoint tree with
+no chunk store behind it — a bare download, a local run, a fixture, which is
+the whole cozy-local substrate — ran on the CPU. Nothing failed. `sd1.5` simply
+took 13 s/step on a card that does it in well under one, and every timing taken
+through the bridge was a CPU timing.
+
+The contract was never ambiguous; it sits four lines above the defect in
+`ctx.load`'s own docstring — *"No `.to("cuda")` (weights land on device) …
+PLACEMENT stays a worker decision and this code names no device"* — and
+`host.py` says the same thing where it picks the device. The streaming arm
+honoured it (`engine_for(..., device=device)`); the eager arm never received it.
+
+Both arms are asserted here, because the interesting half is the SECOND:
+
+1. handed a device, the bridge places every component on it;
+2. handed NOTHING, the bridge places nothing — a bare `LoadContext(...)` and
+   the derive path must not acquire a device because this fix exists.
+
+The CUDA arm skips without a device; arm 2 runs everywhere, so the "names no
+device of its own" half of the contract is measured on every runner.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from diffusers import StableDiffusionPipeline  # noqa: E402
+
+from gen_worker.serving.context import DeployBinding, LoadContext  # noqa: E402
+
+#: The smallest real diffusers pipeline that exists. Not a hand-built double:
+#: the defect was in what `from_pretrained` returns, so a fake that skips
+#: `from_pretrained` could not have caught it.
+FIXTURE = "hf-internal-testing/tiny-stable-diffusion-pipe"
+
+
+def _local_snapshot() -> Path:
+    """The fixture's cached tree, or skip. Never a download: this suite must
+    not reach the network to answer a question about device placement.
+
+    The cache is walked directly rather than through
+    `snapshot_download(local_files_only=True)`, which refuses a tree that
+    diffusers loads perfectly well: it demands EVERY file the repo lists,
+    including `README.md`, `.gitattributes` and the flax weights, and raises
+    "incomplete" without them. Gating on it skips this suite on machines that
+    can run it — a false skip, which reads as coverage and is exactly what the
+    pgw#966 census exists to stop. The real precondition is the one asserted
+    here: a snapshot dir with a `model_index.json` in it.
+    """
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    repo = "models--" + FIXTURE.replace("/", "--")
+    snapshots = sorted(Path(HF_HUB_CACHE).glob(f"{repo}/snapshots/*"))
+    for snapshot in snapshots:
+        if (snapshot / "model_index.json").is_file():
+            return snapshot
+    pytest.skip(f"{FIXTURE} is not in the local HF cache ({HF_HUB_CACHE})")
+
+
+def _devices(pipe: Any) -> Dict[str, str]:
+    return {
+        name: str(next(module.parameters()).device)
+        for name, module in (
+            ("unet", pipe.unet),
+            ("vae", pipe.vae),
+            ("text_encoder", pipe.text_encoder),
+        )
+    }
+
+
+def _load(device: str) -> Any:
+    binding = DeployBinding(
+        checkpoint_ref="ckpt:tiny@fixture", checkpoint_dir=_local_snapshot()
+    )
+    return LoadContext(binding=binding, device=device).load(StableDiffusionPipeline)
+
+
+def _nvml_is_healthy() -> bool:
+    """Whether this host's NVML matches its driver.
+
+    A mismatched NVML (`nvidia-smi` -> "Driver/library version mismatch") does
+    not stop raw CUDA — a matmul and `nn.Module.to("cuda")` both work — but a
+    diffusers `pipeline.to("cuda")` walks torch's PeerToPeerAccess check, which
+    calls `nvmlInit_v2_` and raises `INTERNAL ASSERT FAILED` under some import
+    orders. That is a fact about the HOST, not about placement, and it must not
+    read as this defect regressing.
+    """
+    try:
+        import ctypes
+
+        return ctypes.CDLL("libnvidia-ml.so.1").nvmlInit_v2() == 0
+    except Exception:  # noqa: BLE001 - unreadable NVML is unhealthy NVML
+        return False
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+@pytest.mark.skipif(
+    not _nvml_is_healthy(),
+    # Kept under the census normalizer's 120-char key truncation (conftest
+    # `_norm`): a longer reason is cut mid-phrase, leaving a trailing space the
+    # census FILE's own `.strip()` removes — a disposition that never matches.
+    reason="this host's NVML is version-mismatched; torch's P2P check raises inside pipeline.to(cuda)",
+)
+def test_the_bridge_places_the_pipeline_where_the_worker_said() -> None:
+    """RED before pgw#1452: every component came back on `cpu` with a CUDA
+    device present and idle."""
+    devices = _devices(_load("cuda"))
+    assert set(devices.values()) == {"cuda:0"}, (
+        f"the worker decided `cuda` and the bridge left components elsewhere: "
+        f"{devices} — this is the pgw#1452 defect, where a bare-tree boot "
+        f"silently serves from system RAM"
+    )
+
+
+def test_the_bridge_names_no_device_of_its_own() -> None:
+    """The other half of the contract, and the reason the fix is not a
+    `.to("cuda")` in the bridge: handed no decision, it must place nothing.
+
+    A bridge that reached for CUDA on its own would take the placement
+    decision away from the worker — and would break the derive path, which
+    builds on `meta` precisely because nothing is supposed to move.
+    """
+    devices = _devices(_load(""))
+    assert set(devices.values()) == {"cpu"}, (
+        f"no placement decision was handed down, so the bridge must place "
+        f"nothing; components landed on {devices}"
+    )


### PR DESCRIPTION
Found by running sd1.5 locally on a real 4070 — which is what the local-execution authorization is for.

## The defect, proven directly
`ctx.load`'s eager arm built the pipeline with `from_pretrained` and returned it **unplaced**:
```
cuda available  : True
component device: {'unet': 'cpu', 'vae': 'cpu', 'text_encoder': 'cpu'}
```
Every checkpoint tree with no chunk store behind it — a bare download, a local run, a fixture, i.e. the entire cozy-local substrate — served from system RAM with an idle GPU beside it.

🔻 **The contract it broke is four lines above it**, in `ctx.load`'s own docstring: *"No `.to("cuda")` (weights land on device) … PLACEMENT stays a worker decision and this code names no device."* True of the pgw#1380 streaming arm, which streams weights **onto** the device. The eager arm — documented in the very next paragraph as the survivor "for a tree with no chunk store behind it" — placed nothing, and author code is device-neutral by design (`residency.py`), so nothing corrected it.

**Nothing failed.** That is the problem: sd1.5 took 13 s/step on a card that does it in well under one, and every timing taken through this bridge was a CPU timing — including ones other lanes are quoting.

## The fix inherits the decision rather than making one
`EndpointHost` already chooses the device and says so where it does it. It now hands that choice to `LoadContext`, which applies it to a bridged pipeline. The bridge still names no device — so a bare `LoadContext(...)` places nothing, the derive path (which builds on `meta` precisely because nothing may move) is untouched, and a worker that picks `cpu` gets `cpu`.

## Both halves asserted
Handed a device, the bridge places every component on it. **Handed nothing, it places nothing** — that arm needs no GPU, runs on every runner, and is what stops the fix quietly becoming a hardcoded `.to("cuda")`.

The CUDA arm is gated on a **direct NVML probe, not on catching the exception**, so a genuine regression still goes red on a healthy box. Census row added, reason kept under the normalizer's 120-char truncation so the disposition can actually match.

The fixture is located by walking the HF cache rather than `snapshot_download(local_files_only=True)`, which calls a tree diffusers loads perfectly well "incomplete" because it wants `README.md` and the flax weights — a false skip that reads as coverage.

## ⚠️ Also fixes two unused imports that are RED on master right now
`fast gates` Lint is failing on `origin/master` for **every lane** — confirmed against a detached control worktree, both hits present without this branch. Fixed here so the gate goes green; not my code and not this PR's subject.

## Verification
`mypy src/gen_worker` and `ruff check src/gen_worker` clean. 37 passed / 1 skipped across the new suite plus `test_model_authoring`, `test_weightless_entrypoints`, `test_self_mint_wiring`.

Fourth defect in this one function in a week — #1447, #1448, #1451, this. Three of four were silent. Tracker: pgw#1452.