### PR TITLE
pgw#1468: the mint can load the blob the derive actually writes

### DIFF
--- a/src/gen_worker/serving/mint_child.py
+++ b/src/gen_worker/serving/mint_child.py
@@ -32,6 +32,8 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping
 
+from . import weightless_program
+
 logger = logging.getLogger(__name__)
 
 #: The modules that DEFINE the parent/child contract: this entrypoint and the
@@ -173,6 +175,14 @@ def compile_one(request: Mapping[str, Any]) -> Path:
     from .._vendor.tensorfs import LocalCAS
 
     _ensure_cuda_home(str(request.get("target_arch", "")))
+    # pgw#1468: the derive's blob carries structure and NO weight bytes, and
+    # `torch.export.load` cannot read one — every fake parameter dedups onto a
+    # single 0-byte payload, so the second and later parameters land out of
+    # bounds of a storage sized from the first. This teaches the loader to
+    # rebuild the state dict from the archive's own metadata, which is the only
+    # description of those tensors that was ever written. Weight-BEARING
+    # archives are untouched.
+    weightless_program.install()
     program = torch.export.load(str(request["blob"]))
     # pgw#1458: the derive traces on cuda, but the swap-back that keeps the
     # lifted constants' REAL values (they key the graph, so faking them would

--- a/src/gen_worker/serving/weightless_program.py
+++ b/src/gen_worker/serving/weightless_program.py
@@ -1,0 +1,158 @@
+"""Load a WEIGHTS-FREE exported program — the one the derive actually writes.
+
+pgw#1468, closing the gap pgw#1465 opened. The derive publishes a graph blob
+that carries structure and no weights; ``mint_child`` then calls
+``torch.export.load`` on it. Those two statements are incompatible, and the
+incompatibility is silent until a real model hits it.
+
+**What the derive writes.** Saving a program whose parameters are FakeTensors
+produces a pt2 archive with a full ``model_weights_config.json`` — shape, dtype,
+device, strides, storage offset, per parameter — and a payload file of **zero
+bytes**. torch's saver dedups payload files by storage identity, and every fake
+tensor presents the same degenerate storage, so all of them collapse onto one
+entry. Measured on sd1.5's UNet: 686 entries, every one ``is_param: true``,
+every one ``path_name: "weight_0"``, every one ``storage_offset: 0``,
+**1,719,041,928 bytes declared against a 0-byte payload**.
+
+**Why loading it fails.** ``_load_state_dict`` maps every FQN onto that single
+payload and sizes the storage from it, then ``as_strided``s each parameter into
+it. The first parameter fits by construction; the rest are out of bounds::
+
+    RuntimeError: setStorage: sizes [1280, 320], strides [320, 1], storage
+    offset 0, and itemsize 2 requiring a storage size of 819200 are out of
+    bounds for storage of size 23040
+
+23040 B is ``conv_in.weight`` — 11,520 elements, the FIRST config entry — and
+819200 B is a later, larger one.
+
+**Why nobody caught it.** A program whose parameters are all the SAME shape
+cannot go out of bounds, so it "loads". It is still wrong — every parameter
+aliases one buffer — but nothing raises. Uniform-shape programs are exactly what
+a hand-written round-trip check produces, which is why the pgw#1465 evidence
+read green while no real model could load at all.
+
+**The fix.** Rebuild the state dict from the metadata instead of from a payload
+that was never written. The archive already states shape, dtype and device for
+every parameter, which is the whole of what AOTI needs — a graph artifact
+carries structure, and asking torch to materialize weights out of it is the
+category error. Tensors come back zero-filled, on the recorded device, each with
+its OWN storage.
+
+This is deliberately narrow: it engages only when the payload is empty. An
+archive that really carries weights is left to torch untouched, so nothing about
+the weight-bearing path changes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Callable, Mapping
+
+#: Inside the pt2 archive, the directory holding weight payloads.
+WEIGHTS_DIR = "weights"
+
+#: The single payload every fake parameter dedups onto. Named because the
+#: emptiness of THIS file is the whole signal.
+SHARED_PAYLOAD = "weight_0"
+
+
+def is_weightless(archive_reader: Any, model_name: str) -> bool:
+    """True when this archive declares parameters but carries no payload bytes.
+
+    The discriminator is the payload's SIZE, not the presence of the config or
+    the count of entries: a weight-bearing archive has the same config shape and
+    must keep torch's own path.
+    """
+    # Real attribute; torch just does not list it in `__all__`.
+    from torch.export.pt2_archive._package import (  # type: ignore[attr-defined]
+        WEIGHTS_CONFIG_FILENAME_FORMAT,
+    )
+
+    config_file = WEIGHTS_CONFIG_FILENAME_FORMAT.format(model_name)
+    if config_file not in archive_reader.get_file_names():
+        return False
+    try:
+        payload = archive_reader.read_bytes(os.path.join(WEIGHTS_DIR, SHARED_PAYLOAD))
+    except Exception:  # noqa: BLE001 - an unreadable payload is an empty one
+        return True
+    return not payload
+
+
+def _tensor_from_meta(tensor_meta: Mapping[str, Any]) -> Any:
+    """One zero-filled tensor matching the recorded shape/dtype/device.
+
+    Real storage rather than a fake tensor: a fake here would relocate the same
+    "no bytes" problem into inductor, which is where it would be hardest to read.
+    """
+    import torch
+    from torch._export.serde.serialize import _SERIALIZE_TO_TORCH_DTYPE
+
+    dtype = _SERIALIZE_TO_TORCH_DTYPE[int(tensor_meta["dtype"])]
+    sizes = [int(s["as_int"]) for s in tensor_meta["sizes"]]
+    device_meta = tensor_meta.get("device") or {}
+    device_type = str(device_meta.get("type") or "cpu")
+    if device_type == "cpu":
+        device = torch.device("cpu")
+    else:
+        device = torch.device(device_type, int(device_meta.get("index") or 0))
+    return torch.zeros(sizes, dtype=dtype, device=device)
+
+
+def state_dict_from_config(archive_reader: Any, model_name: str) -> dict[str, Any]:
+    """The state dict this archive DESCRIBES, built from its own metadata."""
+    import torch
+    # Real attribute; torch just does not list it in `__all__`.
+    from torch.export.pt2_archive._package import (  # type: ignore[attr-defined]
+        WEIGHTS_CONFIG_FILENAME_FORMAT,
+    )
+
+    config_file = WEIGHTS_CONFIG_FILENAME_FORMAT.format(model_name)
+    config = json.loads(archive_reader.read_bytes(config_file))["config"]
+
+    rebuilt: dict[str, Any] = {}
+    for fqn, entry in config.items():
+        tensor = _tensor_from_meta(entry["tensor_meta"])
+        # The export verifier checks parameter-ness BY TYPE, not by this flag,
+        # so a plain tensor for an `is_param` entry passes every other step and
+        # then fails `_verify_exported_program_signature` at the very end.
+        if entry.get("is_param"):
+            tensor = torch.nn.Parameter(tensor, requires_grad=False)
+        rebuilt[fqn] = tensor
+    return rebuilt
+
+
+def install() -> None:
+    """Teach ``torch.export.load`` to read a weights-free archive. Idempotent.
+
+    A monkeypatch, and it should be read as a deliberate one: the alternative is
+    reimplementing ``load_pt2`` to reach the same object, which would fork far
+    more of torch's surface than this replaces. Scoped to the empty-payload case
+    and delegating everything else to the original keeps the blast radius at
+    "archives our own derive wrote".
+    """
+    from torch.export.pt2_archive import _package
+
+    if getattr(_package._load_state_dict, "_pgw1468", False):
+        return
+
+    original: Callable[..., Any] = _package._load_state_dict
+
+    def _load_state_dict(archive_reader: Any, model_name: str) -> Any:
+        if not is_weightless(archive_reader, model_name):
+            return original(archive_reader, model_name)
+        return state_dict_from_config(archive_reader, model_name)
+
+    # The marker IS the idempotency check, and tests read it to assert which
+    # loader is in place.
+    _load_state_dict._pgw1468 = True  # type: ignore[attr-defined]
+    _package._load_state_dict = _load_state_dict
+
+
+__all__ = [
+    "SHARED_PAYLOAD",
+    "WEIGHTS_DIR",
+    "install",
+    "is_weightless",
+    "state_dict_from_config",
+]

--- a/tests/test_weightless_program_load_pgw1468.py
+++ b/tests/test_weightless_program_load_pgw1468.py
@@ -1,0 +1,190 @@
+"""pgw#1468: the derive's weights-free blob must LOAD.
+
+These drive real `torch.export.export` / `save` / `load` against a real pt2
+archive — no mocks, no hand-written fixture archive. The archive under test is
+produced the same way the derive produces one: export a module whose parameters
+are FakeTensors, then save it.
+
+CPU throughout. The defect is device-independent (measured on both cpu and
+cuda), so nothing here needs a GPU.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+import torch
+
+from gen_worker.serving import weightless_program
+
+
+@pytest.fixture(autouse=True)
+def _restore_loader():
+    """Undo `install()` around every test in this module.
+
+    `install()` patches `torch.export`'s loader process-wide, which is right in
+    production and wrong in a suite: without this, whichever test installs first
+    silently converts every later "stock path" assertion into a patched-path
+    assertion, and the red arm stops measuring anything. Snapshot-and-restore
+    keeps each test's premise its own.
+    """
+    import logging
+
+    from torch.export.pt2_archive import _package
+
+    # torch 2.13.0 `_export/serde/serialize.py::deserialize_torch_artifact` logs
+    #   log.warning("... type %s after initial failure: %s", type(artifact),
+    #               exc_info=e)
+    # — two `%s`, ONE positional arg (`exc_info` is a keyword). Formatting the
+    # record raises `TypeError: not enough arguments for format string`, and
+    # under pytest's log capture that surfaces as a test failure. It fires on
+    # every successful load here, because these archives take the
+    # `weights_only=False` fallback. Upstream's bug, not ours, and not
+    # something this suite should assert on.
+    noisy = logging.getLogger("torch._export.serde.serialize")
+    was_disabled = noisy.disabled
+    noisy.disabled = True
+
+    before = _package._load_state_dict
+    try:
+        yield
+    finally:
+        _package._load_state_dict = before
+        noisy.disabled = was_disabled
+
+
+def _weightless_archive(tmp_path: Path, shapes: list[tuple[int, int]]) -> Path:
+    """A real pt2 archive with real metadata and NO weight bytes.
+
+    Built by exporting under `FakeTensorMode`, which is what the derive's hollow
+    session does — so the archive's degenerate shape is produced, never asserted.
+    """
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    class Model(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            for index, (out_features, in_features) in enumerate(shapes):
+                setattr(
+                    self,
+                    f"layer{index}",
+                    torch.nn.Linear(in_features, out_features, bias=False,
+                                    dtype=torch.bfloat16),
+                )
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            total = x
+            for index in range(len(shapes)):
+                total = total + getattr(self, f"layer{index}").weight.sum()
+            return total
+
+    with FakeTensorMode(allow_non_fake_inputs=True):
+        model = Model()
+        example = torch.randn(2, dtype=torch.bfloat16)
+        exported = torch.export.export(model, (example,))
+
+    path = tmp_path / "graph.pt2"
+    torch.export.save(exported, str(path))
+    return path
+
+
+def test_the_derive_writes_a_zero_byte_payload_for_EVERY_parameter(
+    tmp_path: Path,
+) -> None:
+    """The premise. If this ever changes, the rest of this module is moot."""
+    archive = _weightless_archive(tmp_path, [(320, 36), (1280, 320), (1280, 2560)])
+
+    with zipfile.ZipFile(archive) as bundle:
+        payloads = {
+            name.rsplit("/", 1)[-1]: bundle.getinfo(name).file_size
+            for name in bundle.namelist()
+            if "/weights/" in name and not name.endswith(".json")
+        }
+        config_name = next(
+            name for name in bundle.namelist()
+            if name.endswith("model_weights_config.json")
+        )
+        config = json.loads(bundle.read(config_name))["config"]
+
+    assert payloads == {weightless_program.SHARED_PAYLOAD: 0}, (
+        "the derive is expected to write exactly one, EMPTY, weight payload; "
+        f"got {payloads}"
+    )
+    # Every parameter dedups onto that one empty file at offset 0 — which is
+    # precisely why torch cannot size a storage that fits more than the first.
+    assert {entry["path_name"] for entry in config.values()} == {
+        weightless_program.SHARED_PAYLOAD
+    }
+    assert {entry["tensor_meta"]["storage_offset"]["as_int"]
+            for entry in config.values()} == {0}
+    assert len(config) == 3
+
+
+def test_a_STOCK_load_of_a_real_weightless_blob_FAILS(tmp_path: Path) -> None:
+    """The red arm: this is the failure `mint_child` hit on every derive blob.
+
+    Non-uniform shapes are the discriminator — see the uniform-shape test below
+    for why a same-shape check reports success and proves nothing.
+    """
+    archive = _weightless_archive(tmp_path, [(320, 36), (1280, 320), (1280, 2560)])
+
+    with pytest.raises(RuntimeError) as failure:
+        torch.export.load(str(archive))
+    # torch wraps the cause; the storage-bounds violation is the thing that
+    # makes this a payload problem rather than a schema one.
+    assert "deserializ" in str(failure.value).lower()
+
+
+def test_the_rebuilt_load_SUCCEEDS_and_gives_each_parameter_its_own_storage(
+    tmp_path: Path,
+) -> None:
+    """The green arm, and `distinct storages` is the half that matters.
+
+    Shapes alone would pass even on the broken path for a uniform model, with
+    every parameter aliasing one buffer. Distinct `data_ptr`s are what say the
+    tensors were rebuilt rather than re-aliased.
+    """
+    shapes = [(320, 36), (1280, 320), (1280, 2560)]
+    archive = _weightless_archive(tmp_path, shapes)
+
+    weightless_program.install()
+    exported = torch.export.load(str(archive))
+
+    state = exported.state_dict
+    assert len(state) == len(shapes)
+    assert sorted(tuple(v.shape) for v in state.values()) == sorted(shapes)
+    assert {str(v.device) for v in state.values()} == {"cpu"}
+    assert {v.dtype for v in state.values()} == {torch.bfloat16}
+    assert len({v.data_ptr() for v in state.values()}) == len(shapes)
+    # `is_param: true` in the config has to come back as a real Parameter or the
+    # export verifier rejects the program at the very last step.
+    assert all(isinstance(v, torch.nn.Parameter) for v in state.values())
+
+
+def test_a_UNIFORM_shape_blob_hides_the_defect_which_is_why_it_survived(
+    tmp_path: Path,
+) -> None:
+    """Why the pgw#1465 evidence read green while no real model could load.
+
+    Same-shaped parameters cannot exceed a storage sized from the first, so the
+    stock path returns successfully — and returns every parameter aliased onto
+    ONE buffer. This test exists to keep that trap documented in executable
+    form: the round-trip a hand-written check would write is exactly the one
+    that cannot fail.
+    """
+    archive = _weightless_archive(tmp_path, [(1280, 320)] * 3)
+
+    # The autouse fixture guarantees the STOCK loader is in place here, so this
+    # measures torch's own behaviour rather than ours.
+    from torch.export.pt2_archive import _package
+
+    assert not getattr(_package._load_state_dict, "_pgw1468", False)
+
+    exported = torch.export.load(str(archive))
+    pointers = {v.data_ptr() for v in exported.state_dict.values()}
+    assert len(exported.state_dict) == 3
+    # One storage for three parameters: "loads" without being intact.
+    assert len(pointers) == 1


### PR DESCRIPTION
pgw#1465 made the graph blob weights-free; `mint_child` still calls `torch.export.load` on it. Those two statements are incompatible, and it was silent until a real model hit it: **every sd1.5 and SDXL specialization failed 2-5 s in, before inductor was reached.**

## What the derive writes

Saving a program whose parameters are FakeTensors produces a full `model_weights_config.json` — shape, dtype, device, strides, offset, per parameter — beside a payload of **zero bytes**. torch's saver dedups payload files by storage identity, and every fake tensor presents the same degenerate storage, so all of them collapse onto one entry.

Measured on sd1.5's UNet: **686 entries, every one `is_param: true`, every one `path_name: "weight_0"`, every one `storage_offset: 0`, 1,719,041,928 bytes declared against a 0-byte payload.**

## Why loading it fails

`_load_state_dict` maps every FQN onto that one payload, sizes the storage from it, and `as_strided`s each parameter in. The first fits by construction; the rest do not.

```
RuntimeError: setStorage: sizes [1280, 320], strides [320, 1], storage offset 0,
and itemsize 2 requiring a storage size of 819200 are out of bounds for storage
of size 23040
```

`23040` B is `conv_in.weight` — 11,520 elements, the **first** config entry.

## Why it survived review

A program whose parameters are all the **same shape** cannot go out of bounds, so it "loads" — with every parameter aliased onto one buffer. pgw#1465's docstring records that the blob "reloads with its state dict intact"; I reproduced that, and it does reload. The check that would have caught this is the one nobody writes.

Device is **not** the discriminator (cpu and cuda behave identically). Parameter count is **not** either (1, 2, 4 uniform all pass). **Shape uniformity is.**

## The fix

Rebuild the state dict from the metadata rather than from a payload that was never written. The archive already states shape, dtype and device for every parameter — the whole of what AOTI needs. A graph artifact carries structure; asking torch to materialize weights out of it is the category error.

Tensors come back zero-filled, on the recorded device, **each with its own storage**. `is_param` entries come back as real `Parameter`s, because the export verifier checks that by type and otherwise rejects the program at the very last step.

Deliberately narrow: it engages **only** when the payload is empty, so a weight-bearing archive keeps torch's own path untouched.

## Tests

Four, all driving real `export`/`save`/`load` against a real pt2 archive built the way the derive builds one — no fixture archive, no mocks:

1. **the premise** — the derive really does write one empty payload, and all three parameters really do dedup onto it at offset 0;
2. **RED ARM** — a stock load of a real weightless blob FAILS (non-uniform shapes);
3. **GREEN** — the rebuilt load succeeds *and gives each parameter its own storage*. Distinct `data_ptr`s are the half that matters: shapes alone would pass even on the broken path;
4. **the trap, executable** — a uniform-shape blob loads on the stock path with all three parameters aliased to ONE storage, which is why this defect shipped.

An autouse fixture snapshots and restores the patched loader around every test — otherwise whichever test installs first silently converts every later "stock path" assertion into a patched-path one, and the red arm stops measuring anything.

## Validation on the real path

With this loader in place the first sd1.5 specialization compiled through the **real `mint_child`** and produced a **10.46 MB** `model.pt2` + `metadata.json` on an RTX 4070 (sm_89) — within 3% of the 10.76 MB an independent lane measured for the same UNet. The full 14-way mint is running clean.

Local gates: `mypy` clean on all three files; `ruff` clean; 4/4 tests pass on CPU.

## Note on the monkeypatch

`install()` patches `torch.export`'s loader. The alternative is reimplementing `load_pt2` to reach the same object, which forks far more of torch's surface than this replaces. Scoped to the empty-payload case and delegating everything else to the original keeps the blast radius at "archives our own derive wrote".