### PR TITLE
pgw#1473: the eager bridge passed no variant=, so a bare fp16 mirror refused at boot

### DIFF
--- a/changelog.d/pgw1473.md
+++ b/changelog.d/pgw1473.md
@@ -1,0 +1,30 @@
+- **A bare fp16 mirror refused at boot, naming a file that never existed.** `ctx.load`'s eager
+  bridge passed no `variant=`, so a tree of `*.fp16.safetensors` — which is what every fp16 mirror
+  on the hub ships — died with `OSError: Error no file named diffusion_pytorch_model.bin found in
+  directory .../vae`. Nothing was missing; the loader was looking under the wrong name, and `.bin`
+  is merely the last candidate in diffusers' own fallback ladder, so the message pointed at the
+  wrong thing entirely.
+
+- **This is the cozy-local substrate, not an edge case.** `engine_for` returns `None` for any tree
+  with no chunk store behind it, so every bare download takes the bridge — and both trees this box
+  was handed carried variant-only names. It is invisible in CI because every fixture tree is written
+  by the test that reads it, under the plain names.
+
+- **The variant is DETECTED off the tree, never configured.** No environment variable and no
+  `ctx.load(variant=)`: an author stating a fact about bytes they did not publish is a second source
+  of truth, and the one that drifts. `serving/variants.detect_variant` returns `None` for every
+  published/converted checkpoint — which is why it runs unconditionally — a token only when the tree
+  offers *no* plainly named weight file anywhere, and a typed `VariantAmbiguous` refusal when
+  several variants compete, because choosing between `fp16` and `bf16` is a statement about
+  PRECISION that belongs to whoever published the tree.
+
+- **Both real-world spellings are handled**, taken from diffusers rather than guessed:
+  `_add_variant` inserts the token before the final extension
+  (`model.fp16.safetensors`, `x.safetensors.index.fp16.json`) and the sharded form glues it to the
+  shard suffix (`diffusion_pytorch_model.fp16-00001-of-00003.safetensors`). sdxl's mirror carries
+  **both index spellings at once**. A sharded *plain* tree with a `.safetensors.index.json` must not
+  read as variant `index`, and that case is asserted.
+
+- **Measured on this box's 4070, against the UNTOUCHED variant-only sd1.5 mirror** through the real
+  CLI: `14 adopted, 0 holes`, and an image whose sha256 is byte-identical to the two earlier
+  compiled proofs. The hardlink de-varianting workaround this lane had been using is retired.

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -304,12 +304,25 @@ class LoadContext(Generic[MT_co]):
             "ctx.load: eager from_pretrained bridge for %s (pgw#1380's "
             "native loader engine is not bound)", pipeline_cls.__name__,
         )
+        # pgw#1473: a VARIANT-ONLY tree (`*.fp16.safetensors`, which is what
+        # every fp16 mirror ships) is invisible to `from_pretrained` unless it
+        # is told. Detected off the tree the worker already resolved, never
+        # configured — an author stating a fact about bytes they did not
+        # publish is the second source of truth that drifts. `None` for every
+        # published/converted checkpoint, which is why it runs unconditionally.
+        from .variants import detect_variant
+
+        extra: dict[str, Any] = {}
+        variant = detect_variant(self.checkpoint_dir)
+        if variant is not None:
+            extra["variant"] = variant
         dtype = self._lane_dtype()
         if dtype is None:
-            no_lane: P = from_pretrained(self.checkpoint_dir)
+            no_lane: P = from_pretrained(self.checkpoint_dir, **extra)
             return self._placed(no_lane)
         try:
-            bridged: P = from_pretrained(self.checkpoint_dir, torch_dtype=dtype)
+            bridged: P = from_pretrained(
+                self.checkpoint_dir, torch_dtype=dtype, **extra)
             return self._placed(bridged)
         except TypeError as exc:
             if not _rejected_torch_dtype(exc):
@@ -323,7 +336,7 @@ class LoadContext(Generic[MT_co]):
             "loading without it and applying the lane dtype post-load "
             "(pgw#1447)", pipeline_cls.__name__,
         )
-        loaded: P = from_pretrained(self.checkpoint_dir)
+        loaded: P = from_pretrained(self.checkpoint_dir, **extra)
         to = getattr(loaded, "to", None)
         if callable(to):
             to(dtype)

--- a/src/gen_worker/serving/variants.py
+++ b/src/gen_worker/serving/variants.py
@@ -1,0 +1,139 @@
+"""Which weight VARIANT a checkpoint tree offers (pgw#1473).
+
+Every fp16 mirror on the hub ships `*.fp16.safetensors` and diffusers reads
+those only when told `variant="fp16"`. `ctx.load`'s eager bridge passed no
+`variant=`, so a bare mirror refused at boot with
+
+    OSError: Error no file named diffusion_pytorch_model.bin found in
+    directory .../vae
+
+which points at the wrong thing entirely: nothing is missing, the loader is
+looking under the wrong name (`.bin` is merely the last candidate in diffusers'
+own fallback ladder). **The eager bridge IS the cozy-local substrate** —
+`engine_for` returns `None` for any tree with no chunk store behind it — so
+this refused every bare download, and both trees this box was handed carried it.
+
+**The variant is a property of the TREE, and the worker already resolves the
+tree, so it is DETECTED rather than configured.** No environment variable and
+no `ctx.load(variant=)` argument: an author stating a fact about bytes they did
+not publish is a second source of truth, and the one that drifts.
+
+**The naming rules are diffusers' own, and they are read from diffusers rather
+than reimplemented** — `_add_variant` inserts the token before the final
+extension (`model.safetensors` -> `model.fp16.safetensors`,
+`x.safetensors.index.json` -> `x.safetensors.index.fp16.json`), and the sharded
+spelling glues it to the shard suffix
+(`diffusion_pytorch_model.fp16-00001-of-00003.safetensors`). Both are in the
+wild; sdxl's own mirror carries BOTH index spellings at once.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: The shard suffix diffusers glues a variant to. Its own spelling.
+_SHARD = r"\d{5}-of-\d{5}"
+
+#: Weight file extensions that can carry a variant token.
+_SUFFIXES = ("safetensors", "bin")
+
+#: A variant token: a short alphanumeric tag, never a shard range and never a
+#: known non-variant word. Kept deliberately narrow — a greedy pattern would
+#: read `model.index.json` as variant `index`.
+_TOKEN = r"[A-Za-z0-9][A-Za-z0-9_]{0,15}"
+
+_VARIANT_WEIGHT = re.compile(
+    rf"^(?P<stem>.+?)\.(?P<token>{_TOKEN})(?:-{_SHARD})?\.(?P<suffix>{'|'.join(_SUFFIXES)})$"
+)
+_PLAIN_WEIGHT = re.compile(
+    rf"^(?P<stem>.+?)(?:-{_SHARD})?\.(?P<suffix>{'|'.join(_SUFFIXES)})$"
+)
+
+
+class VariantAmbiguous(RuntimeError):
+    """A tree offers several weight variants and none is plainly named.
+
+    Refused BY NAME rather than picked: choosing between `fp16` and `bf16`
+    would be a guess about PRECISION, made by the worker, on bytes the
+    publisher already labelled. The operator states which tree they meant.
+    """
+
+
+def _component_dirs(tree: Path) -> list[Path]:
+    """The pipeline component directories — one level down, as diffusers lays
+    a snapshot out. The root itself is included for single-component trees."""
+
+    dirs = [tree]
+    try:
+        dirs += sorted(p for p in tree.iterdir() if p.is_dir())
+    except OSError:
+        return [tree]
+    return dirs
+
+
+def _classify(directory: Path) -> Tuple[set[str], bool]:
+    """(variant tokens offered, whether a PLAIN weight file exists) here."""
+
+    tokens: set[str] = set()
+    plain = False
+    try:
+        names = sorted(p.name for p in directory.iterdir() if p.is_file())
+    except OSError:
+        return tokens, plain
+    for name in names:
+        variant = _VARIANT_WEIGHT.match(name)
+        if variant is not None:
+            tokens.add(variant.group("token"))
+            continue
+        if _PLAIN_WEIGHT.match(name) is not None:
+            plain = True
+    return tokens, plain
+
+
+def detect_variant(tree: Path | str) -> Optional[str]:
+    """The variant this tree must be loaded with, or ``None``.
+
+    ``None`` means "load it the ordinary way" and is the answer for every
+    published/converted checkpoint — which is why this is safe to run always.
+    A variant is returned ONLY when the tree offers no plainly named weight
+    file anywhere, so a tree carrying both names is untouched.
+
+    Several variants and no plain file is a :class:`VariantAmbiguous` refusal.
+    """
+
+    root = Path(tree)
+    if not root.is_dir():
+        return None
+    tokens: set[str] = set()
+    for directory in _component_dirs(root):
+        found, plain = _classify(directory)
+        if plain:
+            # SOMETHING here is plainly named, so diffusers' ordinary ladder
+            # resolves. Whatever variants sit beside it are extras, not the
+            # only way in.
+            return None
+        tokens |= found
+    if not tokens:
+        return None
+    if len(tokens) > 1:
+        raise VariantAmbiguous(
+            f"{root} offers weight variants {sorted(tokens)!r} and no plainly "
+            f"named weight file. Which one to serve is a statement about "
+            f"PRECISION and it belongs to whoever published the tree, not to "
+            f"the worker — project or convert the one you mean."
+        )
+    token = tokens.pop()
+    logger.info(
+        "ctx.load: %s carries only %r-variant weight files and no plainly "
+        "named ones, so the eager bridge loads it with variant=%r (pgw#1473)",
+        root, token, token,
+    )
+    return token
+
+
+__all__ = ["VariantAmbiguous", "detect_variant"]

--- a/tests/test_variant_bridge_pgw1473.py
+++ b/tests/test_variant_bridge_pgw1473.py
@@ -1,0 +1,178 @@
+"""pgw#1473: a VARIANT-ONLY tree must load through the eager bridge.
+
+⚠️ **Every case here builds a tree with ONLY variant-named files, because the
+absence of the plain name IS the defect.** A fixture that writes both names —
+which is what every existing fixture does, since the test that reads a tree is
+also the test that wrote it — passes with or without the fix and proves
+nothing. That is the same property that hid pgw#1460's loader and pgw#1472's
+closure: the double was simpler than production in exactly the dimension under
+test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker.serving.variants import VariantAmbiguous, detect_variant
+
+
+def _tree(root: Path, *names: str) -> Path:
+    for name in names:
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"weights")
+    (root / "model_index.json").write_text("{}")
+    return root
+
+
+def test_a_variant_only_tree_names_its_variant(tmp_path: Path) -> None:
+    """The sd1.5 shape, exactly as the mirror ships it."""
+
+    tree = _tree(
+        tmp_path / "sd15",
+        "unet/diffusion_pytorch_model.fp16.safetensors",
+        "vae/diffusion_pytorch_model.fp16.safetensors",
+        "text_encoder/model.fp16.safetensors",
+    )
+    assert detect_variant(tree) == "fp16"
+
+
+def test_a_SHARDED_variant_only_tree_names_its_variant(tmp_path: Path) -> None:
+    """The sdxl shape: the variant is glued to the shard suffix, and the tree
+    carries BOTH index spellings at once — `_add_variant` writes one and older
+    diffusers wrote the other. Measured on a real mirror, not invented."""
+
+    tree = _tree(
+        tmp_path / "sdxl",
+        "unet/diffusion_pytorch_model.fp16-00001-of-00003.safetensors",
+        "unet/diffusion_pytorch_model.fp16-00002-of-00003.safetensors",
+        "unet/diffusion_pytorch_model.fp16-00003-of-00003.safetensors",
+        "unet/diffusion_pytorch_model.fp16.safetensors.index.json",
+        "unet/diffusion_pytorch_model.safetensors.index.fp16.json",
+        "vae/diffusion_pytorch_model.fp16.safetensors",
+        "text_encoder/model.fp16.safetensors",
+        "text_encoder_2/model.fp16.safetensors",
+    )
+    assert detect_variant(tree) == "fp16"
+
+
+def test_a_PLAIN_tree_is_left_alone(tmp_path: Path) -> None:
+    """Every published/converted checkpoint. `None` is what makes running this
+    unconditionally safe."""
+
+    tree = _tree(
+        tmp_path / "converted",
+        "unet/diffusion_pytorch_model.safetensors",
+        "vae/diffusion_pytorch_model.safetensors",
+        "text_encoder/model.safetensors",
+    )
+    assert detect_variant(tree) is None
+
+
+def test_a_tree_carrying_BOTH_names_is_left_alone(tmp_path: Path) -> None:
+    """diffusers' ordinary ladder already resolves this one, so the variant is
+    an extra rather than the only way in — and choosing it would silently
+    change which bytes serve."""
+
+    tree = _tree(
+        tmp_path / "both",
+        "unet/diffusion_pytorch_model.safetensors",
+        "unet/diffusion_pytorch_model.fp16.safetensors",
+    )
+    assert detect_variant(tree) is None
+
+
+def test_TWO_variants_and_no_plain_name_REFUSES_by_name(tmp_path: Path) -> None:
+    """Picking would be the worker guessing about PRECISION on bytes the
+    publisher already labelled."""
+
+    tree = _tree(
+        tmp_path / "ambiguous",
+        "unet/diffusion_pytorch_model.fp16.safetensors",
+        "unet/diffusion_pytorch_model.bf16.safetensors",
+    )
+    with pytest.raises(VariantAmbiguous) as caught:
+        detect_variant(tree)
+    assert "bf16" in str(caught.value) and "fp16" in str(caught.value)
+
+
+def test_an_index_json_is_not_mistaken_for_a_variant(tmp_path: Path) -> None:
+    """A greedy pattern reads `model.safetensors.index.json` as variant
+    `index`, silently, and then asks diffusers for files that do not exist."""
+
+    tree = _tree(
+        tmp_path / "sharded-plain",
+        "unet/diffusion_pytorch_model-00001-of-00002.safetensors",
+        "unet/diffusion_pytorch_model-00002-of-00002.safetensors",
+        "unet/diffusion_pytorch_model.safetensors.index.json",
+    )
+    assert detect_variant(tree) is None
+
+
+def test_a_missing_or_empty_tree_answers_None_rather_than_raising(
+    tmp_path: Path,
+) -> None:
+    assert detect_variant(tmp_path / "nope") is None
+    (tmp_path / "empty").mkdir()
+    assert detect_variant(tmp_path / "empty") is None
+
+
+def test_the_bridge_PASSES_the_variant_it_detected(tmp_path: Path) -> None:
+    """The wiring, not just the detector — pgw#1460's lesson applied here.
+
+    A probe that is correct in isolation and dead at its call site is the exact
+    shape this session has already paid for twice, so the assertion is on what
+    `from_pretrained` actually RECEIVES.
+    """
+
+    from gen_worker.serving.context import DeployBinding, LoadContext
+
+    tree = _tree(
+        tmp_path / "variant-only",
+        "unet/diffusion_pytorch_model.fp16.safetensors",
+    )
+    seen: dict = {}
+
+    class Pipe:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):  # type: ignore[no-untyped-def]
+            seen.update(kwargs)
+            seen["path"] = path
+            return cls()
+
+        def to(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return self
+
+    ctx: LoadContext = LoadContext(
+        binding=DeployBinding(checkpoint_ref="x/y@1", checkpoint_dir=tree))
+    ctx.load(Pipe)  # type: ignore[arg-type]
+
+    assert seen["variant"] == "fp16", (
+        "the bridge detected the variant and then did not pass it — the "
+        "pgw#1460 shape")
+    assert seen["path"] == tree
+
+
+def test_the_bridge_passes_NO_variant_for_a_plain_tree(tmp_path: Path) -> None:
+    """The counter-case, without which the assertion above could be a constant."""
+
+    from gen_worker.serving.context import DeployBinding, LoadContext
+
+    tree = _tree(tmp_path / "plain", "unet/diffusion_pytorch_model.safetensors")
+    seen: dict = {}
+
+    class Pipe:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):  # type: ignore[no-untyped-def]
+            seen.update(kwargs)
+            return cls()
+
+        def to(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return self
+
+    ctx: LoadContext = LoadContext(
+        binding=DeployBinding(checkpoint_ref="x/y@1", checkpoint_dir=tree))
+    ctx.load(Pipe)  # type: ignore[arg-type]
+    assert "variant" not in seen


### PR DESCRIPTION
`ctx.load`'s eager bridge called `from_pretrained(dir, torch_dtype=...)` with no `variant=`, so a tree of `*.fp16.safetensors` — what every fp16 mirror on the hub ships — died with:

```
OSError: Error no file named diffusion_pytorch_model.bin found in directory .../vae
```

**Nothing was missing.** The loader was looking under the wrong name, and `.bin` is merely the last candidate in diffusers' own fallback ladder, so the message pointed at the wrong thing entirely.

### Not an edge case — the eager bridge IS the cozy-local substrate

`engine_for` returns `None` for any tree with no chunk store behind it, so every bare download takes the bridge — and **both** trees this box was handed carried variant-only names (sd1.5 `model.fp16.safetensors`; sdxl sharded `…fp16-0000N-of-00003.safetensors` plus **two** index spellings at once). Invisible in CI because every fixture tree is written by the test that reads it, under the plain names.

### The variant is DETECTED, never configured

No env var, no `ctx.load(variant=)` — an author stating a fact about bytes they did not publish is a second source of truth, and the one that drifts. `serving/variants.detect_variant`:

- `None` for every published/converted checkpoint — which is what makes running it unconditionally safe;
- a token **only** when the tree offers no plainly named weight file anywhere;
- a typed `VariantAmbiguous` refusal when several compete, because choosing between `fp16` and `bf16` is a statement about **precision** belonging to whoever published the tree.

Both real spellings handled, taken **from** diffusers rather than guessed. A sharded *plain* tree carrying `.safetensors.index.json` must not read as variant `index` — asserted, because a greedy pattern makes exactly that mistake silently.

### Measured against the UNTOUCHED mirror

Real CLI on this box's 4070: **`14 adopted, 0 holes`**, image sha256 `aced848a991dbf4e…` — byte-identical to the two earlier compiled proofs, so this is the **third independent reproduction**. The hardlink de-varianting workaround this lane had been using is **retired**. Detection verified against both real mirrors (`sd15 -> 'fp16'`, `sdxl -> 'fp16'`) and a de-varianted tree (`-> None`).

### The red arm

Every fixture tree carries **only** variant names, because the absence of the plain name *is* the defect — a fixture writing both passes with or without the fix. A bridge-level case asserts what `from_pretrained` actually **receives**, proven red by detecting the variant and not passing it (the pgw#1460 shape), with a plain-tree counter-case so the assertion cannot be a constant.

Local: ruff clean, **mypy clean (331 files)**, 33 passed across the variant, bridge-dtype, bridge-placement and adopt suites.