### PR TITLE
pgw#1466: one blob, ONE device story — the meta demotion is deleted, not adjusted

### DIFF
--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -72,6 +72,11 @@ from .trace_context import (
 
 _LOG = logging.getLogger("gen_worker.release.derive")
 
+#: A hollow derive's REAL tensors are config-computed buffers and lifted
+#: constants -- KB to MB. Anything past this is a checkpoint weight that
+#: escaped hollow instantiation, and it must never reach a graph blob.
+_REAL_TENSOR_BYTES_CEILING = 64 * 1024 * 1024
+
 DOCUMENT_KIND = "gen-worker.release-metadata@1"
 
 #: Auto-enumeration cross-product cap. Overflow warns and traces the
@@ -178,7 +183,7 @@ def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
     cas = LocalCAS(Path(cas_root))
 
     def sink(graph: str, program: Any) -> str:
-        _demote_fakes_to_meta(torch, program)
+        _assert_weights_free(torch, program)
         buffer = io.BytesIO()
         torch.export.save(program, buffer)
         del graph
@@ -226,44 +231,54 @@ def _trace_device() -> str:
     return "cpu"
 
 
-def _demote_fakes_to_meta(torch: Any, program: Any) -> None:
-    """Replace the traced program's FAKE tensors with META tensors.
+def _assert_weights_free(torch: Any, program: Any) -> None:
+    """Prove the blob carries no weights -- WITHOUT rewriting anyone's device.
 
-    A derive traces under ``FakeTensorMode``, and ``torch.export.save`` writes
-    a fake tensor's PHANTOM storage -- the archive then claims a shape whose
-    bytes are not there, and ``torch.export.load`` dies with
-    ``setStorage: ... out of bounds for storage of size N`` (measured on the
-    real SDXL UNet: a [1280, 320] bf16 parameter wanting 819,200 bytes over a
-    23,040-byte storage). Meta tensors are shape+dtype ONLY, which is exactly
-    what a graph artifact should carry: the miner binds the checkpoint's real
-    weights before it compiles. So this is the honest serialization, not a
-    workaround -- and it is the same reason the blob holds no weights.
+    This used to be ``_demote_fakes_to_meta``, which replaced every fake tensor
+    with a META one. The rationale was real -- ``torch.export.save`` must not
+    write a phantom storage that makes the archive claim bytes it does not have
+    -- but the cure destroyed the device, and pgw#1458 made the device
+    load-bearing. The result was one blob with TWO device stories: 1,922 graph
+    node metas on ``cuda:0`` against 686 state-dict entries on ``meta``, and
+    AOTI reads BOTH, so every sd1.5 class died on
+    ``FakeTensorDeviceMismatchError cuda:0 and meta`` -- the mirror image of
+    the failure the device work had just fixed. ``meta`` has no device
+    sub-type, so it cannot express "no bytes, on cuda"; a fake tensor already
+    does.
 
-    Buffers hollow_session computed for REAL are left alone; only fakes move.
+    Measured, which is why the rewrite is gone rather than adjusted: saving a
+    fake-parameter program writes **0 bytes** of weight payload and records the
+    fake tensor's OWN device in ``model_weights_config.json`` (cpu trace ->
+    cpu, cuda trace -> cuda), and the cpu blob reloads with its state dict
+    intact. Shape + dtype + device + no bytes is exactly the property the
+    demotion was reaching for, and the fake tensor has it already.
+
+    What survives is the INVARIANT, asserted instead of enforced by rewriting:
+    a real tensor with real storage in the state dict would put weights in a
+    graph artifact. Buffers hollow_session computed for REAL are legitimate and
+    small (their values are what a literal-bearing trace digests), so the
+    refusal names a size floor rather than realness.
     """
 
     from torch._subclasses.fake_tensor import FakeTensor
 
-    def demote(value: Any) -> Any:
-        if not isinstance(value, FakeTensor):
-            return value
-        meta = torch.empty_strided(
-            value.shape, value.stride(), dtype=value.dtype, device="meta"
+    heavy = []
+    for holder in ("state_dict", "constants"):
+        for name, value in (getattr(program, holder, None) or {}).items():
+            if not isinstance(value, torch.Tensor) or isinstance(value, FakeTensor):
+                continue
+            if value.device.type == "meta":
+                continue
+            if value.numel() * value.element_size() > _REAL_TENSOR_BYTES_CEILING:
+                heavy.append(f"{holder}.{name} ({value.numel() * value.element_size()} bytes)")
+    if heavy:
+        raise DeriveError(
+            f"the derive is about to serialize {len(heavy)} REAL tensor(s) far too "
+            f"large to be config-derived buffers into a graph blob: {heavy[:6]!r}. "
+            f"A graph artifact carries structure, never weights -- the miner binds "
+            f"the checkpoint's real tensors before it compiles. Something was "
+            f"loaded with weights instead of hollow."
         )
-        if isinstance(value, torch.nn.Parameter):
-            return torch.nn.Parameter(meta, requires_grad=False)
-        return meta
-
-    for holder in (
-        getattr(program, "state_dict", None),
-        getattr(program, "constants", None),
-    ):
-        if not isinstance(holder, dict):
-            continue
-        for name, value in list(holder.items()):
-            demoted = demote(value)
-            if demoted is not value:
-                holder[name] = demoted
 
 
 def _lane_model_class(module: ModuleType) -> Optional[type]:

--- a/tests/test_release_derive.py
+++ b/tests/test_release_derive.py
@@ -291,3 +291,62 @@ def test_priming_omits_a_src_dir_that_does_not_exist(tmp_path: Path) -> None:
         assert str(root / "src") not in sys.path
     finally:
         sys.path[:] = saved
+
+
+def test_the_blob_keeps_ONE_device_story_and_carries_no_weights(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    """pgw#1465: the graph's device and the state dict's device must AGREE.
+
+    `_demote_fakes_to_meta` rewrote every fake tensor to META. Its rationale
+    was real -- a phantom storage must not make the archive claim bytes it
+    does not have -- but the cure destroyed the device, and pgw#1458 made the
+    device load-bearing. One blob then told TWO device stories (1,922 graph
+    node metas on cuda:0 against 686 state-dict entries on meta), AOTI reads
+    both, and every sd1.5 class died on `FakeTensorDeviceMismatchError`.
+
+    So this reads the blob's OWN recorded devices -- the same archive metadata
+    a CPU-side check can read without a GPU -- and asserts they are the single
+    device the trace ran on, plus that no real weight rode along.
+    """
+
+    import json
+    import zipfile
+
+    out = tmp_path / "doc.json"
+    cas = tmp_path / "graph-cas"
+    assert _derive(
+        "tiny_endpoint", config_only_tree, out, "--graph-cas", str(cas)
+    ) == 0
+
+    written = [
+        path for path in cas.rglob("*")
+        if path.is_file() and zipfile.is_zipfile(path)
+    ]
+    assert written, "the derive stored no exported-program blob to inspect"
+
+    for blob in written:
+        devices: set[str] = set()
+        payload = 0
+        with zipfile.ZipFile(blob) as archive:
+            for name in archive.namelist():
+                if name.endswith(
+                    ("model_weights_config.json", "model_constants_config.json")
+                ):
+                    for entry in json.loads(archive.read(name))["config"].values():
+                        devices.add(str(entry["tensor_meta"]["device"]["type"]))
+                elif "/weights/" in name and not name.endswith(".json"):
+                    payload += archive.getinfo(name).file_size
+        assert "meta" not in devices, (
+            f"{blob.name} records META-device tensors: the demotion is back, and "
+            f"a meta state dict against a device-stamped graph is the pgw#1465 "
+            f"two-device-stories failure AOTI refuses"
+        )
+        assert len(devices) <= 1, (
+            f"{blob.name} tells more than one device story {sorted(devices)!r}; "
+            f"AOTI reads the graph AND the state dict and refuses a mismatch"
+        )
+        assert payload == 0, (
+            f"{blob.name} carries {payload} bytes of weight payload; a graph "
+            f"artifact carries structure and the miner binds real weights"
+        )


### PR DESCRIPTION
**Unblocks the sd1.5 mint. pgw-only — no re-vendor, no torchcg bump.**

The mirror image of pgw#1458, and **my assertion that "the cuda stamp survives on the graph" was wrong.** AOTI reads the device from **both** stores, and the local-4070 lane measured it on the real sd1.5 UNet: graph node metas `cuda:0` ×1922 against state-dict entries `meta` ×686 → `FakeTensorDeviceMismatchError cuda:0 and meta`, on every class.

`_demote_fakes_to_meta`'s **rationale stands** — a phantom storage must not make the archive claim bytes it does not have — but **`meta` has no device axis**, so it cannot express *"no bytes, on cuda"*. The cure destroyed exactly the fact pgw#1458 had just made load-bearing.

## Deleted rather than adjusted

The property it was reaching for already exists. Measured before writing anything:

| | result |
|---|---|
| weight payload of a saved fake-parameter program | **0 bytes** |
| device recorded in `model_weights_config.json` | the fake tensor's **own** — cpu trace → `cpu`, cuda trace → `cuda` |
| cpu blob reload | state dict intact |

Shape + dtype + device + no bytes **is what a fake tensor already is**. There was nothing to demote it *to* that was better than leaving it alone.

## What survives is the invariant, asserted instead of enforced by rewriting

`_assert_weights_free` refuses a real tensor too large to be a config-computed buffer. Buffers `hollow_session` computed for real are legitimate and small — their values are what a literal-bearing trace digests — so the refusal names a **size floor** rather than realness, and a checkpoint weight that escaped hollow instantiation is caught by name instead of riding into a graph artifact.

## Red arm

`test_the_blob_keeps_ONE_device_story_and_carries_no_weights` reads the pt2 archive's **own** recorded devices — the same metadata a CPU-side check can read with no GPU — and asserts one device, never `meta`, and zero weight payload.

Disarmed by **restoring the old demotion behind `if True:`**, not by cutting lines: it fails at the assertion naming `meta` (`assert 'meta' not in {'meta'}`), and goes green again only because the behaviour came back.

## Verification

`ruff` clean. `tests/test_release_derive.py`: **11 passed**, driving a real diffusers `StableDiffusionPipeline` end to end.