### PR TITLE
pgw#1477: master's `uv sync --locked` is broken — the torchcg pin moved and the lock did not

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=8e8c5ca6acdb3ed13f94ae6878c8248114ecd9c7" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=12c99841f01f9ccba22c279b72bebc30bd7b22d2" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=8e8c5ca6acdb3ed13f94ae6878c8248114ecd9c7#8e8c5ca6acdb3ed13f94ae6878c8248114ecd9c7" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=12c99841f01f9ccba22c279b72bebc30bd7b22d2#12c99841f01f9ccba22c279b72bebc30bd7b22d2" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
**Every pgw PR opened since 2026-08-19 04:19Z fails all three checks before running anything.**

`fad60a8b` (pgw#1460) bumped `pyproject.toml`'s torchcg pin to `12c99841` and did not re-lock. `uv.lock` still recorded `8e8c5ca6`:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

**Measured** on PR #1036, which changed neither file — its `uv.lock` and `pyproject.toml` are byte-identical to `origin/master`'s:

| job | verdict | time | step |
|---|---|---|---|
| `drift` | fail | 9 s | `uv sync --locked --extra dev` |
| `fast gates` | fail | 13 s | `uv sync --locked --extra dev` |
| `tests` | fail | 38 s | `uv sync --locked --extra dev` |

The failure is at INSTALL, so it presents as three unrelated red checks rather than as one stale line — which is why it survived a merge.

## The fix

`uv lock`. Two lines, in the two places the lock spells the rev. `Resolved 107 packages` unchanged; no dependency version moves.

Separated from the lane that found it (pgw#1474 / th#2201) deliberately: it unblocks every other lane too, and none of them should have to carry a feature branch's CI cycle to get it.