### PR TITLE
pgw#1475: the v2 serve path had no reserved-repo materialization — `_set_source_path` was a writer-less setter and 25 of 27 conversion producers died at 0 GPU-seconds

### DIFF
--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -1226,6 +1226,86 @@ def gate_rows_without_reasons(
         if is_gate_label(label) and not reasons.get(label))
 
 
+# --------------------------------------------------------------------------
+# pgw#1475: WRITER-LESS PRIVATE SETTERS — the blind spot that cost 25 producers
+# --------------------------------------------------------------------------
+#
+# `collect_definitions` SKIPS every `_`-prefixed name (a private callable is
+# not surface), which is right for the surface question and exactly wrong for
+# one shape: a private SETTER whose public reader is the contract. Nothing on
+# the ratchet ever mentioned `RequestContext._set_source_path`, because it was
+# never a candidate — so when pgw#1373 deleted its only caller with
+# `executor.py`, `ctx.source_path` kept returning `None` forever and 25 of 27
+# conversion producers died on their own first line at 0 GPU-seconds.
+#
+# A reader with no writer renders its failure as ABSENCE, which is why no test
+# caught it: the property exists and answers `None`. So this check has NO
+# BASELINE FILE, deliberately — bulk-appending rows to one is what made a
+# correct instrument silent in pgw#1425. Its only escape valve is an INLINE
+# `# writerless: <owner/issue> — <reason>` comment on the `def` line or the
+# line above it: one sentence, next to the code, un-regenerable in bulk, and
+# it REFUSES an empty reason.
+
+#: `_set_<x>` on a context class is the WRITE half of the public `<x>` reader.
+_SETTER_RE = re.compile(r"^_set_[a-z0-9_]+$")
+_WRITERLESS_OK = re.compile(r"#\s*writerless:\s*(?P<reason>\S.*)$")
+
+
+def _writerless_marker(lines: List[str], lineno: int) -> Optional[str]:
+    """The inline sentence excusing a writer-less setter, or None."""
+    for idx in (lineno - 1, lineno - 2):
+        if 0 <= idx < len(lines):
+            m = _WRITERLESS_OK.search(lines[idx])
+            if m:
+                return m.group("reason").strip()
+    return None
+
+
+def writerless_private_setters() -> List[Tuple[str, Path, int]]:
+    """Private `_set_*` methods defined in src/ that nothing in src/ calls."""
+    files = py_files(POD_ROOTS)
+    defined: Dict[str, Tuple[Path, int]] = {}
+    excused: Set[str] = set()
+    called: Set[str] = set()
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError:
+            continue
+        lines = text.splitlines()
+        for node in ast.walk(tree):
+            if (isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and _SETTER_RE.match(node.name)):
+                defined.setdefault(node.name, (path, node.lineno))
+                if _writerless_marker(lines, node.lineno):
+                    excused.add(node.name)
+            elif isinstance(node, ast.Call):
+                fn = node.func
+                # `ctx._set_source_path(p)` and `(set_path or ctx._set_x)(p)`
+                # are both calls; a bare `getattr(ctx, "_set_x")` reference is
+                # covered by the Attribute/Constant walk below.
+                if isinstance(fn, ast.Attribute) and _SETTER_RE.match(fn.attr):
+                    called.add(fn.attr)
+                elif isinstance(fn, ast.Name) and _SETTER_RE.match(fn.id):
+                    called.add(fn.id)
+            elif isinstance(node, ast.Attribute) and _SETTER_RE.match(node.attr):
+                called.add(node.attr)
+            elif (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                    and _SETTER_RE.match(node.value)):
+                # `getattr(ctx, "_set_source_path")` — an indirection is still
+                # a writer, and refusing to see it would push the fix toward
+                # a fake direct call.
+                called.add(node.value)
+    out: List[Tuple[str, Path, int]] = []
+    for name, (path, line) in sorted(defined.items()):
+        # A definition site mentions its own name once (the `def`); reach is
+        # any OTHER mention, which the call/attr walk above collects.
+        if name not in called and name not in excused:
+            out.append((name, path, line))
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--all", action="store_true",
@@ -1285,6 +1365,23 @@ def main() -> int:
     if args.write_baseline:
         rewrite_baseline(current)
         return 0
+
+    writerless = writerless_private_setters()
+    for name, path, line in writerless:
+        print(f"WRITER-LESS SETTER: {path.relative_to(REPO)}:{line}: {name}\n"
+              f"  Nothing in src/ calls it, so the PUBLIC reader it fills "
+              f"answers `None` forever — a contract that fails as ABSENCE, "
+              f"which no test that imports the property can catch (pgw#1475: "
+              f"`_set_source_path` lost its only caller with `executor.py` and "
+              f"killed 25 of 27 conversion producers at 0 GPU-seconds).\n"
+              f"    WIRE IT   restore the step that fills it, at the seam the "
+              f"deleted caller had it;\n"
+              f"    DELETE IT with the reader it writes — a property nobody "
+              f"can fill is not a contract.\n"
+              f"  There is no baseline for this check, deliberately: silencing "
+              f"it by regeneration is the pgw#1425 failure mode, and this "
+              f"class of defect is invisible precisely when it is silent.",
+              file=sys.stderr)
 
     known, notes, reasons = baseline_rows()
     unexplained = gate_rows_without_reasons(known, reasons)
@@ -1356,7 +1453,7 @@ def main() -> int:
                   f"nothing can. Delete its line from {BASELINE.name} in the "
                   f"same commit as the deletion. (Do not go looking for its new "
                   f"caller — there isn't one.)", file=sys.stderr)
-    return 1 if (new or stale or unexplained) else 0
+    return 1 if (new or stale or unexplained or writerless) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -418,12 +418,22 @@ gen_worker.numerics_ladder.compare_outputs()
 gen_worker.numerics_ladder.declared_thresholds()
 gen_worker.request_context.JobContext.metric()
 gen_worker.request_context._PublisherMixin.materialize_blob()
-gen_worker.request_context._PublisherMixin.resolve_dataset()
 gen_worker.topology.device_group_scope
 gen_worker.topology.pin_cuda_device_for_group()
 gen_worker.warm_spans.WarmLedger
-gen_worker.wire_snapshots.index_snapshots()
 gen_worker.worker_fatal.report_worker_error_async()
+
+# pgw#1475 — TWO MORE ROWS WIRED, 2026-08-19, and they are the ELEVENTH member of
+# the pgw#1425 family: `_PublisherMixin.resolve_dataset()` (the reserved
+# `payload.datasets` contract) and `wire_snapshots.index_snapshots()` (the
+# ref-keyed snapshot view a reserved `source` materializes against) both acquired
+# a production caller in `serving/reserved_repos.py`. Both were appended by the
+# same `--write-baseline` sweep. The row this issue was actually filed on —
+# `RequestContext._set_source_path` — was NEVER on this list: private names are
+# not collected as surface at all, which is why the guard that computed the whole
+# orphan family the day `executor.py` died said nothing about the one that killed
+# 25 of 27 conversion producers. That blind spot now has its own unbaselineable
+# check (`writerless_private_setters`), and it found two more within the hour.
 
 # pgw#1425 — THIRTEEN ROWS WIRED AND TWO SENTENCED, 2026-08-18. All fifteen were
 # appended wholesale by pgw#1373's `--write-baseline` (722e30b9, +79 rows) when

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -29,6 +29,7 @@ from ..lifecycle_intents import IntentRegistry
 from ..pb import worker_scheduler_pb2 as pb
 from ..redact import sanitize as _sanitize
 from ..topology import current_device_group
+from ..wire_snapshots import resolved_repo_from_snapshot
 from . import cozy_snapshot, disk_gc, disk_telemetry, projection
 from . import residency as residency_mod
 from . import staging as staging_mod
@@ -37,11 +38,7 @@ from .config_identity import CANONICAL_JSON_MAX_BYTES, canonical_json_digest
 from .cozy_snapshot import _norm_rel_path, delete_blobs
 from .download import ensure_local, lookup_provider_for_ref
 from .errors import MissingSnapshotError, UrlExpiredError
-from .hub_client import (
-    WorkerResolvedChunk,
-    WorkerResolvedRepo,
-    WorkerResolvedRepoFile,
-)
+from .hub_client import WorkerResolvedRepo
 from .loading import safetensors_file_valid
 from .refs import WireRef
 from .residency import Residency
@@ -75,43 +72,13 @@ _DISK_GC_GRACE_S = 300.0
 # with ModelEvent emission. Single-loop, per-ref asyncio locks.
 
 def _snapshot_to_resolved(snap: pb.Snapshot) -> "WorkerResolvedRepo":
-    """pb.Snapshot -> the typed resolved-manifest struct: the ONE
-    wire-boundary conversion; everything downstream (ensure_local,
-    ensure_snapshot_async) is typed — no dict laundering."""
+    """pb.Snapshot -> the typed resolved-manifest struct.
 
-    return WorkerResolvedRepo(
-        snapshot_digest=snap.digest,
-        files=[
-            WorkerResolvedRepoFile(
-                path=f.path,
-                size_bytes=int(f.size_bytes),
-                url=f.url or None,
-                # The algorithm-tagged digest and the
-                # ordered chunk list. Dropping these here is what would make
-                # every chunked snapshot look like a whole file with no URL.
-                #
-                # DIRECT FIELD ACCESS, deliberately — not `getattr(f, "digest",
-                # "")`. These were read defensively at first, and the default
-                # turned "the generated stub does not have this field" into
-                # "the hub sent an empty value": the vendored proto WAS stale
-                # (no `digest`/`chunks` at all), so every v2 snapshot arrived
-                # blank on the production gRPC path and nothing said why. A
-                # missing field must be an AttributeError at import-adjacent
-                # code, not a silent empty string — same class as guarding a
-                # digest check on the legacy field's truthiness.
-                digest=f.digest or "",
-                chunks=tuple(
-                    WorkerResolvedChunk(
-                        sha256=(c.sha256 or "").strip().lower(),
-                        url=c.url,
-                        length=int(c.len),
-                    )
-                    for c in f.chunks
-                ),
-            )
-            for f in snap.files
-        ],
-    )
+    ONE spelling, in ``wire_snapshots`` — the v2 serve path needs the same
+    conversion for reserved repo fields (pgw#1475) and a second copy here is
+    how the two would drift.
+    """
+    return cast("WorkerResolvedRepo", resolved_repo_from_snapshot(snap))
 
 def _is_terminal_download_error(exc: BaseException) -> bool:
     if isinstance(exc, (UrlExpiredError, InsufficientDiskError, MissingSnapshotError)):

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -377,6 +377,7 @@ class RequestContext(Generic[D]):
         config generation. Read-only; a returned copy."""
         return dict(self._config)
 
+    # writerless: pgw#1475 -> owed to the config-plane cutover, expiry 2026-09-15 — the THIRD sibling the hardcut orphaned, but unlike source_path and execution_lane it cannot simply be re-wired: `@endpoint(config=[ConfigParam(...)])` is v1's declaration and `@entrypoint` declares no config at all, so there is no schema to decode `RunJob.config_params` against. Whether v2 gains a config declaration is a design call, not a repair; `subproc.py:194` still reads `_config_snapshot`, so it is not dead either.
     def _set_config(
         self,
         values: Optional[Mapping[str, Any]],

--- a/src/gen_worker/serving/entrypoints.py
+++ b/src/gen_worker/serving/entrypoints.py
@@ -345,8 +345,15 @@ def entrypoint(
     * ``NamesReservedRefs(kind) != inference`` — an inference row gets NO
       preflight resolution and NO dispatch-time read grant for the reserved
       ``source`` / ``text_encoder`` / ``destination`` / dataset-pin payload
-      fields. A ported conversion producer would reach its body with
-      ``ctx.source_path is None`` and raise on its own first line.
+      fields, so the dispatch carries no snapshot for them and
+      ``serving/reserved_repos.py`` has nothing to pin against.
+      **Do NOT read a ``ctx.source_path is None`` failure as proof that
+      ``kind=`` is wrong.** pgw#1475 is exactly that symptom with ``kind=
+      "conversion"`` correctly declared: the SDK's own materialization step
+      had been deleted with ``executor.py``, and this note sent the first
+      reader hunting for a declaration that was already right. Check
+      ``git grep -n _set_source_path -- src/`` for a WRITER before suspecting
+      the kind.
     * ``WorkerCapabilityTokenTTL`` — 1h for inference, 24h for conversion. A
       multi-hour quantization would spend its life renewing.
     * ``SizesDiskFromSource`` — true for conversion and eval only. An

--- a/src/gen_worker/serving/reserved_repos.py
+++ b/src/gen_worker/serving/reserved_repos.py
@@ -1,0 +1,235 @@
+"""The reserved-repo payload contract on the v2 serve path (pgw#1475).
+
+A producer payload may name up to four reserved REPO fields — ``source``,
+``text_encoder``, ``candidate``, ``resume_from`` — plus the write-side
+``destination`` and a ``datasets`` list. The platform materializes each named
+repo locally BEFORE the body runs and hands the body a path; the body never
+fetches. ``conversion/_common.source_from_ctx`` calls itself *"the ONE door all
+25 ``source``-taking producers enter through"*, and its first line is
+``if not ctx.source_path: raise``.
+
+**This module is the writer.** ``executor.py`` held it until pgw#1373 deleted
+that file, and the v2 rewrite carried the READERS across and not the step that
+fills them: ``RequestContext._set_source_path`` was a setter with no caller
+anywhere in ``src/``, so 25 of 27 conversion producers died on their own first
+line at 0 GPU-seconds. The two survivors are the ingest clones, which name an
+upstream URL instead of a reserved ``source`` — the population partitions
+exactly at this module's boundary.
+
+Semantics are v1's, preserved deliberately:
+
+* the path handed over is the RAW materialized snapshot directory, not a
+  tier-3 view. The projected tree's tensor containers are ``TFSSTUB1``
+  pointers, and answering them is the CONSUMER's call — ``real_source_tree``
+  (jobs#298) applies ``models.materialized_view.third_party_dir`` at the one
+  producer-side door, because only the consumer knows it is about to hand the
+  path to a ``safetensors`` reader. Projecting here would cost every producer
+  a full copy, including the ones that never read a tensor;
+* the ref is NORMALIZED where it enters (pgw#1217). It is client-supplied and
+  is then used as the ``snapshots`` lookup key, and that map is keyed in
+  normal form — taken verbatim, a non-normal spelling misses its pinned
+  snapshot and re-downloads under a second identity. ``snapshots`` is the
+  dispatch's own ref-keyed, already-typed view
+  (``wire_snapshots.resolved_repos(run.snapshots, run.models)``): the hub
+  resolves and ships reserved-repo snapshots unconditionally
+  (``ExtractReservedRepoBindingsFromPayload`` -> ``attachJobSourceSnapshots``),
+  keyed by REF for artifacts with no composition, which is exactly what a
+  payload ``source`` is. v1 passed an EMPTY map here and resolved with no
+  digest pin (th#2052); this does not;
+* an empty ``ref`` on a declared struct is a typed ``ValidationError``, never
+  a silent skip. An ABSENT field is a skip: most producers declare one or two
+  of the five.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple
+
+import msgspec
+
+from ..api.errors import ValidationError
+from ..models.cache_paths import tensorhub_cas_dir, tensorhub_fill_source_dir
+from ..models.download import ensure_local
+from ..models.refs import normalize_model_ref
+
+logger = logging.getLogger(__name__)
+
+#: The reserved repo fields the platform MATERIALIZES, each with the context
+#: setter that receives its local path. ``destination`` is deliberately absent:
+#: it is a WRITE target that need not exist yet, and fetching it would be a
+#: download of the thing the job is about to produce.
+RESERVED_REPO_FIELDS: Tuple[str, ...] = (
+    "source",
+    "text_encoder",
+    "candidate",
+    "resume_from",
+)
+
+#: Every reserved struct STAMPED onto the context as a plain dict, materialized
+#: or not. ``ctx.source`` is read beside ``ctx.source_path`` — `source_from_ctx`
+#: reads `info["ref"]` and `info["attributes"]` — so a stamp missing here is the
+#: same defect one field over.
+RESERVED_INFO_FIELDS: Tuple[str, ...] = RESERVED_REPO_FIELDS + ("destination",)
+
+_SETTER_FOR: Dict[str, str] = {
+    "source": "_set_source_path",
+    "text_encoder": "_set_text_encoder_path",
+    "candidate": "_set_candidate_path",
+    "resume_from": "_set_resume_from_path",
+}
+
+
+def reserved_repo_info(payload: Any, field_name: str) -> Dict[str, Any]:
+    """``payload.<field_name>`` as a plain dict ({} when absent).
+
+    Producer payloads carry these reserved-name structs (#376, pgw#594,
+    pgw#684, pgw#1242). The set of names is hardcoded above; pgw#690 tracks
+    making it declarative.
+    """
+    obj = getattr(payload, field_name, None)
+    if obj is None:
+        return {}
+    if isinstance(obj, dict):
+        return dict(obj)
+    try:
+        out = msgspec.to_builtins(obj)
+    except Exception:
+        return {}
+    return out if isinstance(out, dict) else {}
+
+
+def reserved_context_kwargs(payload: Any) -> Dict[str, Any]:
+    """The ``*_info`` constructor kwargs for this payload's reserved structs.
+
+    Passed to ``RequestContext`` at construction, because the mixin holding
+    them takes them as constructor arguments and the body may read
+    ``ctx.source`` without ever reading ``ctx.source_path``.
+    """
+    return {
+        f"{name}_info": reserved_repo_info(payload, name)
+        for name in RESERVED_INFO_FIELDS
+    }
+
+
+async def _materialize_one(
+    ctx: Any,
+    payload: Any,
+    field_name: str,
+    snapshots: Mapping[str, Any],
+    *,
+    hf_token: str = "",
+) -> None:
+    info = reserved_repo_info(payload, field_name)
+    if not info:
+        return
+    raw = str(info.get("ref") or "").strip()
+    if not raw:
+        raise ValidationError(
+            f"payload.{field_name}.ref must be a non-empty repo ref"
+        )
+    try:
+        ref = normalize_model_ref(raw)
+    except ValueError as exc:
+        raise ValidationError(
+            f"payload.{field_name}.ref {raw!r} is not a valid repo ref: {exc}"
+        ) from exc
+    setter: Optional[Callable[[str], None]] = getattr(
+        ctx, _SETTER_FOR[field_name], None
+    )
+    if not callable(setter):
+        raise ValidationError(
+            f"payload.{field_name} needs a producer context; this context has "
+            f"no {_SETTER_FOR[field_name]}"
+        )
+    path = await ensure_local(
+        str(ref),
+        snapshot=snapshots.get(ref),
+        cache_dir=tensorhub_cas_dir(),
+        hf_token=hf_token or None,
+        fill_source_dir=tensorhub_fill_source_dir(),
+    )
+    setter(str(path))
+    logger.info(
+        "reserved repo materialized field=%s ref=%s path=%s",
+        field_name, ref, path,
+    )
+
+
+async def _materialize_datasets(ctx: Any, payload: Any) -> None:
+    """Reserved-datasets contract (gw#425): every ``payload.datasets`` entry
+    resolved into a local dataset snapshot before the body runs. Paths land in
+    ``ctx.dataset_paths``."""
+    datasets = getattr(payload, "datasets", None)
+    if not datasets:
+        return
+    resolve = getattr(ctx, "resolve_dataset", None)
+    if not callable(resolve):
+        raise ValidationError(
+            "payload.datasets requires a producer context with resolve_dataset"
+        )
+    for entry in datasets:
+        ref = str(getattr(entry, "ref", "") or "").strip()
+        if not ref:
+            raise ValidationError("payload.datasets entries need a non-empty ref")
+        await asyncio.to_thread(resolve, ref)
+
+
+async def materialize_reserved_inputs_async(
+    ctx: Any,
+    payload: Any,
+    snapshots: Mapping[str, Any],
+    *,
+    hf_token: str = "",
+) -> None:
+    """Fill every reserved path this payload declares, then its datasets."""
+    for field_name in RESERVED_REPO_FIELDS:
+        await _materialize_one(
+            ctx, payload, field_name, snapshots, hf_token=hf_token
+        )
+        ctx.raise_if_cancelled("canceled")
+    await _materialize_datasets(ctx, payload)
+    ctx.raise_if_cancelled("canceled")
+
+
+def materialize_reserved_inputs(
+    ctx: Any,
+    payload: Any,
+    snapshots: Mapping[str, Any],
+    *,
+    hf_token: str = "",
+) -> None:
+    """The SYNCHRONOUS entry the serve loop calls.
+
+    ``ServeLoop.invoke`` runs on a worker thread (``asyncio.to_thread``) and
+    has no loop of its own, so ``asyncio.run`` here is correct rather than
+    lucky — the same reason ``invoke`` already drives an ``async def``
+    entrypoint that way. Downloading on the dispatch's event loop instead
+    would block every other job's heartbeat behind a multi-GB fetch.
+    """
+    asyncio.run(
+        materialize_reserved_inputs_async(
+            ctx, payload, snapshots, hf_token=hf_token
+        )
+    )
+
+
+def declared_reserved_fields(payload: Any) -> Tuple[str, ...]:
+    """Which reserved repo fields this payload actually names — for logs and
+    for the tests that assert the population boundary."""
+    return tuple(
+        name for name in RESERVED_REPO_FIELDS
+        if reserved_repo_info(payload, name)
+    )
+
+
+__all__ = [
+    "RESERVED_INFO_FIELDS",
+    "RESERVED_REPO_FIELDS",
+    "declared_reserved_fields",
+    "materialize_reserved_inputs",
+    "materialize_reserved_inputs_async",
+    "reserved_context_kwargs",
+    "reserved_repo_info",
+]

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -50,6 +50,10 @@ from .host import ServeDispatchError
 from .loader import LoadedEndpoint
 from .model import Model, lane_handle, model_type
 from .placement import warn_if_degraded
+from .reserved_repos import (
+    materialize_reserved_inputs,
+    reserved_context_kwargs,
+)
 from .residency import InstanceSizer, ResidencyManager
 
 logger = logging.getLogger(__name__)
@@ -185,6 +189,7 @@ class ServeLoop:
         on_loaded: Optional[Callable[[type, Any], None]] = None,
         output_dir: Optional[Path] = None,
         context_kwargs: Optional[Mapping[str, Any]] = None,
+        hf_token: str = "",
     ) -> None:
         self.loaded = loaded
         self.residency = residency
@@ -199,6 +204,10 @@ class ServeLoop:
         self._on_loaded = on_loaded
         self._output_dir = output_dir
         self._context_kwargs = dict(context_kwargs or {})
+        #: The pod's HF credential — a producer-contract fact (`ctx.hf_token`)
+        #: AND what an upstream-mirror reserved repo downloads with. Pod-wide,
+        #: never per-request: it is the machine's credential, not the caller's.
+        self._hf_token = str(hf_token or "")
         #: Live backends by residency key, so a lease hit reuses the author
         #: object instead of rebuilding it. Guarded: leases serialize per
         #: key, but two DIFFERENT keys mutate this table concurrently.
@@ -249,6 +258,7 @@ class ServeLoop:
         request_id: str,
         attempt: int = 0,
         input_assets: Sequence[InputManifestEntry] = (),
+        snapshots: Optional[Mapping[str, Any]] = None,
         context: Optional[Mapping[str, Any]] = None,
         on_context: Optional[Callable[[RequestContext[Any]], None]] = None,
     ) -> InvokeOutcome:
@@ -269,6 +279,13 @@ class ServeLoop:
         needs. pgw#1418: the v1 executor called it and the v2 rewrite did not,
         so every typed media input reached the author with ``local_path``
         unset and every asset-taking endpoint failed the request.
+
+        ``snapshots`` is the dispatch's ref-keyed resolved-repo map
+        (``wire_snapshots.resolved_repos(run.snapshots, run.models)``), which
+        the RESERVED REPO fields materialize against. pgw#1475: the same
+        hardcut deleted that step too, so ``ctx.source_path`` had a reader in
+        every conversion producer and no writer anywhere in ``src/``, and 25 of
+        27 died on their own first line at 0 GPU-seconds.
 
         ``on_context`` is handed this request's :class:`RequestContext` the
         instant it exists — the seam a caller needs to renew the capability
@@ -320,7 +337,9 @@ class ServeLoop:
             primary_binding = self._resolver.resolve(
                 model_slots[first_slot], picks[first_slot]
             )
-        ctx = self._make_context(request_id, primary_binding, spec, context)
+        ctx = self._make_context(
+            request_id, primary_binding, spec, context, payload=decoded.payload
+        )
         if on_context is not None:
             on_context(ctx)
 
@@ -346,6 +365,24 @@ class ServeLoop:
         # A PRE-handler stage: input fetch is not the author's runtime, and
         # folding it in makes every asset-taking endpoint look slow.
         ctx._stages.record_pre("input_fetch", time.monotonic() - input_fetch_t0)
+
+        # THE SAME SEAM, ONE FIELD OVER (pgw#1475). A reserved `source` /
+        # `text_encoder` / `candidate` / `resume_from` names a REPO the
+        # platform materializes before the body runs, and the body reads only
+        # `ctx.source_path`. Here, and not after the leases, for the v1 reason
+        # and one more: a weightless producer takes no lease at all, so
+        # anything placed inside the ExitStack below would never run for the
+        # 27 conversion producers this exists for.
+        source_fetch_t0 = time.monotonic()
+        materialize_reserved_inputs(
+            ctx,
+            decoded.payload,
+            snapshots or {},
+            hf_token=str(per_request.get("hf_token") or self._hf_token or ""),
+        )
+        ctx._stages.record_pre(
+            "source_fetch", time.monotonic() - source_fetch_t0
+        )
 
         with ExitStack() as leases:
             models: Dict[str, Model[Any]] = {}
@@ -394,6 +431,18 @@ class ServeLoop:
                 models[slot.name] if slot.kind == "model" else adapters[slot.name]
                 for slot in spec.slots
             ]
+            # pgw#1475, SAME FAMILY, found by the writer-less-setter fence this
+            # issue added rather than by a rented pod: `_set_execution_lane`
+            # also lost its only caller with `executor.py`, so every v2 request
+            # read the property's "bf16-w16a16+eager" DEFAULT no matter what it
+            # ran — and a body that declared `handles=[...]` branched on it.
+            # The executing lane is the PRIMARY slot's; a weightless entrypoint
+            # has none and keeps the default.
+            if spec.model_params:
+                primary_lane, primary_handle = self._lane_of(spec.model_params[0][1])
+                if primary_lane is not None:
+                    ctx._set_execution_lane(primary_handle)
+
             # The author's own span. Everything outside it — envelope decode,
             # input fetch, admission, weight load — is platform time, and
             # `handler_open`/`handler_close` are what let a slow request be
@@ -433,6 +482,7 @@ class ServeLoop:
         binding: Optional[DeployBinding],
         spec: Optional[Any] = None,
         per_request: Optional[Mapping[str, Any]] = None,
+        payload: Any = None,
     ) -> RequestContext[Any]:
         kwargs: Dict[str, Any] = dict(self._context_kwargs)
         # Per-request facts WIN over the loop's construction-time defaults:
@@ -440,6 +490,15 @@ class ServeLoop:
         kwargs.update({k: v for k, v in (per_request or {}).items() if v is not None})
         if self._output_dir is not None:
             kwargs.setdefault("local_output_dir", str(self._output_dir))
+        if self._hf_token:
+            kwargs.setdefault("hf_token", self._hf_token)
+        if payload is not None:
+            # pgw#1475: the reserved STRUCTS, stamped at construction because
+            # the mixin that holds them takes them as constructor arguments.
+            # `ctx.source` is read beside `ctx.source_path` — `source_from_ctx`
+            # builds its `Source` from `info["ref"]` and `info["attributes"]`
+            # — so a path with no info is the same defect one field over.
+            kwargs.update(reserved_context_kwargs(payload))
         if spec is not None:
             # pgw#1406: the AUTHORITY declarations, stamped from the spec onto
             # the context the body receives. This is the SDK half of "one

--- a/src/gen_worker/wire_snapshots.py
+++ b/src/gen_worker/wire_snapshots.py
@@ -29,6 +29,61 @@ class AmbiguousManifestError(ValidationError):
     message. Deterministic: no retry changes it."""
 
 
+def resolved_repo_from_snapshot(snap: Any) -> Any:
+    """``pb.Snapshot`` -> the typed ``WorkerResolvedRepo`` the download layer
+    speaks: the ONE wire-boundary conversion. Everything downstream
+    (``ensure_local``, ``ensure_snapshot_async``) is typed — no dict laundering.
+
+    DIRECT FIELD ACCESS on ``digest``/``chunks``, deliberately — not
+    ``getattr(f, "digest", "")``. These were read defensively once, and the
+    default turned "the generated stub does not have this field" into "the hub
+    sent an empty value": the vendored proto WAS stale, so every v2 snapshot
+    arrived blank on the production gRPC path and nothing said why.
+    """
+    from .models.hub_client import (
+        WorkerResolvedChunk,
+        WorkerResolvedRepo,
+        WorkerResolvedRepoFile,
+    )
+
+    return WorkerResolvedRepo(
+        snapshot_digest=snap.digest,
+        files=[
+            WorkerResolvedRepoFile(
+                path=f.path,
+                size_bytes=int(f.size_bytes),
+                url=f.url or None,
+                digest=f.digest or "",
+                chunks=tuple(
+                    WorkerResolvedChunk(
+                        sha256=(c.sha256 or "").strip().lower(),
+                        url=c.url,
+                        length=int(c.len),
+                    )
+                    for c in f.chunks
+                ),
+            )
+            for f in snap.files
+        ],
+    )
+
+
+def resolved_repos(
+    wire: Mapping[str, Any],
+    bindings: Iterable[Any] = (),
+) -> Dict[str, Any]:
+    """:func:`index_snapshots`, with every entry already converted to the
+    typed ``WorkerResolvedRepo``. The shape a materializer wants.
+
+    Keys are plain ``str`` — still canonical refs, but the serve layer holds
+    no ``WireRef`` vocabulary and a NewType key would make an invariant
+    ``Mapping`` refuse it there for no gain."""
+    return {
+        str(ref): resolved_repo_from_snapshot(snap)
+        for ref, snap in index_snapshots(wire, bindings).items()
+    }
+
+
 def index_snapshots(
     wire: Mapping[str, Any],
     bindings: Iterable[Any] = (),
@@ -65,4 +120,9 @@ def index_snapshots(
     return out
 
 
-__all__ = ["AmbiguousManifestError", "index_snapshots"]
+__all__ = [
+    "AmbiguousManifestError",
+    "index_snapshots",
+    "resolved_repo_from_snapshot",
+    "resolved_repos",
+]

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -43,6 +43,7 @@ from . import process_role
 from . import receipts
 from . import serve_posture
 from . import worker_credential
+from .api.errors import ValidationError as ApiValidationError
 from .capability_renewal import renew_capability_while_running
 from .config import Settings
 from .failure_traceback import MAX_BYTES as MAX_TRACEBACK_BYTES
@@ -73,6 +74,7 @@ from .transport import (
     Transport,
 )
 from .v1_deleted import MIGRATION, refuse_module
+from .wire_snapshots import resolved_repos
 
 logger = logging.getLogger(__name__)
 
@@ -515,6 +517,10 @@ class Worker:
                 on_loaded=(
                     self.adoption.loaded if self.adoption is not None else None
                 ),
+                # pgw#1475: the pod's HF credential — `ctx.hf_token` for the
+                # producer contract, and what an upstream-mirror reserved repo
+                # downloads with.
+                hf_token=str(getattr(settings, "hf_token", "") or ""),
             )
         except EndpointLoadError as exc:
             # A multi-lane model needs the deploy's lane pick, which no wire
@@ -967,6 +973,15 @@ class Worker:
                         # every Image/Video/AudioAsset reached the author with
                         # `local_path` unset.
                         input_assets=manifest_from_run_job(run.input_assets),
+                        # pgw#1475: the dispatch's ref-keyed snapshot map, the
+                        # pin every RESERVED repo field materializes against.
+                        # The hub ships them unconditionally
+                        # (`ExtractReservedRepoBindingsFromPayload` ->
+                        # `attachJobSourceSnapshots`) and keys an
+                        # uncomposed artifact — which a payload `source` is —
+                        # by ref. Without this the map is empty and every
+                        # tensorhub source refuses `missing_snapshot`.
+                        snapshots=resolved_repos(run.snapshots, run.models),
                         context=self._request_context_facts(run),
                         on_context=_bind_context,
                     )
@@ -990,7 +1005,16 @@ class Worker:
         # surface of a body failure, and it cost a $0.50, 455-GPU-second
         # flagship run to learn nothing but the five characters `'keys'` — the
         # exception object was in hand at this exact site the entire time.
-        except (EnvelopeError, ServeDispatchError, msgspec.ValidationError) as exc:
+        except (
+            EnvelopeError,
+            ServeDispatchError,
+            msgspec.ValidationError,
+            # pgw#1475: a reserved repo field naming an unparseable or empty
+            # ref is BAD INPUT, and retrying it costs a pod-minute to reach
+            # the same refusal. `api.errors.ValidationError` says "do not
+            # retry" in its own docstring; the wire status has to agree.
+            ApiValidationError,
+        ) as exc:
             status, message = pb.JOB_STATUS_INVALID, f"{type(exc).__name__}: {exc}"
             tb = traceback_tail(exc)
             logger.warning("job %s attempt=%d rejected: %s", *key, exc)

--- a/tests/release_fixtures/conversion_endpoint.py
+++ b/tests/release_fixtures/conversion_endpoint.py
@@ -1,0 +1,102 @@
+"""A CONVERSION producer — the pgw#1475 shape, verbatim.
+
+`cast-dtype` and 24 of its siblings enter through `conversion/_common.py`'s
+`source_from_ctx`, whose first line raises when `ctx.source_path` is falsy.
+The raise site below is that one, character for character, so a green run
+proves the PLATFORM materialized the reserved `source` and not that the check
+was removed.
+
+`ingest` is the OTHER half of the population: `clone-huggingface` names an
+upstream URL and no reserved `source`, and it SUCCEEDED on the same release
+in the same minute `cast-dtype` failed. Keeping both here means the fixture
+partitions exactly where the defect did.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+import msgspec
+
+from gen_worker import RequestContext, ValidationError, entrypoint
+
+
+class SourceRepo(msgspec.Struct, forbid_unknown_fields=True):
+    """The reserved `source` struct the hub resolves and pins."""
+
+    ref: str
+    attributes: dict[str, str] = {}
+
+
+class DestinationRepo(msgspec.Struct, forbid_unknown_fields=True):
+    repo: str = ""
+    release: str = ""
+
+
+class CastInput(msgspec.Struct, forbid_unknown_fields=True):
+    source: SourceRepo
+    dtypes: list[str] = []
+    destination: Optional[DestinationRepo] = None
+
+
+class CastOutput(msgspec.Struct):
+    source_path: str
+    source_ref: str
+    source_attributes: dict[str, str]
+    tensor_bytes: int
+    destination_repo: str
+
+
+class IngestInput(msgspec.Struct, forbid_unknown_fields=True):
+    upstream_url: str
+
+
+class IngestOutput(msgspec.Struct):
+    upstream_url: str
+    source_path_is_none: bool
+
+
+def _source_from_ctx(ctx: Any) -> tuple[Path, dict[str, Any]]:
+    """`conversion/_common.source_from_ctx`, carried over unchanged — THE
+    raise site the production failure came from, and the door all 25
+    `source`-taking producers enter through."""
+    if not ctx.source_path:
+        raise ValidationError(
+            "this function requires the reserved `source` payload field; "
+            "the worker materializes it and populates ctx.source_path"
+        )
+    return Path(ctx.source_path), ctx.source or {}
+
+
+@entrypoint(kind="conversion", publishes=True)
+def cast_dtype(ctx: RequestContext, payload: CastInput) -> CastOutput:
+    path, info = _source_from_ctx(ctx)
+    # jobs#298's half: the materialized tree is PROJECTED — every
+    # `*.safetensors` in it is a ~128 B `TFSSTUB1` pointer — and the producer
+    # asks tier 3 for real bytes because it is about to hand the path to a
+    # safetensors reader. The platform hands over the RAW tree; this call is
+    # the consumer's, and it must still work on what the platform handed over.
+    from gen_worker.models.materialized_view import third_party_dir
+
+    real = Path(third_party_dir(path, why="pgw#1475 fixture reads tensors"))
+    total = sum(
+        p.stat().st_size for p in real.rglob("*")
+        if p.is_file() and p.suffix == ".safetensors"
+    )
+    return CastOutput(
+        source_path=str(path),
+        source_ref=str(info.get("ref") or ""),
+        source_attributes=dict(info.get("attributes") or {}),
+        tensor_bytes=total,
+        destination_repo=str((ctx.destination or {}).get("repo") or ""),
+    )
+
+
+@entrypoint(kind="conversion", publishes=True)
+def ingest(ctx: RequestContext, payload: IngestInput) -> IngestOutput:
+    """The `clone-huggingface` shape: no reserved `source` at all."""
+    return IngestOutput(
+        upstream_url=payload.upstream_url,
+        source_path_is_none=ctx.source_path is None,
+    )

--- a/tests/test_producer_declarations.py
+++ b/tests/test_producer_declarations.py
@@ -322,6 +322,11 @@ def test_the_serve_loop_stamps_the_declaration(producers: ModuleType) -> None:
     host = object.__new__(ServeLoop)
     host._context_kwargs = {}
     host._output_dir = None
+    # pgw#1475: this hand-built host must state every field `_make_context`
+    # reads. Left absent it is an AttributeError, which is the right answer —
+    # a `getattr(..., "")` default in production would turn "this loop was
+    # never given the pod's HF credential" into "the pod has none".
+    host._hf_token = ""
 
     producer = host._make_context("r1", None, spec(producers.cast_dtype))
     assert producer.publishes is True

--- a/tests/test_reserved_repo_contract.py
+++ b/tests/test_reserved_repo_contract.py
@@ -1,4 +1,6 @@
-"""The reserved-repo materialization the hardcut deleted (pgw#1475).
+"""The reserved-repo payload contract: `source`, its three siblings, datasets.
+
+# pgw#1475: the v2 serve path had no writer for `ctx.source_path`.
 
 `executor.py` held `_materialize_reserved_repo`, whose last line was
 `(set_path or ctx._set_source_path)(str(path))`. pgw#1373 deleted the file and

--- a/tests/test_reserved_repo_wires_pgw1475.py
+++ b/tests/test_reserved_repo_wires_pgw1475.py
@@ -1,0 +1,320 @@
+"""The reserved-repo materialization the hardcut deleted (pgw#1475).
+
+`executor.py` held `_materialize_reserved_repo`, whose last line was
+`(set_path or ctx._set_source_path)(str(path))`. pgw#1373 deleted the file and
+the v2 rewrite carried the READERS across without it, so
+`RequestContext._set_source_path` was a setter with no caller anywhere in
+`src/` — and 25 of 27 conversion producers died on their own first line at 0
+GPU-seconds, on a release whose hub half was completely correct.
+
+Every arm here drives the WIRE through `ServeLoop.invoke`, with a REAL
+projected snapshot published by the production chokepoint
+(`ensure_snapshot_async`) into a real CAS. Nothing about the materialization
+is faked: the tree the body reads is the tree a pod gets, stubs and all.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+import projection_fixture as fixture
+from gen_worker._vendor.tensorfs import LocalCAS
+from gen_worker.api.errors import ValidationError
+from gen_worker.models import projection
+from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+from gen_worker.models.refs import normalize_model_ref
+from gen_worker.serving.loader import load_endpoint_module
+from gen_worker.serving.residency import ResidencyManager
+from gen_worker.serving.serve_loop import ServeLoop
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+MODULE = "conversion_endpoint"
+
+#: The payload's ref, in the NON-NORMAL spelling a client may send. The
+#: snapshot map is keyed in normal form, so an arm that skipped normalization
+#: would miss its pin and fall through to `missing_snapshot` (pgw#1217).
+RAW_REF = "tensorhub/e2e1890-minilm-l6-v2@v1"
+
+#: Big enough that ~128 B stubs are noise against it.
+_SHARD_BYTES = 1 << 18
+
+
+class _NeverResolver:
+    def resolve(self, model_cls: type, checkpoint_ref: str) -> Any:
+        raise AssertionError("a weightless producer resolved a binding")
+
+    def default_pick(self, model_cls: type, slot_name: str) -> str:
+        raise AssertionError("a weightless producer asked for a default pick")
+
+
+class _NeverSizer:
+    def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        raise AssertionError("a weightless producer sized a residency slot")
+
+    def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        raise AssertionError("a weightless producer reserved activation bytes")
+
+
+@pytest.fixture(autouse=True)
+def _module_path() -> Iterator[None]:
+    import sys
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        yield
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+
+def _loop() -> ServeLoop:
+    return ServeLoop(
+        load_endpoint_module(MODULE),
+        residency=ResidencyManager(1 << 30, _NeverSizer()),
+        resolver=_NeverResolver(),
+    )
+
+
+def _write_model(source: Path) -> None:
+    """A sentence-transformers-shaped tree: config, tokenizer, one shard."""
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "config.json").write_text(json.dumps({"model_type": "bert"}))
+    (source / "tokenizer_config.json").write_text(json.dumps({"model_max_length": 512}))
+    (source / "model.safetensors").write_bytes(
+        fixture.safetensors_bytes(
+            {"encoder.weight": ("F32", (_SHARD_BYTES // 4,),
+                                fixture.varied(_SHARD_BYTES, 13))}
+        )
+    )
+
+
+@pytest.fixture()
+def cas(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[WorkerResolvedRepo]:
+    """The pod's CAS, with every file of the source model resident in it, and
+    the resolved manifest the hub would have shipped on `RunJob.snapshots`."""
+    source = tmp_path / "source-model"
+    _write_model(source)
+    root = tmp_path / "tensorhub-cache"
+    (root / "cas").mkdir(parents=True)
+    # The production knob, through the production loader — not a patched
+    # function. `TENSORHUB_CACHE_DIR` is the ONE place the CAS root comes from,
+    # and `reserved_repos` reads it the way every other pod caller does.
+    from gen_worker.config import process as config_process
+
+    monkeypatch.setenv("TENSORHUB_CACHE_DIR", str(root))
+    config_process.reload_for_test()
+
+    store = LocalCAS(root / "cas")
+    files: list[WorkerResolvedRepoFile] = []
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        body = path.read_bytes()
+        files.append(
+            WorkerResolvedRepoFile(
+                path.relative_to(source).as_posix(),
+                len(body),
+                # Resident already: a fetch here would be the transfer layer's
+                # subject, not this file's. An attempted fetch fails loudly.
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(store.put_bytes(body)),
+            )
+        )
+    try:
+        yield WorkerResolvedRepo(snapshot_digest="sha256:" + "a" * 64, files=files)
+    finally:
+        config_process.reset_for_test()
+
+
+def _snapshots(resolved: WorkerResolvedRepo) -> dict[str, WorkerResolvedRepo]:
+    """The ref-keyed map `worker.py` builds from the dispatch. Keyed in NORMAL
+    form, which is what the hub does and what makes the normalization in
+    `reserved_repos` load-bearing."""
+    return {normalize_model_ref(RAW_REF): resolved}
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        "input": {
+            "source": {"ref": RAW_REF, "attributes": {"family": "bert"}},
+            "dtypes": ["bf16"],
+            "destination": {"repo": "acme/out", "release": "v1"},
+        }
+    }
+
+
+# -- the regression ---------------------------------------------------------
+
+
+def test_the_serve_path_materializes_the_reserved_source(
+    cas: WorkerResolvedRepo,
+) -> None:
+    """THE regression, in the shape it was measured.
+
+    `cast-dtype` failed at 0 GPU-seconds and 0 uUSD on release 0.12.21 with
+    exactly the message the fixture's raise site carries. This passes only if
+    the PLATFORM filled `ctx.source_path` before the body ran.
+    """
+    outcome = _loop().invoke(
+        "cast_dtype",
+        _payload(),
+        request_id="pgw1475-drive",
+        attempt=1,
+        snapshots=_snapshots(cas),
+    )
+    tree = Path(outcome.result.source_path)
+    assert tree.is_dir()
+    # RAW, not projected: `real_source_tree` (jobs#298) is the CONSUMER's call
+    # and it needs a projected tree to answer. A platform that handed over a
+    # tier-3 view would cost every producer a full copy of the source,
+    # including the ones that never read a tensor.
+    assert projection.resolve_projection(tree) is not None
+    assert projection.stub_at(tree / "model.safetensors") is not None
+    # And the producer's own tier-3 call still turns it into real bytes.
+    assert outcome.result.tensor_bytes >= _SHARD_BYTES
+
+
+def test_the_reserved_info_struct_is_stamped_beside_the_path(
+    cas: WorkerResolvedRepo,
+) -> None:
+    """`source_from_ctx` builds its `Source` from `ctx.source` as well as
+    `ctx.source_path` — `info["ref"]` and `info["attributes"]`. A path with no
+    info is the same defect one field over, and it was writer-less too."""
+    outcome = _loop().invoke(
+        "cast_dtype", _payload(), request_id="pgw1475-info", attempt=1,
+        snapshots=_snapshots(cas),
+    )
+    assert outcome.result.source_ref == RAW_REF
+    assert outcome.result.source_attributes == {"family": "bert"}
+    # `ctx.destination` is a READ-ONLY stamp: the write ROUTE is unchanged.
+    assert outcome.result.destination_repo == "acme/out"
+
+
+def test_the_regression_itself_without_the_wire(
+    cas: WorkerResolvedRepo, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RED-PROOF: remove the call the fix added and the measured failure comes
+    back VERBATIM — the message from the standing-stack A/B, character for
+    character. Without this, a green suite proves only that the fixture is
+    easy to satisfy."""
+    from gen_worker.serving import serve_loop as loop_mod
+
+    monkeypatch.setattr(
+        loop_mod, "materialize_reserved_inputs", lambda *a, **kw: None
+    )
+    with pytest.raises(
+        ValidationError,
+        match=r"this function requires the reserved `source` payload field",
+    ):
+        _loop().invoke(
+            "cast_dtype", _payload(), request_id="pgw1475-red", attempt=1,
+            snapshots=_snapshots(cas),
+        )
+
+
+def test_the_survivor_arm_is_unaffected_either_way(
+    cas: WorkerResolvedRepo, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The population boundary, asserted rather than asserted-about.
+
+    `clone-huggingface` names no reserved `source` and SUCCEEDED on the broken
+    release in the same minute `cast-dtype` failed. So the fixture's `ingest`
+    must pass with the wire AND without it — if it did not, this test file
+    would be measuring something other than the defect.
+    """
+    payload = {"input": {"upstream_url": "https://hf.co/acme/model"}}
+    with_wire = _loop().invoke(
+        "ingest", payload, request_id="pgw1475-clone", attempt=1,
+        snapshots=_snapshots(cas),
+    )
+    assert with_wire.result.source_path_is_none is True
+
+    from gen_worker.serving import serve_loop as loop_mod
+
+    monkeypatch.setattr(
+        loop_mod, "materialize_reserved_inputs", lambda *a, **kw: None
+    )
+    without = _loop().invoke(
+        "ingest", payload, request_id="pgw1475-clone-red", attempt=1,
+        snapshots=_snapshots(cas),
+    )
+    assert without.result.source_path_is_none is True
+
+
+# -- the refusals -----------------------------------------------------------
+
+
+def test_an_empty_ref_on_a_declared_struct_REFUSES(
+    cas: WorkerResolvedRepo,
+) -> None:
+    """Never a silent skip: an empty `ref` on a struct the payload DECLARED is
+    the caller's error, and a skip would hand the body `None` and reproduce
+    the very failure this issue is about, one layer down."""
+    payload = _payload()
+    payload["input"]["source"]["ref"] = "   "
+    with pytest.raises(ValidationError, match=r"payload\.source\.ref must be"):
+        _loop().invoke(
+            "cast_dtype", payload, request_id="pgw1475-empty", attempt=1,
+            snapshots=_snapshots(cas),
+        )
+
+
+def test_an_unpinned_tensorhub_ref_REFUSES_typed(
+    cas: WorkerResolvedRepo,
+) -> None:
+    """The dispatch shipping no snapshot for a tensorhub ref is a
+    deterministic local condition, and the download layer says so by name
+    rather than burning retries on it."""
+    from gen_worker.models.errors import MissingSnapshotError
+
+    with pytest.raises(MissingSnapshotError, match="needs an orchestrator"):
+        _loop().invoke(
+            "cast_dtype", _payload(), request_id="pgw1475-unpinned", attempt=1,
+            snapshots={},
+        )
+
+
+# -- the fence --------------------------------------------------------------
+
+
+def test_the_fence_finds_a_writer_less_setter() -> None:
+    """The guard that should have caught this, proven able to go red.
+
+    `lint_unreached_surface` SKIPS every `_`-prefixed name, so
+    `_set_source_path` was never a candidate and the sweep that computed the
+    whole orphan family the day `executor.py` died said nothing about the one
+    that killed 25 producers. The new check has no baseline file, deliberately
+    — but a check that cannot go red is worse than no check, so drive it.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "pgw1475_lint",
+        Path(__file__).resolve().parents[1] / "scripts"
+        / "lint_unreached_surface.py",
+    )
+    assert spec is not None and spec.loader is not None
+    lint = importlib.util.module_from_spec(spec)
+    import sys
+
+    sys.modules[spec.name] = lint
+    try:
+        spec.loader.exec_module(lint)
+    finally:
+        sys.modules.pop(spec.name, None)
+
+    # GREEN on the shipped tree: every `_set_*` in src/ has a writer or an
+    # inline, owned reason.
+    assert lint.writerless_private_setters() == []
+
+    # RED when a setter has no caller — the pgw#1475 condition, synthesized.
+    lines = ["    def _set_totally_unwired(self, v: str) -> None:", "        pass"]
+    assert lint._writerless_marker(lines, 1) is None
+    assert lint._writerless_marker(
+        ["    # writerless: pgw#1 — because", *lines], 2
+    ) == "pgw#1 — because"


### PR DESCRIPTION
Fixes the P0 measured by the jobs#299 lane on the standing `master` stack: conversion **0.12.21** (`@entrypoint`-ported, hub half fully correct) failed `cast-dtype` at **0 GPU-s / 0 uUSD** while `clone-huggingface` — which names no reserved `source` — **succeeded** in the same minute. The acceptance pair partitions the population exactly at the defect boundary.

## Root cause

`executor.py` held `_materialize_reserved_repo`, whose last line was

```python
path = await self.store.ensure_local(ref, snapshots.get(ref))
(set_path or ctx._set_source_path)(str(path))
```

pgw#1373 deleted the file. The v2 rewrite carried the READERS across and not the step that fills them, so `RequestContext._set_source_path` had **no caller anywhere in `src/`** and `ctx.source_path` answered `None` forever. `conversion/_common.source_from_ctx` calls itself *"the ONE door all 25 `source`-taking producers enter through"*, and its first line raises on exactly that.

**This is the ELEVENTH member of the pgw#1425 orphaned-wire family**, and the same shape: a hardcut orphaned a serve-path call and the guard did not say so.

## The wiring

`src/gen_worker/serving/reserved_repos.py` — `source` / `text_encoder` / `candidate` / `resume_from` plus `payload.datasets`, called from `ServeLoop.invoke` at the **payload seam**, after `materialize_input_assets` and **before the residency leases**. Not after: a weightless producer takes no lease at all, so anything inside the `ExitStack` would never run for the 27 producers this exists for.

v1 semantics preserved deliberately:

* the path handed over is the **RAW** materialized snapshot dir, not a tier-3 view. Answering the projected tree's `TFSSTUB1` pointers is the CONSUMER's call (`real_source_tree`, jobs#298) because only it knows it is about to hand the path to a `safetensors` reader — projecting here would cost a full copy to every producer that never reads a tensor;
* the ref is **normalized where it enters** (pgw#1217): it is the `snapshots` lookup key and that map is keyed in normal form;
* an empty `ref` on a DECLARED struct refuses typed; an ABSENT field is skipped;
* the reserved **structs** are stamped at construction — `source_from_ctx` reads `ctx.source["ref"]`/`["attributes"]` beside the path.

The pin is real: `wire_snapshots.resolved_repos(run.snapshots, run.models)`. v1 passed an EMPTY map here and resolved with no digest (th#2052); this does not. `index_snapshots` and `_PublisherMixin.resolve_dataset` both **leave the ratchet** by acquiring a production caller.

## The guard's blind spot, closed

pgw#1425 computed the whole orphan family the day `executor.py` died and said nothing about the one that killed 25 producers: `lint_unreached_surface` skips every `_`-prefixed name, so a private setter whose public reader IS the contract was never a candidate. `writerless_private_setters` closes it, with **no baseline file** — its only escape valve is an inline `# writerless: <owner> — <reason>` beside the code, which cannot be bulk-regenerated (the pgw#1425 failure mode).

It found two more siblings within the hour:

| sibling | disposition |
|---|---|
| `_set_execution_lane` | **WIRED** — every v2 request reported the property's `bf16-w16a16+eager` default whatever it ran, and a `handles=[...]` body branched on it |
| `_set_config` | **MARKED with its ruling** — `@entrypoint` declares no config, so there is no schema to decode `RunJob.config_params` against. A design call, not a repair; `subproc.py:194` still reads `_config_snapshot`, so it is not dead either |

## Also

* a reserved-field `ValidationError` is now **INVALID**, not FATAL — retrying an unparseable ref costs a pod-minute to reach the same refusal;
* `serving/entrypoints.py:347-349` no longer attributes this symptom solely to a missing `kind=`. That note sent the first reader hunting for a declaration that was already right.

## Verification

`tests/test_reserved_repo_wires_pgw1475.py` — **7 passed**. A real `@entrypoint(kind="conversion")` body keeping `source_from_ctx`'s raise site verbatim, over a REAL projected snapshot published by the production chokepoint (`ensure_snapshot_async`) into a real CAS, reached through the real `TENSORHUB_CACHE_DIR` loader — no patched seam. The **RED-PROOF** stubs the added call back out and gets the measured message character for character. The `clone-huggingface`-shaped arm passes **with the wire and without it**, which is what makes the file measure the defect rather than the fixture.

No regressions: `test_serve_path_wires_pgw1425` + `test_serve_loop_envelope` + `test_endpoint_discovery` + `test_weightless_entrypoints` + this suite = **48 passed, 2 failed**, and those 2 are exactly master's standing pair (`…_with_fake_tensors`, and `tensorfs.contracts` pending tensorfs#111). `ruff` clean. `mypy` shows master's own two rows in the locked env, neither in a file this diff touches. The `lint_unreached_surface` gate carries 4 pre-existing `trace_context` rows from master (which had 5) — none of them this lane's.