### PR TITLE
pgw#1472 (local half): the env identity had two producers, so a locally derived document was adoptable by nothing

### DIFF
--- a/changelog.d/pgw1472.md
+++ b/changelog.d/pgw1472.md
@@ -1,0 +1,35 @@
+- **The env-identity closure had two producers and no single meaning, so a locally derived document
+  was adoptable by nothing — including the local serve it exists for.** `gen-worker lock` stamps the
+  endpoint's `uv.lock`; a serving process restated `importlib.metadata`. Those are incomparable by
+  construction, for three independent reasons measured against `sd15/uv.lock` and its own venv: PEP
+  503 name spelling (**10 packages** on that one endpoint agree only after normalization), the PEP
+  440 local version segment (`torch 2.13.0` in a lock vs `2.13.0+cu129` installed — a lock cannot
+  state it and an installed CUDA wheel always has one), and platform-conditional lock entries
+  (`colorama` will never install on Linux). `assert_exact_env` then demanded exact equality.
+
+- **`gen_worker.env_identity` is now the ONE definition**, and `release/derive.py` reads it rather
+  than carrying its own. Proven byte-stable across the move: sd15's document closure still hashes to
+  `40471a90…`, so no document ever stamped is rekeyed.
+
+- **`python -m gen_worker.serving` states this boot's identity from the endpoint's own `uv.lock`** —
+  the same file `gen-worker lock` hashed — so the two ends finally name one source. `--env-lockfile`
+  overrides it and `--env-lockfile=-` forces the installed set, which is what a release-image derive
+  stamps and therefore the right answer on a pod. **Production is deliberately untouched**: the
+  builder passes no `--lockfile`, so the fleet is installed-at-both-ends today and landing the
+  worker half alone would break it. That migration is sequenced separately.
+
+- **installed-vs-lock is a typed DRIFT SIGNAL, never the gate.** Normalized on both sides so it
+  reports real divergence instead of spelling — a signal that fires on `PyYAML` vs `pyyaml` is
+  measuring itself. Printed at boot with a count before the examples.
+
+- **A permanent adoption refusal is now a countable STATE.** `sink_for` swallows every failure into
+  eager-forever, which is right as a boot policy and wrong as an observability one: an unconditional
+  refusal is indistinguishable from a correct one, and that is exactly how this defect could have
+  made every boot eager while looking healthy. `PERMANENT_REFUSALS` names the set in code (a fence
+  asserts every member is actually emitted), `ServeAdoption.refusal_permanent` is readable off the
+  object, and the count remains `phase IN PERMANENT_REFUSALS` on the existing typed wire field —
+  no new proto field is invented by a serving module.
+
+- **Measured end to end on this box's 4070**, through the real CLI with no harness:
+  `adopt: env identity stated from sd15/uv.lock (87 packages)`, `14 adopted, 0 holes`, and an image
+  whose sha256 is byte-identical to the one the compiled proof produced earlier.

--- a/src/gen_worker/env_identity.py
+++ b/src/gen_worker/env_identity.py
@@ -1,0 +1,195 @@
+"""ONE definition of "what environment is this", for both ends (pgw#1472).
+
+A release document's `closure` is a hash of a package set, and the serving side
+must be able to RESTATE it or adoption refuses. So the two ends have to name
+the same set with the same spelling — and until this module existed they did
+not:
+
+* `gen-worker lock` stamps the endpoint's `uv.lock` (`release/derive.py`);
+* a serving process restates `importlib.metadata` (`installed_closure()`).
+
+Those are incomparable, and not by a little. Measured against
+`serverless-endpoints/sd15/uv.lock` and its own venv, THREE independent reasons
+they can never be equal:
+
+1. **Name spelling.** uv normalizes to PEP 503; `importlib.metadata` reports the
+   DECLARED name. Ten packages on that one endpoint agree only after
+   normalization: `pyyaml`/`PyYAML`, `huggingface-hub`/`huggingface_hub`,
+   `typing-extensions`/`typing_extensions`, and seven more.
+2. **The local version segment.** A lock says `torch = "2.13.0"`; every
+   installed CUDA wheel says `2.13.0+cu129`. A lock cannot state it and an
+   installed distribution always has one.
+3. **Platform-conditional entries.** `colorama` is in that lock and will never
+   install on Linux — a lock enumerates the resolution for every marker, an
+   install enumerates one platform.
+
+**Ruled (2026-08-19): the LOCKFILE is the identity at both ends.** The
+weights-free derive can only ever state the lock, and the lock is the one
+artifact mint and serve pods share by construction. This module is that single
+source, so a second copy cannot drift from it.
+
+**And the comparison installed-vs-lock is a DRIFT SIGNAL, never a gate.** It is
+normalized on both sides precisely so it reports real divergence instead of
+spelling — a signal that fires on `PyYAML` vs `pyyaml` is measuring itself.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+#: What `uv` writes beside a project, and therefore what `gen-worker lock`
+#: hashed. Named once so the CLI and the serve runner cannot disagree.
+LOCKFILE_NAME = "uv.lock"
+
+_SEPARATORS = re.compile(r"[-_.]+")
+
+
+class EnvIdentityError(ValueError):
+    """A lockfile cannot be read, or states no resolved packages."""
+
+
+def normalize_name(name: str) -> str:
+    """The PEP 503 normalized distribution name.
+
+    `PyYAML`, `pyyaml` and `Py.YAML` are ONE distribution. Comparing them raw
+    is not strictness, it is a bug with no upside — it makes a drift report
+    fire on ten packages that are identical.
+    """
+
+    return _SEPARATORS.sub("-", str(name)).lower()
+
+
+def normalize_version(version: str) -> str:
+    """The version without its PEP 440 LOCAL segment (`2.13.0+cu129` ->
+    `2.13.0`).
+
+    Stripping it is a real loss and it is stated rather than hidden: `+cu129`
+    against `+cu130` is exactly the kind of difference a compiled artifact
+    cares about. But a lockfile CANNOT express it — uv records the version and
+    the wheel URL separately — so a comparison that keeps it can only ever
+    report a difference that is not one. The local segment is recoverable from
+    the artifact's own requirements manifest, which is where the compiled side
+    checks it.
+    """
+
+    return str(version).split("+", 1)[0]
+
+
+def closure_entries_from_lockfile(lockfile: Path | str) -> dict[str, str]:
+    """`{name: version}` for every package a `uv.lock` resolves.
+
+    Verbatim names and versions: this is the hashed identity, so normalization
+    must NOT happen here — it would change every closure hash ever stamped.
+    Normalization belongs to the DRIFT comparison, which is not an identity.
+    """
+
+    path = Path(lockfile)
+    try:
+        parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise EnvIdentityError(f"cannot read lockfile {path}: {exc}") from exc
+    entries: dict[str, str] = {}
+    for package in parsed.get("package", ()):
+        name = package.get("name")
+        version = package.get("version")
+        if not isinstance(name, str) or not isinstance(version, str):
+            continue
+        known = entries.get(name)
+        if known is not None and known != version:
+            raise EnvIdentityError(
+                f"lockfile {path} resolves {name!r} to both {known!r} and "
+                f"{version!r}; a release env has ONE resolved closure"
+            )
+        entries[name] = version
+    if not entries:
+        raise EnvIdentityError(f"lockfile {path} states no resolved packages")
+    return entries
+
+
+def lockfile_beside(endpoint_dir: Path | str) -> Path | None:
+    """The endpoint's own `uv.lock`, or `None` — never a guess elsewhere.
+
+    This is the SAME file `gen-worker lock` hashes for the document it writes,
+    which is the whole point: a locally derived document and a local serve now
+    read one file rather than two sources.
+    """
+
+    candidate = Path(endpoint_dir) / LOCKFILE_NAME
+    return candidate if candidate.is_file() else None
+
+
+@dataclass(frozen=True, slots=True)
+class DriftRow:
+    """One package on which the installed set and the stated closure differ."""
+
+    name: str
+    #: ``missing`` (stated, not installed), ``extra`` (installed, not stated),
+    #: ``version`` (both, different versions). A closed vocabulary.
+    kind: str
+    stated: str = ""
+    installed: str = ""
+
+    def __str__(self) -> str:  # pragma: no cover - diagnostics
+        if self.kind == "version":
+            return f"{self.name} {self.stated} != {self.installed}"
+        if self.kind == "missing":
+            return f"{self.name} {self.stated} stated, not installed"
+        return f"{self.name} {self.installed} installed, not stated"
+
+
+def closure_drift(
+    installed: Mapping[str, str], stated: Mapping[str, str]
+) -> tuple[DriftRow, ...]:
+    """How far the running env is from the one the release states.
+
+    NORMALIZED on both sides, so every row is a real divergence. Sorted by name
+    so two runs of the same pair produce the same report.
+    """
+
+    live = {normalize_name(n): normalize_version(v) for n, v in installed.items()}
+    want = {normalize_name(n): normalize_version(v) for n, v in stated.items()}
+    rows: list[DriftRow] = []
+    for name in sorted(set(want) - set(live)):
+        rows.append(DriftRow(name, "missing", stated=want[name]))
+    for name in sorted(set(live) - set(want)):
+        rows.append(DriftRow(name, "extra", installed=live[name]))
+    for name in sorted(set(live) & set(want)):
+        if live[name] != want[name]:
+            rows.append(
+                DriftRow(name, "version", stated=want[name], installed=live[name])
+            )
+    return tuple(rows)
+
+
+def describe_drift(rows: tuple[DriftRow, ...], *, limit: int = 8) -> str:
+    """A one-line drift summary. ``""`` when the sets agree.
+
+    Deliberately says the COUNT before the examples: a report that shows six
+    rows out of sixty reads as "six problems".
+    """
+
+    if not rows:
+        return ""
+    counts = {kind: sum(1 for r in rows if r.kind == kind)
+              for kind in ("missing", "extra", "version")}
+    head = ", ".join(f"{n} {k}" for k, n in counts.items() if n)
+    shown = "; ".join(str(row) for row in rows[:limit])
+    more = f" (+{len(rows) - limit} more)" if len(rows) > limit else ""
+    return f"{len(rows)} package(s) differ ({head}): {shown}{more}"
+
+
+__all__ = [
+    "LOCKFILE_NAME",
+    "DriftRow",
+    "EnvIdentityError",
+    "closure_drift",
+    "closure_entries_from_lockfile",
+    "describe_drift",
+    "lockfile_beside",
+    "normalize_name",
+    "normalize_version",
+]

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -906,28 +906,20 @@ def _unique_component(instance: Any, name: str, component: Any) -> bool:
 
 
 def _closure_entries_from_lockfile(lockfile: Path) -> dict[str, str]:
-    import tomllib
+    """The lockfile closure, from the ONE definition (pgw#1472).
+
+    Kept as a name here because callers and fences reference it, but the body
+    moved to :mod:`gen_worker.env_identity`: the SERVING side has to restate
+    this exact set or adoption refuses, and a second implementation of "what
+    packages are we" is precisely how the two ends came to disagree.
+    """
+
+    from ..env_identity import EnvIdentityError, closure_entries_from_lockfile
 
     try:
-        parsed = tomllib.loads(lockfile.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as exc:
-        raise DeriveError(f"cannot read lockfile {lockfile}: {exc}") from exc
-    entries: dict[str, str] = {}
-    for package in parsed.get("package", ()):
-        name = package.get("name")
-        version = package.get("version")
-        if not isinstance(name, str) or not isinstance(version, str):
-            continue
-        known = entries.get(name)
-        if known is not None and known != version:
-            raise DeriveError(
-                f"lockfile {lockfile} resolves {name!r} to both {known!r} and "
-                f"{version!r}; a release env has ONE resolved closure"
-            )
-        entries[name] = version
-    if not entries:
-        raise DeriveError(f"lockfile {lockfile} states no resolved packages")
-    return entries
+        return closure_entries_from_lockfile(lockfile)
+    except EnvIdentityError as exc:
+        raise DeriveError(str(exc)) from exc
 
 
 def _defaults_schema(model_type: Optional[type]) -> Optional[dict[str, Any]]:

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -29,7 +29,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
 import msgspec
 
@@ -142,6 +142,13 @@ def _parser() -> argparse.ArgumentParser:
                              "broker — the PRODUCTION path, allowlisted as "
                              "`release.compiled_graphs`")
     parser.add_argument("--sm", default="", help="this GPU's sm (e.g. sm_89)")
+    parser.add_argument(
+        "--env-lockfile", default="",
+        help="uv.lock stating this boot's env identity (pgw#1472). Default: "
+             "the endpoint's own uv.lock when it has one, which is the SAME "
+             "file `gen-worker lock` hashed into the document being adopted. "
+             "`--env-lockfile=-` forces the installed distribution set "
+             "instead, which is what a release-image derive stamps.")
     parser.add_argument("--artifacts-dir", default=".compiled-graphs")
     parser.add_argument("--mint", action="store_true",
                         help="after boot, fill this (lane x sm)'s holes "
@@ -248,6 +255,60 @@ def _toolchain() -> Mapping[str, str]:
     return dict(toolchain_digest())
 
 
+def _stated_env(
+    args: argparse.Namespace, document: Any
+) -> "Optional[Mapping[str, str]]":
+    """This boot's env identity, from the SAME source the document was stamped
+    from (pgw#1472).
+
+    `gen-worker lock` hashes the endpoint's `uv.lock`; a serving process
+    otherwise restates `importlib.metadata`, and the two are incomparable by
+    construction (PEP 503 spelling, PEP 440 local segments, platform-conditional
+    lock entries). So a locally derived document was adoptable by NOTHING —
+    including the local serve it exists for. Reading the endpoint's own lock
+    here is what makes `gen-worker lock` and this runner agree.
+
+    `None` means "no lock offered": the adopt session falls back to the
+    installed set, which is what a release-image derive stamps and therefore
+    the right answer on a pod.
+
+    The comparison between the two is a DRIFT REPORT and never a gate — it is
+    printed, normalized, and then ignored.
+    """
+    if document is None:
+        return None
+    from ..env_identity import (
+        EnvIdentityError,
+        closure_drift,
+        closure_entries_from_lockfile,
+        describe_drift,
+        lockfile_beside,
+    )
+
+    given = str(args.env_lockfile or "").strip()
+    if given == "-":
+        return None  # the operator asked for the installed set, explicitly
+    lockfile = Path(given) if given else lockfile_beside(args.endpoint_dir)
+    if lockfile is None:
+        return None
+    try:
+        stated = closure_entries_from_lockfile(lockfile)
+    except EnvIdentityError as exc:
+        raise SystemExit(f"--env-lockfile: {exc}")
+
+    from .._vendor.torchcg.graph_identity import installed_closure
+
+    drift = closure_drift(installed_closure(), stated)
+    summary = describe_drift(drift)
+    print(
+        f"adopt: env identity stated from {lockfile} "
+        f"({len(stated)} packages); installed-vs-lock drift: "
+        f"{summary or 'none'}",
+        file=sys.stderr,
+    )
+    return stated
+
+
 def _serve_envelopes(args: argparse.Namespace, loaded: Any) -> int:
     """Envelope mode: the production dispatch loop, locally — the
     signature-derived envelope through ServeLoop with residency leases
@@ -321,6 +382,7 @@ def main(argv: list[str] | None = None) -> int:
         loaded, binding, lane_contract=args.lane, output_dir=Path(args.output_dir)
     )
     store, document = _adoption_source(args, loaded.module_name)
+    installed = _stated_env(args, document)
     # No `loader=`: pgw#1460. The byte-identical raw `aoti_load_package` that
     # used to sit here discarded the record and armed a WEIGHTLESS package with
     # an empty constant buffer. `torchcg.serve.aoti_loader` (tcg#58) is the
@@ -329,6 +391,7 @@ def main(argv: list[str] | None = None) -> int:
     host.setup(
         store=store, document=document, sm=args.sm,
         artifacts_dir=Path(args.artifacts_dir),
+        installed=installed,
     )
     if host.adoption is not None:
         report: dict[str, Any] = {

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -46,6 +46,19 @@ logger = logging.getLogger(__name__)
 #: exact shape that made this gap invisible for as long as it existed.
 KIND_ADOPT_REFUSED = "adopt_refused"
 
+#: The refusal phases that will NEVER fix themselves on this pod (pgw#1472).
+#: A refusal that is unconditional is indistinguishable from one that is
+#: correct — both read as "serving eager" — and that is how an env-identity
+#: mismatch could have made every pod eager forever while looking healthy. So
+#: the distinction is CARRIED, not inferred later from a log: `permanent`
+#: means "a successor with the same inputs refuses identically; stop waiting".
+PERMANENT_REFUSALS = frozenset({
+    "eager_permanent",       # the release document says so
+    "environment_mismatch",  # the pod is not the release's env; a retry cannot help
+    "no_document",           # the release is stamped with no lane for this (lane x sm)
+    "EnvironmentMismatch",   # the same, arriving as an exception type name
+})
+
 # pgw#1460: THERE IS NO ARTIFACT LOADER IN THIS MODULE ANY MORE, and its
 # absence is the fix. What lived here was
 # `torch._inductor.aoti_load_package(str(path))` — the `GraphRecord` accepted
@@ -103,6 +116,11 @@ class ServeAdoption:
         self.store: Any = None
         #: Why this pod serves eager, when it does. Empty while adopting.
         self.refusal: str = ""
+        #: Whether that refusal is PERMANENT for this pod (pgw#1472). Read off
+        #: the object rather than scraped: `sink_for` swallows every failure
+        #: into eager-forever by design, so "refused once, will refuse always"
+        #: has to be a state something can COUNT.
+        self.refusal_permanent: bool = False
         #: The lane the session was built against, for the outcome event.
         self.contract: str = ""
 
@@ -260,10 +278,24 @@ class ServeAdoption:
 
     def _refuse(self, phase: str, detail: str) -> None:
         self.refusal = f"{phase}: {detail}"
-        logger.warning("adopt: serving eager — %s", self.refusal)
+        self.refusal_permanent = phase in PERMANENT_REFUSALS
+        logger.warning(
+            "adopt: serving eager (%s) — %s",
+            "PERMANENT" if self.refusal_permanent else "retryable",
+            self.refusal,
+        )
+        # The COUNT is by `phase`, which is already a typed wire field: the
+        # permanence question is answered by `phase IN PERMANENT_REFUSALS`.
+        # No new wire field is invented here — `emit_event`'s keyword set is
+        # the proto's, and widening it is a coordinated proto/wire change, not
+        # something a serving module does on its own. What this fix adds is
+        # that the SET is named in code instead of being folklore, and that
+        # the answer is readable off the live object.
         activity_mod.emit_event(
             KIND_ADOPT_REFUSED,
-            f"release {self.release_id} sm={self.sm}: {detail}"[:2000],
+            f"release {self.release_id} sm={self.sm} "
+            f"({'PERMANENT' if self.refusal_permanent else 'retryable'}): "
+            f"{detail}"[:2000],
             phase=phase,
         )
 

--- a/tests/test_adopt_refusal_permanence_pgw1472.py
+++ b/tests/test_adopt_refusal_permanence_pgw1472.py
@@ -1,0 +1,72 @@
+"""pgw#1472: a permanent adoption refusal must be a STATE, not a log line.
+
+`ServeAdoption.sink_for` swallows every failure into eager-forever, and that is
+correct as a boot policy — adoption must never kill a pod. It is wrong as an
+observability one: **an unconditional refusal is indistinguishable from a
+correct one**, because both read as "serving eager". That is how an env-identity
+mismatch could have made every locally derived boot eager forever while looking
+healthy, and it is why the first version of pgw#1472's own filing was wrong for
+an hour.
+
+So the distinction is carried on the object.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker.serving.serve_adoption import PERMANENT_REFUSALS, ServeAdoption
+
+
+@pytest.fixture()
+def adoption(tmp_path: Path) -> ServeAdoption:
+    return ServeAdoption("rel-1", sm="sm_89", artifacts_dir=tmp_path / "artifacts")
+
+
+def test_a_fresh_session_claims_no_refusal_at_all(adoption: ServeAdoption) -> None:
+    """Absent must not render as `False`-because-nothing-happened: before any
+    refusal, BOTH the reason and the permanence read as unset."""
+
+    assert adoption.refusal == ""
+    assert adoption.refusal_permanent is False
+
+
+def test_an_environment_mismatch_is_marked_PERMANENT(adoption: ServeAdoption) -> None:
+    """A retry cannot fix the pod not being the release's env."""
+
+    adoption._refuse("environment_mismatch", "resolved closure abc != stamped def")
+    assert adoption.refusal_permanent is True
+    assert "environment_mismatch" in adoption.refusal
+
+
+def test_a_hub_failure_is_marked_RETRYABLE(adoption: ServeAdoption) -> None:
+    """The counter-case, without which the flag could be a constant."""
+
+    adoption._refuse("TimeoutError", "the adopt route did not answer in time")
+    assert adoption.refusal_permanent is False
+
+
+def test_the_permanent_set_is_named_and_every_member_is_reachable() -> None:
+    """A vocabulary nothing emits is folklore. Each of these is a phase this
+    module actually passes to `_refuse`, or an exception type it catches."""
+
+    import gen_worker.serving.serve_adoption as module
+
+    source = Path(module.__file__).read_text()
+    for phase in PERMANENT_REFUSALS:
+        assert f'"{phase}"' in source, (
+            f"{phase!r} is declared permanent but this module never emits it; "
+            f"a set that cannot fire is not a classification")
+
+
+def test_the_refusal_is_readable_off_the_OBJECT_not_only_the_log(
+    adoption: ServeAdoption, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The whole point. A pod's stdout goes nowhere (pgw#760), so a fact that
+    reaches only the logger is a fact nothing can count."""
+
+    adoption._refuse("environment_mismatch", "closure mismatch")
+    assert (adoption.refusal, adoption.refusal_permanent) == (
+        "environment_mismatch: closure mismatch", True)

--- a/tests/test_env_identity_pgw1472.py
+++ b/tests/test_env_identity_pgw1472.py
@@ -1,0 +1,174 @@
+"""pgw#1472: the two ends of the env identity must name the same set.
+
+The defect this file fences is not "a hash was wrong". It is that the PUBLISH
+side hashed a `uv.lock` and the SERVE side hashed `importlib.metadata`, and
+those two are incomparable by construction — so a locally derived document was
+adoptable by nothing, including the local serve it exists for.
+
+⚠️ **Why no existing test could fail on it.** Every adopt test builds its
+document from the same `installed=` mapping it then audits against, so the two
+sources are ONE dict by construction. The fixture made the bug unrepresentable.
+The cases here therefore work from a REAL `uv.lock` on disk and from a real
+`importlib.metadata` reading, because that difference is the whole subject.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from gen_worker.env_identity import (
+    EnvIdentityError,
+    closure_drift,
+    closure_entries_from_lockfile,
+    describe_drift,
+    lockfile_beside,
+    normalize_name,
+    normalize_version,
+)
+
+LOCK = """\
+version = 1
+
+[[package]]
+name = "torch"
+version = "2.13.0"
+
+[[package]]
+name = "PyYAML"
+version = "6.0.3"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+"""
+
+
+@pytest.fixture()
+def lockfile(tmp_path: Path) -> Path:
+    path = tmp_path / "uv.lock"
+    path.write_text(LOCK)
+    return path
+
+
+def test_the_lockfile_reader_keeps_names_and_versions_VERBATIM(lockfile: Path) -> None:
+    """The identity is hashed from this, so normalizing here would silently
+    rekey every document ever stamped."""
+
+    entries = closure_entries_from_lockfile(lockfile)
+    assert entries == {"torch": "2.13.0", "PyYAML": "6.0.3", "colorama": "0.4.6"}
+
+
+def test_a_lockfile_resolving_one_package_twice_refuses(tmp_path: Path) -> None:
+    path = tmp_path / "uv.lock"
+    path.write_text(LOCK + '\n[[package]]\nname = "torch"\nversion = "2.12.0"\n')
+    with pytest.raises(EnvIdentityError, match="ONE resolved closure"):
+        closure_entries_from_lockfile(path)
+
+
+def test_an_empty_lockfile_refuses_rather_than_hashing_nothing(tmp_path: Path) -> None:
+    path = tmp_path / "uv.lock"
+    path.write_text("version = 1\n")
+    with pytest.raises(EnvIdentityError, match="no resolved packages"):
+        closure_entries_from_lockfile(path)
+
+
+def test_lockfile_beside_finds_the_endpoints_own_and_never_guesses(
+    tmp_path: Path, lockfile: Path
+) -> None:
+    assert lockfile_beside(lockfile.parent) == lockfile
+    assert lockfile_beside(tmp_path / "elsewhere") is None
+
+
+# -- the drift signal -------------------------------------------------------
+
+
+def test_drift_does_not_fire_on_SPELLING(lockfile: Path) -> None:
+    """THE case that makes the signal worth having.
+
+    `PyYAML` and `pyyaml` are one distribution. A drift report that lists them
+    is measuring its own normalization, and on one real endpoint that was TEN
+    of the rows.
+    """
+
+    stated = closure_entries_from_lockfile(lockfile)
+    installed = {"torch": "2.13.0", "pyyaml": "6.0.3", "colorama": "0.4.6"}
+    assert closure_drift(installed, stated) == ()
+
+
+def test_drift_does_not_fire_on_the_LOCAL_VERSION_SEGMENT(lockfile: Path) -> None:
+    """A lock cannot state `+cu129`; an installed CUDA wheel always has one."""
+
+    stated = closure_entries_from_lockfile(lockfile)
+    installed = {"torch": "2.13.0+cu129", "PyYAML": "6.0.3", "colorama": "0.4.6"}
+    assert closure_drift(installed, stated) == ()
+
+
+def test_drift_DOES_fire_on_a_real_difference_and_names_it(lockfile: Path) -> None:
+    stated = closure_entries_from_lockfile(lockfile)
+    installed = {"torch": "2.12.0+cu129", "PyYAML": "6.0.3", "extra-thing": "1.0"}
+    rows = closure_drift(installed, stated)
+    kinds = {(r.name, r.kind) for r in rows}
+    assert kinds == {
+        ("colorama", "missing"),
+        ("extra-thing", "extra"),
+        ("torch", "version"),
+    }
+    summary = describe_drift(rows)
+    assert "3 package(s) differ" in summary
+    assert "torch 2.13.0 != 2.12.0" in summary
+    assert describe_drift(()) == ""
+
+
+@pytest.mark.parametrize(
+    "raw,want",
+    [("PyYAML", "pyyaml"), ("typing_extensions", "typing-extensions"),
+     ("huggingface_hub", "huggingface-hub"), ("Py.YAML", "py-yaml")],
+)
+def test_pep503_name_normalization(raw: str, want: str) -> None:
+    assert normalize_name(raw) == want
+
+
+def test_local_version_segment_is_stripped_and_nothing_else_is() -> None:
+    assert normalize_version("2.13.0+cu129") == "2.13.0"
+    assert normalize_version("2.13.0rc1") == "2.13.0rc1"
+
+
+# -- the end-to-end property, against the REAL producer ---------------------
+
+
+def test_the_derive_and_the_serve_runner_hash_the_SAME_source(
+    lockfile: Path,
+) -> None:
+    """The whole issue, as one assertion.
+
+    `release/derive.py` stamps a document's closure from a lockfile; the serve
+    runner states this boot's identity from one. If those two ever stop being
+    the same function, a locally derived document becomes adoptable by nothing
+    again — silently, because `sink_for` turns the refusal into eager-forever.
+    """
+
+    from gen_worker.release.derive import _closure_entries_from_lockfile
+
+    assert _closure_entries_from_lockfile(lockfile) == closure_entries_from_lockfile(
+        lockfile
+    )
+
+
+def test_a_real_endpoint_lock_hashes_to_a_stable_closure(tmp_path: Path) -> None:
+    """Guards the MOVE itself: the reader now lives in `env_identity`, and if
+    the move had changed a single byte of its output every document ever
+    stamped would have been rekeyed."""
+
+    from gen_worker._vendor.torchcg.graph_identity import closure_hash
+
+    path = tmp_path / "uv.lock"
+    path.write_text(LOCK)
+    entries = closure_entries_from_lockfile(path)
+    # Recomputed from the parsed TOML, independently of the reader under test.
+    parsed = tomllib.loads(LOCK)
+    expected = {p["name"]: p["version"] for p in parsed["package"]}
+    assert entries == expected
+    assert closure_hash(entries) == closure_hash(expected)


### PR DESCRIPTION
`gen-worker lock` stamps the endpoint's `uv.lock`; a serving process restated `importlib.metadata`. Those are incomparable **by construction** — measured against `sd15/uv.lock` and its own venv:

- **PEP 503 name spelling** — ten packages on that one endpoint agree only after normalization (`PyYAML`/`pyyaml`, `huggingface_hub`/`huggingface-hub`, …)
- **PEP 440 local version segment** — a lock says `torch 2.13.0`, every installed CUDA wheel says `2.13.0+cu129`, and a lock cannot express it
- **Platform-conditional lock entries** — `colorama` will never install on Linux

`assert_exact_env` then demanded exact equality, so a document this box derived was adoptable by **nothing**, including the local serve it exists for.

### What landed

- **`gen_worker.env_identity` is the ONE definition**; `release/derive.py` reads it. **Proven byte-stable across the move:** sd15's document closure still hashes to `40471a90…`, so nothing ever stamped is rekeyed — the one thing that could have gone silently and catastrophically wrong.
- **`python -m gen_worker.serving` states identity from the endpoint's own `uv.lock`** — the same file `gen-worker lock` hashed. `--env-lockfile` overrides; `--env-lockfile=-` forces the installed set.
- **installed-vs-lock is a typed drift SIGNAL, never the gate** — normalized on both sides, so it reports real divergence instead of spelling.
- **A permanent refusal is a countable STATE.** `PERMANENT_REFUSALS` names the set in code (with a fence asserting every member is actually emitted) and `ServeAdoption.refusal_permanent` is readable off the object. The count stays `phase IN PERMANENT_REFUSALS` on the existing typed wire field — `emit_event`'s keyword set is the **proto's**, and widening it is a coordinated wire change, not a serving module's decision.

### Production is deliberately untouched

`tensorhub/internal/builder/derive_runner.go:129` passes no `--lockfile`, so the fleet is installed-at-both-ends today and **nothing there is broken**. Landing the worker half alone would break a working fleet; that migration is sequenced separately.

### Measured end to end, real CLI, no harness

```
adopt: env identity stated from serverless-endpoints/sd15/uv.lock (87 packages);
       installed-vs-lock drift: 43 package(s) differ (3 missing, 19 extra, 21 version): ...
{"adopted": [14 graphs], "holes": []}
image sha256 aced848a991dbf4e...
```
That sha256 is **byte-identical** to the image the compiled proof produced through a completely different entry point. Note the drift report names `colorama`, `peft`, `sd15` and dev extras — and **none of the ten spelling cases**, which is the property that makes it worth printing.

### Why no existing test could fail on this

Every adopt test builds its document from the same `installed=` mapping it then audits against, so the two sources are **one dict by construction** — the fixture made the bug unrepresentable. The new cases work from a real `uv.lock` on disk and a real `importlib.metadata` reading, because that difference *is* the subject.

Local: ruff clean, **mypy clean (330 files)**, raw-AOTI-load fence clean, 19 new cases + 58 passed across the adopt/mint/vendor suites.