### PR TITLE
pgw#1464: the mint composes the CUDA root, the derive hands over its session, and the torchcg pin tracks the vendor

### DIFF
--- a/changelog.d/pgw1464.md
+++ b/changelog.d/pgw1464.md
@@ -1,0 +1,21 @@
+- **The mint composes the CUDA root before it compiles.** `cuda_root.py` existed for exactly one
+  failure and nothing on the mint path called it: AOTInductor resolves `CUDA_HOME` at the LINK step,
+  so a mint without one does the whole codegen and kernel build and *then* dies with
+  `OSError: CUDA_HOME environment variable is not set` — a pod's entire mint wall-clock spent to
+  produce nothing, attributed to nothing. `_ensure_cuda_home` now runs in `compile_one` before the
+  program is even loaded. A `CUDA_HOME` already in the environment WINS and is never second-guessed
+  (a devel base image, a distro package, or a developer box that cannot write `/usr/local`), and it
+  only fires for `sm_*` targets — a CPU target needs no CUDA root.
+
+- **The derive hands its hollow session to discovery.** A GPU-less cuda trace fakes the lifted
+  constants, and `discover_modules` restores their real values *from the session* before it hashes
+  and before the program sink serializes. Both call sites are wired; the second only runs when a
+  marked module was not reached by the budgeted drive, so a half-wiring would have stayed invisible
+  until a model that compiles something after the denoise loop.
+
+- **The dev `torchcg` pin tracks the vendored rev.** They are a matched pair and nothing enforced
+  it: a re-vendor that moved only `_vendor/` left the tree with `_vendor/torchcg` at `8d7ab577`
+  serving mint and serving, and the *installed* `torchcg` at `ad399093` serving the DERIVE — which
+  imports torchcg from the env it runs in, by design. The result was a `TypeError` for a keyword
+  argument that demonstrably existed in the vendored source. Bumped, re-locked, and the reason is
+  recorded at the pin.

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -1065,7 +1065,14 @@ def _derive_lane(
             checkpoint_ref=f"trace:{checkpoint_dir.name}",
             step_budget=TRACE_STEP_BUDGET,
         )
-        with hollow.hollow_session():
+        # pgw#1458: the session is CAPTURED and handed to discovery. A
+        # GPU-less cuda trace fakes the lifted constants; `discover_modules`
+        # restores their real values FROM THE SESSION before it hashes and
+        # before `program_sink` serializes. Omitting `session=` does not
+        # degrade quietly — torchcg raises `DiscoveryError` naming the faked
+        # constants — but a digest taken over faked values would be a lie,
+        # so the wiring is the point, not the refusal.
+        with hollow.hollow_session() as session:
             try:
                 model.load(load_ctx)
             except hollow.HollowError as exc:
@@ -1153,7 +1160,8 @@ def _derive_lane(
 
             try:
                 lane_graphs = torchcg.discover_modules(
-                    handle, modules, drive, program_sink=program_sink
+                    handle, modules, drive, program_sink=program_sink,
+                    session=session,
                 )
                 if set(lane_graphs.targets) - {
                     record.target for record in lane_graphs.graphs
@@ -1163,7 +1171,8 @@ def _derive_lane(
                     # before calling it unobserved.
                     request_ctx.step_budget = None
                     lane_graphs = torchcg.discover_modules(
-                        handle, modules, drive, program_sink=program_sink
+                        handle, modules, drive, program_sink=program_sink,
+                        session=session,
                     )
             except DeriveError:
                 raise

--- a/src/gen_worker/serving/mint_child.py
+++ b/src/gen_worker/serving/mint_child.py
@@ -26,9 +26,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
 
 #: The modules that DEFINE the parent/child contract: this entrypoint and the
 #: mint that spawns it. Their bytes are the request/response shape, so a child
@@ -106,6 +110,42 @@ def _place_constants(program: "Any", target_arch: str) -> None:
             constants[name] = value.to("cuda")
 
 
+
+def _ensure_cuda_home(target_arch: str) -> None:
+    """Make the CUDA root exist BEFORE inductor needs it (pgw#1464).
+
+    `cuda_root.py` exists for exactly one failure and nothing on the mint path
+    called it. Its own docstring names the shape: AOTI "dies with *CUDA_HOME
+    environment variable is not set*" -- and it dies at the LINK step, so the
+    codegen and the kernel work are already paid for. Measured on a real
+    compile: the whole thing runs, then `InductorError: OSError: CUDA_HOME
+    environment variable is not set`. On a pod that is a mint's entire
+    wall-clock spent to produce nothing, attributed to nothing.
+
+    A CUDA_HOME already in the environment WINS and is never second-guessed:
+    that is the operator stating where their toolkit is (a devel base image, a
+    distro package, a developer box that cannot write to `/usr/local`). Only
+    when nobody has said does this compose one, and `compose()` is itself
+    idempotent -- a pre-existing root is left alone rather than rebuilt.
+
+    Only for `sm_*`: a CPU target needs no CUDA root, and composing one there
+    would be work done to answer a question nobody asked.
+    """
+    if not target_arch.startswith("sm_"):
+        return
+    if os.environ.get("CUDA_HOME", "").strip():
+        return
+    from .. import cuda_root
+
+    cuda_root.compose()
+    os.environ["CUDA_HOME"] = str(cuda_root.CUDA_ROOT)
+    logger.info(
+        "mint: composed the CUDA root at %s and set CUDA_HOME (pgw#1464) — "
+        "AOTI resolves it at the link step, after the compile is already paid",
+        cuda_root.CUDA_ROOT,
+    )
+
+
 def compile_one(request: Mapping[str, Any]) -> Path:
     """Deserialize one graph blob and AOTI-compile it into ``destination``."""
     # pgw#1444/pgw#840, BEFORE any work: this child must BE the parent. It is
@@ -132,6 +172,7 @@ def compile_one(request: Mapping[str, Any]) -> Path:
     from .._vendor.torchcg import CallIngress, Engine, GraphClassSpec, RuntimeCompatibility
     from .._vendor.tensorfs import LocalCAS
 
+    _ensure_cuda_home(str(request.get("target_arch", "")))
     program = torch.export.load(str(request["blob"]))
     # pgw#1458: the derive traces on cuda, but the swap-back that keeps the
     # lifted constants' REAL values (they key the graph, so faking them would


### PR DESCRIPTION
Three things the sd1.5 number run needed, each found by running the real path on a 4070.

## pgw#1464 — the mint composes the CUDA root
`cuda_root.py` exists for exactly one failure and **nothing on the mint path called it**:
```
grep -c cuda_root serving/mint.py serving/mint_child.py  ->  0   0
```
AOTInductor resolves `CUDA_HOME` at the **link** step, so the failure is *paid*: measured on a real compile, inductor does the codegen and the kernel work and **then** dies with `OSError: CUDA_HOME environment variable is not set`. On a pod that is an entire mint's wall-clock spent to produce nothing, attributed to nothing. `_ensure_cuda_home` now runs before the program is even loaded.

- **An existing `CUDA_HOME` wins and is never second-guessed** — the operator stating where their toolkit is (devel base image, distro package, or a developer box that can't write `/usr/local`). `compose()` is itself idempotent and leaves a real install alone.
- **`sm_*` only** — a CPU target needs no CUDA root, and that matters now that `mint_child`'s end-to-end test compiles on CPU.

## The derive hands its session to discovery
A GPU-less cuda trace fakes the lifted constants, and `discover_modules` restores their real values **from the session** before it hashes and before the sink serializes. Omitting `session=` raises rather than degrading quietly — but a digest taken over faked values would be a lie, so the wiring is the point, not the refusal.

Both call sites are wired. The second runs only when a marked module wasn't reached by the budgeted drive, so wiring one and not the other would have stayed invisible until a model that compiles something *after* the denoise loop.

## 🔻 The dev `torchcg` pin tracks the vendored rev
The re-vendor moved `_vendor/` to `8d7ab577` and never touched `pyproject.toml`/`uv.lock`, so the tree ran **two torchcg versions at once**: the vendored snapshot for mint and serving, and the installed `ad399093` for the **derive** — which imports torchcg from the env it runs in, by design and by comment (`pyproject.toml:130`).

The symptom was `TypeError: discover_modules() got an unexpected keyword argument 'session'` for a keyword demonstrably present in the vendored source. Two true facts, one broken run. Bumped, re-locked, and the requirement is written at the pin so the next re-vendor reads it. **A lint fence asserting the two revs are equal would make this class unrepresentable** — flagged to the torchcg lane.

## Verification
Re-derive on the bumped pin: **14 graph classes, 165.27 s, document `ae7b4c8a…`** (the v3→v4 rekey, as expected). The mint then reaches torchcg's compiler on **all 14** — it dies there for a reason that is not this PR's: **pgw#1465**, where torchcg strips `example_inputs` in `discovery.py:216` and requires them in `compiler.py:138`, both at `8d7ab577`.

`ruff check src/gen_worker` clean. Tracker: pgw#1464.