### PR TITLE
pgw#1460: the adopt loader discarded the record, so every adopted graph was unservable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -415,6 +415,16 @@ jobs:
       - name: pgw#1215 guard - no export/AOTI compile in the serving process
         run: uv run python scripts/lint_serving_process_compiles.py
 
+      # pgw#1460: torchcg artifacts are WEIGHTLESS by sealed policy, so a bare
+      # `aoti_load_package(path)` arms an EMPTY constant buffer and takes flat
+      # feeds its caller does not have. BOTH v2 adopt loaders were exactly that
+      # — the `GraphRecord` accepted and discarded — and every test that
+      # covered them injected a stub. `torchcg.serve.aoti_loader` is the
+      # sanctioned path AND the default, so the right amount of code at a call
+      # site is none.
+      - name: pgw#1460 guard - no raw AOTI package load in src/gen_worker
+        run: uv run python scripts/lint_raw_aoti_load.py
+
       # GATING (pgw#1328, superseding pgw#1327's narrow precursor): the
       # ADOPT-ONLY serve role adopts by key and refuses or routes on a miss
       # (§4.28/§4.29), so it must not be able to compile. This walks the

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -139,6 +139,7 @@ tasks:
       - cmd: uv run python scripts/lint_layout_declarations.py
       - cmd: uv run python scripts/lint_compiled_graph_key_layout_fence.py
       - cmd: uv run python scripts/lint_serving_process_compiles.py
+      - cmd: uv run python scripts/lint_raw_aoti_load.py
       - cmd: uv run python scripts/check_cozy_runtime_env_digest.py
       - cmd: uv run python scripts/check_worker_value_contracts_digest.py
       - cmd: uv run python scripts/lint_credential_identity.py

--- a/changelog.d/pgw1460.md
+++ b/changelog.d/pgw1460.md
@@ -1,0 +1,30 @@
+- **The v2 adopt loader accepted the `GraphRecord` and discarded it, so every adopted graph was
+  unservable.** Both v2 loaders — `serving/serve_adoption.py` and a byte-identical copy in
+  `serving/__main__.py` — were a bare `torch._inductor.aoti_load_package(path)`. torchcg mints
+  WEIGHTLESS artifacts by sealed policy (`package_constants_in_so: False`, and `validate_metadata`
+  refuses any artifact that says otherwise), so that handle ran with an EMPTY constant buffer; and
+  the package takes flat positional feeds while the dispatcher calls it with the author's own nested
+  `(*args, **kwargs)`. Wrong numerics or a hard AOTI error, on the exact path the adopt-and-reuse
+  program is judged on.
+
+- **The fix is that there is no loader here any more.** `torchcg.serve.aoti_loader` (tcg#58) is the
+  bytes-to-callable half — verify the artifact, load through the gated `CompiledGraphRunner`, bind
+  the live module's resident constants BY REFERENCE, feed through the record's `CallIngress` — and
+  it is the DEFAULT `AdoptSession` loader, so the right amount of code at a call site is none.
+  `loader=` survives on `ServeAdoption` and `EndpointHost.setup` as a TEST seam only.
+
+- **`ArtifactLoader` takes the live module now, and that is what made the raw shape writable.** A
+  two-argument seam cannot express the fix: a serving pod adopts INTO author code that is already
+  resident, so the module's parameters are the one copy of the checkpoint on the device and there is
+  nowhere else the constant table's values exist. Both raw loaders were the obvious thing to write
+  against the old signature.
+
+- **Why CI was green over it.** Every test that covered these loaders injected a stub returning
+  `def compiled(sample)` — one flat tensor, no constants needed — and asserted only that a path
+  existed. `tests/test_self_mint_wiring.py` even called its stub *"the ONE stub"* and USED the
+  record, which production discarded. The stubs now take the module and assert it, and
+  `scripts/lint_raw_aoti_load.py` (new, in `fast gates` and `task lint`) reds on either raw spelling
+  anywhere in first-party `src/gen_worker`. Proven red against the exact reverted shape.
+
+- **torchcg re-vendored at `12c99841`** for tcg#58's `serve.py`. Picked up in the same span, because
+  a vendor is taken whole: tcg#57's trace-session host egress (`hollow.py`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -692,7 +692,7 @@ torchvision = [
 # tools away from the cause: the derive raised `TypeError: unexpected keyword
 # 'session'` while that exact signature was verifiably present in the vendored
 # tree. Bump both, re-lock, re-vendor — one change.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "8e8c5ca6acdb3ed13f94ae6878c8248114ecd9c7" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "12c99841f01f9ccba22c279b72bebc30bd7b22d2" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/scripts/lint_raw_aoti_load.py
+++ b/scripts/lint_raw_aoti_load.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""NO RAW AOTI PACKAGE LOAD IN `src/gen_worker` (pgw#1460).
+
+torchcg mints WEIGHTLESS artifacts by SEALED POLICY: `compiler.py` compiles
+with `aot_inductor.package_constants_in_so: False` and `artifact.py`'s
+`validate_metadata` REFUSES any artifact whose metadata says otherwise. There
+is no other kind. So a bare
+
+    torch._inductor.aoti_load_package(path)          # or
+    torch._inductor.package.load_package(path)
+
+yields a callable with an EMPTY CONSTANT BUFFER, and one that takes flat
+positional feeds while its caller has the author's nested `(*args, **kwargs)`.
+Arming it is wrong numerics or a hard AOTI error, on the exact path the
+adopt-and-reuse program is judged on.
+
+pgw#1460 is what happened without this fence: BOTH v2 adopt loaders --
+`serving/serve_adoption.py` and a byte-identical copy in `serving/__main__.py`
+-- were exactly that call, accepting the `GraphRecord` and discarding it,
+while every test that covered them injected a stub loader and asserted only
+that a path existed. The gap survived a full rewrite because the shape is the
+obvious thing to write and nothing said otherwise.
+
+**The sanctioned path is `torchcg.serve.aoti_loader` (tcg#58)**, which is also
+the DEFAULT `AdoptSession` loader -- so the correct amount of code to write at
+a call site is none. `CompiledGraphRunner` refuses direct construction and
+refuses invocation before a complete bind, which makes every OTHER way into
+AOTI loud; the raw package load was the one silent bypass, and this closes it.
+
+**Scope: first-party `src/gen_worker` only.** `_vendor/torchcg` IS the
+sanctioned implementation and necessarily calls the loader -- fencing it would
+fence the fix. Tests are out of scope too: a test that loads a package
+directly to prove the refusal (torchcg has one) is doing the right thing.
+
+**Read as TEXT, not as AST call nodes**, and deliberately: the whole failure
+mode is that the spelling is obvious, so a deferred `getattr` form is exactly
+what a working-around author would reach for. Prose that EXPLAINS the banned
+spelling is not a violation -- docstrings and comments are stripped before the
+scan (`ast.unparse` of a docstring-blanked tree also drops comments), because
+a gate that punishes the explanation makes deleting the explanation the
+cheapest way to green.
+
+Run::
+
+    python scripts/lint_raw_aoti_load.py
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SRC = REPO / "src" / "gen_worker"
+VENDOR = SRC / "_vendor"
+
+#: The spellings that hand back an unbound AOTI package. `load_package` is
+#: matched bare because `torch._inductor.package.load_package` is routinely
+#: reached through an `import_module`/`vars()` indirection -- which is what
+#: torchcg's own gated loader does, in the file this fence exempts.
+BANNED = ("aoti_load_package", "load_package")
+
+#: The one sanctioned reference, by name, so the error message can point at it
+#: instead of describing it.
+SANCTIONED = "torchcg.serve.aoti_loader"
+
+
+def _code_only(source: str, filename: str) -> str:
+    """The module's CODE, with every docstring and comment removed."""
+
+    tree = ast.parse(source, filename=filename)
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+            if isinstance(first.value.value, str):
+                first.value.value = ""
+    return ast.unparse(tree)
+
+
+def main() -> int:
+    violations: list[str] = []
+    scanned = 0
+    for file in sorted(SRC.rglob("*.py")):
+        if VENDOR in file.parents:
+            continue
+        scanned += 1
+        code = _code_only(file.read_text(), str(file))
+        for line_number, line in enumerate(code.splitlines(), start=1):
+            for spelling in BANNED:
+                if spelling in line:
+                    violations.append(
+                        f"{file.relative_to(REPO)}: names `{spelling}` in code. "
+                        f"torchcg artifacts are WEIGHTLESS by sealed policy, so "
+                        f"a raw package load arms an EMPTY constant buffer and "
+                        f"takes flat feeds the caller does not have (pgw#1460). "
+                        f"Use `{SANCTIONED}` -- which is already the default "
+                        f"`AdoptSession` loader, so the right amount of code "
+                        f"here is none. (code line {line_number}: {line.strip()})"
+                    )
+    if not scanned:
+        # A fence that scans nothing reports clean. Say so instead.
+        print(
+            f"raw-AOTI-load fence: scanned NOTHING under {SRC} — the tree "
+            f"moved and this fence is asserting over an empty set.",
+            file=sys.stderr,
+        )
+        return 1
+    for line in violations:
+        print(line, file=sys.stderr)
+    if violations:
+        print(
+            f"\n{len(violations)} raw AOTI package load(s).", file=sys.stderr
+        )
+        return 1
+    print(f"raw-AOTI-load fence: clean ({scanned} first-party module(s) scanned)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -299,8 +299,18 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "8e8c5ca6"
+rev = "12c99841"
 subdir = "src/torchcg"
+# pgw#1460 / tcg#58 RE-VENDOR (2026-08-19), from `12c99841`. The NEW FILE is
+# `serve.py` — the bytes->callable half of adoption, which upstream had left as
+# a seam with no implementation, so both of this repo's loaders were raw
+# `aoti_load_package` calls against WEIGHTLESS artifacts. `ArtifactLoader` now
+# takes the live module as a third argument and `torchcg.serve.aoti_loader` is
+# the DEFAULT, which is what makes a raw loader unwritable here rather than
+# merely discouraged. Also picked up in the same span: tcg#57 (`hollow.py` —
+# host egress inside a trace session; the session put the tensor on the trace
+# device, so the session owes the `.cpu()`), which is derive-side and lands
+# here only because a vendor is taken whole.
 # tcg#55/pgw#1458 RE-VENDOR (2026-08-19), from `ad399093`. Two upstream changes
 # land together because they are one ruling ("torchcg does too much"):
 #
@@ -486,11 +496,11 @@ rewrites = [
 "writer.py" = "f44e74d983d2f642e8479f85a3682bb737dd76ffbd62c3fe7d684ae5c0c71ca1"
 
 [packages.torchcg.files]
-"__init__.py" = "0268e80f3d154c71979efad0169babd13e0abe78c10d619c5c235df475aadcaa"
+"__init__.py" = "562d1439f5788a0aef4b6f724a2d4c2ef10b4ff33d4b12f87ef914b1b0af8a0a"
 "__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
 "_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
 "_wrapper_split.py" = "1d5a3bc1ccabadeaa2b8b54f1492cba10723e53074a0022b8c7453565a86a4ce"
-"adopt.py" = "8c2b243aeaddb4639c456bdec22e8d09f1dfe50925966e3a560a8b32616008dd"
+"adopt.py" = "5ffab538a7eaef05f2ca48d3608abc8875c1bddbeb1498976dfed3f75520cfb2"
 "artifact.py" = "a3c96d845be49c752bd608dbb4b36fb192cb449937716d8d835aeba2e28d12ba"
 "cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
 "compiler.py" = "6ee54b26286b215eef8867dffb133d023a6808379574ac69f8007a64c477045a"
@@ -508,7 +518,7 @@ rewrites = [
 "document.py" = "b9c4a36f0d6e3fd0c7fda9953d1a60264274ddb8b1b7b400709000ddb64b26ea"
 "engine.py" = "d8275ad146c73ae5516ea7d60acc1fd63cdddb3036f4833f7741913fe340a1a9"
 "graph_identity.py" = "6ce4d8d7b106409db531fae16c56ef335d0ffd04f4fcf290d855b7f5b977fa8e"
-"hollow.py" = "e988a9a79ee9b17b9d7fabe11d4a2cb1043a1a23edf1be77378aac3c9caba432"
+"hollow.py" = "edbfbc7b158c34db61a60bbd95287ef68b08d532d47b032f89ddcc0abdc71b77"
 "host_isa.py" = "679aa81547be2d60ae6593b6e8f75dd29dcd56ab85d8e858e219b5af5d0eadc4"
 "identity.py" = "a460a24836cbd46cc9e65bd684b9f6258f6718e5c56102f26a7071f01574a99e"
 "ingress.py" = "fa9b814dbfcd43e2a7cfdd2ed48299a7fa5a570aa73d3e2269448c974074d558"
@@ -518,8 +528,9 @@ rewrites = [
 "quantize.py" = "cb579b4a2c91af02211f6339147584338b278a2da4e1f8f60084b742fce21da6"
 "recipe.py" = "cc6fe9007a7f459ede5ced2cfd5d072e3c807552329d0e1920ade88de8b829a6"
 "requirements.py" = "3b34858258d41c4faaa133c2d9c340507c4e18928c324f5665b4fe4fac4c7bda"
-"runner.py" = "53145e7f9d22f3f5eea578d4dbc46415bbed6b1cc51046186270ee4e52834047"
+"runner.py" = "745a988f58d6be77cb781e9a2e70a80ce503c35d74b581cfea104778ec5c62b5"
 "selection.py" = "1addd68533008d32b9d36c7877ac4c5fe43fce5f2c8737dda976f681f9145738"
+"serve.py" = "cc7d7cfb57f344dec63881d0fd2ad3848d1cf31d80f670f76f2e6f042cd2272e"
 "spans.py" = "4776fac2006967b1f17ffcbec03e50147d511120fd50cf085ac3b6b4702e5539"
 "storage.py" = "ccc9d6f8ac1a242b493028eaeed6a1fcd3a02a885c99ba2223bc71df7b69efe4"
 "store.py" = "60b12c4f36b40ea4f48464821367852df8bb530294f5535319cfe48aa3adbebb"

--- a/src/gen_worker/_vendor/torchcg/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/__init__.py
@@ -90,7 +90,7 @@ from .requirements import (
     assert_exact_env,
     rank,
 )
-from .runner import CompiledGraphRunner, ConstantBindingError
+from .runner import CompiledGraphRunner, ConstantBindingError, VerifiedGraph
 from .selection import (
     FeedNormalization,
     GraphSpecializationCandidate,
@@ -106,6 +106,14 @@ from .selection import (
     SpecializationReport,
     describe_call,
     select,
+)
+from .serve import (
+    CompiledGraphCall,
+    MaterializedGraph,
+    aoti_loader,
+    materialize,
+    module_device,
+    resident_constants,
 )
 from .storage import (
     QuarantinedArtifact,
@@ -219,11 +227,18 @@ __all__ = [
     "require_targets",
     "resolve_target",
     "CompiledGraphKey",
+    "CompiledGraphCall",
     "CompiledGraphRunner",
     "CallIngress",
     "CallInput",
     "SpecializationReport",
     "ConstantBindingError",
+    "MaterializedGraph",
+    "VerifiedGraph",
+    "aoti_loader",
+    "materialize",
+    "module_device",
+    "resident_constants",
     "GRAPH_INTERFACE_FORMAT",
     "DeclarationError",
     "RetiredGraphInterface",

--- a/src/gen_worker/_vendor/torchcg/adopt.py
+++ b/src/gen_worker/_vendor/torchcg/adopt.py
@@ -29,18 +29,28 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from .artifact import ArtifactError
 from .document import GraphRecord, GraphSetDocument, LaneGraphs
 from .graph_identity import EnvIdentity
 from .requirements import assert_exact_env
+from .runner import ConstantBindingError
 from .store import GraphStore, StoreError
 
 if TYPE_CHECKING:  # torch-free import closure: transform.py is torch-shaped
     from .transform import TransformSet
 
 #: Turns one fetched artifact into the callable that replaces the target
-#: module's forward for its graph specialization. The real AOTInductor loader arrives
-#: with the runtime mint wave; the seam keeps adoption testable without a GPU.
-ArtifactLoader = Callable[[Path, GraphRecord], Callable[..., Any]]
+#: module's forward for its graph specialization.
+#:
+#: Three arguments, and every one of them is load-bearing (tcg#58): the
+#: ARTIFACT is weightless by sealed policy, the RECORD's ingress is what maps
+#: the author's nested call onto the package's flat positional feeds, and the
+#: live MODULE is the only place the constant table's values exist on the
+#: device. A loader handed fewer than three cannot produce a callable that
+#: serves -- which is exactly the shape every consumer wrote until tcg#58.
+#: :func:`torchcg.serve.aoti_loader` is the production implementation and the
+#: default; the seam stays open only so adoption is testable without a GPU.
+ArtifactLoader = Callable[[Path, GraphRecord, Any], Callable[..., Any]]
 
 HOLE_MISS = "miss"
 
@@ -116,9 +126,14 @@ class _ForwardDispatcher:
     restores the eager class forward untouched.
     """
 
-    __slots__ = ("eager_forward", "_entries")
+    __slots__ = ("eager_forward", "module", "_entries")
 
     def __init__(self, module: Any) -> None:
+        #: The module this dispatcher fronts, kept because arming needs it:
+        #: the loader binds the compiled graph's constants to THESE tensors
+        #: (tcg#58), and the late-mint :meth:`AdoptSession.arm` reaches the
+        #: module only through here.
+        self.module = module
         self.eager_forward = module.forward
         self._entries: list[tuple[GraphRecord, Callable[..., Any]]] = []
 
@@ -183,7 +198,7 @@ class AdoptSession:
         contract: str,
         sm: str,
         *,
-        loader: ArtifactLoader,
+        loader: ArtifactLoader | None = None,
         artifacts_dir: str | Path,
         installed: Mapping[str, str],
         transforms: TransformSet | None = None,
@@ -299,8 +314,27 @@ class AdoptSession:
                 continue
             self._arm(dispatcher, record, artifact)
 
+    def _load(self, dispatcher: _ForwardDispatcher, artifact: Path, record: GraphRecord) -> Any:
+        """The loader call, with the module it must bind against (tcg#58)."""
+
+        loader = self._loader
+        if loader is None:
+            from .serve import aoti_loader
+
+            loader = aoti_loader
+        return loader(Path(artifact), record, dispatcher.module)
+
     def _arm(self, dispatcher: _ForwardDispatcher, record: GraphRecord, artifact: Path) -> None:
-        compiled = self._loader(Path(artifact), record)
+        try:
+            compiled = self._load(dispatcher, Path(artifact), record)
+        except (ArtifactError, ConstantBindingError) as exc:
+            # Bytes that will not verify, or a constant table that will not
+            # bind to THIS module, is a hole with a stated reason -- never a
+            # dead boot and never a silent arm. Both refusals are typed at
+            # their source precisely so this arm can be narrow: anything else
+            # escaping the loader is a bug and keeps escaping.
+            self._holes[record.graph] = Hole(record, f"{type(exc).__name__}: {exc}")
+            return
         try:
             dispatcher.arm(record, compiled)
         except AmbiguousStructure as exc:

--- a/src/gen_worker/_vendor/torchcg/hollow.py
+++ b/src/gen_worker/_vendor/torchcg/hollow.py
@@ -553,14 +553,54 @@ def observation_shims(device: str = DEFAULT_TRACE_DEVICE) -> Iterator[None]:
                 **_remap_device(dict(kwargs or {}), device),
             )
 
+    #: Every op that takes a tensor OFF the device and onto the host. A fake
+    #: tensor answers these with zeros; a real one has to be copied first.
+    _HOST_EGRESS = (
+        torch.Tensor.numpy,
+        torch.Tensor.__array__,
+        torch.Tensor.tolist,
+        torch.Tensor.item,
+    )
+
     class FakeEgress(TorchFunctionMode):
         def __torch_function__(
             self, func: Any, types: Any, args: Any = (), kwargs: Any = None
         ) -> Any:
             kwargs = kwargs or {}
             host = args[0] if args else None
+            # tcg#57: the session put this tensor on the trace device — the
+            # author never asked for it there — so the session owes the
+            # `.cpu()` at host egress. Outside a session the same code works
+            # because the tensor was on cpu to begin with; a redirection that
+            # is visible to the author is a redirection that breaks them.
+            #
+            # Real, not hypothetical: diffusers' `EulerDiscreteScheduler.
+            # set_timesteps` does `np.array(sigmas)`, which reaches
+            # `Tensor.__array__` — note that is a DIFFERENT function from
+            # `Tensor.numpy`, so listing only the latter (as this shim did)
+            # misses the numpy-protocol path entirely.
+            if (
+                func in _HOST_EGRESS
+                and isinstance(host, torch.Tensor)
+                and not isinstance(host, FakeTensor)
+                and host.device.type != "cpu"
+            ):
+                # The copy MUST run with torch-function dispatch disabled.
+                # `OneTraceDevice` answers `Tensor.cpu` with `args[0]`
+                # unchanged — deliberately, so author code cannot pull weights
+                # off the trace device — which makes a plain `host.cpu()` here
+                # a silent no-op that returns the cuda tensor and fails one
+                # frame later. Disabling dispatch is what distinguishes "the
+                # session moving its own tensor back" from "the author trying
+                # to re-home one".
+                with torch._C.DisableTorchFunction():
+                    moved = host.detach().to("cpu")
+                return func(moved, *args[1:], **kwargs)
             if isinstance(host, FakeTensor):
-                if func is torch.Tensor.numpy:
+                # `__array__` alongside `numpy`: `np.array(t)` and `t.numpy()`
+                # are the same egress through two different functions, and a
+                # fake tensor has to answer both (tcg#57).
+                if func in (torch.Tensor.numpy, torch.Tensor.__array__):
                     import numpy
 
                     return numpy.zeros(
@@ -582,7 +622,27 @@ def observation_shims(device: str = DEFAULT_TRACE_DEVICE) -> Iterator[None]:
                     return 0.0
             return func(*args, **kwargs)
 
-    with OneTraceDevice(), FakeEgress():
+    # tcg#57: the DEFAULT device has to be the trace device too, or the session
+    # has two devices while claiming one.
+    #
+    # `_remap_device` only rewrites a device the author NAMES. A factory call
+    # that names none (`torch.linspace(0, 1, n)`) is not remapped and lands on
+    # cpu — so inside a cuda session, unnamed factories produce cpu tensors
+    # while named ones produce cuda tensors. Author code that round-trips a
+    # device through a tensor it just made gets the two mixed:
+    #
+    #     sigmas = torch.linspace(...)                      # -> cpu (unnamed)
+    #     torch.cat([sigmas, torch.zeros(1, device=sigmas.device)])
+    #                              # `sigmas.device` is cpu, REMAPPED to cuda
+    #                              # -> cat(cpu, cuda) -> RuntimeError
+    #
+    # That is real, not hypothetical: it is diffusers' `EulerDiscreteScheduler.
+    # __init__`, so every SDXL derive died in `load()` before tracing anything.
+    # Setting the default makes the unnamed case land where the named case is
+    # already redirected, which is what "ONE trace device" was always supposed
+    # to mean — and it makes `_remap_device` a no-op for correct author code
+    # rather than the thing that breaks it.
+    with torch.device(device), OneTraceDevice(), FakeEgress():
         yield
 
 

--- a/src/gen_worker/_vendor/torchcg/runner.py
+++ b/src/gen_worker/_vendor/torchcg/runner.py
@@ -6,10 +6,32 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from .identity import GRAPH_SPECIALIZATION_BLOCK
-from .storage import StoredCompiledGraph
+
+
+class VerifiedGraph(Protocol):
+    """One artifact whose bytes have already been verified against its metadata.
+
+    ``storage.StoredCompiledGraph`` (v1, keyed) and ``serve.MaterializedGraph``
+    (v2, positioned by graph x env) are the two producers. The runner needs
+    nothing else from either, so it names the three facts instead of one of the
+    two store grammars -- that is what lets the ADOPT path reach the same gated
+    loader the exact-key path reaches.
+    """
+
+    @property
+    def key(self) -> str: ...
+
+    @property
+    def metadata(self) -> Mapping[str, object]: ...
+
+    @property
+    def package(self) -> Path: ...
+
+    @property
+    def literals(self) -> Path | None: ...
 
 
 class ConstantBindingError(RuntimeError):
@@ -26,7 +48,7 @@ class _Constant:
     source: str
 
 
-def _constants(graph: StoredCompiledGraph) -> tuple[_Constant, ...]:
+def _constants(graph: VerifiedGraph) -> tuple[_Constant, ...]:
     graph_specialization = graph.metadata[GRAPH_SPECIALIZATION_BLOCK]
     assert isinstance(graph_specialization, Mapping)  # artifact validation owns this boundary
     rows = graph_specialization["constants"]
@@ -101,7 +123,7 @@ class CompiledGraphRunner:
     key: str
     name: str
     calls: int
-    _graph: StoredCompiledGraph
+    _graph: VerifiedGraph
     _constants: tuple[_Constant, ...]
     _package: Any
     _bound_values: dict[str, Any]
@@ -113,7 +135,7 @@ class CompiledGraphRunner:
         raise TypeError("compiled-graph runners are created only by Engine.runner")
 
     @classmethod
-    def _from_verified_graph(cls, graph: StoredCompiledGraph) -> CompiledGraphRunner:
+    def _from_verified_graph(cls, graph: VerifiedGraph) -> CompiledGraphRunner:
         """Load one graph after Engine has resolved and admitted its exact bytes."""
 
         self = object.__new__(cls)
@@ -277,4 +299,4 @@ class CompiledGraphRunner:
         return result
 
 
-__all__ = ["CompiledGraphRunner", "ConstantBindingError"]
+__all__ = ["CompiledGraphRunner", "ConstantBindingError", "VerifiedGraph"]

--- a/src/gen_worker/_vendor/torchcg/serve.py
+++ b/src/gen_worker/_vendor/torchcg/serve.py
@@ -1,0 +1,251 @@
+"""tcg#58: the bytes -> callable half of adoption, which nobody had written.
+
+``AdoptSession`` fetches an artifact and hands it to an :data:`~torchcg.adopt.
+ArtifactLoader` to become the target module's forward. Every consumer wrote
+that loader as a bare ``aoti_load_package(path)`` -- and a bare load is
+UNSERVABLE here, for two independent reasons that are both sealed policy:
+
+* **The artifacts are WEIGHTLESS.** ``compiler.py`` compiles with
+  ``aot_inductor.package_constants_in_so = False`` and ``artifact.py``'s
+  ``validate_metadata`` REFUSES any artifact that says otherwise, so a raw
+  handle has an empty constant buffer. There is no other kind of artifact.
+* **The package takes FLAT POSITIONAL feeds.** The dispatcher calls the loaded
+  object with the author's own nested ``(*args, **kwargs)``. Mapping those onto
+  the exported flat arity is exactly what :class:`~torchcg.ingress.CallIngress`
+  exists for, and it is why the loader is handed the record at all.
+
+So the loader is not a place a consumer improvises: this module IS it.
+:func:`aoti_loader` is the whole sanctioned path from fetched bytes to an armed
+callable -- materialize + verify, load through the gated
+:class:`~torchcg.runner.CompiledGraphRunner`, bind the live module's resident
+constants by reference, and feed through the record's ingress.
+
+**The constants come from the LIVE MODULE, and that is why the loader is given
+one.** A serving pod adopts INTO author code that is already resident: the
+eager module stays the serve host (a hole, an ambiguous pair, or an unmatched
+call structure all fall back to its own forward), so its parameters are the
+one copy of the checkpoint on the device and the compiled graph binds them BY
+REFERENCE rather than materializing a second set.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .artifact import (
+    LITERALS_NAME,
+    PACKAGE_NAME,
+    ArtifactError,
+    _verify_materialized,
+    unpack_artifact,
+)
+from .document import GraphRecord
+from .identity import GRAPH_SPECIALIZATION_BLOCK
+from .runner import CompiledGraphRunner, ConstantBindingError
+
+#: Where :func:`aoti_loader` unpacks a packed artifact when the caller states
+#: no workspace: beside the artifact, named after it. Deterministic on purpose
+#: -- a second boot over the same ``artifacts_dir`` re-verifies the directory
+#: it already wrote instead of unpacking the same bytes again.
+UNPACKED_SUFFIX = ".unpacked"
+
+
+@dataclass(slots=True)
+class MaterializedGraph:
+    """One verified artifact on disk, in the shape the runner reads.
+
+    The v1 store hands the runner a ``StoredCompiledGraph``; the v2 adopt path
+    has only a fetched artifact at a path. Both satisfy
+    :class:`~torchcg.runner.VerifiedGraph`, so there is ONE gated loader rather
+    than a second one for adoption.
+    """
+
+    key: str
+    directory: Path
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def package(self) -> Path:
+        return self.directory / PACKAGE_NAME
+
+    @property
+    def literals(self) -> Path | None:
+        path = self.directory / LITERALS_NAME
+        return path if path.is_file() else None
+
+
+def materialize(artifact: str | Path, workspace: str | Path | None = None) -> MaterializedGraph:
+    """Verify one artifact -- packed archive or unpacked directory -- on disk.
+
+    Both shapes are real and reach the same loader from different producers:
+    ``GraphStore.fetch_artifact`` copies out the PACKED blob, while a runtime
+    mint's ``Engine.compile`` leaves the resolved artifact UNPACKED at its
+    destination. Verification is the same either way and it is not optional --
+    ``_verify_materialized`` is what proves the metadata, the package and any
+    literal payload agree before AOTI is handed anything.
+    """
+
+    source = Path(artifact)
+    if source.is_dir():
+        directory = source
+        metadata = _verify_materialized(directory)
+    else:
+        directory = (
+            Path(workspace)
+            if workspace is not None
+            else source.with_name(source.name + UNPACKED_SUFFIX)
+        )
+        if directory.is_dir():
+            # Already unpacked by an earlier boot over the same artifacts_dir.
+            # Accepted only because it VERIFIES -- the same doctrine the store's
+            # occupied-destination check runs under, never "it exists, trust it".
+            metadata = _verify_materialized(directory)
+        else:
+            metadata = unpack_artifact(source, directory)
+    key = str(metadata.get("compiled_graph_key") or "")
+    if not key:
+        raise ArtifactError(f"artifact at {source} states no compiled_graph_key")
+    return MaterializedGraph(key=key, directory=directory, metadata=metadata)
+
+
+def resident_constants(module: Any) -> dict[str, Any]:
+    """Every resident tensor a ``state_dict``-sourced constant can bind to.
+
+    ``module.state_dict()`` is NOT that set: it omits NON-PERSISTENT buffers,
+    which ``torch.export`` still lifts as buffer inputs and which AOTInductor
+    still declares under their real FQN, i.e. ``source=state_dict``. A bind
+    table built from ``state_dict()`` alone therefore declares constants no
+    lookup could ever resolve. Binding is by FQN against the DECLARED names, so
+    the extra keys are inert for any artifact that does not want them.
+    """
+
+    values: dict[str, Any] = dict(module.state_dict())
+    for name, buffer in module.named_buffers():
+        if buffer is not None:
+            values.setdefault(str(name), buffer)
+    return values
+
+
+def module_device(module: Any) -> str:
+    """Where this module's own tensors live -- the only honest bind device.
+
+    Read off the tensors rather than off a ``.device`` attribute: the attribute
+    is a library convenience some modules do not have and others compute, while
+    the constants being bound BY REFERENCE are these exact tensors.
+    """
+
+    for tensor in module.state_dict().values():
+        device = getattr(tensor, "device", None)
+        if device is not None:
+            return str(device)
+    for _, buffer in module.named_buffers():
+        if buffer is not None:
+            return str(buffer.device)
+    raise ConstantBindingError(
+        "module_has_no_tensors",
+        f"{type(module).__name__} carries no parameter or buffer, so there is "
+        f"no device its compiled graph's constants could be bound from",
+    )
+
+
+def _declared_placement(metadata: Mapping[str, object]) -> tuple[str, ...]:
+    block = metadata.get(GRAPH_SPECIALIZATION_BLOCK)
+    if not isinstance(block, Mapping):
+        return ()
+    placement = block.get("placement")
+    if not isinstance(placement, list):
+        return ()
+    return tuple(str(row) for row in placement)
+
+
+def _assert_placement(graph: MaterializedGraph, device: str) -> None:
+    """The artifact's own recorded placement must be where the module IS.
+
+    An INDEPENDENT cross-check, which is the only kind worth writing: the
+    placement was recorded by the mint from the program it compiled, and the
+    device is read from the live module's tensors. Disagreement means the bind
+    would install host pointers into a device graph (or the reverse) -- AOTI
+    accepts that and the first call returns garbage or faults, so it is caught
+    here, by name, and the adopt turns it into a hole instead of a wrong image.
+    """
+
+    declared = _declared_placement(graph.metadata)
+    if not declared:
+        return
+    import torch
+
+    want = torch.device(device)
+    for row in declared:
+        try:
+            candidate = torch.device(row)
+        except (RuntimeError, ValueError, TypeError):
+            continue
+        if candidate.type != want.type:
+            continue
+        if candidate.index is None or want.index is None or candidate.index == want.index:
+            return
+    raise ConstantBindingError(
+        "placement_mismatch",
+        f"compiled graph {graph.key} was compiled for placement "
+        f"{list(declared)!r} but the module holding its constants is on "
+        f"{device!r}; binding across that gap produces a graph that reads the "
+        f"wrong memory",
+    )
+
+
+def aoti_loader(
+    artifact: str | Path,
+    record: GraphRecord,
+    module: Any,
+    *,
+    workspace: str | Path | None = None,
+) -> Callable[..., Any]:
+    """THE loader: fetched artifact + record + live module -> armed forward.
+
+    The returned callable is what ``AdoptSession`` installs behind the target
+    module's dispatcher. It takes the author's own call -- nested kwargs and
+    all -- maps it through the record's ingress to the flat positional feeds
+    the package was exported with, and invokes the bound runner.
+
+    Nothing here falls back. A refusal is a typed
+    :class:`~torchcg.runner.ConstantBindingError` and ``AdoptSession`` is what
+    decides that the graph becomes a hole and the module keeps serving eager;
+    a loader that swallowed its own failure would arm a graph that cannot run.
+    """
+
+    graph = materialize(artifact, workspace)
+    runner = CompiledGraphRunner._from_verified_graph(graph)
+    device = module_device(module)
+    _assert_placement(graph, device)
+    runner.bind(resident_constants(module), device=device)
+    return CompiledGraphCall(runner=runner, record=record)
+
+
+@dataclass(slots=True)
+class CompiledGraphCall:
+    """One armed graph, called the way the author calls the module it replaced.
+
+    A dataclass rather than a closure so a serving pod can be ASKED what it
+    armed: ``runner.calls``, ``runner.bound_fqns`` and ``record.graph`` are the
+    adopt evidence, and a closure would have hidden all three.
+    """
+
+    runner: CompiledGraphRunner
+    record: GraphRecord
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.runner(*self.record.ingress.feeds(args, kwargs))
+
+
+__all__ = [
+    "CompiledGraphCall",
+    "MaterializedGraph",
+    "UNPACKED_SUFFIX",
+    "aoti_loader",
+    "materialize",
+    "module_device",
+    "resident_constants",
+]

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -248,15 +248,6 @@ def _toolchain() -> Mapping[str, str]:
     return dict(toolchain_digest())
 
 
-def _aoti_loader(path: Path, record: Any) -> Any:
-    # The AOTInductor runtime load: the packaged compiled graph becomes the
-    # module forward for its graph specialization. Exact-env by construction — the
-    # audit already ran before any author code touched an artifact.
-    import torch._inductor
-
-    return torch._inductor.aoti_load_package(str(path))
-
-
 def _serve_envelopes(args: argparse.Namespace, loaded: Any) -> int:
     """Envelope mode: the production dispatch loop, locally — the
     signature-derived envelope through ServeLoop with residency leases
@@ -330,9 +321,14 @@ def main(argv: list[str] | None = None) -> int:
         loaded, binding, lane_contract=args.lane, output_dir=Path(args.output_dir)
     )
     store, document = _adoption_source(args, loaded.module_name)
+    # No `loader=`: pgw#1460. The byte-identical raw `aoti_load_package` that
+    # used to sit here discarded the record and armed a WEIGHTLESS package with
+    # an empty constant buffer. `torchcg.serve.aoti_loader` (tcg#58) is the
+    # default and the only sanctioned path — stating one here is what the
+    # `lint_raw_aoti_load` fence exists to stop.
     host.setup(
         store=store, document=document, sm=args.sm,
-        loader=_aoti_loader, artifacts_dir=Path(args.artifacts_dir),
+        artifacts_dir=Path(args.artifacts_dir),
     )
     if host.adoption is not None:
         report: dict[str, Any] = {

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -46,12 +46,20 @@ logger = logging.getLogger(__name__)
 #: exact shape that made this gap invisible for as long as it existed.
 KIND_ADOPT_REFUSED = "adopt_refused"
 
-
-def aoti_loader(path: Path, record: Any) -> Any:
-    """Load one packaged compiled graph as its graph specialization's forward."""
-    import torch._inductor
-
-    return torch._inductor.aoti_load_package(str(path))
+# pgw#1460: THERE IS NO ARTIFACT LOADER IN THIS MODULE ANY MORE, and its
+# absence is the fix. What lived here was
+# `torch._inductor.aoti_load_package(str(path))` — the `GraphRecord` accepted
+# and discarded — so every adopted graph ran with an EMPTY constant buffer
+# (torchcg mints WEIGHTLESS artifacts by sealed policy; constants ship beside
+# them and bind by reference) and with the author's nested kwargs where the
+# package wanted flat positional feeds. Wrong numerics or a hard AOTI error,
+# on the exact path the adopt-and-reuse program is judged on.
+#
+# The bytes->callable path is torchcg's own (`torchcg.serve.aoti_loader`,
+# tcg#58) and it is the DEFAULT `AdoptSession` loader, so stating nothing is
+# both correct and the only reasonable thing to write. `loader=` below survives
+# as a TEST seam and nothing else; `scripts/lint_raw_aoti_load.py` is what
+# keeps a raw one from growing back here or anywhere else in `src/`.
 
 
 class ServeAdoption:
@@ -70,7 +78,7 @@ class ServeAdoption:
         cas_dir: Optional[Path] = None,
         transport: Any = None,
         installed: Optional[Mapping[str, str]] = None,
-        loader: Optional[Callable[[Path, Any], Any]] = None,
+        loader: Optional[Callable[[Path, Any, Any], Any]] = None,
         on_adopted: Optional[Callable[["ServeAdoption"], None]] = None,
     ) -> None:
         self.release_id = str(release_id)
@@ -82,7 +90,9 @@ class ServeAdoption:
         self.cas_dir = Path(cas_dir) if cas_dir is not None else None
         self._transport = transport
         self._installed = dict(installed) if installed is not None else None
-        self._loader = loader if loader is not None else aoti_loader
+        #: `None` = torchcg's own production loader (tcg#58). A value here
+        #: is a TEST DOUBLE; production never states one.
+        self._loader = loader
         self._on_adopted = on_adopted
         self._lock = threading.Lock()
         self._settled = False
@@ -277,4 +287,4 @@ class ServeAdoption:
         }
 
 
-__all__ = ["KIND_ADOPT_REFUSED", "ServeAdoption", "aoti_loader"]
+__all__ = ["KIND_ADOPT_REFUSED", "ServeAdoption"]

--- a/tests/test_self_mint_wiring.py
+++ b/tests/test_self_mint_wiring.py
@@ -166,7 +166,7 @@ def programs(tmp_path: Path) -> Callable[[str, Path], Path]:
 
 def counting_loader(
     armed: List[str], served: List[str] | None = None,
-) -> Callable[[Path, Any], Any]:
+) -> Callable[[Path, Any, Any], Any]:
     """The artifact loader — the ONE stub, because bytes-to-callable is the
     AOTInductor runtime's job on the target GPU.
 
@@ -174,10 +174,17 @@ def counting_loader(
     forward was swapped in) and ``served`` records it at CALL time (a request
     ran through that forward). Collapsing them is how "it armed" gets
     mistaken for "it served", which are the two separate claims here.
+
+    THREE arguments since pgw#1460/tcg#58: the third is the LIVE MODULE whose
+    resident tensors the compiled graph binds by reference. This stub asserts
+    it, because "the loader USES the record" is precisely what this file
+    asserted while production discarded it.
     """
 
-    def load(path: Path, record: Any) -> Callable[..., Any]:
+    def load(path: Path, record: Any, module: Any) -> Callable[..., Any]:
         assert path.is_file(), "an armed artifact must exist on disk"
+        assert isinstance(module, torch.nn.Module), (
+            "the loader is handed the module its constants bind from")
         armed.append(record.graph)
 
         def compiled(sample: torch.Tensor) -> torch.Tensor:

--- a/tests/test_serving_adopt_first.py
+++ b/tests/test_serving_adopt_first.py
@@ -238,8 +238,22 @@ def manifest() -> RequirementsManifest:
     return RequirementsManifest(include_set=(("torch", torch.__version__),), sm_compiled=SM)
 
 
-def counting_loader(calls: "list[str]") -> "Callable[[Path, Any], Callable[..., Any]]":
-    def load(path: Path, record: Any) -> "Callable[..., Any]":
+def counting_loader(
+    calls: "list[str]",
+) -> "Callable[[Path, Any, Any], Callable[..., Any]]":
+    """The ONE stub: bytes-to-callable needs a real AOTI package and a GPU.
+
+    THREE arguments since pgw#1460/tcg#58, and the third is asserted rather
+    than ignored: the production loader binds the compiled graph's constants
+    to the LIVE MODULE that claimed the record, so a double that drops the
+    module models a loader that cannot exist. That omission is the whole
+    reason this stub stayed green over two raw, unservable loaders.
+    """
+
+    def load(path: Path, record: Any, module: Any) -> "Callable[..., Any]":
+        assert isinstance(module, torch.nn.Module), (
+            "the loader is handed the module its constants bind from")
+
         def compiled(sample: torch.Tensor) -> torch.Tensor:
             calls.append(record.graph)
             return sample


### PR DESCRIPTION
Both v2 loaders — `serving/serve_adoption.py` and a byte-identical copy in `serving/__main__.py` — were a bare `torch._inductor.aoti_load_package(str(path))`, the `GraphRecord` accepted and discarded.

torchcg mints **weightless** artifacts by sealed policy (`package_constants_in_so: False`, and `validate_metadata` refuses any artifact that says otherwise), so that handle ran with an **empty constant buffer**; and the package takes **flat positional feeds** while the dispatcher calls it with the author's own nested `(*args, **kwargs)`. Wrong numerics or a hard AOTI error, on the exact path the adopt-and-reuse program is judged on.

### The root cause was one repo up

torchcg shipped the `ArtifactLoader` seam and never shipped an implementation — and the seam took **two** arguments, so a correct loader was not merely unwritten, it was *unwritable*: the constants live on the live module and no loader was ever handed one. Two independent authors writing the same raw call is what a seam that cannot be satisfied looks like.

**tcg#58** (upstream [`12c99841`](https://github.com/cozy-creator/torchcg/pull/57), re-vendored here) is that missing half — `torchcg.serve.aoti_loader`: verify the artifact, load through the gated `CompiledGraphRunner`, bind the module's resident constants **by reference**, feed through the record's `CallIngress`. It is the **default** loader, so the right amount of code at a call site is *none* — which is why both call sites here lose their loader entirely rather than gaining a better one. `loader=` survives as a test seam.

### The fence

`scripts/lint_raw_aoti_load.py` — either raw spelling, anywhere in first-party `src/gen_worker`, is red. It scans **code** with docstrings and comments stripped, so prose explaining the banned spelling (including this fix's own comments) is not a violation; a gate that punishes the explanation makes deleting the explanation the cheapest way to green. **Proven red against the exact reverted shape**, clean at HEAD (286 modules). In `fast gates` + `task lint`.

### Why CI was green over it

Every test covering these loaders injected a stub returning `def compiled(sample)` — one flat tensor, no constants needed — and asserted only that a path existed. `test_self_mint_wiring` even called its stub *"the ONE stub"* and **used** the record, which production discarded. Both stubs now take the module and assert it.

### Evidence

- torchcg PR #57 ships the arm that was missing: a real CPU AOTInductor compile → real `LocalGraphStore` → real `AdoptSession` with **no loader argument** → output asserted against the eager answer recorded before the swap. An empty constant buffer cannot pass it.
- Here: ruff clean (`src/gen_worker`), **mypy clean (328 files)**, `test_serving_adopt_first` + `test_self_mint_wiring` + `test_vendored_snapshot_pgw1310` = **39 passed**.
- The real-artifact serve proof (sd15's 14 minted specializations on this box's 4070) follows in the same lane once the mint lane hands over the card; it drives these exact bytes, not a fixture.

### Also in this diff

torchcg re-vendored at `12c99841` (VENDORED.toml rev + digest table regenerated, dev pin bumped). tcg#57's trace-session host egress (`hollow.py`) rides along — a vendor is taken whole.

### Adjacent P0 found and NOT fixed here (pgw#1466 lane owns it)

`BackgroundMint._mint_one` cannot publish or manifest what `mint_child` returns: the child returns `destination`, which `Engine.compile` → `_store.resolve` leaves as an **unpacked directory**, and then `LocalGraphStore.publish_artifact` refuses it (`if not source.is_file()`) and `needed_libraries()` refuses it again (`read_bytes()` + `\x7fELF`). The arm leg is fine — `materialize()` accepts the directory deliberately.