### PR TITLE
pgw#1466: `gen-worker lock` — discovery and the trace become one file

### DIFF
--- a/src/gen_worker/cli/__init__.py
+++ b/src/gen_worker/cli/__init__.py
@@ -55,6 +55,12 @@ def _build_parser() -> argparse.ArgumentParser:
     from . import release as _release_mod
     _release_mod.add_subparser(sub)
 
+    # pgw#1466 — the endpoint-level surface: lock pins, sync materializes,
+    # serve stays resident, run executes one. Four front doors onto ONE
+    # serving core; see each module's docstring.
+    from . import lock as _lock_mod
+    _lock_mod.add_subparser(sub)
+
     return parser
 
 

--- a/src/gen_worker/cli/endpoint_lock.py
+++ b/src/gen_worker/cli/endpoint_lock.py
@@ -160,6 +160,41 @@ def torchcg_format_versions() -> tuple[int, int]:
     return int(GRAPH_INTERFACE_FORMAT), int(DOCUMENT_FORMAT)
 
 
+def tracer_digest() -> str:
+    """A fingerprint of the CODE THAT TRACES: torchcg plus gen_worker's derive.
+
+    The env closure (``uv.lock``) is the right identity when both are resolved
+    from the lockfile — but the cozy-local shape Paul asked for runs them off
+    ``PYTHONPATH`` from working trees, where the lockfile mentions neither. In
+    that shape a tracer change is invisible to the closure, so a saved trace
+    would be reused across a fix that changes what tracing MEANS.
+
+    That is not hypothetical: tcg#57 changed the hollow session's default
+    device and pgw#1465 deleted the meta demotion. Both alter the emitted
+    graphs, and neither moved ``uv.lock``. Without this field the skip check
+    would happily serve pre-fix graphs that no mint can compile.
+
+    Best-effort by construction: a tracer we cannot locate contributes the empty
+    string rather than raising, because a missing fingerprint must not break a
+    lock — it only costs a re-derive.
+    """
+    h = hashlib.sha256()
+    for module_name in ("torchcg", "gen_worker.release"):
+        try:
+            module = __import__(module_name, fromlist=["__file__"])
+            origin = Path(getattr(module, "__file__", "") or "")
+        except Exception:  # noqa: BLE001 - absence is an answer, not a failure
+            continue
+        if not origin.is_file():
+            continue
+        for path in sorted(origin.parent.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            h.update(path.name.encode("utf-8"))
+            h.update(_file_digest(path).encode("ascii"))
+    return h.hexdigest()
+
+
 def program_digests(document: Mapping[str, Any]) -> tuple[str, ...]:
     """Every exported-program CAS digest the document names, deduped + sorted.
 
@@ -252,6 +287,10 @@ def inputs_digest(
     # instead of a silently-misread document.
     field("interface_v", str(interface_v))
     field("document_v", str(document_v))
+    # The tracer's own source. See `tracer_digest`: in the cozy-local shape the
+    # lockfile does not mention torchcg or gen_worker, so this is the only thing
+    # standing between a tracer fix and a silently-reused pre-fix graph set.
+    field("tracer", tracer_digest())
     field("module", module_name)
     field("checkpoint_ref", checkpoint_ref)
     field("trace_device", trace_device)
@@ -317,7 +356,8 @@ def derive_is_reusable(
         return Reuse(
             False,
             "inputs changed (author source, uv.lock closure, checkpoint ref, "
-            "trace device or a torchcg format version)",
+            "trace device, a torchcg format version, or the tracer's own "
+            "source)",
         )
     try:
         document = block.decoded()

--- a/src/gen_worker/cli/endpoint_lock.py
+++ b/src/gen_worker/cli/endpoint_lock.py
@@ -1,0 +1,411 @@
+"""``endpoint.lock`` — the discovery manifest PLUS the derive document.
+
+pgw#1466. Before this module a lock carried only what discovery could read
+statically (``entrypoints``/``execution_lanes``/``decode_set``) and the trace
+lived nowhere: every process that wanted a graph set re-derived it, at ~165s a
+go. Paul's ruling is that the trace is expensive and machine-independent, so it
+is "worth saving locally for sure" — the derive DOCUMENT goes in the lock.
+
+The split is the whole design:
+
+* the DOCUMENT (small, declarative — specializations, ingress, digests) is
+  embedded verbatim in ``[derive]``;
+* the exported-program BLOBS stay in the tensorfs CAS, addressed by digests the
+  document already carries.
+
+Two rules this module exists to enforce, both from the 2026-08-19
+"torchcg DOES TOO MUCH" ruling:
+
+1. **Nothing derivable is restated.** The block stores the document's bytes and
+   its digest. It does not lift ``specialization_hash``, dims, shapes or program
+   digests up to the top level for convenience. Every such copy is a second
+   place a producer can lie, and a reader that trusts the copy over the document
+   is the bug. Callers that want a specialization read it back OUT of the
+   document (:func:`program_digests`), which is why that function parses rather
+   than looks up.
+2. **Hashes are opaque addresses.** ``specialization_hash`` folds
+   ``specialization_dims`` into itself and is the graph axis of every cg-key. We
+   never recompute one and never restate its inputs — a mismatch would not raise,
+   it would read as a cache miss and silently re-mint the fleet.
+
+The skip check is therefore NOT "does the document's digest match" (you cannot
+know that without paying the 165s to produce it). It is an INPUTS digest: hash
+everything the derive reads — author source, env closure, checkpoint identity,
+trace device — and skip when that is unchanged AND every program blob the
+document names is still in the CAS. Inputs are cheap to hash and are not derived
+facts, so this adds no lie-seam.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+import msgspec
+
+#: The file every verb reads and ``lock`` writes, in the endpoint directory.
+LOCK_FILENAME = "endpoint.lock"
+
+#: Top-level table holding the derive document. Named once, here.
+DERIVE_BLOCK = "derive"
+
+#: Bumped when the BLOCK's own shape changes. Part of the inputs digest, so a
+#: format change invalidates every stored lock rather than being read wrongly.
+DERIVE_BLOCK_V = 1
+
+
+class LockError(RuntimeError):
+    """The lock on disk cannot be used as it stands."""
+
+
+@dataclass(frozen=True)
+class DeriveBlock:
+    """``[derive]`` — the trace, saved.
+
+    ``document`` is the exact bytes :func:`gen_worker.release.derive_release`
+    emitted. Verbatim matters: ``document_digest`` is a sha256 OF THOSE BYTES,
+    so a re-encode (TOML round-trip, key reorder, pretty-print) would break the
+    only thing that makes the document verifiable. It is carried as an ASCII
+    string and hashed on the way back in.
+    """
+
+    #: Block format version (``DERIVE_BLOCK_V`` at write time).
+    v: int
+    #: torchcg's OWN graph-document interface version, read off the document
+    #: rather than pinned here. The interface is v4 today and tcg#56 rekeys it
+    #: again; a reader that parses an unfamiliar version is how a stale
+    #: specialization gets adopted, so :func:`derive_is_reusable` treats any
+    #: change as a MISS-that-re-derives instead of something to migrate.
+    interface_v: int
+    #: sha256 over the derive's INPUTS. The skip key; see module docstring.
+    inputs_digest: str
+    #: sha256 of ``document``'s bytes, as the producer computed it. OPAQUE.
+    document_digest: str
+    #: The derive document, verbatim ASCII JSON.
+    document: str
+    #: ``cuda`` or ``cpu`` — the device CLASS traced, `derive._trace_device`'s
+    #: answer. A cpu-traced graph is a DIFFERENT graph class, not a degraded
+    #: cuda one, so it is stated rather than assumed by every reader.
+    trace_device: str
+    #: The endpoint identity the derive stamped (``module:Class``).
+    endpoint: str
+
+    def decoded(self) -> dict[str, Any]:
+        """The document as a dict. Verifies the digest before returning it."""
+        raw = self.document.encode("ascii")
+        actual = hashlib.sha256(raw).hexdigest()
+        if actual != self.document_digest:
+            raise LockError(
+                f"[{DERIVE_BLOCK}] document does not match its own digest "
+                f"(stored {self.document_digest}, actual {actual}). The lock "
+                f"was edited by hand or truncated in transit; re-run "
+                f"`gen-worker lock --force`."
+            )
+        return dict(json.loads(raw))
+
+    def as_table(self) -> dict[str, Any]:
+        return {
+            "v": self.v,
+            "interface_v": self.interface_v,
+            "inputs_digest": self.inputs_digest,
+            "document_digest": self.document_digest,
+            "trace_device": self.trace_device,
+            "endpoint": self.endpoint,
+            "document": self.document,
+        }
+
+    @classmethod
+    def from_table(cls, table: Mapping[str, Any]) -> "DeriveBlock":
+        missing = [
+            k
+            for k in ("v", "interface_v", "inputs_digest", "document_digest",
+                      "document", "trace_device", "endpoint")
+            if k not in table
+        ]
+        if missing:
+            raise LockError(
+                f"[{DERIVE_BLOCK}] is missing {missing}; it was written by a "
+                f"different version of `gen-worker lock`. Re-run "
+                f"`gen-worker lock --force`."
+            )
+        return cls(
+            v=int(table["v"]),
+            interface_v=int(table["interface_v"]),
+            inputs_digest=str(table["inputs_digest"]),
+            document_digest=str(table["document_digest"]),
+            document=str(table["document"]),
+            trace_device=str(table["trace_device"]),
+            endpoint=str(table["endpoint"]),
+        )
+
+
+def torchcg_format_versions() -> tuple[int, int]:
+    """``(GRAPH_INTERFACE_FORMAT, DOCUMENT_FORMAT)`` — IMPORTED, never spelled.
+
+    These are torchcg's numbers and this module must not carry a second copy of
+    them: a hardcoded ``4`` here would keep answering 4 after torchcg rekeys, and
+    a stale specialization would be adopted instead of re-derived. tcg#56 will
+    bump the interface, which is exactly the case this must not sleep through.
+
+    Both fold into :func:`inputs_digest`, so a bump invalidates every stored lock
+    automatically — an old lock becomes a MISS that re-derives, never a document
+    this code tries to migrate or parse under new rules.
+    """
+    from .._vendor.torchcg import DOCUMENT_FORMAT, GRAPH_INTERFACE_FORMAT
+
+    return int(GRAPH_INTERFACE_FORMAT), int(DOCUMENT_FORMAT)
+
+
+def program_digests(document: Mapping[str, Any]) -> tuple[str, ...]:
+    """Every exported-program CAS digest the document names, deduped + sorted.
+
+    Parsed out of the document on demand and deliberately NOT stored beside it:
+    a stored copy is a fact that can disagree with its source. The walk is
+    structural (any ``program`` key under ``graphs``) rather than a fixed path,
+    because the graph document's nesting is torchcg's to change and this reader
+    must not encode a second copy of its schema.
+    """
+    found: set[str] = set()
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                # torchcg spells the exported-program address `program` (the
+                # digest `_program_sink` returned). Anything else recurses.
+                if key == "program" and isinstance(value, str) and value:
+                    found.add(value)
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(document.get("graphs", {}))
+    return tuple(sorted(found))
+
+
+def _file_digest(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def source_files(root: Path) -> tuple[Path, ...]:
+    """The author source the derive actually imports, sorted and stable.
+
+    ``src/**/*.py`` plus top-level ``*.py`` — the two layouts ``prime_sys_path``
+    supports. Test trees and caches are excluded because changing a test cannot
+    change a traced graph, and including them would make every test edit re-spend
+    the trace.
+    """
+    seen: set[Path] = set()
+    src = root / "src"
+    if src.is_dir():
+        seen.update(p for p in src.rglob("*.py"))
+    seen.update(p for p in root.glob("*.py"))
+    skip = ("__pycache__", ".venv", ".mypy_cache", ".pytest_cache")
+    return tuple(
+        sorted(
+            p
+            for p in seen
+            if p.is_file() and not any(part in skip for part in p.parts)
+        )
+    )
+
+
+def inputs_digest(
+    *,
+    root: Path,
+    module_name: str,
+    checkpoint_ref: str,
+    trace_device: str,
+    lockfile: Optional[Path],
+    extra: Iterable[str] = (),
+) -> str:
+    """Hash everything the derive READS. Unchanged inputs => skippable re-run.
+
+    Deliberately excludes anything the derive PRODUCES. The point of an inputs
+    digest is that it can be computed in milliseconds before deciding whether to
+    spend ~165s; a digest over outputs could only be checked after paying.
+
+    ``lockfile`` (``uv.lock``) is the env-identity closure — torch's version
+    changes what a trace means, so a lock derived under a different closure is
+    not reusable even when the author source is byte-identical.
+    """
+    h = hashlib.sha256()
+
+    def field(label: str, value: str) -> None:
+        # Length-prefixed so no two different field sets can collide by
+        # concatenation (``a=1,b=23`` vs ``a=12,b=3``).
+        h.update(f"{label}:{len(value)}:{value}\n".encode("utf-8"))
+
+    interface_v, document_v = torchcg_format_versions()
+    field("block_v", str(DERIVE_BLOCK_V))
+    # A torchcg rekey changes what a saved trace MEANS, so it changes the skip
+    # key. This is the whole mechanism by which tcg#56 forces a re-derive
+    # instead of a silently-misread document.
+    field("interface_v", str(interface_v))
+    field("document_v", str(document_v))
+    field("module", module_name)
+    field("checkpoint_ref", checkpoint_ref)
+    field("trace_device", trace_device)
+    field("lockfile", _file_digest(lockfile) if lockfile and lockfile.is_file() else "")
+    for path in source_files(root):
+        field(f"src:{path.relative_to(root).as_posix()}", _file_digest(path))
+    for item in extra:
+        field("extra", item)
+    return h.hexdigest()
+
+
+@dataclass(frozen=True)
+class Reuse:
+    """Whether a stored derive can be reused, and — always — WHY NOT.
+
+    ``reason`` is populated on both branches. A skip decision that can only say
+    "miss" turns every unexpected re-trace into a 165s mystery; naming the
+    changed input is the difference between a cache and a black box.
+    """
+
+    ok: bool
+    reason: str
+    block: Optional[DeriveBlock] = None
+    document: Optional[dict[str, Any]] = None
+
+
+def derive_is_reusable(
+    block: Optional[DeriveBlock],
+    *,
+    want_inputs_digest: str,
+    want_trace_device: str,
+    cas_has: Any = None,
+) -> Reuse:
+    """The skip check: can we serve this lock's trace instead of re-deriving?
+
+    ``cas_has`` is a predicate over an exported-program digest (typically
+    ``LocalCAS.contains``). It is checked because the document and the blobs are
+    stored SEPARATELY by design — a garbage-collected CAS leaves a lock whose
+    document is intact and whose programs are gone, and re-deriving is the only
+    correct response. Pass ``None`` to skip the blob check when the caller does
+    not need the programs (e.g. `run`, which never compiles).
+    """
+    if block is None:
+        return Reuse(False, "no [derive] block — the trace was never saved")
+    if block.v != DERIVE_BLOCK_V:
+        return Reuse(
+            False,
+            f"[derive] block format v{block.v}, this gen-worker writes "
+            f"v{DERIVE_BLOCK_V}",
+        )
+    # Device class is IDENTITY-BEARING: a cpu-traced graph and a cuda-traced
+    # graph are different specializations, and a cuda mint of a cpu document
+    # refuses by name (pgw#1458). Reusing across the boundary would produce a
+    # lock that cannot be minted on the machine that reads it.
+    if block.trace_device != want_trace_device:
+        return Reuse(
+            False,
+            f"saved trace is {block.trace_device}-class, this host traces "
+            f"{want_trace_device}-class — different specializations, not a "
+            f"degraded one",
+        )
+    if block.inputs_digest != want_inputs_digest:
+        return Reuse(
+            False,
+            "inputs changed (author source, uv.lock closure, checkpoint ref, "
+            "trace device or a torchcg format version)",
+        )
+    try:
+        document = block.decoded()
+    except LockError as exc:
+        return Reuse(False, str(exc))
+    if cas_has is not None:
+        missing = [d for d in program_digests(document) if not cas_has(d)]
+        if missing:
+            return Reuse(
+                False,
+                f"{len(missing)} exported-program blob(s) named by the document "
+                f"are not in the CAS (first: {missing[0]}) — the document "
+                f"survived a GC its programs did not",
+            )
+    return Reuse(True, "inputs unchanged and every program blob present",
+                 block=block, document=document)
+
+
+def read_lock(path: Path) -> dict[str, Any]:
+    """The lock file as a dict, or a typed refusal naming the file."""
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise LockError(f"no {path} — run `gen-worker lock` first") from exc
+    try:
+        decoded = msgspec.toml.decode(raw)
+    except Exception as exc:  # noqa: BLE001 - any decode failure is the answer
+        raise LockError(f"{path} is not valid TOML: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise LockError(f"{path} must decode to a TOML table")
+    return dict(decoded)
+
+
+def read_derive_block(path: Path) -> Optional[DeriveBlock]:
+    """``[derive]`` from the lock at ``path``, or None when it carries none.
+
+    None is the honest answer for a lock built by the BAKE path
+    (``python -m gen_worker.discovery``), which emits discovery blocks only.
+    Callers treat it as "trace not saved yet", never as an error — that is what
+    lets `serve` overlap a trace with the weight download instead of refusing.
+    """
+    table = read_lock(path).get(DERIVE_BLOCK)
+    if table is None:
+        return None
+    if not isinstance(table, dict):
+        raise LockError(f"[{DERIVE_BLOCK}] in {path} must be a table")
+    return DeriveBlock.from_table(table)
+
+
+def write_lock(
+    path: Path, manifest: Mapping[str, Any], derive: Optional[DeriveBlock]
+) -> None:
+    """Write discovery blocks + ``[derive]`` to ``path``, atomically.
+
+    Atomic because every other verb reads this file: a `serve` that starts while
+    `lock` is halfway through a write must see the old lock or the new one, never
+    a truncated one. TOML has no way to express "incomplete", so the rename is
+    what carries that guarantee.
+    """
+    # TOML has no null type, and the manifest carries optional fields nested
+    # arbitrarily deep (an entrypoint's absent `execution_lane_exclusions`, a
+    # slot's absent engine). Stripping only the top level encodes a wrong belief
+    # about how deep None can be — the bake path strips recursively and so must
+    # this one, or the two producers write different files from one manifest.
+    from ..discovery.discover import _strip_none
+
+    document: dict[str, Any] = dict(_strip_none(dict(manifest)))
+    if derive is not None:
+        document[DERIVE_BLOCK] = derive.as_table()
+    encoded = msgspec.toml.encode(document)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp.write_bytes(encoded)
+    tmp.replace(path)
+
+
+__all__ = [
+    "DERIVE_BLOCK",
+    "DERIVE_BLOCK_V",
+    "LOCK_FILENAME",
+    "DeriveBlock",
+    "LockError",
+    "Reuse",
+    "derive_is_reusable",
+    "inputs_digest",
+    "program_digests",
+    "read_derive_block",
+    "read_lock",
+    "source_files",
+    "torchcg_format_versions",
+    "write_lock",
+]

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -1,0 +1,268 @@
+"""``gen-worker lock`` — discovery + the graph trace, in one command.
+
+pgw#1466, Paul's verb 1: "go through the code and produce the endpoint.lock".
+
+Two things were separate before and had no business being: discovery
+(``python -m gen_worker.discovery``, static, seconds) and the trace
+(``gen-worker release derive``, real author code on a real device, ~165s). Both
+answer "what does this endpoint consist of", both are invalidated by the same
+edit, and a lock carrying one without the other is a lock every later verb has
+to finish. So ``lock`` runs both and writes one file.
+
+The expensive half is skipped on a re-run. Paul: "re-runs don't need to
+regenerate". The skip key is a digest over the derive's INPUTS — author source,
+``uv.lock`` closure, checkpoint ref, trace device, torchcg's format versions —
+so it can be computed in milliseconds and answered before paying anything. See
+``endpoint_lock`` for why it is inputs and not outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from . import endpoint_lock as el
+from . import workspace as ws
+
+
+def add_subparser(sub: Any) -> None:
+    parser = sub.add_parser(
+        "lock",
+        help="discover entrypoints and trace the graphs; write endpoint.lock",
+        description=__doc__,
+    )
+    parser.add_argument(
+        "endpoint_dir",
+        nargs="?",
+        default=".",
+        help="endpoint project root — the directory holding pyproject.toml "
+             "and endpoint.toml (default: cwd)",
+    )
+    parser.add_argument(
+        "--checkpoint-ref",
+        default="",
+        help="owner/name@revision to trace against. Required for an endpoint "
+             "that declares a model slot; a weightless endpoint needs none.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default="",
+        help="a local checkpoint tree, INSTEAD of resolving --checkpoint-ref "
+             "through the weight CAS (for a tree the store does not hold)",
+    )
+    parser.add_argument(
+        "--graph-cas",
+        default="",
+        help=f"exported-program CAS root (default: {ws.DEFAULT_GRAPH_CAS})",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="re-trace even when the saved trace is reusable",
+    )
+    parser.add_argument(
+        "--discovery-only",
+        action="store_true",
+        help="write the discovery blocks and no [derive] — the bake-time shape",
+    )
+    parser.add_argument(
+        "-o", "--out",
+        default="",
+        help=f"lock path (default: <endpoint_dir>/{el.LOCK_FILENAME})",
+    )
+    parser.set_defaults(_handler=run_lock)
+
+
+def _say(message: str) -> None:
+    """Progress to stderr, so stdout stays the machine-readable summary."""
+    print(message, file=sys.stderr, flush=True)
+
+
+def _checkpoint_tree(args: argparse.Namespace) -> tuple[Optional[Path], str]:
+    """(tree, ref-string). Both may be absent — a weightless endpoint has none."""
+    if args.checkpoint:
+        tree = Path(args.checkpoint).resolve()
+        if not tree.is_dir():
+            raise ws.WorkspaceError(f"--checkpoint {tree} is not a directory")
+        # A local tree still needs an identity for the skip key. Without one,
+        # swapping the tree under a stable path would reuse a stale trace.
+        return tree, args.checkpoint_ref or f"local:{tree}"
+    if not args.checkpoint_ref:
+        return None, ""
+    ref = ws.parse_checkpoint_ref(args.checkpoint_ref)
+    return ws.resolve_checkpoint(ref), str(ref)
+
+
+def run_lock(args: argparse.Namespace) -> int:
+    from ..discovery.discover import discover_manifest, prime_sys_path
+    from ..discovery.project import load_project_config
+
+    root = Path(args.endpoint_dir).resolve()
+    if not root.is_dir():
+        _say(f"error: {root} is not a directory")
+        return 2
+    out = Path(args.out).resolve() if args.out else root / el.LOCK_FILENAME
+
+    try:
+        config = load_project_config(root)
+    except Exception as exc:  # noqa: BLE001 - the author's config is the check
+        _say(f"error: {root}: {exc}")
+        return 2
+
+    # ---------------------------------------------------------------- discovery
+    started = time.monotonic()
+    try:
+        manifest = discover_manifest(root)
+    except Exception as exc:  # noqa: BLE001 - author import errors are the check
+        _say(f"error: discovery failed: {exc}")
+        return 1
+    entrypoints = manifest.get("entrypoints") or []
+    _say(
+        f"lock: discovered {len(entrypoints)} entrypoint(s) in "
+        f"{config.main} ({time.monotonic() - started:.1f}s)"
+    )
+
+    if args.discovery_only:
+        el.write_lock(out, manifest, None)
+        _say(f"lock: wrote {out} (discovery only, no [derive])")
+        print(json.dumps({"lock": str(out), "derive": "skipped:--discovery-only"}))
+        return 0
+
+    # ------------------------------------------------------------------- trace
+    try:
+        tree, ref_text = _checkpoint_tree(args)
+    except ws.WorkspaceError as exc:
+        _say(f"error: {exc}")
+        return 2
+
+    device = ws.trace_device()
+    graph_cas_root = Path(args.graph_cas).resolve() if args.graph_cas else ws.graph_cas_root()
+    lockfile = root / "uv.lock"
+
+    want = el.inputs_digest(
+        root=root,
+        module_name=config.main,
+        checkpoint_ref=ref_text,
+        trace_device=device,
+        lockfile=lockfile if lockfile.is_file() else None,
+    )
+
+    existing: Optional[el.DeriveBlock]
+    try:
+        existing = el.read_derive_block(out) if out.is_file() else None
+    except el.LockError as exc:
+        _say(f"lock: ignoring unusable saved trace: {exc}")
+        existing = None
+
+    cas = ws.local_cas(graph_cas_root)
+    reuse = el.derive_is_reusable(
+        existing,
+        want_inputs_digest=want,
+        want_trace_device=device,
+        cas_has=lambda digest: bool(cas.contains(digest)),
+    )
+    if reuse.ok and not args.force:
+        # The whole point of the verb. Rewrite the lock so freshly-discovered
+        # blocks land, but carry the saved [derive] through untouched — the
+        # bytes are the document's identity and re-encoding would break the
+        # digest that makes it verifiable.
+        el.write_lock(out, manifest, reuse.block)
+        assert reuse.block is not None
+        _say(f"lock: reusing saved trace ({reuse.reason})")
+        _say(f"lock: wrote {out}")
+        print(json.dumps({
+            "lock": str(out),
+            "derive": "reused",
+            "document_digest": reuse.block.document_digest,
+            "trace_device": reuse.block.trace_device,
+        }))
+        return 0
+    if args.force and existing is not None:
+        _say("lock: --force, re-tracing despite a saved trace")
+    else:
+        _say(f"lock: tracing — {reuse.reason}")
+
+    if tree is None:
+        # Weightless is legal (pgw#1392) and derive_release handles it, but a
+        # model-bearing endpoint reaching here with no tree would trace nothing
+        # and write a document that looks eager-permanent. Refuse by name.
+        _say(
+            "lock: no --checkpoint-ref/--checkpoint. Tracing a weightless "
+            "endpoint; if this endpoint declares a model slot the derive will "
+            "say so rather than emit an empty document."
+        )
+
+    prime_sys_path(root)
+    try:
+        module = importlib.import_module(config.main)
+    except Exception as exc:  # noqa: BLE001
+        _say(f"error: failed to import {config.main!r}: {exc}")
+        return 1
+
+    from ..release.derive import DeriveError, derive_release
+
+    _say(
+        f"lock: trace device is {device}-class"
+        + ("" if device == "cuda" else " — CPU-class graphs are NOT servable on "
+                                       "a GPU; a cuda mint refuses by name")
+    )
+    started = time.monotonic()
+    try:
+        result = derive_release(
+            module,
+            checkpoint_dir=tree if tree is not None else root,
+            lockfile=lockfile if lockfile.is_file() else None,
+            graph_cas=graph_cas_root,
+        )
+    except DeriveError as exc:
+        _say(f"error: derive: {exc}")
+        return 1
+    elapsed = time.monotonic() - started
+
+    for warning in result.warnings:
+        _say(f"warning: {warning}")
+
+    interface_v, _document_v = el.torchcg_format_versions()
+    block = el.DeriveBlock(
+        v=el.DERIVE_BLOCK_V,
+        interface_v=interface_v,
+        inputs_digest=want,
+        document_digest=result.digest,
+        document=result.document.decode("ascii"),
+        trace_device=device,
+        endpoint=result.endpoint,
+    )
+    el.write_lock(out, manifest, block)
+
+    graphs = sum(len(h) for h in result.lane_graphs.values())
+    programs = el.program_digests(json.loads(result.document))
+    for lane, hashes in result.lane_graphs.items():
+        _say(f"lock: lane {lane}: {len(hashes)} specialization(s)")
+    if result.eager_permanent:
+        why = ("no model class — weightless endpoint, nothing to compile"
+               if result.weightless else "no lanes — eager-permanent by declaration")
+        _say(f"lock: {result.endpoint}: {why}")
+    _say(
+        f"lock: traced {graphs} specialization(s), {len(programs)} exported "
+        f"program(s) in the CAS at {graph_cas_root} ({elapsed:.1f}s)"
+    )
+    _say(f"lock: wrote {out}")
+    print(json.dumps({
+        "lock": str(out),
+        "derive": "traced",
+        "endpoint": result.endpoint,
+        "document_digest": result.digest,
+        "trace_device": device,
+        "specializations": graphs,
+        "programs": len(programs),
+        "seconds": round(elapsed, 1),
+    }))
+    return 0
+
+
+__all__ = ["add_subparser", "run_lock"]

--- a/src/gen_worker/cli/workspace.py
+++ b/src/gen_worker/cli/workspace.py
@@ -1,0 +1,188 @@
+"""The box-shared stores the four verbs share, and how a ref becomes a tree.
+
+pgw#1466. ``lock``, ``sync``, ``serve`` and ``run`` are four front doors onto
+one set of stores; this module is where "where do weights live" and "where do
+graphs live" are each answered ONCE. A verb that computed its own answer would
+be a verb that can disagree with its siblings — `sync` pre-warming into a
+directory `serve` never reads is the failure mode, and it is silent.
+
+Two stores, deliberately separate:
+
+* the **weight CAS** — the box-shared tensorfs store. Big, blake3-addressed,
+  shared with every other tool on this machine, and NOT ours to invent a layout
+  for: we read the one that is already there.
+* the **graph CAS** — exported-program blobs from the trace, and the compiled
+  artifacts minted from them. Ours, small, per-user.
+
+Weights and graphs are split because their lifetimes differ by orders of
+magnitude: a weight tree is worth 6 GB and survives every code change, a graph
+blob is invalidated by a torch bump. One CAS would make a GC policy that is
+right for one of them wrong for the other.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+#: The box-shared tensorfs weight CAS. This path is not a preference — it is
+#: where the store on this machine already is, populated by the hub client.
+#: Overridable for tests and for a second box layout, never guessed.
+WEIGHTS_CAS_ENV = "COZY_WEIGHTS_CAS"
+DEFAULT_WEIGHTS_CAS = Path.home() / ".cache" / "tensorhub" / "cas"
+
+#: Exported programs (from `lock`) and compiled artifacts (from `sync`).
+GRAPH_CAS_ENV = "COZY_GRAPH_CAS"
+DEFAULT_GRAPH_CAS = Path.home() / ".cache" / "cozy" / "graph-cas"
+
+
+class WorkspaceError(RuntimeError):
+    """A store or a ref could not be resolved to something on disk."""
+
+
+def weights_cas_root() -> Path:
+    return Path(os.environ.get(WEIGHTS_CAS_ENV) or DEFAULT_WEIGHTS_CAS)
+
+
+def graph_cas_root() -> Path:
+    return Path(os.environ.get(GRAPH_CAS_ENV) or DEFAULT_GRAPH_CAS)
+
+
+def trace_device() -> str:
+    """The device CLASS this host traces on. ``derive._trace_device`` IS the law.
+
+    Imported rather than reimplemented: the CLI deciding "cuda" while the derive
+    decides "cpu" would write a lock whose ``trace_device`` disagrees with the
+    document inside it, and the skip check would then hit forever or miss
+    forever. There is one answer to this question and it lives in the derive.
+
+    Note for this box specifically: the answer comes from
+    ``torch.cuda.is_available()``, which uses the CUDA driver API. NVML is
+    broken here (userspace 595.84 against a 570.211.01 kernel module), so
+    ``nvidia-smi`` and ``pynvml`` both report no GPU while the device works
+    perfectly. Never health-check the GPU through NVML in this codebase.
+    """
+    from ..release.derive import _trace_device
+
+    return str(_trace_device())
+
+
+@dataclass(frozen=True)
+class CheckpointRef:
+    """``owner/name@rev`` — parsed, never re-spelled by hand."""
+
+    owner: str
+    name: str
+    rev: str
+
+    @property
+    def repo(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+    def __str__(self) -> str:
+        return f"{self.owner}/{self.name}@{self.rev}"
+
+
+def parse_checkpoint_ref(raw: str) -> CheckpointRef:
+    """``tensorhub/sd15-base@latest`` -> a CheckpointRef.
+
+    A bare ``owner/repo`` pins NOTHING — the revision it happens to resolve to
+    today is not the revision it resolves to tomorrow, and a lock keyed on an
+    unpinned ref is a lock that silently describes a different model later. So
+    an absent ``@rev`` is refused rather than defaulted.
+    """
+    text = raw.strip()
+    if "@" not in text:
+        raise WorkspaceError(
+            f"checkpoint ref {raw!r} pins nothing: it needs an explicit "
+            f"@revision (e.g. {text}@latest). A bare owner/repo resolves to "
+            f"whatever is current, which makes every lock derived from it "
+            f"unreproducible."
+        )
+    repo, _, rev = text.partition("@")
+    if repo.count("/") != 1 or not all(repo.split("/")) or not rev:
+        raise WorkspaceError(
+            f"checkpoint ref {raw!r} is not owner/name@revision"
+        )
+    owner, name = repo.split("/")
+    return CheckpointRef(owner=owner, name=name, rev=rev)
+
+
+def resolve_checkpoint(ref: CheckpointRef, *, cas_root: Optional[Path] = None) -> Path:
+    """The materialized snapshot tree for ``ref``, or a refusal that says why.
+
+    Reads the on-disk store layout directly (``refs/<owner>/<name>/<rev>``
+    holding a snapshot id, ``snapshots/<id>`` holding the tree) rather than going
+    through a client, because that layout is what exists on this box and the
+    verbs need to work against it TODAY. The hub-fetch path that populates a cold
+    store is a separate concern; this function's job is to answer "is it here",
+    and to be unambiguous when the answer is no.
+    """
+    root = Path(cas_root) if cas_root is not None else weights_cas_root()
+    if not root.is_dir():
+        raise WorkspaceError(
+            f"no weight CAS at {root} (set {WEIGHTS_CAS_ENV} to point at one)"
+        )
+    ref_file = root / "refs" / ref.owner / ref.name / ref.rev
+    if not ref_file.is_file():
+        available = sorted(
+            p.relative_to(root / "refs").as_posix()
+            for p in (root / "refs").rglob("*")
+            if p.is_file()
+        )
+        raise WorkspaceError(
+            f"{ref} is not in the weight CAS at {root}.\n"
+            f"  refs present: {', '.join(available) if available else '(none)'}\n"
+            f"  run `gen-worker sync` to materialize it."
+        )
+    snapshot_id = ref_file.read_text(encoding="utf-8").strip()
+    if not snapshot_id:
+        raise WorkspaceError(f"{ref_file} is empty — the store is corrupt")
+    tree = root / "snapshots" / snapshot_id
+    if not tree.is_dir():
+        raise WorkspaceError(
+            f"{ref} points at snapshot {snapshot_id}, which is not "
+            f"materialized at {tree}. The ref outlived its tree; re-fetch."
+        )
+    return tree
+
+
+def tree_bytes(tree: Path) -> int:
+    """Total size of a materialized tree. The residency budget's input.
+
+    Walks rather than trusting a manifest because a partially-materialized tree
+    is exactly the case where a manifest's number and reality disagree, and
+    sizing residency off the manifest would admit a model that does not fit.
+    """
+    return sum(p.stat().st_size for p in tree.rglob("*") if p.is_file())
+
+
+def local_cas(root: Path) -> Any:
+    """A tensorfs ``LocalCAS`` at ``root``, created if absent.
+
+    The graph CAS is ours to create; the weight CAS is not (see module
+    docstring), so only callers holding the graph root should use this.
+    """
+    from .._vendor.tensorfs import LocalCAS
+
+    root.mkdir(parents=True, exist_ok=True)
+    return LocalCAS(root)
+
+
+__all__ = [
+    "DEFAULT_GRAPH_CAS",
+    "DEFAULT_WEIGHTS_CAS",
+    "GRAPH_CAS_ENV",
+    "WEIGHTS_CAS_ENV",
+    "CheckpointRef",
+    "WorkspaceError",
+    "graph_cas_root",
+    "local_cas",
+    "parse_checkpoint_ref",
+    "resolve_checkpoint",
+    "trace_device",
+    "tree_bytes",
+    "weights_cas_root",
+]


### PR DESCRIPTION
The first of the four endpoint verbs (**lock · sync · serve · run**). `sync`/`serve`/`run` are not in this PR — see "Not in this PR" below.

## What it does

Discovery (static, seconds) and the graph trace (real author code on a real device, ~145 s) answered the same question — *what does this endpoint consist of* — were invalidated by the same edit, and lived in two commands. A lock carrying one without the other is a lock every later verb has to finish. So `lock` runs both and writes one file.

The derive **document** goes in the lock; the exported-program **blobs** stay in the CAS, addressed by digests the document already carries. Measured on sd1.5: a 37 KB document inside a 53 KB lock, against 14 exported programs in the CAS.

## Re-runs don't regenerate

The skip key is a digest over the derive's **inputs** — author source, `uv.lock` closure, checkpoint ref, trace device, torchcg's two format constants, and a fingerprint of the tracer's own source — never over its outputs, because an outputs digest can only be checked *after* paying the 145 s it exists to avoid.

Every miss **names the input that changed**. A skip check that can only say "miss" turns each unexpected re-trace into a 145 s mystery.

## What it deliberately does NOT do

From the 2026-08-19 "torchcg DOES TOO MUCH" ruling:

- **No restating.** `specialization_hash` is carried as an opaque address, never recomputed; its inputs (dims) are never lifted out of the document. `program_digests()` **parses** the document instead of reading a stored copy, because a stored copy is a second place a producer can lie.
- **No spelling torchcg's version numbers.** Both format constants are imported and folded into the inputs digest, so tcg#56's rekey turns every stored lock into a miss-that-re-derives rather than a document this code parses under new rules.
- **No treating a cpu-traced document as a degraded cuda one.** Device class is identity-bearing (pgw#1458); a mismatch is a miss, so a lock made on a GPU-less box is never silently unmintable.

## Evidence — real path, RTX 4070 sm_89, checkpoints resolved from the box-shared tensorfs CAS

| endpoint | result | trace |
|---|---|---|
| sd15 | **14 specializations**, cuda-class | 299.4 s → **5.6 s** re-run (reused, identical digest) |
| sdxl | **18 specializations**, cuda-class | 513.2 s |
| anima | **eager-permanent, 0 specializations** | 0.2 s |

Every miss branch verified to name its cause: cpu-vs-cuda host, changed checkpoint ref, GC'd program blobs, absent block, hand-edited document (caught by the document's own digest).

Post-fix blobs verified mintable via torchcg's `exported_program_devices()`: **14/14 stamped `('cuda',)`**, zero meta, zero mixed — against 14/14 meta-carrying before the rebase onto `a9e8fea8`.

## The second commit is a bug this PR found in itself

The skip key was blind to the **tracer**. The closure is the right identity when both tracers resolve from `uv.lock`, but the cozy-local shape runs torchcg and gen_worker off working trees on `PYTHONPATH`, where `uv.lock` mentions neither. `a9e8fea8` (meta demotion deleted) and tcg#57 both landed in that window, each altering the emitted graphs while moving nothing the digest could see. Cost of not noticing, measured: a pre-fix derive yields `state_dict {'meta': 686}` against `graph_metas {'cuda:0': 1922}`, and **13 of 14 specializations fail to mint**. The lock would have served that set as a hit forever.

## Notes for reviewers

- **anima is blocked in the endpoint, not here.** `serverless-endpoints` master still carries v1 anima (`RuntimeFormula`, `@endpoint`) and raises `V1SdkDeleted`; the migrated version lives on the held branch `781-kae-anima-krea2-held` (se#781) and omits `lanes=` pending pgw#1434. The derive refuses that **by name**. With `lanes=()` declared in a scratchpad copy it locks cleanly as eager-permanent, and the log distinguishes that from *weightless* (pgw#1392).
- **This PR depends on torchcg PR #56 (tcg#57)** for SDXL to trace at all.
- One bug fixed by running it: `write_lock` stripped `None` only at the top level, so a nested optional killed the TOML encode. Both producers now share the bake path's recursive helper.

## Not in this PR

`sync`, `serve`, `run`. Their shared substrate is landed here — `cli/workspace.py` (store roots, ref→tree resolution, and `trace_device()` delegating to `derive._trace_device` so the CLI can never disagree with the derive) and `cli/endpoint_lock.py`. `lock` is independently useful: it is what produces the mintable graph set.