### PR TITLE
pgw#1478: re-vendor tcg#61 — the adopted graph is CALLED correctly, and sd1.5 serves through AOTI

### DIFF
--- a/changelog.d/pgw1478.md
+++ b/changelog.d/pgw1478.md
@@ -1,0 +1,17 @@
+- **The adopted graph is now CALLED correctly, and sd1.5 serves through AOTI end to end.** tcg#58
+  landed the loader; it also shipped one wrong line. `CompiledGraphCall` pre-flattened the call with
+  `CallIngress.feeds()`, which is the contract for the RAW AOTI runner — but
+  `torch._inductor.package.load_package()` returns an `AOTICompiledModel`, and that re-flattens with
+  the `in_spec` the export recorded, so it wants the AUTHOR'S call shape. Measured on a 4070 against
+  sd1.5's 14 real minted specializations: adopt, fetch, materialize, verify, bind and dispatch were
+  all correct — 14/14 armed, 686/992 constants bound each — and the call itself died on
+  `ValueError: Ran into a kwarg keyword mismatch`. torchcg re-vendored at `6c91b83d`.
+
+- **Measured, on this box's RTX 4070, through the real `EndpointHost` boot.** 14/14 adopted, 0
+  holes, `_ForwardDispatcher` installed, **26 of 26 unet calls served by a compiled graph** with no
+  eager fall-through. Compiled 3.01 s warm / 3199 MiB peak allocated against eager 3.13 s / 2675 MiB
+  — same card, prompt, steps, seed and resolution. **That is 1.04x: the mechanism is proven, a
+  speedup is not.** SD1.5 at 512x512 batch-2 is a small graph and AOTI removes dispatch overhead
+  that was not the bottleneck; the compiled arm also costs +524 MiB of workspace. The same seed
+  produces the same image to 0.9% mean bf16 drift, which is what a correct constant bind looks like
+  and what an empty buffer cannot produce.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -692,7 +692,7 @@ torchvision = [
 # tools away from the cause: the derive raised `TypeError: unexpected keyword
 # 'session'` while that exact signature was verifiably present in the vendored
 # tree. Bump both, re-lock, re-vendor — one change.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "12c99841f01f9ccba22c279b72bebc30bd7b22d2" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "6c91b83d8fb2e45a6d568569dc15884c4d6b26e3" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -299,8 +299,16 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "12c99841"
+rev = "6c91b83d"
 subdir = "src/torchcg"
+# pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
+# stops pre-flattening the call: the loaded package is torch's
+# `AOTICompiledModel` and it re-flattens with the export's OWN `in_spec`, so it
+# wants the AUTHOR'S call shape. Measured on a 4070 against sd1.5's 14 real
+# minted specializations -- everything upstream of the call was correct and the
+# call itself died on `Ran into a kwarg keyword mismatch`. With it, sd1.5 serves
+# 26/26 unet calls through AOTI.
+#
 # pgw#1460 / tcg#58 RE-VENDOR (2026-08-19), from `12c99841`. The NEW FILE is
 # `serve.py` — the bytes->callable half of adoption, which upstream had left as
 # a seam with no implementation, so both of this repo's loaders were raw
@@ -528,9 +536,9 @@ rewrites = [
 "quantize.py" = "cb579b4a2c91af02211f6339147584338b278a2da4e1f8f60084b742fce21da6"
 "recipe.py" = "cc6fe9007a7f459ede5ced2cfd5d072e3c807552329d0e1920ade88de8b829a6"
 "requirements.py" = "3b34858258d41c4faaa133c2d9c340507c4e18928c324f5665b4fe4fac4c7bda"
-"runner.py" = "745a988f58d6be77cb781e9a2e70a80ce503c35d74b581cfea104778ec5c62b5"
+"runner.py" = "5293d1f296485963e400dd57332c44ba890a5df6bb0a92fc251e3977a1d9fb2f"
 "selection.py" = "1addd68533008d32b9d36c7877ac4c5fe43fce5f2c8737dda976f681f9145738"
-"serve.py" = "cc7d7cfb57f344dec63881d0fd2ad3848d1cf31d80f670f76f2e6f042cd2272e"
+"serve.py" = "a1f3b6fe5e46305bc9aea9848ac5935537b7bb37e2586ae3f0393f66cead2ade"
 "spans.py" = "4776fac2006967b1f17ffcbec03e50147d511120fd50cf085ac3b6b4702e5539"
 "storage.py" = "ccc9d6f8ac1a242b493028eaeed6a1fcd3a02a885c99ba2223bc71df7b69efe4"
 "store.py" = "60b12c4f36b40ea4f48464821367852df8bb530294f5535319cfe48aa3adbebb"

--- a/src/gen_worker/_vendor/torchcg/runner.py
+++ b/src/gen_worker/_vendor/torchcg/runner.py
@@ -288,13 +288,29 @@ class CompiledGraphRunner:
         self._bound_values = values
         self._bound = True
 
-    def __call__(self, *feeds: object) -> Any:
+    def __call__(self, *args: object, **kwargs: object) -> Any:
+        """Invoke the graph with the AUTHOR'S OWN call, unflattened (tcg#61).
+
+        The loaded package is torch's ``AOTICompiledModel``, and its
+        ``__call__`` performs its own ``tree_flatten((args, reorder_kwargs(
+        kwargs, in_spec)))`` against the ``in_spec`` the export recorded. So
+        the flattening is torch's, not ours, and it wants the call in the
+        shape the author writes it -- handing it pre-flattened positional
+        feeds is met with ``ValueError: Ran into a kwarg keyword mismatch:
+        Got the following keywords [] but expected [...]``.
+
+        This is the ruling ("shed everything derivable from the
+        ExportedProgram") arriving at the one place it is load-bearing: the
+        argument structure IS in the artifact, so a second copy of it here
+        could only ever disagree with the first.
+        """
+
         if not self._bound:
             raise ConstantBindingError(
                 "constants_unbound",
                 f"refusing to invoke graph {self.name!r} before complete binding",
             )
-        result = self._package(*feeds)
+        result = self._package(*args, **kwargs)
         self.calls += 1
         return result
 

--- a/src/gen_worker/_vendor/torchcg/serve.py
+++ b/src/gen_worker/_vendor/torchcg/serve.py
@@ -237,7 +237,14 @@ class CompiledGraphCall:
     record: GraphRecord
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        return self.runner(*self.record.ingress.feeds(args, kwargs))
+        # STRAIGHT THROUGH (tcg#61). The package carries the export's own
+        # `in_spec` and flattens with it, so the author's call is exactly what
+        # it wants. `CallIngress` still owns DISPATCH -- `_matches` is what
+        # decides this graph may answer this call at all -- but it does not
+        # own the calling convention, and the version of this line that
+        # thought it did died on the first real artifact with
+        # `Ran into a kwarg keyword mismatch`.
+        return self.runner(*args, **kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
tcg#58 landed the loader and shipped one wrong line with it. `CompiledGraphCall` pre-flattened the call with `CallIngress.feeds()` — the contract for the **raw** AOTI runner. `torch._inductor.package.load_package()` returns an `AOTICompiledModel`, which re-flattens with the `in_spec` the export recorded, so it wants the **author's** call shape.

### Measured on this box's RTX 4070, against sd1.5's 14 REAL minted specializations, through the real `EndpointHost` boot — never a fixture

```
document closure=40471a9099eb4406... lane=sd15.diffusers-bf16@1 graphs=14
boot 3.0s   adoption=YES
adopted=14  holes=0  armed_on_unet=14   dispatcher=_ForwardDispatcher
  3d3e7e17cccabaaa942d bound=True constants=686/992 shapes=[[2,4,64,64],[],[2,77,768]]
run 0: 3.49s  compiled_graph_calls=26
run 1: 3.01s  compiled_graph_calls=26    peak 3199 MiB alloc / 3946 reserved
```

Everything upstream of the call was already correct — adopt, fetch, materialize, verify, bind, dispatch. The call died on `ValueError: Ran into a kwarg keyword mismatch`. **26 of 26 unet calls now serve through a compiled graph with no eager fall-through** (this checkpoint's PNDM config yields 26 timesteps for 25 declared steps).

### Compiled vs eager — same card, prompt, steps, seed, resolution, process shape

| arm | run 0 | run 1 (warm) | peak alloc | compiled calls |
|---|---|---|---|---|
| compiled | 3.49 s | **3.01 s** | 3199 MiB | 26 / 26 |
| eager | 3.57 s | **3.13 s** | 2675 MiB | 0 |

**1.04× — the mechanism is proven and a speedup is not.** SD1.5 at 512×512 batch-2 is a small graph and AOTI removes dispatch overhead that was not the bottleneck; the compiled arm costs **+524 MiB** of workspace. Stated plainly rather than dressed up: sdxl at 1024×1024 is the test that decides whether compile pays here.

### Numerics — the evidence the bind is real

Same seed, compiled vs eager differ by **2.35/255 mean absolute (0.9%)** on the same composition — bf16 kernel-ordering drift between two schedules of one computation. An empty constant buffer cannot produce the same astronaut on the same horse.

### Also

torchcg re-vendored at `6c91b83d` (VENDORED.toml rev + per-file digest table regenerated, dev pin bumped — the matched pair the fence requires).

Local: ruff clean (`src/gen_worker`; the 4 errors under `scripts/` are pre-existing on master and outside the gate, which both Taskfile:115 and ci.yaml:248 scope to `src/gen_worker`), raw-AOTI-load fence clean, `test_vendored_snapshot_pgw1310` + `test_serving_adopt_first` + `test_self_mint_wiring` = 39 passed.