### PR TITLE
pgw#1479 / th#2202: a SCRATCH destination DERIVES its release — the SDK's precondition was unsatisfiable

### DIFF
--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -747,7 +747,9 @@ def run_clone(
     # th#1987: every published artifact attaches to an ALREADY-CUT release,
     # named by the invoking request. Resolved before the download so a clone
     # that could never publish costs nothing.
-    release = _destination_release(ctx, destination_release)
+    # th#2202: a SCRATCH destination derives its release hub-side, and since
+    # th#1901 that is what the hub rewrites EVERY producer's destination to.
+    release = _destination_release(ctx, destination_release, destination)
     layout_hint = str(target_layout or MULTI_FILE).strip().lower() or MULTI_FILE
     specs = normalize_outputs(outputs, layout_hint=layout_hint)
     include = normalize_source_include(source_include)

--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from .. import activity as _activity
+from .. import scratchrepo
 from ..api.errors import ValidationError
 from ..hubio.client import CommitFile, CommitResult, HubClient, files_from_tree
 from ..hubio.publish_state import JOURNAL_NAME
@@ -181,7 +182,7 @@ def _publish_leg(dest: str, artifact: str, stage: str, facts: Mapping[str, Any])
         phase=stage)
 
 
-def destination_release(ctx: Any, explicit: str = "") -> str:
+def destination_release(ctx: Any, explicit: str = "", dest: str = "") -> str:
     """THE release a producer's output attaches to: the explicit argument, else
     the invoking request's ``destination.release``.
 
@@ -189,6 +190,13 @@ def destination_release(ctx: Any, explicit: str = "") -> str:
     can name none has a caller-side defect. Refusing here — before a byte
     moves — names the field the invoke must carry instead of costing the run a
     multi-GB upload and a 400.
+
+    th#2202: ``dest`` is the repo actually being published into, and a SCRATCH
+    one DERIVES its release. Since th#1901 the hub rewrites EVERY producer's
+    destination to `<org>/_job-<request-id>` on the wire, so this is the
+    ordinary case, not the exception — and demanding a release the caller has
+    no payload member to state made the whole scalar-destination surface
+    unpublishable. Empty is returned and the hub cuts.
     """
     rel = str(explicit or "").strip()
     if rel:
@@ -196,6 +204,8 @@ def destination_release(ctx: Any, explicit: str = "") -> str:
     info = getattr(ctx, "destination", None) or {}
     if isinstance(info, dict):
         rel = str(info.get("release") or "").strip()
+    if not rel and scratchrepo.derives_its_release(dest):
+        return ""
     if not rel:
         raise ValueError(
             "release is required (th#1987): the invoke named no "
@@ -276,7 +286,7 @@ def publish_flavors(
     if callable(require):
         require("publish_flavors")
     dest = destination_ref(ctx, destination_repo)
-    release = destination_release(ctx, release)
+    release = destination_release(ctx, release, dest)
 
     client = HubClient.from_ctx(ctx)
     # A v2 publish mints a new identity and inherits nothing, so a publish into

--- a/src/gen_worker/hubio/client.py
+++ b/src/gen_worker/hubio/client.py
@@ -37,6 +37,7 @@ from gen_worker.transfer.grants import TransferGrant, upload
 from gen_worker.transfer.journal import TransferJournal, TransferSession
 
 from .. import activity as _activity
+from .. import scratchrepo
 from ..http_origin import is_definite_hub_answer, response_is_from_hub
 from ..models.cache_paths import open_worker_cas
 from ..stall import SilenceWindow
@@ -603,7 +604,16 @@ class HubClient:
             raise HubPublishError("publish_v2 requires at least one file")
         attaches_to_no_release = release == COMPILED_GRAPH_NO_RELEASE
         release = "" if release == COMPILED_GRAPH_NO_RELEASE else release.strip()
-        if not release and not attaches_to_no_release:
+        # th#2202: a SCRATCH repo DERIVES its release, so an empty one is legal
+        # there and the body simply omits the field. This precondition is the
+        # SDK's mirror of the hub's own rule and must not be stricter than it:
+        # the scratch repo is the destination the hub hands EVERY publishing
+        # run, and a callee whose typed input declares the scalar
+        # `destination_repo` can never be told a `destination.release` — so this
+        # refusal used to make `ctx.save_checkpoint` impossible, client-side,
+        # before any HTTP, at step 200 of a paid-for training run.
+        derives = scratchrepo.derives_its_release(destination_repo)
+        if not release and not attaches_to_no_release and not derives:
             raise HubReleaseRequiredError(
                 f"publish into {destination_repo!r} names no release: th#1987 "
                 "made `release` mandatory. Cut one "

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
 from ..hostfacts import cuda_ready
+from .. import scratchrepo
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -622,11 +623,35 @@ class RequestContext(Generic[D]):
     def _repo_job_release(self) -> str:
         """The release a repo-CAS checkpoint publish attaches to, or "".
 
-        th#1987 made it mandatory hub-side; it is the caller's
-        `destination.release`, carried through the execution hints. Empty means
-        the invoke named none — a caller-side defect the publish refuses by
-        name rather than a transfer problem."""
+        It is the caller's `destination.release`, carried through the execution
+        hints. Empty means the invoke named none — which is th#2202's ORDINARY
+        case, not a defect: see :meth:`_checkpoint_release`."""
         return str((self._execution_hints or {}).get("destination_release") or "").strip()
+
+    def _checkpoint_release(self, repo: str) -> str:
+        """THE release `ctx.save_checkpoint` publishes under, or "" to let the
+        hub derive one. Raises when neither is available.
+
+        th#2202. This is a NAMED decision rather than an inline `if` because
+        the `if` was wrong for a year of cost and nothing could see it at $0:
+        the only carrier for `destination.release` is the reserved
+        `destination:{ref,release}` object, and an endpoint whose typed input
+        declares the scalar `destination_repo` with `forbid_unknown_fields`
+        can never be handed that key. So this raised at step 200 of a paid-for
+        training run, on the SCRATCH repo the hub itself named — a repo no
+        author ever names a release for, and one the hub cuts a release for on
+        every publish. The refusal survives for a destination that HAS an
+        author, which is where th#1987's deliberation rule lives.
+        """
+        release = self._repo_job_release()
+        if release or scratchrepo.is_scratch_name(repo):
+            return release
+        raise RuntimeError(
+            f"cannot publish into {repo!r}: the request named no "
+            "`destination.release`, and th#1987 made it mandatory for a repo "
+            "with an author — the hub refuses the declare with "
+            "`release_required`. Cut a release and invoke with "
+            "destination={ref, release}.")
 
     def _tensor_upload_execution_kind(self) -> str:
         hints = dict(self._execution_hints or {})

--- a/src/gen_worker/request_context/_stream.py
+++ b/src/gen_worker/request_context/_stream.py
@@ -351,14 +351,13 @@ class _RequestOutputStream:
                 self._chunks_uploaded = parts_done
             self._maybe_emit_progress(stage="stream_upload")
 
-        release = ctx._repo_job_release()
-        if not release:
-            raise RuntimeError(
-                f"save_checkpoint({self._ref!r}) cannot publish into "
-                f"{repo_owner}/{repo}: the request named no `destination.release`, "
-                "and th#1987 made it mandatory — the hub refuses the declare with "
-                "`release_required`. Cut a release and invoke with "
-                "destination={ref, release}.")
+        # th#2202: a mid-run checkpoint goes to the run's own SCRATCH repo,
+        # which DERIVES its release — the decision, and the surviving refusal
+        # for a destination that HAS an author, live in one named place.
+        try:
+            release = ctx._checkpoint_release(repo)
+        except RuntimeError as exc:
+            raise RuntimeError(f"save_checkpoint({self._ref!r}) {exc}") from None
         result = client.publish_v2(
             destination_repo=f"{repo_owner}/{repo}",
             files=[CommitFile(

--- a/src/gen_worker/scratchrepo.py
+++ b/src/gen_worker/scratchrepo.py
@@ -19,4 +19,22 @@ def is_scratch_name(name: str) -> bool:
     return str(name or "").strip().lower().startswith(PREFIX)
 
 
-__all__ = ["PREFIX", "is_scratch_name"]
+def derives_its_release(ref: str) -> bool:
+    """Whether a publish into ``ref`` gets its release DERIVED by the hub.
+
+    th#2202: a scratch repo cuts its own release on every publish, because
+    th#1987's "name the release" is an act of DELIBERATION and nobody authors
+    ``_job-<request-id>`` — the hub names it, hard-privates it, TTLs it and
+    reaps it. So an empty ``release`` is LEGAL here and only here, and the SDK
+    must not refuse it: this precondition used to fire client-side, before any
+    HTTP, and killed a training run at its first checkpoint on a rented A100.
+
+    Accepts either ``owner/name`` or a bare name; selectors are ignored.
+    """
+    text = str(ref or "").strip().lower()
+    for sep in (":", "@", "#"):
+        text = text.split(sep, 1)[0]
+    return is_scratch_name(text.rsplit("/", 1)[-1])
+
+
+__all__ = ["PREFIX", "is_scratch_name", "derives_its_release"]

--- a/tests/test_scratch_repo_derives_its_release_pgw1479.py
+++ b/tests/test_scratch_repo_derives_its_release_pgw1479.py
@@ -1,0 +1,173 @@
+"""pgw#1479 / th#2202 — a SCRATCH destination DERIVES its release, so the SDK
+must not refuse an empty one.
+
+The bug, measured by the te#304 lane at step 200 of a real training run on a
+$1.39/hr A100, after the pod, the image and 15.8 GB of base weights were paid
+for::
+
+    RuntimeError: save_checkpoint('checkpoints/lora_000000200.safetensors')
+    cannot publish into tensorhub/_job-b102f721-...: the request named no
+    `destination.release`, and th#1987 made it mandatory
+
+That refusal fired CLIENT-SIDE, before any HTTP, and it was unsatisfiable:
+``ctx._repo_job_release()`` reads ``execution_hints["destination_release"]``,
+which the executor derives ONLY from ``payload.destination.release`` — a
+reserved struct an endpoint whose typed input declares the scalar
+``destination_repo`` with ``forbid_unknown_fields=True`` can never be given.
+So the destination the hub itself hands EVERY publishing run (``th#1901``
+rewrites every producer's destination to ``<org>/_job-<request-id>``) was the
+one destination this SDK could not publish into.
+
+th#2202 ruled it: the release stops being a payload fact for a repo nobody
+authored. The hub cuts one per checkpoint. This SDK precondition is the mirror
+of the hub's rule and may not be stricter than it.
+
+RED-VERIFY (each independently):
+  - drop ``not derives`` from HubClient.publish_v2's guard ->
+    ``test_publish_v2_admits_an_empty_release_into_a_scratch_repo`` fails;
+  - drop the scratch arm of ``destination_release`` ->
+    ``test_destination_release_derives_for_a_scratch_destination`` fails;
+  - make ``RequestContext._checkpoint_release`` raise on an empty release
+    unconditionally -> ``test_checkpoint_release_derives_for_the_runs_own_
+    scratch_repo`` fails with the verbatim step-200 message;
+  - keep either guard unconditional -> the corresponding "still refuses"
+    control keeps passing, so none of these is an always-green assertion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker import scratchrepo
+from gen_worker.convert.publish import destination_release
+from gen_worker.request_context import RequestContext
+from gen_worker.hubio.client import (
+    COMPILED_GRAPH_NO_RELEASE,
+    CommitFile,
+    HubClient,
+    HubPublishError,
+    HubReleaseRequiredError,
+)
+
+
+class _Ctx:
+    """The reserved-struct half of a RequestContext, and nothing else."""
+
+    def __init__(self, destination: dict | None = None) -> None:
+        self.destination = destination or {}
+
+
+# --------------------------------------------------------------------------
+# The naming predicate — the one fact both halves key on.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("ref,expected", [
+    ("tensorhub/_job-b102f721-4d62-41c4-9df2-136f9a72df83", True),
+    ("_job-b102f721", True),
+    ("TENSORHUB/_JOB-B102F721", True),
+    ("tensorhub/_job-b102f721@r1", True),
+    ("tensorhub/te304-renewal-lora", False),
+    ("tensorhub/flux2-klein-4b", False),
+    # A repo merely CONTAINING the prefix is not one. The reserved grammar is
+    # anchored, or a user repo could squat the derivation.
+    ("tensorhub/not_job-b102f721", False),
+    ("", False),
+])
+def test_derives_its_release_reads_the_reserved_grammar(ref: str, expected: bool) -> None:
+    assert scratchrepo.derives_its_release(ref) is expected
+
+
+# --------------------------------------------------------------------------
+# HubClient.publish_v2 — the guard that fired before any HTTP.
+# --------------------------------------------------------------------------
+
+def _publish(destination_repo: str, release: str):
+    """Drive publish_v2 far enough to clear (or trip) the release guard.
+
+    The guard is the FIRST thing after the empty-files check, and the next step
+    reaches the local CAS — so a by-reference file gives us a deterministic,
+    network-free stop AFTER the guard. Reaching that second refusal is the
+    proof the first one did not fire.
+    """
+    client = HubClient(base_url="http://hub.invalid", token="t")
+    return client.publish_v2(
+        destination_repo=destination_repo,
+        files=[CommitFile(path="checkpoints/lora_000000200.safetensors", local_path=None)],
+        release=release,
+    )
+
+
+def test_publish_v2_admits_an_empty_release_into_a_scratch_repo() -> None:
+    with pytest.raises(HubPublishError) as caught:
+        _publish("tensorhub/_job-b102f721-4d62-41c4-9df2-136f9a72df83", "")
+    assert not isinstance(caught.value, HubReleaseRequiredError), (
+        "the SDK refused a scratch publish with no release — this is the "
+        "client-side raise that killed a training run at step 200 on an A100"
+    )
+    assert "by-reference" in str(caught.value)
+
+
+def test_publish_v2_still_refuses_an_empty_release_into_a_repo_a_person_owns() -> None:
+    """The control. th#1987 is untouched for a repo with an author."""
+    with pytest.raises(HubReleaseRequiredError):
+        _publish("tensorhub/te304-renewal-lora", "")
+
+
+def test_publish_v2_still_admits_the_compiled_graph_exemption() -> None:
+    with pytest.raises(HubPublishError) as caught:
+        _publish("tensorhub/te304-renewal-lora", COMPILED_GRAPH_NO_RELEASE)
+    assert not isinstance(caught.value, HubReleaseRequiredError)
+
+
+# --------------------------------------------------------------------------
+# convert.publish.destination_release — the FINAL publish of a training run.
+# --------------------------------------------------------------------------
+
+def test_destination_release_derives_for_a_scratch_destination() -> None:
+    got = destination_release(_Ctx(), "", "tensorhub/_job-b102f721-4d62-41c4")
+    assert got == "", "a scratch destination derives; the SDK states nothing"
+
+
+def test_destination_release_still_refuses_an_authored_destination() -> None:
+    with pytest.raises(ValueError, match="release is required"):
+        destination_release(_Ctx(), "", "tensorhub/te304-renewal-lora")
+
+
+def test_an_explicit_release_always_wins() -> None:
+    assert destination_release(_Ctx(), "v1", "tensorhub/_job-b102f721") == "v1"
+
+
+def test_the_reserved_struct_still_carries_a_release_when_the_caller_names_one() -> None:
+    """The reserved object is NOT retired: a caller who can state a release
+    still does, and it still reaches the publish."""
+    ctx = _Ctx({"ref": "tensorhub/te304-renewal-lora", "release": "v1"})
+    assert destination_release(ctx, "", "tensorhub/_job-b102f721") == "v1"
+
+
+# --------------------------------------------------------------------------
+# RequestContext._checkpoint_release — THE line that raised at step 200.
+#
+# It is a named method rather than an inline `if` for exactly this reason: the
+# decision is now assertable at $0, off the production context, with no pod, no
+# hub and no file. th#2199's lesson one layer down.
+# --------------------------------------------------------------------------
+
+def _ctx(release: str = "") -> RequestContext:
+    hints = {"kind": "training", "destination_repo": "tensorhub/_job-b102f721"}
+    if release:
+        hints["destination_release"] = release
+    return RequestContext("b102f721-4d62-41c4", job_id="j", execution_hints=hints, publishes=True)
+
+
+def test_checkpoint_release_derives_for_the_runs_own_scratch_repo() -> None:
+    assert _ctx()._checkpoint_release("_job-b102f721-4d62-41c4") == ""
+
+
+def test_checkpoint_release_still_refuses_a_repo_with_an_author() -> None:
+    with pytest.raises(RuntimeError, match="release_required"):
+        _ctx()._checkpoint_release("te304-renewal-lora")
+
+
+def test_a_named_release_is_carried_through_untouched() -> None:
+    assert _ctx("v1")._checkpoint_release("te304-renewal-lora") == "v1"
+    assert _ctx("v1")._checkpoint_release("_job-b102f721-4d62-41c4") == "v1"


### PR DESCRIPTION
The client half of th#2202 (tensorhub #1529). Without it the hub fix is unreachable: this raise fires **before any HTTP**.

Measured by the te#304 lane at step 200 of a real training run, on a $1.39/hr A100, after the pod, the image and 15.8 GB of base weights:

```
RuntimeError: save_checkpoint('checkpoints/lora_000000200.safetensors') cannot publish into
tensorhub/_job-b102f721-...: the request named no `destination.release`, and th#1987 made it
mandatory — the hub refuses the declare with `release_required`.
```

**Nothing could satisfy it.** `ctx._repo_job_release()` reads `execution_hints["destination_release"]`, which `executor.py` derives ONLY from `payload.destination.release` — a reserved struct an endpoint whose typed input declares the scalar `destination_repo` with `forbid_unknown_fields=True` can never be handed (`400 invalid_payload "/: additional properties 'destination' not allowed"`). And since th#1901 the hub rewrites EVERY producer's destination on the wire to `<org>/_job-<request-id>` — so the destination this SDK could not publish into is the only destination a publishing run ever gets.

th#2202 ruled it hub-side: a scratch repo cuts its own release on every publish, because "cutting a release is a deliberate act" is about a repo a PERSON owns and nobody authors `_job-<rid>`. This is the SDK mirror; the precondition survives wherever the destination HAS an author.

Four call sites, one predicate (`scratchrepo.derives_its_release`):

- **`RequestContext._checkpoint_release`** — new, and named on purpose. The decision was an inline `if` that cost a rented A100 to read; it is now assertable at $0 off the production context, with no pod, hub or file.
- `HubClient.publish_v2`'s `release_required` guard.
- `convert.publish.destination_release` (a training run's FINAL publish), which now takes the resolved destination.
- `convert.clone`, passing its normalized destination through.

## Red/green

Each arm independently red-verified, each with a paired "still refuses an authored destination" control that stays green in BOTH directions:

- drop `not derives` from `publish_v2`'s guard → the scratch publish is refused again;
- drop the scratch arm of `destination_release` → its scratch case fails;
- make `_checkpoint_release` raise unconditionally → it fails with the verbatim step-200 message.

18 new tests; `tests/convert` + `tests/test_producer_declarations.py` unchanged (173 passed, 4 skipped).