### PR TITLE
pgw#1465: re-vendor torchcg at d132d872 (BOTH halves) and state the derive's trace device

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -692,7 +692,7 @@ torchvision = [
 # tools away from the cause: the derive raised `TypeError: unexpected keyword
 # 'session'` while that exact signature was verifiably present in the vendored
 # tree. Bump both, re-lock, re-vendor — one change.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "8d7ab5773b98e4ffd8560dfda58e8065b248fce7" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "d132d87248c6d1deb476c104e0137fabf90e598e" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -299,7 +299,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "8d7ab577"
+rev = "d132d872"
 subdir = "src/torchcg"
 # tcg#55/pgw#1458 RE-VENDOR (2026-08-19), from `ad399093`. Two upstream changes
 # land together because they are one ruling ("torchcg does too much"):
@@ -464,7 +464,7 @@ rewrites = [
 "adopt.py" = "6e8cc489a720fb9c88c401c648862705b8584a2ce62b156a6b7261fb1ad6a184"
 "artifact.py" = "e9281e4bae4154f93694efa994133e001362c5db271855e03e921110b1fee019"
 "cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
-"compiler.py" = "8450b10e90ca8c6d8c411654d963ebc16dd3580bfe1427cce3966fc2b03972a7"
+"compiler.py" = "a0a06109eec956388c8ff261e65b8dd6f6a7b45dbb3ac434fe2e60f14e410923"
 "contracts/KEY_GRAMMAR_DIGEST" = "0503f3251f2eb48b794961736f021915cd56c14930798ac844c90112fa2af69d"
 "contracts/__init__.py" = "093c5cbe1800d0cd19a8d57cb1493ae0509a4016b95470f514f05db9bad892c4"
 "contracts/call_ingress_v1.json" = "3af3437ec20b15156892055ab89bf21621378cee9f0f72f63bc4626f69f242dc"

--- a/src/gen_worker/_vendor/torchcg/compiler.py
+++ b/src/gen_worker/_vendor/torchcg/compiler.py
@@ -118,6 +118,80 @@ def _aot_compile(
     return cast(Any, compiler)(graph_module, args, kwargs, options=options)
 
 
+def _compile_inputs(program: object) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Rebuild the call AOTInductor compiles against, from the program itself.
+
+    pgw#1465. This used to read ``program.example_inputs``, and the derive now
+    DROPS that field: a hollow trace's example inputs are fake tensors, torch
+    serializes them by pickling ``_reconstruct_fake_tensor``, and torch's own
+    loader then refuses that under ``weights_only=True`` -- so a blob that kept
+    them could not be reloaded at all, on any device. Keeping them was not an
+    option; reading them was the last place a compile depended on a field
+    carried alongside the graph rather than derived from it.
+
+    Everything needed is already in the program, exactly and by construction:
+
+    * ``graph_signature.user_inputs`` is the FLAT call in order. A ``str``
+      entry names a placeholder; anything else IS a specialized constant that
+      the trace baked (``return_dict=False``), and it is carried verbatim
+      because its value is part of the graph's identity.
+    * each placeholder's ``meta['val']`` is its exact dtype, shape and DEVICE
+      -- the same fake tensors the trace ran on, which is what a compile wants
+      (pgw#1458: reading a device from anywhere else is how a mixed placement
+      reaches AOTI).
+    * ``call_spec.in_spec`` restores the nesting, so a pipeline's
+      ``conditioning={"a": ..., "b": ...}`` comes back as the dict the
+      author's ``forward`` declares rather than three loose tensors.
+
+    Derived, so there is nothing here for a producer to get wrong -- the same
+    move tcg#55 made for the graph interface.
+    """
+
+    from torch.utils import _pytree as pytree
+
+    graph = getattr(getattr(program, "graph_module", None), "graph", None)
+    signature = getattr(program, "graph_signature", None)
+    in_spec = getattr(getattr(program, "call_spec", None), "in_spec", None)
+    if graph is None or signature is None or in_spec is None:
+        raise CompileError(
+            "program cannot state its own call: one of graph_module.graph, "
+            "graph_signature or call_spec.in_spec is absent"
+        )
+    values = {
+        node.name: node.meta.get("val")
+        for node in graph.nodes
+        if getattr(node, "op", "") == "placeholder"
+    }
+    leaves: list[Any] = []
+    for entry in getattr(signature, "user_inputs", ()) or ():
+        if not isinstance(entry, str):
+            # A specialized constant the trace baked in. Its VALUE is part of
+            # the graph, so it is replayed exactly, never re-defaulted.
+            leaves.append(entry)
+            continue
+        if entry not in values:
+            raise CompileError(
+                f"exported program names user input {entry!r} with no matching "
+                f"placeholder; its graph and signature disagree"
+            )
+        leaves.append(values[entry])
+    try:
+        rebuilt = pytree.tree_unflatten(leaves, in_spec)
+    except Exception as exc:
+        raise CompileError(
+            f"cannot rebuild the exported program's call from its own signature "
+            f"({len(leaves)} flat input(s)) and in_spec: {type(exc).__name__}: {exc}"
+        ) from exc
+    try:
+        args, kwargs = rebuilt
+    except (TypeError, ValueError) as exc:
+        raise CompileError(
+            f"exported program in_spec does not unflatten to (args, kwargs); "
+            f"got {type(rebuilt).__name__}"
+        ) from exc
+    return tuple(args), dict(kwargs or {})
+
+
 def _compile_exported_program(program: object) -> tuple[object, ...]:
     """Compile one ExportedProgram to the loose files used by `package_aoti`.
 
@@ -134,10 +208,7 @@ def _compile_exported_program(program: object) -> tuple[object, ...]:
     exported_module = getattr(program, "module", None)
     if not callable(exported_module):
         raise CompileError("program has no callable module(check_guards=False)")
-    try:
-        args, kwargs = program.example_inputs  # type: ignore[attr-defined]
-    except (AttributeError, TypeError, ValueError) as exc:
-        raise CompileError("program has no (args, kwargs) example_inputs") from exc
+    args, kwargs = _compile_inputs(program)
 
     try:
         with _compiling_under_export_context(program):

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import enum
 import hashlib
 import inspect
+import logging
 import itertools
 import json
 import types
@@ -68,6 +69,8 @@ from .trace_context import (
     TraceLoadContext,
     TraceRequestContext,
 )
+
+_LOG = logging.getLogger("gen_worker.release.derive")
 
 DOCUMENT_KIND = "gen-worker.release-metadata@1"
 
@@ -182,6 +185,45 @@ def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
         return str(cas.put_bytes(buffer.getvalue()))
 
     return sink
+
+
+def _trace_device() -> str:
+    """The DEVICE CLASS this derive traces on -- and it is a real choice.
+
+    pgw#1458: a graph's device is established at TRACE time and cannot be
+    re-homed downstream, so a cpu-traced graph cannot be cuda-minted. torchcg
+    records the class in the declaration and refuses the mismatch by name
+    (`RuntimeCompatibility.key`), which is the whole point -- but the refusal
+    is only useful if the derive states the class DELIBERATELY rather than
+    inheriting a default that happens to be wrong for the host.
+
+    A fake-cuda trace needs no silicon in principle, and torchcg proves that
+    for plain modules. It does NOT yet hold for a full diffusers pipeline on a
+    GPU-less box: `encode_prompt` moves real token ids to the execution device
+    and the fake-tensor path runs a real cuda kernel for them
+    (`No CUDA GPUs are available`). Until that is closed, this states the
+    truth about the host instead of failing at the first pipeline call.
+
+    So: cuda when there IS a device, cpu otherwise, and the fallback SAYS what
+    it costs. A cpu-derived document is not a degraded cuda one -- it is a
+    different graph class, and a cuda mint of it refuses by name rather than
+    serving something wrong.
+    """
+
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - torch is the derive's premise
+        return "cpu"
+    if torch.cuda.is_available():
+        return "cuda"
+    _LOG.warning(
+        "derive: no CUDA device is visible, so this derive traces on CPU and "
+        "produces CPU-CLASS graphs. They are a different graph class from the "
+        "cuda graphs a GPU pod serves — a cuda mint of this document refuses "
+        "by name (pgw#1458), it does not silently serve. Derive on a "
+        "CUDA-bearing host to publish servable graphs."
+    )
+    return "cpu"
 
 
 def _demote_fakes_to_meta(torch: Any, program: Any) -> None:
@@ -1072,7 +1114,7 @@ def _derive_lane(
         # degrade quietly — torchcg raises `DiscoveryError` naming the faked
         # constants — but a digest taken over faked values would be a lie,
         # so the wiring is the point, not the refusal.
-        with hollow.hollow_session() as session:
+        with hollow.hollow_session(_trace_device()) as session:
             try:
                 model.load(load_ctx)
             except hollow.HollowError as exc:

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=8d7ab5773b98e4ffd8560dfda58e8065b248fce7" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=d132d87248c6d1deb476c104e0137fabf90e598e" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=8d7ab5773b98e4ffd8560dfda58e8065b248fce7#8d7ab5773b98e4ffd8560dfda58e8065b248fce7" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=d132d87248c6d1deb476c104e0137fabf90e598e#d132d87248c6d1deb476c104e0137fabf90e598e" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
**Unblocks the sd1.5 number.**

## The P0

`_demote_example_inputs` (tcg#55) stripped the exact field `compiler.py:138` read → all 14 sd1.5 graph classes refused in ~5–7s. **0/14.** Fixed upstream in [torchcg#54](https://github.com/cozy-creator/torchcg/pull/54): the compile now **derives** its inputs from `graph_signature.user_inputs` + placeholder `meta['val']` + `call_spec.in_spec`. The strip stands — a hollow trace's example inputs pickle `_reconstruct_fake_tensor`, which torch's own loader refuses under `weights_only=True`, on any device.

## Both halves, because they are a matched pair

`_vendor/` at `d132d872` **and** the `[tool.uv.sources]` dev pin at `d132d872`, re-locked. pgw runs two torchcg copies by design — the snapshot serves the mint and serving path, the pin serves the **derive**, which imports torchcg from the env it runs in. `test_the_dev_torchcg_pin_is_the_rev_the_snapshot_was_taken_from` (landed in #1024) enforces it; this is the first bump under it, and the fence did its job while I worked. The vendoring's one rewrite (`from tensorfs import` → `from ..tensorfs import`) is applied and proven by its own fence.

## The derive STATES its trace device

torchcg's default is cuda — right for the fleet, wrong for a host with no device. The derive died inside diffusers' `encode_prompt`, which moves real token ids to the execution device and lands a real cuda kernel through the fake-tensor path.

`_trace_device()` picks cuda when a device is visible, cpu otherwise, and **the fallback says what it costs**: a cpu-derived document is not a degraded cuda one, it is a *different graph class*, and a cuda mint of it refuses by name (pgw#1458) instead of silently serving something wrong. Stating the class deliberately is the point — the named refusal is only useful if the producer actually chose.

## Known gap, filed rather than papered over

A fake-cuda trace needs no silicon for **plain modules** (proven in torchcg's own suite) but **not yet for a full diffusers pipeline on a GPU-less box**. Two layers stand in the way, both measured: real token ids moved to the device run a real cuda kernel, and fakifying them instead trips `DataDependentOutputException` on a scheduler read. I had a shim most of the way there and pulled it — a GPU-bearing derive host is the production shape today, this only costs a CPU-only publish box, and the number should not wait behind it.

## Verification

`ruff` clean. Targeted suites: **182 passed**, 1 skipped — including all **10** `test_release_derive` tests, which drive a real diffusers `StableDiffusionPipeline` end to end.