### PR TITLE
pgw#1455: the worker emits the weight download BYTE POSITION — "downloading" becomes "downloading is PROGRESSING"

### DIFF
--- a/changelog.d/pgw1455.md
+++ b/changelog.d/pgw1455.md
@@ -1,0 +1,26 @@
+- **The worker now says "downloading is PROGRESSING", not just "downloading".** The serving-path
+  weight fetch emits its BYTE POSITION — integral MiB accounted for the snapshot — on the worker
+  activity stream under a new kind, `weight_fetch`. Rental #6 (e2e#1910) parked a request on
+  `model_download_pending` for 49 minutes and ~$0.59 with **0 rows** in `worker_activity_events`,
+  and nothing anywhere could say whether the download was finishing. The hub's judgment becomes
+  *is the position advancing*.
+- **No clocks, and nothing keyed on `attempts`.** The scheduler's `attempts=2963` counts its own
+  1 Hz placement poll and tracks wall-clock seconds 1:1 — it reads identically whether a download
+  is healthy, slow or wedged, so it carries no download information at all. The position is the
+  fact; differencing it is the reader's job (the hub advances on strict increase, th#1243).
+- **pgw#1397's shape, reused including its documented fraction trap.** The hub parses an INTEGER
+  off the position field, so a position carried in GiB truncates to `int(0.97) == 0` for the first
+  gigabyte and reports a healthy transfer as frozen. `weight_position.FetchPosition` emits
+  `bytes // MiB` and nothing may make it a float.
+- **`started` and `fetched` are unconditional.** A fetch that wedges before its first whole MiB
+  would otherwise emit nothing, and "no rows" is exactly the reading that cost rental #6 — absence
+  has to render as a row that says zero.
+- Emission is at `models/store.py`'s single download funnel, the one layer that sees every
+  materialization path and knows the ref; cadence is bounded by BOTH a 256 MiB stride and a 60 s
+  floor (matched to the hub's own `workerActivityProgressEventInterval`), so a 7 GB pull writes
+  ~28 rows and a slow one about one a minute. Positions ride `emit_event` rather than a running
+  activity, for `snapshot_pull`'s reason: a second RUNNING activity would put "a message arrived
+  recently" into the hub's serving-blocked and stall predicates.
+- Proven against the REAL fetch loop — real HTTP origin that trickles, real
+  `transfer.grants.download`, real `ensure_snapshot_async`, positions read back off a bound
+  activity sink: a 9 MiB pull emitted `[0, 1, 3, 4, 6, 7, 9, 9]`.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -280,6 +280,19 @@ KIND_BOOT_STAGES = "boot_stages"
 # KIND_SERVE_DEGRADE, which is the countable quality-confession channel
 # (th#2075's ingest), so the two questions stay two rows.
 KIND_ENGINE_BOOT = "engine_boot"
+# pgw#1455: the serving-path weight download's BYTE POSITION, in integral MiB
+# on the typed `step`/`total_steps` columns. Its own KIND because it is the only
+# fact that separates "downloading" from "downloading is PROGRESSING": rental #6
+# parked a request on `model_download_pending` for 49 minutes with 0 rows in
+# `worker_activity_events`, and the scheduler's `attempts` counter — its own 1 Hz
+# placement poll — carries no download information at all. `snapshot_pull` is a
+# terminal roll-up of a pull that ALREADY FINISHED, so it answers nothing about
+# one in flight; `warmup`'s byte counter rides whichever activity happens to be
+# open, which for a steady-state materialization is none. The hub keys
+# `info.Activities` on kind alone and reads THIS kind's `step` into the
+# `model_download_pending` decline explain (th#2191). Phases are a closed
+# vocabulary (`weight_position.PHASE_*`).
+KIND_WEIGHT_FETCH = "weight_fetch"
 # th#1322: the roll-up phase both mint routes report their TOTAL under. A
 # reader groups on (kind, phase) and must never sum a roll-up together with
 # its own children.

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -23,6 +23,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, c
 from .. import activity as activity_mod
 from .. import boot_phases as boot_mod
 from .. import progress as progress_mod
+from .. import weight_position
 from ..capability import InsufficientDiskError
 from ..lifecycle_intents import IntentRegistry
 from ..pb import worker_scheduler_pb2 as pb
@@ -1348,9 +1349,17 @@ class ModelStore:
             # is one, so it advances that scope's clock and no other.
             dl_counter = activity_mod.scoped_counter(
                 f"download:{ref}", progress_mod.UNIT_BYTES, total=known_total)
+            # pgw#1455: the counter above is IN-MEMORY on the hub and rides
+            # whichever activity is open — none, for a steady-state
+            # materialization. The position is the durable fact the
+            # `model_download_pending` explain reads, so it is emitted on the
+            # activity stream from this same funnel, which is the one layer
+            # that sees every materialization path and knows the ref.
+            position = weight_position.FetchPosition(ref, total_bytes=known_total)
 
             def _progress(done: int, total: Optional[int]) -> None:
                 nonlocal last_progress
+                position.progress(done, total)
                 dl_counter.set_done(float(done))
                 if total:
                     dl_counter.set_total(float(total))
@@ -1367,6 +1376,7 @@ class ModelStore:
                     self._loop,
                 )
 
+            position.open()
             await self._event(
                 ref, pb.MODEL_STATE_DOWNLOADING, identity=operation_identity,
                 bytes_total=known_total,
@@ -1509,6 +1519,10 @@ class ModelStore:
                 raise
             finally:
                 dl_counter.finish()
+                # Where the transfer STOPPED, whether it finished or raised —
+                # a fetch that ends with no terminal row is one nobody can
+                # distinguish from a fetch still running.
+                position.close(ok=fetch_exc is None)
                 if fetch_span is not None:
                     net = int(net_scope.network_bytes)
                     if net > 0:

--- a/src/gen_worker/weight_position.py
+++ b/src/gen_worker/weight_position.py
@@ -1,0 +1,172 @@
+"""pgw#1455: the BYTE POSITION of a serving-path weight download, as a wire fact.
+
+Rental #6 (e2e#1910) parked a request on `model_download_pending` for 49 minutes
+and ~$0.59, and nothing anywhere could say whether the download was finishing.
+The scheduler's `attempts=2963` counts its own 1 Hz placement poll and tracks
+wall-clock seconds 1:1 — it reads the same whether a download is healthy, slow
+or wedged, so it carries no download information at all. `worker_activity_events`
+held 0 rows for the pod. The honest state was "nobody can tell".
+
+**No clocks.** The judgment a consumer, an operator and the scheduler all need is
+*is the position advancing* — not *how long has it been*. So this emits a
+POSITION and lets the reader difference it, exactly as [[pgw#1397]] did for the
+clone path (the hub advances on strict increase).
+
+## Integral MiB, never a fraction — pgw#1397's documented trap
+
+The hub parses an INTEGER off the position field (`ActivityUpdate.step` ->
+`worker_activity_events.step`). A position expressed in GiB spends the first
+1073741823 bytes truncating to `int(0.97) == 0`, so a healthy multi-GB transfer
+reports a frozen position and reads as the wedge it is not. The position here is
+`bytes // MiB` — already an integer, monotone, and one unit of it is small
+enough that a live transfer moves it within a second.
+
+## What the position MEANS, and why it is the aggregate
+
+`bytes accounted for the snapshot`, not `bytes off the wire`. The fetch loop
+(`models/cozy_snapshot._ensure_objects`) runs a residency scan first — ~1 s/GiB
+warm, ~14 s/GiB cold-and-contended — during which no wire byte moves and a
+wire-only position would sit at 0 for minutes, which is the same lie #1397 fixed
+(`progress_position = 0` for the whole fetch). The consumer-side question is
+"how much of this model does the pod have", and the aggregate answers it through
+both phases.
+
+## Rows, not a beat
+
+Positions ride `emit_event` (a self-contained COMPLETED event) rather than a
+running activity, for `snapshot_pull`'s reason: an extra RUNNING activity would
+put "a message arrived recently" into the hub's serving-blocked and stall
+predicates, and a download must never be able to satisfy a liveness rule by
+existing. Cadence is bounded by BOTH a byte stride and a time floor, so a fast
+7 GB pull writes ~28 rows and a slow one writes about one a minute.
+
+`started` is emitted unconditionally, at position 0. Without it a transfer that
+wedges before its first MiB emits nothing, and "no rows" is the exact reading
+that cost rental #6 — absence has to render as a row that says zero.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+MIB = 1024 * 1024
+
+#: The fetch opened; position 0. Always emitted, so a wedge at zero is a ROW.
+PHASE_STARTED = "started"
+#: One position, mid-transfer.
+PHASE_FETCHING = "fetching"
+#: The fetch returned; position is what landed.
+PHASE_FETCHED = "fetched"
+#: The fetch raised or was cancelled; position is where it stopped.
+PHASE_ABANDONED = "abandoned"
+
+#: Emit at most one row per this many MiB of advance...
+STRIDE_MIB = 256
+#: ...and at least one per this many seconds while the position moves. Matched
+#: to the hub's own `workerActivityProgressEventInterval` (1 min), which is the
+#: cadence at which it makes an in-phase position durable.
+MIN_INTERVAL_S = 60.0
+
+
+def _token(value: str) -> str:
+    """A `k=v` value with no spaces in it, and never empty — the grammar the
+    th#1839 route serves verbatim and every reader parses as `(\\w+)=(\\S+)`."""
+    cleaned = "".join(ch for ch in str(value or "") if not ch.isspace())
+    return cleaned or "-"
+
+
+class FetchPosition:
+    """The position reporter for ONE ref's weight fetch.
+
+    ``progress(done, total)`` is deliberately the ``ProgressFn`` shape the
+    download layer already calls, so the reporter is wired by handing this
+    method to the same callback chain rather than by threading a second one.
+    """
+
+    def __init__(self, ref: str, total_bytes: int = 0) -> None:
+        self.ref = str(ref or "")
+        self._total_bytes = max(0, int(total_bytes or 0))
+        self._pos_bytes = 0
+        #: Last position PUT ON THE WIRE, in MiB. Rows are emitted on strict
+        #: increase only, which is what makes the hub's #1243 rule applicable
+        #: to them unchanged.
+        self._emitted_mib = -1
+        self._emitted_at = 0.0
+        self._opened = False
+        self._closed = False
+
+    # -- the position itself ------------------------------------------------
+
+    @property
+    def position_mib(self) -> int:
+        """Integral MiB accounted for. Never a fraction; see the module note."""
+        return self._pos_bytes // MIB
+
+    @property
+    def total_mib(self) -> int:
+        return self._total_bytes // MIB
+
+    # -- the three call sites -----------------------------------------------
+
+    def open(self) -> None:
+        """State position 0 before a byte moves."""
+        if self._opened:
+            return
+        self._opened = True
+        self._emit(PHASE_STARTED)
+
+    def progress(self, done: int, total: Optional[int] = None) -> None:
+        """One ``ProgressFn`` tick from the fetch loop."""
+        try:
+            self._pos_bytes = max(0, int(done))
+            if total:
+                self._total_bytes = max(self._total_bytes, int(total))
+        except (TypeError, ValueError):
+            return
+        pos = self.position_mib
+        if pos <= self._emitted_mib:  # strict increase, always
+            return
+        now = time.monotonic()
+        if (pos - self._emitted_mib) < STRIDE_MIB and (
+            now - self._emitted_at
+        ) < MIN_INTERVAL_S:
+            return
+        self._emit(PHASE_FETCHING)
+
+    def close(self, ok: bool = True) -> None:
+        """The terminal position. Emitted whether or not it advanced — where
+        the transfer STOPPED is the fact, and a fetch that moved less than one
+        MiB has to leave a row saying so."""
+        if self._closed:
+            return
+        self._closed = True
+        self._emit(PHASE_FETCHED if ok else PHASE_ABANDONED)
+
+    # -- emission -----------------------------------------------------------
+
+    def _emit(self, phase: str) -> None:
+        pos = self.position_mib
+        self._emitted_mib = pos
+        self._emitted_at = time.monotonic()
+        detail = (
+            f"ref={_token(self.ref)} pos_mib={pos} total_mib={self.total_mib} "
+            f"pos_bytes={self._pos_bytes} total_bytes={self._total_bytes}"
+        )
+        try:
+            # Lazy: `activity` pulls in protobuf and psutil, and this module is
+            # imported from the download path the discovery build keeps thin.
+            from . import activity as activity_mod
+
+            activity_mod.emit_event(
+                activity_mod.KIND_WEIGHT_FETCH,
+                detail,
+                phase=phase,
+                step=pos,
+                total_steps=self.total_mib,
+            )
+        except Exception:  # pragma: no cover — telemetry never fails a fetch
+            logger.debug("weight position event dropped", exc_info=True)

--- a/tests/test_weight_position.py
+++ b/tests/test_weight_position.py
@@ -1,0 +1,286 @@
+"""The weight download's byte POSITION, off the real fetch loop.
+
+# pgw#1455: rental #6 (e2e#1910) parked a request on `model_download_pending` for
+# 49 minutes, ~$0.59, with 0 rows in `worker_activity_events`. The scheduler's
+# `attempts=2963` is its own 1 Hz placement poll and tracks wall-clock seconds
+# 1:1, so it reads identically whether a download is healthy, slow or wedged.
+# Nothing anywhere said whether the download was PROGRESSING.
+
+Everything here drives the REAL pull: objects are served by a real HTTP origin
+that TRICKLES them out, fetched by the real `gen_worker.transfer.grants.download`
+through the real `ensure_snapshot_async`, and the positions are read back off a
+bound activity sink as `ActivityUpdate` envelopes — the same wire the th#1839
+route serves and the hub decodes.
+
+The reporter is wired by handing `FetchPosition.progress` to the download layer's
+own `progress=` callback, which is exactly what `models/store.py` does at the one
+funnel every materialization path passes through. So the object under test here
+is the object that runs in production, on the loop that runs in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import http.server
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker import activity, weight_position
+from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+from gen_worker.models.refs import TensorhubRef
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.weight_position import MIB, FetchPosition
+
+#: Six objects at 1.5 MiB. Small enough to stay CPU-cheap, large enough that the
+#: position moves through several whole MiB while the transfer is in flight.
+OBJECT_BYTES = 3 * MIB // 2
+OBJECTS = 6
+
+
+def _sha(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *_args: object) -> None:
+        pass
+
+    def do_GET(self) -> None:  # noqa: N802
+        key = self.path.rsplit("/", 1)[-1]
+        body = self.server.blobs.get(key)  # type: ignore[attr-defined]
+        if body is None:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        # THE THROTTLE. A source that answers instantly cannot tell a position
+        # that advances DURING a transfer from one computed after it.
+        chunk = len(body) // 4 or len(body)
+        for start in range(0, len(body), chunk):
+            self.wfile.write(body[start:start + chunk])
+            self.wfile.flush()
+            time.sleep(0.01)
+
+
+class _Origin:
+    """A real, slow HTTP origin."""
+
+    def __init__(self) -> None:
+        self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.server.blobs = {}  # type: ignore[attr-defined]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def put(self, data: bytes) -> str:
+        digest = _sha(data)
+        self.server.blobs[digest] = data  # type: ignore[attr-defined]
+        host, port = self.server.server_address[:2]
+        return f"http://{host!s}:{port!s}/{digest}"
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join()
+
+
+class _Wire:
+    """A bound activity sink, collecting what a real pull emits."""
+
+    def __init__(self) -> None:
+        self.updates: list[pb.ActivityUpdate] = []
+
+    async def send(self, msg: pb.WorkerMessage) -> None:
+        if msg.WhichOneof("msg") == "activity_update":
+            self.updates.append(msg.activity_update)
+
+    def positions(self) -> list[pb.ActivityUpdate]:
+        return [u for u in self.updates if u.kind == activity.KIND_WEIGHT_FETCH]
+
+
+def _detail(update: pb.ActivityUpdate) -> dict[str, str]:
+    """The wire grammar every reader parses, `(\\w+)=(\\S+)`."""
+    return dict(re.findall(r"(\w+)=(\S+)", update.detail))
+
+
+def _resolved(files: list[tuple[str, bytes, str]]) -> WorkerResolvedRepo:
+    fingerprint = hashlib.sha256(
+        b"|".join(f"{path}:{_sha(body)}".encode() for path, body, _url in files)
+    ).hexdigest()
+    return WorkerResolvedRepo(
+        snapshot_digest="sha256:" + fingerprint,
+        files=[
+            WorkerResolvedRepoFile(path, len(body), url, digest=_sha(body))
+            for path, body, url in files
+        ],
+    )
+
+
+def _pull(wire: _Wire, base: Path, repo: str, resolved: WorkerResolvedRepo,
+          position: FetchPosition) -> None:
+    """One real snapshot pull with the position reporter wired the way
+    `models/store.py` wires it: its `progress` IS the download's callback."""
+
+    async def run() -> None:
+        activity.bind_sink(wire.send, asyncio.get_running_loop())
+        position.open()
+        try:
+            await ensure_snapshot_async(
+                base_dir=base,
+                ref=TensorhubRef(owner="acme", repo=repo, release="latest"),
+                resolved=resolved,
+                progress=position.progress,
+            )
+        finally:
+            position.close(ok=True)
+        # The sink ships through `create_task`; give those tasks their turn.
+        for _ in range(4):
+            await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+
+@pytest.fixture(autouse=True)
+def _clean_sink() -> Any:
+    activity.reset_for_tests()
+    yield
+    activity.reset_for_tests()
+
+
+@pytest.fixture()
+def _fine_cadence(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Production emits one row per 256 MiB or per minute; this suite moves 9 MiB
+    in under a second. The CADENCE is policy and is asserted separately — what
+    this fixture buys is that the ADVANCEMENT mechanism is exercised at test
+    scale instead of being read."""
+    monkeypatch.setattr(weight_position, "STRIDE_MIB", 1)
+    monkeypatch.setattr(weight_position, "MIN_INTERVAL_S", 0.0)
+    yield
+
+
+def test_the_position_advances_while_the_fetch_runs(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """THE FACT rental #6 did not have. A trickling multi-MiB pull leaves a
+    STRICTLY INCREASING sequence of byte positions on the activity stream, so
+    'downloading' and 'downloading is PROGRESSING' stop being the same
+    observation."""
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        resolved = _resolved([(p, b, origin.put(b)) for p, b in blobs])
+        wire = _Wire()
+        position = FetchPosition("tensorhub:acme/model-a@latest",
+                                 total_bytes=OBJECTS * OBJECT_BYTES)
+        _pull(wire, tmp_path / "pod", "model-a", resolved, position)
+
+        rows = wire.positions()
+        phases = [r.phase for r in rows]
+        assert phases[0] == weight_position.PHASE_STARTED
+        assert phases[-1] == weight_position.PHASE_FETCHED
+        # The advancement itself, on the TYPED column the hub reads.
+        steps = [r.step for r in rows]
+        assert steps[0] == 0, "the opening row states position zero"
+        assert steps[-1] == (OBJECTS * OBJECT_BYTES) // MIB
+        assert len(rows) >= 4, f"a 9 MiB trickle left only {len(rows)} position(s)"
+        # STRICT increase across every row the transfer produced while running.
+        # The terminal `fetched` row is deliberately outside this: it restates
+        # where the fetch stopped and may repeat the last position, which is the
+        # only way a fetch that ends between strides gets a closing row at all.
+        running = [r.step for r in rows if r.phase != weight_position.PHASE_FETCHED]
+        assert all(b > a for a, b in zip(running, running[1:])), (
+            f"positions must strictly increase; got {steps}")
+        assert steps[-1] >= running[-1]
+        # A hub reading these differences the way th#1243 does sees movement.
+        assert steps[-1] > steps[0]
+
+        for row in rows:
+            assert row.state == pb.ActivityState.ACTIVITY_STATE_COMPLETED
+            got = _detail(row)
+            assert got["ref"] == "tensorhub:acme/model-a@latest"
+            # The typed column and the sentence can never disagree.
+            assert int(got["pos_mib"]) == row.step
+            assert int(got["total_mib"]) == row.total_steps
+    finally:
+        origin.close()
+
+
+def test_a_sub_mib_fetch_still_leaves_rows_at_zero(tmp_path: Path) -> None:
+    """Absence renders as a row that says zero, at the PRODUCTION cadence (no
+    fixture here). A transfer too small to move a whole MiB emits no `fetching`
+    row — and would emit nothing at all without the unconditional `started` and
+    `fetched` pair, which is the 0-rows reading that cost rental #6."""
+    origin = _Origin()
+    try:
+        body = b"c" * 4096
+        resolved = _resolved([("config/model.safetensors", body, origin.put(body))])
+        wire = _Wire()
+        position = FetchPosition("tensorhub:acme/tiny@latest", total_bytes=len(body))
+        _pull(wire, tmp_path / "pod", "tiny", resolved, position)
+
+        rows = wire.positions()
+        assert [r.phase for r in rows] == [
+            weight_position.PHASE_STARTED, weight_position.PHASE_FETCHED]
+        assert [r.step for r in rows] == [0, 0]
+        assert [r.total_steps for r in rows] == [0, 0]
+    finally:
+        origin.close()
+
+
+def test_the_position_is_integral_mib_never_a_fraction() -> None:
+    """pgw#1397's documented trap, which this reuses the shape of.
+
+    The hub parses an INTEGER off the position field. A position carried in GiB
+    spends the first 1073741823 bytes truncating to `int(0.97) == 0`, so a
+    healthy multi-GB transfer would report a frozen position — the wedge it is
+    not. Integral MiB is the unit for that reason and nothing may make it a
+    float."""
+    position = FetchPosition("tensorhub:acme/big@latest", total_bytes=7 * 1024 * MIB)
+    for done, expected in (
+        (0, 0),
+        (MIB - 1, 0),
+        (MIB, 1),
+        (4212 * MIB + 900_000, 4212),
+        (7 * 1024 * MIB, 7168),
+    ):
+        position._pos_bytes = done
+        assert position.position_mib == expected
+        assert isinstance(position.position_mib, int)
+
+
+def test_a_frozen_or_regressing_position_emits_nothing_new(_fine_cadence: Any) -> None:
+    """The hub advances on STRICT INCREASE, so the worker must never manufacture
+    an increase. A flat position (the wedge) and a position that goes backwards
+    (a retry re-reporting fewer materialized bytes) both leave the last row
+    standing — its age is then the evidence, which is the hub's to read."""
+    wire: list[pb.ActivityUpdate] = []
+    original = weight_position.FetchPosition._emit
+
+    def spy(self: FetchPosition, phase: str) -> None:
+        wire.append(pb.ActivityUpdate(phase=phase, step=self.position_mib))
+        original(self, phase)
+
+    position = FetchPosition("tensorhub:acme/model-a@latest", total_bytes=8 * MIB)
+    try:
+        weight_position.FetchPosition._emit = spy  # type: ignore[method-assign]
+        position.open()
+        position.progress(4 * MIB, 8 * MIB)
+        emitted = len(wire)
+        position.progress(4 * MIB, 8 * MIB)          # frozen
+        position.progress(4 * MIB + MIB - 1, 8 * MIB)  # under a whole MiB
+        position.progress(1 * MIB, 8 * MIB)          # a retry, backwards
+        assert len(wire) == emitted, f"{wire[emitted:]} should not have been emitted"
+        position.progress(6 * MIB, 8 * MIB)          # real movement resumes
+        assert [u.step for u in wire] == [0, 4, 6]
+    finally:
+        weight_position.FetchPosition._emit = original  # type: ignore[method-assign]


### PR DESCRIPTION
Rental #6 (e2e#1910) parked a request on `model_download_pending` for **49 minutes** on a rented
RTX 4090, ~**$0.59**, no image, with **0 rows** in `worker_activity_events`. Nothing anywhere said
whether the download was finishing.

**`attempts=2963` is a clock, not a failure count, and nothing here is keyed on it.** 22:24:22 →
22:24:53 is +31 attempts in 31 s — exactly 1/second, tracking wall clock 1:1. It counts the
scheduler's own placement poll and would read the same on a healthy, a slow, or a wedged download.
The honest state of that incident was *"nobody can tell"*; the presigned-URL-403 hypothesis remains
completely untested, and this instrument is what makes testing it cheap.

## What lands

- `gen_worker/weight_position.py` — `FetchPosition`, the byte-position reporter. Position is
  **integral MiB accounted for the snapshot**, emitted on strict increase only.
- `activity.KIND_WEIGHT_FETCH = "weight_fetch"` — its own kind, with the reasoning for why
  `snapshot_pull` (a terminal roll-up) and `warmup`'s counter (rides whatever activity is open, which
  for a steady-state materialization is none) both fail to answer this.
- Wired at `models/store.py`'s single download funnel — the one layer that sees every
  materialization path and knows the ref.

## pgw#1397's shape, including its documented fraction trap

The hub parses an **integer** off the position field. A position carried in GiB truncates to
`int(0.97) == 0` for its first gigabyte, so a healthy multi-GB transfer reports a frozen position —
the wedge it is not. Position is `bytes // MiB` and a test pins it.

`started` and `fetched` are unconditional: a fetch that wedges before its first whole MiB would
otherwise emit nothing, and **"no rows" is the exact reading that cost rental #6.**

## Aggregate, not wire-only

The fetch loop runs a residency scan first (~1 s/GiB warm, ~14 s/GiB cold-and-contended) during which
no wire byte moves. A wire-only position would sit at 0 for minutes — the same lie #1397 fixed
(`progress_position = 0` for the whole fetch).

## Evidence — isolate-first, $0

Real HTTP origin that **trickles**, real `transfer.grants.download`, real `ensure_snapshot_async`,
positions read back off a bound activity sink as `ActivityUpdate` envelopes. A 9 MiB pull emitted:

```
[0, 1, 3, 4, 6, 7, 9, 9]
```

Red-verified on the way: the strict-increase assertion first caught the terminal row restating its
position, which is why the running rows and the closing row are asserted separately.

Cadence: 256 MiB stride **or** 60 s (matched to the hub's `workerActivityProgressEventInterval`), so
a 7 GB pull writes ~28 rows.

## Wheel-pending

The live proof — a real cold boot showing positions in `worker_activity_events` — rides the next
wheel cut (v0.126.3 was last) plus any rental another lane makes. Acceptance query banked in the
tracker.

Hub half: cozy-creator/tensorhub th#2191.