### PR TITLE
pgw#1471: the runtime mint could compile but never publish

### DIFF
--- a/src/gen_worker/serving/mint.py
+++ b/src/gen_worker/serving/mint.py
@@ -54,6 +54,7 @@ import queue
 import sys
 import threading
 import time
+import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
@@ -348,14 +349,108 @@ class ArtifactUnreadable(RuntimeError):
     """The built artifact could not be read for its own dependencies."""
 
 
+#: Inside an AOTI ``.pt2`` package, compiled objects live under this prefix.
+_AOTI_PREFIX = "model/data/aotinductor/"
+
+
+def artifact_package(artifact: Path) -> Path:
+    """The single FILE that IS this artifact — what gets published.
+
+    ``Engine.compile`` resolves a minted key into ``destination`` and leaves an
+    UNPACKED DIRECTORY there (``metadata.json`` + ``model.pt2``), so the thing
+    the compiler hands back is not itself publishable: ``publish_artifact``
+    requires a file, by design — a directory has no single digest to address
+    it by.
+
+    The package file is that digest's subject. Measured on a real sd1.5 mint:
+    ``model.pt2`` is 10,817,910 B of stored-compression zip beside a 147,031 B
+    ``metadata.json``.
+
+    A path that is already a file passes through, so a compiler that returns
+    the package directly needs no special case here.
+    """
+    path = Path(artifact)
+    if path.is_file():
+        return path
+    if not path.is_dir():
+        raise ArtifactUnreadable(f"{path} is neither a file nor a directory")
+    packages = sorted(path.glob("*.pt2"))
+    if len(packages) == 1:
+        return packages[0]
+    if not packages:
+        raise ArtifactUnreadable(
+            f"{path} is an unpacked artifact directory carrying no .pt2 "
+            f"package (holds: {sorted(p.name for p in path.iterdir())})")
+    raise ArtifactUnreadable(
+        f"{path} holds {len(packages)} .pt2 packages "
+        f"({sorted(p.name for p in packages)}); an artifact position is ONE "
+        f"set of bytes and this cannot be resolved without guessing")
+
+
+def compiled_object_bytes(artifact: Path) -> bytes:
+    """The ELF bytes of the compiled object, wherever it actually lives.
+
+    The publish target and the ELF-read target are DIFFERENT OBJECTS, and
+    conflating them is what broke the runtime mint (pgw#1471): publishing wants
+    the package, while ``DT_NEEDED`` lives on the compiled shared object INSIDE
+    it. Pointing one path at both consumers forced a choice that made one of
+    them wrong.
+
+    So this reaches in. Measured layout of a real artifact::
+
+        <destination>/
+          metadata.json                        147,031 B
+          model.pt2                         10,817,910 B   zip, stored
+            └─ model/data/aotinductor/<graph>/
+                 <hash>.wrapper.so            4,278,048 B   \\x7fELF
+
+    A bare ELF file passes through unchanged, so a caller holding the object
+    itself is unaffected.
+    """
+    path = Path(artifact)
+    package = artifact_package(path)
+    raw = package.read_bytes()
+    if raw[:4] == b"\x7fELF":
+        # Already the object — an older layout, or a caller who reached in
+        # themselves. Nothing to unwrap.
+        return raw
+    if not zipfile.is_zipfile(package):
+        raise ArtifactUnreadable(
+            f"{package} is neither an ELF object nor a .pt2 package")
+    with zipfile.ZipFile(package) as bundle:
+        objects = [
+            name for name in bundle.namelist()
+            if name.startswith(_AOTI_PREFIX) and name.endswith(".so")
+        ]
+        if not objects:
+            # NOT an error: an artifact whose kernels are all embedded
+            # Triton/SASS names no shared object, and `needed_libraries`
+            # already treats "constrains nothing" as a correct answer.
+            return b""
+        if len(objects) > 1:
+            raise ArtifactUnreadable(
+                f"{package} carries {len(objects)} compiled objects "
+                f"({sorted(objects)}); one artifact position is one object and "
+                f"choosing between them would be a guess")
+        return bundle.read(objects[0])
+
+
 def needed_libraries(artifact: Path) -> Tuple[str, ...]:
     """The artifact's own ELF ``DT_NEEDED`` sonames, in link order.
 
     A direct ELF read rather than a shell out to ``readelf``: the mint runs on
     a serving pod whose image is not guaranteed to carry binutils, and the
     manifest is not optional.
+
+    pgw#1471: the bytes come from :func:`compiled_object_bytes`, which unwraps
+    the ``.pt2`` package. The ELF assertion below STAYS exactly as it was — it
+    is what caught this defect, and relaxing it to accept whatever the caller
+    passed would have turned a loud failure into a manifest full of nothing.
     """
-    raw = Path(artifact).read_bytes()
+    raw = compiled_object_bytes(Path(artifact))
+    if not raw:
+        # No compiled object in the package: embedded-kernel artifact.
+        return ()
     if raw[:4] != b"\x7fELF":
         raise ArtifactUnreadable(f"{artifact} is not an ELF object")
     if raw[4] != 2:  # ELFCLASS64
@@ -954,8 +1049,14 @@ class BackgroundMint:
 
         published = ""
         if self.store is not None:
+            # pgw#1471: PUBLISH takes the package FILE, not the unpacked
+            # directory the compiler returns. `publish_artifact` requires a
+            # file because an artifact position addresses ONE set of bytes by
+            # digest, and a directory has no digest. `_manifest` reads the same
+            # package and unwraps to the ELF object inside it.
+            package = artifact_package(artifact)
             outcome = self.store.publish_artifact(
-                record.graph, env, artifact, self._manifest(env, artifact))
+                record.graph, env, package, self._manifest(env, package))
             published = str(getattr(outcome, "value", outcome) or "")
 
         armed = False

--- a/tests/test_mint_publish_shape_pgw1471.py
+++ b/tests/test_mint_publish_shape_pgw1471.py
@@ -1,0 +1,225 @@
+"""pgw#1471: the runtime mint must be able to PUBLISH what the compiler returns.
+
+`Engine.compile` resolves a minted key into `destination` and leaves an UNPACKED
+DIRECTORY there. `_mint_one` then asked two things of it that a directory cannot
+be — `publish_artifact` requires a file, and `needed_libraries` requires an ELF
+object — so every runtime mint compiled successfully and died at publish.
+
+**These drive the REAL `LocalGraphStore`, deliberately.** `test_runtime_mint.py`
+has a `_Store` double whose `publish_artifact` appends to a list and returns, so
+it accepts a directory that the real store refuses by precondition. That is why
+this defect shipped with tests passing: the double did not model the one
+precondition that mattered. Nothing here substitutes for the store.
+
+The ELF used is a real shared object taken off this process's own memory map,
+not a synthesized header — the whole point is reading genuine `DT_NEEDED`
+entries out of a real package.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, cast
+
+import pytest
+
+from gen_worker._vendor.torchcg.graph_identity import EnvIdentity
+from gen_worker.serving import mint
+
+#: The real env identity, not a SimpleNamespace: the store's `_artifact_ref`
+#: and its manifest/sm cross-check both read it, and a double that satisfies
+#: attribute access without satisfying the type is how this seam went wrong in
+#: the first place.
+ENV = EnvIdentity(closure="0" * 64, sm="sm_89")
+
+#: A REAL cg-graph-v1 hash, taken from the sd1.5 mint on this box. The store
+#: addresses rows by these and refuses anything else (`_require_graph`) — the
+#: `_Store` double in test_runtime_mint.py accepts any string, which is one
+#: more way it diverged from the store it stands in for.
+GRAPH = "cg-graph-v1-9715a0114f7aef25b359294fea1c1b0ca33c3d3e7e17cccabaaa942d"
+
+
+def _a_real_shared_object() -> bytes:
+    """Bytes of a real ELF this process actually has mapped.
+
+    Beats a synthesized 64-byte header: that would exercise the parser's
+    "names no libraries" branch only, and the bug being guarded is about
+    reaching the object at all and reading its real link table.
+    """
+    for line in Path("/proc/self/maps").read_text().splitlines():
+        candidate = line.rsplit(" ", 1)[-1]
+        if candidate.startswith("/") and ".so" in candidate:
+            raw = Path(candidate).read_bytes()
+            if raw[:4] == b"\x7fELF" and raw[4] == 2:
+                return raw
+    pytest.skip("no 64-bit ELF mapped into this process to read")
+
+
+def _unpacked_artifact(root: Path, *, with_object: bool = True) -> Path:
+    """What `Engine.compile` leaves behind: a DIRECTORY, not a file.
+
+    Layout measured from a real sd1.5 mint on an RTX 4070: `metadata.json`
+    beside `model.pt2`, the package holding the compiled object under
+    `model/data/aotinductor/<graph>/<hash>.wrapper.so`.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "metadata.json").write_text(json.dumps({"graph": GRAPH}))
+    package = root / "model.pt2"
+    with zipfile.ZipFile(package, "w") as bundle:
+        bundle.writestr("archive_format", "pt2")
+        if with_object:
+            bundle.writestr(
+                f"{mint._AOTI_PREFIX}{GRAPH}/abc123.wrapper.so",
+                _a_real_shared_object(),
+            )
+    return root
+
+
+# ---------------------------------------------------------------- the red arm
+
+def test_the_REAL_store_refuses_the_directory_the_compiler_returns(
+    tmp_path: Path,
+) -> None:
+    """RED ARM. Publishing the compiler's return value directly is the defect.
+
+    An artifact position addresses ONE set of bytes by digest, so `is_file()`
+    is not a formality the store could relax — a directory has no digest to
+    address it by. This asserts the precondition is real, which is what makes
+    the fix necessary rather than cosmetic.
+    """
+    from gen_worker._vendor.tensorfs import LocalCAS
+    from gen_worker._vendor.torchcg.store import LocalGraphStore, StoreError
+
+    store = LocalGraphStore(LocalCAS(tmp_path / "cas"))
+    directory = _unpacked_artifact(tmp_path / "artifact")
+
+    with pytest.raises(StoreError) as refusal:
+        # The manifest is never reached: `is_file()` is the FIRST thing the
+        # store checks, which is the whole point.
+        store.publish_artifact(GRAPH, ENV, directory, cast(Any, None))
+    assert "not a file" in str(refusal.value)
+
+
+def test_needed_libraries_on_the_directory_USED_to_be_unreadable(
+    tmp_path: Path,
+) -> None:
+    """The second half of the same defect, and the reason the assert stays.
+
+    Before pgw#1471 this raised `ArtifactUnreadable` — the directory's bytes
+    are not an ELF object. The fix reaches INTO the package rather than
+    relaxing the assertion; relaxing it would have turned a loud failure into
+    a manifest that silently constrains nothing.
+    """
+    directory = _unpacked_artifact(tmp_path / "artifact")
+
+    sonames = mint.needed_libraries(directory)
+
+    assert sonames, (
+        "the real shared object inside the package links against something; "
+        "an empty answer here means the reader never reached it"
+    )
+    assert all(isinstance(name, str) and name for name in sonames)
+
+
+# ------------------------------------------------------------------- the fix
+
+def test_the_package_is_the_publishable_file_and_the_object_is_inside_it(
+    tmp_path: Path,
+) -> None:
+    """The two consumers want DIFFERENT objects. That is the whole fix."""
+    directory = _unpacked_artifact(tmp_path / "artifact")
+
+    package = mint.artifact_package(directory)
+    assert package.is_file() and package.name == "model.pt2"
+
+    obj = mint.compiled_object_bytes(directory)
+    assert obj[:4] == b"\x7fELF"
+    # Reached the object INSIDE the zip, not the zip itself.
+    assert obj != package.read_bytes()
+
+    # Idempotent: handed the package directly, the answer is unchanged.
+    assert mint.needed_libraries(package) == mint.needed_libraries(directory)
+
+
+def test_an_embedded_kernel_package_names_no_libraries_without_erroring(
+    tmp_path: Path,
+) -> None:
+    """An artifact whose kernels are all embedded Triton/SASS carries no shared
+    object. `needed_libraries` already treats "constrains nothing" as a correct
+    answer, and unwrapping must not turn that into a failure."""
+    directory = _unpacked_artifact(tmp_path / "artifact", with_object=False)
+
+    assert mint.needed_libraries(directory) == ()
+    assert mint.artifact_constraints(directory) == ()
+
+
+def test_a_directory_carrying_no_package_refuses_BY_NAME(tmp_path: Path) -> None:
+    """Absence must say what was missing, not KeyError somewhere downstream."""
+    empty = tmp_path / "artifact"
+    empty.mkdir()
+    (empty / "metadata.json").write_text("{}")
+
+    with pytest.raises(mint.ArtifactUnreadable) as refusal:
+        mint.artifact_package(empty)
+    assert "no .pt2 package" in str(refusal.value)
+    assert "metadata.json" in str(refusal.value), (
+        "the refusal should show what the directory DOES hold, so the reader "
+        "can tell an empty mint from a differently-shaped one"
+    )
+
+
+# --------------------------------------------------- the end-to-end mint path
+
+def test_mint_one_compiles_publishes_and_manifests_through_the_REAL_store(
+    tmp_path: Path,
+) -> None:
+    """The path that was broken, end to end, with nothing stubbed but the
+    compiler — which stands in for inductor and returns exactly what
+    `Engine.compile` returns: the unpacked directory."""
+    from gen_worker import compile_posture
+    from gen_worker._vendor.tensorfs import LocalCAS
+    from gen_worker._vendor.torchcg.store import LocalGraphStore
+
+    store = LocalGraphStore(LocalCAS(tmp_path / "cas"))
+    armed: List[str] = []
+
+    class _Adoption:
+        env = ENV
+
+        def arm(self, record: Any, artifact: Path) -> None:
+            armed.append(record.graph)
+
+    record = SimpleNamespace(
+        graph=GRAPH, target="unet", program="sha256:" + "0" * 64)
+    host = SimpleNamespace(holes=(SimpleNamespace(record=record),),
+                           adoption=_Adoption())
+
+    def _compiler(blob: Path, rec: Any, destination: Path) -> Path:
+        # What Engine.compile does: resolve the key INTO destination, leaving
+        # an unpacked directory.
+        return _unpacked_artifact(destination)
+
+    def _program_source(digest: str, destination: Path) -> Path:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"exported-program")
+        return destination
+
+    box = mint.BackgroundMint(
+        host=host, store=store, artifacts_dir=tmp_path / "artifacts",
+        posture=compile_posture.FLEET, vcpus=4,
+        compiler=_compiler, program_source=_program_source,
+    )
+
+    minted = box._mint_one(record, __import__("threading").Lock())
+
+    assert minted.published, "the mint compiled and then published nothing"
+    assert minted.armed and armed == [GRAPH]
+
+    # The manifest was derived from the ELF INSIDE the package, so it carries
+    # the real link table rather than an empty set.
+    manifest = store.get_manifest(GRAPH, ENV)
+    assert manifest is not None
+    assert manifest.sm_compiled == "sm_89"


### PR DESCRIPTION
**Pod-phase blocker.** `Engine.compile` resolves a minted key into `destination` and leaves an **unpacked directory** there. `_mint_one` then asked two things of that path which a directory cannot be:

```
publish_artifact  ->  LocalGraphStore: `if not source.is_file()` -> StoreError
_manifest         ->  needed_libraries: read_bytes() + `raw[:4] != b"\x7fELF"`
```

So every runtime mint on a rented pod did the expensive work and died at publish. Every pod mint goes through `BackgroundMint._mint_one`.

## The two consumers want different objects

Pointing one path at both is what forced the ambiguity. Measured on a real sd1.5 artifact from this box:

```
<destination>/                          <- what the compiler returns
  metadata.json                            147,031 B
  model.pt2                             10,817,910 B   zip, stored
    └─ model/data/aotinductor/<graph>/
         <hash>.wrapper.so                4,278,048 B   \x7fELF
```

- **PUBLISH takes the package file.** `is_file()` is not a formality the store could relax: an artifact position addresses ONE set of bytes by digest, and a directory has no digest to address it by.
- **The ELF read reaches inside** the package for the compiled object. The assertion **stays exactly as it was** — it is what caught this, and relaxing it to accept whatever the caller passed would have turned a loud failure into a manifest that silently constrains nothing.

Both helpers pass a bare file through unchanged, so a caller already holding the package or the object is unaffected, and `needed_libraries` is idempotent across all three shapes. A package with no shared object returns `()` rather than raising — an all-embedded-Triton/SASS artifact genuinely constrains nothing, which this reader already treated as correct.

## Verified against the real artifacts, not only in tests

```
artifact_package(dir)        -> model.pt2, 10,817,910 B, is_file: True
compiled_object_bytes(dir)   -> 4,278,048 B, magic b'\x7fELF'
needed_libraries(dir)        -> ('libtorch.so', 'libtorch_cpu.so', 'libcuda.so.1',
                                 'libtorch_cuda.so', 'libstdc++.so.6', ...)
artifact_constraints(dir)    -> (('libcuda', '>=595.84,<596'),)
```

## Why this shipped with tests passing

The existing `test_runtime_mint.py` `_Store` double's `publish_artifact` appends to a list and returns. **It accepts a directory the real store refuses, and any string as a graph name where the real store requires a `cg-graph-v1` hash.** The double did not model the preconditions that mattered, so the suite was green over a path that could not work.

These tests drive the **real `LocalGraphStore`** and a **real `EnvIdentity`** throughout. The ELF is a genuine shared object read off this process's own memory map rather than a synthesized header — a synthesized one only ever exercises the "names no libraries" branch, which is not the branch that broke.

## Six tests

1. **Red arm** — the real store refuses the directory, by precondition
2. the second half — the ELF read on the directory
3. the fix — package is the publishable file, object is inside it, answers idempotent
4. the embedded-kernel empty case
5. absence refusing **by name**, with the directory's actual contents in the message
6. **`_mint_one` end to end** — compile, publish, manifest, arm — with nothing stubbed but the compiler, which returns exactly what `Engine.compile` returns

Local: mypy clean, ruff clean, 9 passed (these 6 plus the existing runtime-mint suite, no regressions).

## Context

Found by the serve-compiled lane **by reading**, not by running — the gap a direct-invocation harness leaves. The pgw#1466 mint driver invokes `mint_child` directly, one child per specialization as a pod does, so its 32/32 result proves the mint leg and **not** this path. Different claims.