### PR TITLE
pgw#1462 / se#786: the derive imports the VENDORED torchcg + tensorfs — the miner's own copies

### DIFF
--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -33,10 +33,15 @@ cap warns and traces the deterministic prefix. Author code wrapped in
 ``torch.inference_mode()`` composes fine with the fake-tensor drive -- no
 special handling; traced graphs are identical.
 
-torchcg is imported TOP-LEVEL and lazily: the derive runs inside the release
-env, torchcg is a release dependency there, and the env's pinned rev is the
-one whose version already sits in the lockfile-closure env identity. A
-missing torchcg is a typed refusal, never a silent fallback.
+torchcg and tensorfs are imported from ``gen_worker._vendor`` -- the SAME
+snapshots the serving miner compiles with (``serving/mint_child.py``,
+``serving/host.py``, ``serving/hub_store.py`` all import
+``gen_worker._vendor.torchcg``). The derive used to import a top-level
+``torchcg`` on the theory that it is a release dependency whose pinned rev is
+part of env identity; since pgw#1310 vendored both packages that theory is
+inverted -- an endpoint-pinned torchcg would let the publish-time TRACE and
+the serving-time MINT disagree about the compiler, which is the exact drift
+the old refusal claimed to prevent (se#786, pgw#1462).
 """
 
 from __future__ import annotations
@@ -130,15 +135,16 @@ class ReleaseDeriveResult:
 
 
 def _torchcg() -> ModuleType:
-    try:
-        import torchcg
-    except ImportError as exc:
-        raise DeriveError(
-            "gen-worker release derive runs INSIDE the release env, and "
-            "torchcg is a release dependency there (the env's pinned rev is "
-            "part of env identity). Install/pin torchcg in the endpoint's "
-            "environment; gen-worker deliberately does not bundle it."
-        ) from exc
+    """The VENDORED torchcg -- the one the miner compiles with.
+
+    Never a top-level ``torchcg``: if an endpoint pinned one, the trace and
+    the mint would run different compilers and their graph identities could
+    disagree silently. The vendored rev is recorded in
+    ``gen_worker/_vendor/VENDORED.toml``.
+    """
+
+    from .._vendor import torchcg
+
     return torchcg
 
 
@@ -152,8 +158,7 @@ def _hollow() -> ModuleType:
 
     import importlib
 
-    _torchcg()
-    return importlib.import_module("torchcg.hollow")
+    return importlib.import_module("gen_worker._vendor.torchcg.hollow")
 
 
 def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
@@ -178,7 +183,8 @@ def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
     import io
 
     import torch
-    from tensorfs import LocalCAS
+
+    from .._vendor.tensorfs import LocalCAS
 
     cas = LocalCAS(Path(cas_root))
 

--- a/tests/test_release_derive.py
+++ b/tests/test_release_derive.py
@@ -19,7 +19,9 @@ import pytest
 pytest.importorskip("torch")
 pytest.importorskip("diffusers")
 pytest.importorskip("transformers")
-pytest.importorskip("torchcg")
+# se#786/pgw#1462: the derive imports the VENDORED torchcg (the miner's copy),
+# which ships in this wheel — so this is a hard import, never a skip.
+import gen_worker._vendor.torchcg  # noqa: E402,F401
 
 FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
 
@@ -350,3 +352,94 @@ def test_the_blob_keeps_ONE_device_story_and_carries_no_weights(
             f"{blob.name} carries {payload} bytes of weight payload; a graph "
             f"artifact carries structure and the miner binds real weights"
         )
+
+
+# se#786 / pgw#1462 / th#2192 — THE BARE RELEASE ENV, AND THE PROGRAM BLOB.
+#
+# Measured 2026-08-19 in `serverless-endpoints/sdxl`'s own venv (the release
+# env, built from its uv.lock): `release derive` refused with
+# "torchcg is a release dependency there ... gen-worker deliberately does not
+# bundle it", and NO endpoint in the fleet pins torchcg. Every other production
+# site — `serving/mint_child.py`, `serving/host.py`, `serving/hub_store.py` —
+# imports `gen_worker._vendor.torchcg`, so an endpoint-pinned torchcg would let
+# the publish-time TRACE and the serving-time MINT run different compilers.
+#
+# The blocker below is the whole test: this env HAS both distributions
+# installed as dev dependencies, so without it the assertion would pass on a
+# derive that never touched the vendored copy.
+
+_BLOCKER = """
+import sys
+class _NoTopLevel:
+    BLOCKED = {"torchcg", "tensorfs"}
+    def find_module(self, name, path=None):
+        return None
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in self.BLOCKED:
+            raise ImportError(
+                "top-level %s is not importable in a real release env" % name
+            )
+        return None
+sys.meta_path.insert(0, _NoTopLevel())
+"""
+
+
+def test_derive_runs_in_a_release_env_with_no_top_level_torchcg_or_tensorfs(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    out = tmp_path / "bare.json"
+    cas = tmp_path / "graph-cas"
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(_BLOCKER)
+
+    import os
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(tmp_path), *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])]
+    )
+    completed = subprocess.run(
+        [
+            sys.executable, "-m", "gen_worker.cli", "release", "derive",
+            "--dir", str(FIXTURES), "--module", "tiny_endpoint",
+            "--checkpoint", str(config_only_tree),
+            "--graph-cas", str(cas),
+            "--out", str(out),
+        ],
+        capture_output=True, text=True, timeout=900, check=False, env=env,
+    )
+    assert completed.returncode == 0, completed.stderr[-4000:]
+
+    # th#2192's consequence, asserted on the OUTPUT: an empty `program` is the
+    # miner's `MissingProgramDigest`, so a derive that stores no blob is not a
+    # mintable derive. `--graph-cas` is the only thing that fills it.
+    document = json.loads(out.read_bytes())
+    programs = [
+        record["program"]
+        for lane in document["graphs"]["lanes"]
+        for record in lane["graphs"]
+    ]
+    assert programs and all(p.strip() for p in programs), document["graphs"]
+    assert cas.is_dir() and any(cas.rglob("*")), "the graph CAS holds no blob"
+
+
+def test_the_blocker_itself_can_go_red(config_only_tree: Path, tmp_path: Path) -> None:
+    """The negative control: with the blocker armed, the OLD import fails.
+
+    Without this, a blocker that silently stopped blocking would make the test
+    above pass for the wrong reason — the exact fixture-instead-of-emitter hole
+    that kept th#2192 green.
+    """
+    import os
+
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(_BLOCKER)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(tmp_path), *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])]
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", "import torchcg"],
+        capture_output=True, text=True, env=env, check=False,
+    )
+    assert proc.returncode != 0 and "not importable in a real release env" in proc.stderr

--- a/tests/test_weightless_entrypoints.py
+++ b/tests/test_weightless_entrypoints.py
@@ -139,7 +139,7 @@ def test_discovery_publishes_a_row_with_no_slots(weightless: ModuleType) -> None
 def test_derive_renders_an_envelope_with_no_model_field(
     weightless: ModuleType, tmp_path: Path
 ) -> None:
-    pytest.importorskip("torchcg")
+    # se#786/pgw#1462: vendored torchcg ships in the wheel — never a skip.
     from gen_worker.release.derive import derive_release
 
     result = derive_release(weightless, checkpoint_dir=tmp_path)


### PR DESCRIPTION
`release/derive.py` was the ONLY site in `src/gen_worker` importing a top-level `torchcg`, and the only one importing a top-level `tensorfs`. Every production site the derive's output is FOR — `serving/mint_child.py`, `serving/host.py`, `serving/hub_store.py`, `serving/mint_store.py`, `aot_serve.py` — imports `gen_worker._vendor.torchcg`.

Since pgw#1310 vendored both packages, the docstring's argument ("torchcg is a release dependency there; the env's pinned rev is part of env identity") is inverted: an endpoint-pinned torchcg would let the publish-time TRACE and the serving-time MINT run **different compilers** — the exact drift the refusal claimed to prevent.

## That drift is not hypothetical — pgw#1464 hit it two hours ago

Verbatim from `6495e793`:

> the re-vendor moved `_vendor/` to `8d7ab577` and never touched `pyproject.toml` or `uv.lock`, so the tree ran TWO torchcg versions at once: the vendored snapshot for mint and serving, and the INSTALLED `ad399093` for the derive — which imports torchcg from the env it runs in, by design and by comment. The symptom was `TypeError: discover_modules() got an unexpected keyword argument 'session'` for a keyword that is demonstrably present in the vendored source.

Their fix makes the **dev pin track the vendored rev** — two copies, and one more thing to keep in step. This PR removes the second copy: after it there is nothing for a pin to track, and that `TypeError` is not expressible.

## Measured, in `serverless-endpoints/sdxl`'s own venv (a real release env from its uv.lock, no top-level torchcg)

| | |
|---|---|
| before | `derive error: gen-worker release derive runs INSIDE the release env, and torchcg is a release dependency there …` |
| after | 1 lane, **18 graph classes**, document `sha256:a166d375db8cc972…`, and with `--graph-cas` a **173 MB** CAS of serialized ExportedPrograms whose digests land in `graphs[].program` |

That refusal is **se#786** — zero endpoints in the fleet pin torchcg, so NO release on the platform could ever stamp a compiled-graph document. It is **vacated** here rather than fixed 29 times, and an endpoint pin is now the wrong thing to add.

`_program_sink`'s `from tensorfs import LocalCAS` is **pgw#1462**'s third half: tensorfs is vendored and NOT in the wheel, so the moment `--graph-cas` was passed the derive died `ModuleNotFoundError`. Both halves move together.

## The fence, with its negative control

This env has both distributions installed as dev dependencies, so a test that merely derives proves nothing.

- `test_derive_runs_in_a_release_env_with_no_top_level_torchcg_or_tensorfs` runs the real CLI in a subprocess behind a meta-path blocker that refuses top-level `torchcg`/`tensorfs`, passes `--graph-cas`, and asserts every `graphs[].program` is non-empty and the CAS holds blobs. An empty program digest is the miner's `MissingProgramDigest` (th#2192), so a derive that stores no blob is not a mintable derive.
- `test_the_blocker_itself_can_go_red` proves the blocker blocks.

Verified **red on master's code**, green here.

## `fast gates` was RED on `origin/master` — five breaks, none of them this PR's

This repo's ruleset has ONE required context, so a red one blocks every lane. Each was reproduced by running the script in the **master checkout**, not inferred from a branch failure:

1. `lint_mypy_ratchet` — three override lists shrank and the marks did not (53→52, 25→24, 227→226) — `07561288`
2. `lint_config_reads` — `serving/engine_runtime.py` seeds the engine child's env, unlisted; the same IPC shape three siblings already carry — `07561288`
3. `mypy` — `test_trace_context_surface_pgw1461.py:148` returns `list.append`'s `None` through an `or` — `70f008d5`
4. `lint_unreached_surface` — pgw#1461's five `TraceRequestContext` methods, whose call site is an ENDPOINT REPO by construction: the derive hands the context to author code and never calls a method on it itself — `70f008d5`
5. `lint_config_reads` + `lint_settings_writers` + `lint_serving_process_compiles` — pgw#1464's `CUDA_HOME` read and write in `serving/mint_child.py`, plus the re-vendored `_vendor/torchcg/hollow.py`'s `torch.export.load` — `6495e793`

`CUDA_HOME` is **classified, not excused**: it is the CUDA toolchain's own variable, AOTI resolves it at the LINK step and exposes no other API, and the conditional is the point — an existing value is the operator stating where their toolkit is. `hollow` is declared child-only for the same reason `_vendor.torchcg.discovery` and `release.derive` already are.

⚠️ The last green master `CI` run is on `50b0a9a4`, **not the tip** — reading "master fast gates: success" from the run list reads a run for an older sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
