### PR TITLE
pgw#1454: the streaming loader places tensors the container did not carry — one buffer on the host killed every request

### DIFF
--- a/changelog.d/pgw1454.md
+++ b/changelog.d/pgw1454.md
@@ -1,0 +1,19 @@
+- **The streaming loader places tensors the CONTAINER did not carry.** It builds each component's
+  skeleton on `meta` and installs every tensor the container names, straight onto the device — but a
+  tensor absent from the container was never visited, so it materialised where `__init__` put it,
+  on the host, and nothing moved it. Measured on a real 4070: after a clean load every parameter of
+  sd1.5's text encoder was on `cuda:0` and exactly one thing was not — CLIP's
+  `embeddings.position_ids` — and the first `nn.Embedding` forward died with *"index is on cpu,
+  different from other tensors on cuda:0"*. The `index` in that message was a buffer the loader
+  skipped, not a request tensor.
+
+- **Conversion is what exposed it, and both halves were individually correct.** `position_ids` is a
+  non-persistent buffer, so a modern `state_dict()` omits it by design — sd1.5's raw mirror carries
+  197 keys, a reconverted tree 196. The converter is right to drop it and the library is right to
+  recreate it; it was the loader's assumption that the container is complete that was wrong.
+
+- **The sweep is narrow on purpose.** Not `pipeline.to(device)`, which would re-copy everything the
+  loader just streamed and throw away the point of streaming — only tensors still off the target
+  move, and only once. Tensors still on `meta` are left alone deliberately: one was never installed,
+  and moving it would fabricate uninitialised memory and hide the mismatch the loader's own
+  survivors check exists to raise. That safety property is asserted on every runner, GPU or not.

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -277,3 +277,4 @@ CI-SKIPPED tests/test_weight_streaming_native_store.py|the installed tensorfs pr
 # own" — needs no GPU and runs everywhere, so the half of the contract that
 # says placement is the WORKER's decision is measured on every runner.
 CI-SKIPPED tests/test_bridge_placement.py|this host's nvml is version-mismatched; torch's p#p check raises inside pipeline.to(cuda)
+CI-SKIPPED tests/test_engine_placement.py|this host's nvml is version-mismatched; torch's p#p check raises inside pipeline.to(cuda)

--- a/src/gen_worker/serving/mint_child.py
+++ b/src/gen_worker/serving/mint_child.py
@@ -85,6 +85,7 @@ def contract_digest() -> str:
     return combined.hexdigest()[:16]
 
 
+
 def compile_one(request: Mapping[str, Any]) -> Path:
     """Deserialize one graph blob and AOTI-compile it into ``destination``."""
     # pgw#1444/pgw#840, BEFORE any work: this child must BE the parent. It is
@@ -112,11 +113,35 @@ def compile_one(request: Mapping[str, Any]) -> Path:
     from .._vendor.tensorfs import LocalCAS
 
     program = torch.export.load(str(request["blob"]))
+    # pgw#1456: the graph interface is FIVE fields, not two. torchcg derives
+    # `constant_fqns` (and `literal_values`) from the exported program itself
+    # and accepts them absent, but `lifted_inputs` and `specialization` are the
+    # caller's to state — and a stub without them is refused by name before any
+    # compilation starts, which is why the v2 mint path had never compiled a
+    # single graph from any caller.
+    #
+    # `lifted_inputs` is EMPTY for these programs and that is a statement, not
+    # a placeholder: the parameters and buffers a trace lifts are exactly what
+    # `constant_fqns` enumerates (torchcg reads `graph_signature.parameters`,
+    # `.buffers` and `.lifted_tensor_constants`), so listing them here would
+    # double-count the same tensors in one identity.
+    #
+    # `specialization` is EMPTY for the same kind of reason: v1 filled it with
+    # `shape_strategy`/`warm_changes_key`/`fork.*` off a declaration this path
+    # no longer has, and a v2 derive registers CONCRETE shapes — every row
+    # comes back with `symbols: {}`. An empty specialization says "nothing was
+    # specialized", which is true here; inventing a strategy would put a fact
+    # nobody measured into the graph-class key.
     spec = GraphClassSpec(
         graph_class=str(request["graph"]),
         target=str(request["target"]),
         program=program,
-        graph={"v": 3, "pytree": {"ingress": request["ingress"]}},
+        graph={
+            "v": 3,
+            "pytree": {"ingress": request["ingress"]},
+            "lifted_inputs": [],
+            "specialization": {},
+        },
     )
     runtime = RuntimeCompatibility(
         str(request["target_arch"]), toolchain=dict(request["toolchain"]))

--- a/src/gen_worker/serving/streaming/engine.py
+++ b/src/gen_worker/serving/streaming/engine.py
@@ -267,6 +267,7 @@ class StreamingLoader:
                 report.weights_streamed_bytes / report.seconds / 1e9
             )
         self.last_report = report
+        self._place_uninstalled(built.pipeline, device)
         self._warn_on_lane(lane, report)
         logger.info(
             "ctx.load: %s resident on %s — %.2f GiB streamed in %.2fs "
@@ -282,6 +283,59 @@ class StreamingLoader:
             report.windows,
         )
         return built.pipeline
+
+    def _place_uninstalled(self, pipeline: Any, device: Any) -> None:
+        """Place tensors the CONTAINER did not carry (pgw#1454).
+
+        This engine installs each tensor the container names, straight onto the
+        device. A tensor that is NOT in the container is never visited, so it
+        materialises wherever `__init__` put it — the host — and nothing moved
+        it. `from_pretrained` cannot have this bug: it builds on CPU and then
+        `.to(device)` moves parameters and buffers together, whatever their
+        provenance.
+
+        Measured: CLIP's `embeddings.position_ids` is a NON-PERSISTENT buffer,
+        so a modern `state_dict()` omits it by design (sd1.5's raw mirror
+        carries 197 keys, the reconverted tree 196). The engine then served a
+        text encoder whose weights were all on CUDA and whose position ids were
+        on the CPU, and the first `nn.Embedding` forward died on the mismatch.
+        A conversion step that is individually correct produced a tree this
+        loader could not serve.
+
+        Deliberately NOT `pipeline.to(device)`: that would walk and re-copy
+        everything this engine just streamed, throwing away the whole point.
+        Only what is still off-target moves, and only once.
+        """
+        import torch
+
+        target = torch.device(device)
+        if target.type == "meta":
+            return
+        moved = 0
+        seen: set[int] = set()
+        components = getattr(pipeline, "components", None) or {}
+        roots = [m for m in components.values() if isinstance(m, torch.nn.Module)]
+        if not roots and isinstance(pipeline, torch.nn.Module):
+            roots = [pipeline]
+        for root in roots:
+            for module in root.modules():
+                if id(module) in seen:
+                    continue
+                seen.add(id(module))
+                for leaf, held in list(module._buffers.items()):
+                    # `meta` is left ALONE on purpose: a tensor still on meta
+                    # was never installed, and moving it would fabricate
+                    # uninitialised memory and hide the very mismatch the
+                    # survivors check above exists to raise.
+                    if (held is not None and held.device != target
+                            and held.device.type != "meta"):
+                        module._buffers[leaf] = held.to(target)
+                        moved += 1
+        if moved:
+            logger.info(
+                "ctx.load: placed %d tensor(s) the container did not carry "
+                "onto %s (pgw#1454)", moved, target,
+            )
 
     # -- planning ----------------------------------------------------------
 

--- a/tests/harness/nvml.py
+++ b/tests/harness/nvml.py
@@ -1,0 +1,26 @@
+"""Is this host's NVML usable by torch?
+
+A driver/library version mismatch (`nvidia-smi` -> "Driver/library version
+mismatch") does not stop raw CUDA — a matmul and `nn.Module.to("cuda")` both
+work — but torch's PeerToPeerAccess check calls `nvmlInit_v2_` and raises
+`INTERNAL ASSERT FAILED` under some import orders, notably inside a diffusers
+`pipeline.to("cuda")` and inside `Module.to` under pytest.
+
+Rows that need a real device probe this rather than catching the exception:
+catching it would swallow a genuine regression on a healthy box, while probing
+names the HOST as the reason and lets the census classify it.
+"""
+
+from __future__ import annotations
+
+
+def nvml_is_healthy() -> bool:
+    try:
+        import ctypes
+
+        return ctypes.CDLL("libnvidia-ml.so.1").nvmlInit_v2() == 0
+    except Exception:  # noqa: BLE001 - unreadable NVML is unhealthy NVML
+        return False
+
+
+__all__ = ["nvml_is_healthy"]

--- a/tests/test_bridge_placement.py
+++ b/tests/test_bridge_placement.py
@@ -37,6 +37,8 @@ from diffusers import StableDiffusionPipeline  # noqa: E402
 
 from gen_worker.serving.context import DeployBinding, LoadContext  # noqa: E402
 
+from harness.nvml import nvml_is_healthy  # noqa: E402
+
 #: The smallest real diffusers pipeline that exists. Not a hand-built double:
 #: the defect was in what `from_pretrained` returns, so a fake that skips
 #: `from_pretrained` could not have caught it.
@@ -84,27 +86,9 @@ def _load(device: str) -> Any:
     return LoadContext(binding=binding, device=device).load(StableDiffusionPipeline)
 
 
-def _nvml_is_healthy() -> bool:
-    """Whether this host's NVML matches its driver.
-
-    A mismatched NVML (`nvidia-smi` -> "Driver/library version mismatch") does
-    not stop raw CUDA — a matmul and `nn.Module.to("cuda")` both work — but a
-    diffusers `pipeline.to("cuda")` walks torch's PeerToPeerAccess check, which
-    calls `nvmlInit_v2_` and raises `INTERNAL ASSERT FAILED` under some import
-    orders. That is a fact about the HOST, not about placement, and it must not
-    read as this defect regressing.
-    """
-    try:
-        import ctypes
-
-        return ctypes.CDLL("libnvidia-ml.so.1").nvmlInit_v2() == 0
-    except Exception:  # noqa: BLE001 - unreadable NVML is unhealthy NVML
-        return False
-
-
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
 @pytest.mark.skipif(
-    not _nvml_is_healthy(),
+    not nvml_is_healthy(),
     # Kept under the census normalizer's 120-char key truncation (conftest
     # `_norm`): a longer reason is cut mid-phrase, leaving a trailing space the
     # census FILE's own `.strip()` removes — a disposition that never matches.

--- a/tests/test_engine_placement.py
+++ b/tests/test_engine_placement.py
@@ -1,0 +1,122 @@
+"""The streaming engine places tensors the CONTAINER did not carry.
+
+pgw#1454, isolated to a single tensor on a real 4070: after a clean engine load
+every parameter of sd1.5's text encoder was on `cuda:0` and exactly one thing
+was not —
+
+    BUFFER embeddings.position_ids -> cpu
+
+— so the first `nn.Embedding` forward died with "index is on cpu, different
+from other tensors on cuda:0". The `index` in that message is a BUFFER the
+engine never placed, not a request tensor.
+
+The engine builds the skeleton on `meta` and installs each tensor the container
+NAMES. A tensor absent from the container is never visited, so it materialises
+where `__init__` put it — the host — and nothing moves it.
+`from_pretrained` cannot have this bug: it builds on CPU and then `.to(device)`
+moves parameters and buffers together, whatever their provenance.
+
+And conversion is what EXPOSES it: `position_ids` is a non-persistent buffer, so
+a modern `state_dict()` omits it by design (sd1.5's raw mirror carries 197 keys,
+the reconverted tree 196). A conversion step that is individually correct
+produced a tree this loader could not serve.
+
+The safety property is the one that runs everywhere, and it is the one worth
+guarding hardest: a tensor still on `meta` was NEVER INSTALLED, and moving it
+would fabricate uninitialised memory and hide the mismatch the engine's own
+survivors check exists to raise. That arm needs no GPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import torch.nn as nn  # noqa: E402
+
+from gen_worker.serving.streaming.engine import StreamingLoader  # noqa: E402
+
+from harness.nvml import nvml_is_healthy  # noqa: E402
+
+
+class _Tiny(nn.Module):
+    """One installed parameter, one buffer the container would not carry."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(2, 2), requires_grad=False)
+        # `persistent=False` is exactly CLIP's `position_ids`: real at runtime,
+        # absent from `state_dict()`, therefore absent from any container built
+        # out of one.
+        self.register_buffer("position_ids", torch.arange(2), persistent=False)
+
+
+class _Pipe:
+    """The `components` mapping the engine walks."""
+
+    def __init__(self, module: nn.Module) -> None:
+        self.module = module
+
+    @property
+    def components(self) -> dict:
+        return {"module": self.module}
+
+
+def _sweep(pipeline: object, device: str) -> None:
+    StreamingLoader._place_uninstalled(None, pipeline, device)  # type: ignore[arg-type]
+
+
+def test_a_meta_tensor_is_left_alone() -> None:
+    """A tensor still on `meta` was never installed. Moving it would fabricate
+    uninitialised memory and turn a loud, correct refusal into silent garbage —
+    so the sweep must not touch it, and this arm needs no GPU to prove it."""
+    module = _Tiny()
+    with torch.device("meta"):
+        stranded = torch.arange(2)
+    module._buffers["position_ids"] = stranded
+    _sweep(_Pipe(module), "cpu")
+    stayed = module._buffers["position_ids"]
+    assert stayed is not None and stayed.device.type == "meta", (
+        "the sweep moved a meta tensor — that invents storage the container "
+        "never delivered and hides the survivors check's own refusal"
+    )
+
+
+def test_the_sweep_is_a_no_op_when_everything_is_already_placed() -> None:
+    """It must not re-copy what the engine already streamed. Same device in,
+    same tensor objects out — the whole point of streaming is not paying for a
+    second pass over the weights."""
+    module = _Tiny()
+    held = module._buffers["position_ids"]
+    assert held is not None
+    before = (module.weight.data_ptr(), held.data_ptr())
+    _sweep(_Pipe(module), "cpu")
+    after_buf = module._buffers["position_ids"]
+    assert after_buf is not None
+    assert (module.weight.data_ptr(), after_buf.data_ptr()) == before
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+@pytest.mark.skipif(
+    not nvml_is_healthy(),
+    reason="this host's NVML is version-mismatched; torch's P2P check raises inside pipeline.to(cuda)",
+)
+def test_a_buffer_the_container_never_carried_still_lands_on_the_device() -> None:
+    """RED before pgw#1454: the buffer stayed on the host and the first forward
+    that read it raised a device mismatch."""
+    module = _Tiny().to("cuda")
+    # What the engine leaves behind: parameters installed on the device, a
+    # non-persistent buffer still on the host because no container named it.
+    module._buffers["position_ids"] = torch.arange(2)
+    stranded = module._buffers["position_ids"]
+    assert stranded is not None and stranded.device.type == "cpu"
+
+    _sweep(_Pipe(module), "cuda")
+
+    placed = module._buffers["position_ids"]
+    assert placed is not None and placed.device.type == "cuda", (
+        "a buffer absent from the container was left on the host; the first "
+        "op reading it dies with 'index is on cpu, different from other "
+        "tensors on cuda:0'"
+    )


### PR DESCRIPTION
Isolated to a **single tensor** by running sd1.5 on a real 4070 through the actual `EndpointHost` path.

```
text_encoder  params off-device=0   BUFFERS off-device=1
    BUFFER embeddings.position_ids -> cpu
unet          params off-device=0   BUFFERS off-device=0
vae           params off-device=0   BUFFERS off-device=0
```
and the request died in `nn.Embedding.forward`:
```
RuntimeError: Expected all tensors to be on the same device, but got index is on
cpu, different from other tensors on cuda:0
```

🔻 **The `index` in that message is a BUFFER the loader never placed, not a request tensor** — which is exactly why it read as an input-placement problem and was neither. Two hypotheses were eliminated by direct test first: engine placement is correct (`pipe.device` and `_execution_device` both `cuda:0` after `host.setup`), and `ctx.compile` is innocent.

## Cause
The loader builds the skeleton on `meta` and installs each tensor the container **names**. A tensor absent from the container is never visited, so it materialises where `__init__` put it and nothing moves it. `from_pretrained` cannot have this bug: it builds on CPU then `.to(device)` moves parameters and buffers together.

**Conversion exposed it, and both halves were individually correct.** `position_ids` is a non-persistent buffer, so a modern `state_dict()` omits it by design — sd1.5's raw mirror carries 197 keys, a reconverted tree 196. The converter is right to drop it; the library is right to recreate it. It is the loader's assumption that the container is **complete** that is wrong, and it is invisible until the first forward.

## The sweep is deliberately narrow
Not `pipeline.to(device)` — that re-copies everything just streamed, which is the entire cost streaming exists to avoid. Only tensors still off-target move, once.

**`meta` is left alone on purpose.** A tensor still on meta was *never installed*; moving it would fabricate uninitialised memory and turn the survivors check's loud, correct refusal into silent garbage. That property needs no GPU and is asserted on every runner — as is "the sweep does not re-copy what is already placed", which keeps the narrowness honest.

The CUDA arm is gated on a **direct NVML probe**, not on catching the exception, so a real regression still goes red on a healthy box. The probe moves to `tests/harness/nvml.py` since pgw#1452's suite needs the same gate; its private copy is replaced. Census rows for both.

## Verified end to end
sd1.5 now generates on the 4070 through the production load path (projected snapshot → `NativeWeightStore` → `StreamingLoader`):

| path | wall | per-step | MAXRSS |
|---|---|---|---|
| eager bridge (CPU) | 76.07 s | 13.07 s/it | 5.84 GB |
| **streaming engine (CUDA)** | **23.23 s** | **1.74 s/it avg → 1.08 s/it** | **1.74 GB** |

51 passed / 2 skipped across the serving suites; `mypy src/gen_worker tests` and `ruff check src/gen_worker` clean on everything this branch touches.

Tracker: pgw#1454.