### PR TITLE
pgw#1477: the torchcg pin had three spellings and nothing made them agree — the re-vendor is ONE act, and a stale lock is ONE self-describing red

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,6 +188,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pgw#1477 — FIRST, ahead of uv itself, and stdlib-only so it can be.
+      # `uv sync --locked` (two steps down, and the first step of every other
+      # job in every other workflow) dies on a stale lock with a message that
+      # names neither file and no rev — so a torchcg re-vendor that moved
+      # pyproject.toml's pin and not uv.lock turned `fast gates`, `tests` and
+      # `drift` red simultaneously, at install, on PRs that had touched
+      # neither file. Twice on 2026-08-19, twenty minutes apart. Nothing in the
+      # required set could report it: a gate cannot fail on something it never
+      # got far enough to read.
+      #
+      # ~30 ms, no venv, no network. The `--selftest` arm runs here only, and
+      # is the reason this line is evidence: it builds a divergent tree in a
+      # tempdir and fails if the check stays green on it.
+      - name: pgw#1477 guard - uv.lock agrees with pyproject.toml's git pins
+        run: |
+          python3 scripts/lint_lock_pin_agreement.py --selftest
+          python3 scripts/lint_lock_pin_agreement.py
+
       # pgw#1264: `@v6` HERE ONLY, and the version is the point. `@v4` bundles
       # `@actions/cache` v3, which speaks the cache API GitHub retired, so
       # `enable-cache: true` on `@v4` is dead config that reads as a working
@@ -655,6 +673,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+
+      # pgw#1477: see `fast gates`. Same guard, same reason — this job's
+      # `uv sync --locked` is one of the three reds a stale lock produces.
+      - name: pgw#1477 guard - uv.lock agrees with pyproject.toml's git pins
+        run: python3 scripts/lint_lock_pin_agreement.py
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/proto-contract.yaml
+++ b/.github/workflows/proto-contract.yaml
@@ -57,6 +57,12 @@ jobs:
       - name: proto drift check (vs PROTO_DIGEST)
         run: PROTO_SKIP_PEER=1 scripts/proto-drift-check.sh
 
+      # pgw#1477, same layer-1 argument: `uv sync --locked` below is where a
+      # stale lock kills this job, with a message naming neither pyproject.toml
+      # nor the divergent rev. This one names both, in ~30 ms, before uv exists.
+      - name: pgw#1477 guard - uv.lock agrees with pyproject.toml's git pins
+        run: python3 scripts/lint_lock_pin_agreement.py
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pgw#1477: a tag whose lock is stale fails AFTER the tag is cut — the
+      # 0.18.0 shape this workflow's `--locked` already exists to prevent, one
+      # step earlier and with the divergent rev named.
+      - name: pgw#1477 guard - uv.lock agrees with pyproject.toml's git pins
+        run: python3 scripts/lint_lock_pin_agreement.py
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -27,6 +27,25 @@ tasks:
     cmds:
       - scripts/probe_sync.sh {{.CLI_ARGS}}
 
+  lock-check:
+    desc: |
+      pgw#1477 — pyproject.toml's git pins, uv.lock and _vendor/VENDORED.toml
+      name the same revs. $0, no venv, no network, ~30ms. Run it before pushing:
+      a stale lock breaks `uv sync --locked`, the FIRST step of EVERY CI job,
+      so it costs three red checks that name neither file.
+    cmds:
+      - python3 scripts/lint_lock_pin_agreement.py
+
+  vendor:
+    desc: |
+      pgw#1477 — re-vendor an upstream snapshot as ONE act: extract at the rev,
+      re-apply the declared mechanical rewrites, regenerate the sha256 table,
+      move the pin in BOTH pyproject.toml and uv.lock, and stage it all.
+      Usage: task vendor -- torchcg <rev>
+      Hand-editing the pin instead is what broke master twice on 2026-08-19.
+    cmds:
+      - python3 scripts/vendor_snapshot.py {{.CLI_ARGS}}
+
   proto-vendor:
     desc: |
       pgw#944 — resync proto/worker_scheduler.proto from tensorhub (which owns
@@ -111,6 +130,10 @@ tasks:
     # A gate that runs a different command under the same name is a different
     # gate wearing its clothes.
     cmds:
+      # pgw#1477 FIRST, and with bare python3 — every line below it is a
+      # `uv run`, which silently RE-RESOLVES a stale lock instead of refusing
+      # it, so `task lint` was green on exactly the tree CI dies installing.
+      - cmd: python3 scripts/lint_lock_pin_agreement.py
       - cmd: uv run --extra dev mypy src/gen_worker tests tests_v2
       - cmd: uv run --extra dev ruff check src/gen_worker
         # Advisory, and this one IS matched by continue-on-error in CI:

--- a/changelog.d/pgw1477.md
+++ b/changelog.d/pgw1477.md
@@ -1,0 +1,16 @@
+- **A stale `uv.lock` can no longer take out every open PR, and it can no longer do it silently.**
+  `uv sync --locked` is the FIRST step of every job in every workflow, so a re-vendor that moved
+  `pyproject.toml`'s torchcg pin without re-locking killed `fast gates`, `tests` and `drift`
+  simultaneously — at install, on PRs that had touched neither file, with a message
+  (`The lockfile at uv.lock needs to be updated`) that names no rev and no cause. It happened twice
+  on 2026-08-19, twenty minutes apart, and nothing in the required set could ever have caught it: a
+  gate cannot fail on something it never got far enough to read. Two rails now:
+  `scripts/vendor_snapshot.py` (`task vendor -- <package> <rev>`) performs a re-vendor as ONE act —
+  extract at the rev, re-apply the declared mechanical rewrites, regenerate the sha256 table, and
+  move the same rev in `_vendor/VENDORED.toml`, `pyproject.toml` AND `uv.lock`, staging all of it —
+  so the tooling path cannot produce the divergence; and `scripts/lint_lock_pin_agreement.py` runs
+  as the first step of all four workflows and the first line of `task lint`, stdlib-only and ahead
+  of uv itself (~30 ms, no venv, no network), naming both files and both revs. Replayed against the
+  real history it is discriminating rather than merely quiet: red on `fad60a8b`, `3966f323` and
+  `c16ebf928` — including the "fix" commit, whose tree was already stale against the re-vendor that
+  had landed seven minutes earlier — and green on `bdecee16` and current master.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -691,7 +691,11 @@ torchvision = [
 # vendored half leaves two versions live in one tree, and the failure lands two
 # tools away from the cause: the derive raised `TypeError: unexpected keyword
 # 'session'` while that exact signature was verifiably present in the vendored
-# tree. Bump both, re-lock, re-vendor — one change.
+# tree. Bump both, re-lock, re-vendor — one change, and pgw#1477 made it one
+# command: `task vendor -- torchcg <rev>`. Editing this line by hand leaves
+# uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
+# job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
+# tree locally and as CI's first step.
 torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "6c91b83d8fb2e45a6d568569dc15884c4d6b26e3" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.

--- a/scripts/lint_lock_pin_agreement.py
+++ b/scripts/lint_lock_pin_agreement.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""pgw#1477: `pyproject.toml`'s git pins and `uv.lock` must name the same rev.
+
+Every job in every workflow begins with `uv sync --locked`. When a re-vendor
+moves the torchcg rev in `[tool.uv.sources]` and nobody re-locks, that step dies
+with
+
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+before ANY gate runs — so `fast gates`, `tests` and `drift` all go red at
+install, on PRs that touched neither file, and nothing in the required set can
+report the cause. It happened twice on 2026-08-19, twenty minutes apart.
+
+This check is the FIRST step of those jobs, ahead of `Install uv`: stdlib only,
+no venv, no network, ~30 ms. Its verdict NAMES both files and both revs.
+
+It also fences the third spelling — `_vendor/VENDORED.toml`'s `rev`, the
+snapshot the mint and serving path run — so a re-vendor cannot leave the derive
+and the mint on different libraries either.
+
+Usage:
+    python3 scripts/lint_lock_pin_agreement.py
+    python3 scripts/lint_lock_pin_agreement.py --selftest   # prove it goes red
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+#: uv writes a git source as `<repo>?rev=<rev>#<resolved>` (lock `source.git`),
+#: and as `<repo>?rev=<rev>` in the `[package.metadata]` tables. One pattern
+#: reads both.
+_LOCK_GIT = re.compile(r"^(?P<repo>[^?#]+)\?(?:[^#]*&)?rev=(?P<rev>[0-9a-fA-F]+)")
+
+RELOCK = "uv lock   # then commit uv.lock"
+
+
+def _norm(repo: str) -> str:
+    """Compare repo URLs the way a human means them: no `.git`, no trailing /."""
+    return repo.removesuffix("/").removesuffix(".git")
+
+
+def _agree(a: str, b: str) -> bool:
+    """Revs agree when one is a prefix of the other (short vs 40-hex spelling)."""
+    return a.startswith(b) or b.startswith(a)
+
+
+def _pyproject_git_pins(pyproject: dict[str, Any]) -> dict[str, tuple[str, str]]:
+    """`{package: (repo, rev)}` for every `[tool.uv.sources]` entry pinned by rev."""
+    sources = pyproject.get("tool", {}).get("uv", {}).get("sources", {})
+    pins: dict[str, tuple[str, str]] = {}
+    for name, spec in sources.items():
+        for entry in spec if isinstance(spec, list) else [spec]:
+            if isinstance(entry, dict) and "git" in entry and "rev" in entry:
+                pins[name] = (_norm(str(entry["git"])), str(entry["rev"]))
+    return pins
+
+
+def _strings(node: object) -> list[str]:
+    if isinstance(node, str):
+        return [node]
+    if isinstance(node, dict):
+        return [s for v in node.values() for s in _strings(v)]
+    if isinstance(node, list):
+        return [s for v in node for s in _strings(v)]
+    return []
+
+
+def _lock_revs_for_repo(lock: dict[str, Any], repo: str) -> set[str]:
+    """Every rev uv.lock spells for `repo`, anywhere in the document."""
+    revs: set[str] = set()
+    for url in _strings(lock):
+        match = _LOCK_GIT.match(url)
+        if match and _norm(match["repo"]) == repo:
+            revs.add(match["rev"])
+    return revs
+
+
+def check(root: Path) -> list[str]:
+    """Return one human-readable failure per divergent pin (empty == green)."""
+    pyproject_path = root / "pyproject.toml"
+    lock_path = root / "uv.lock"
+    manifest_path = root / "src" / "gen_worker" / "_vendor" / "VENDORED.toml"
+
+    pyproject = tomllib.loads(pyproject_path.read_text())
+    lock = tomllib.loads(lock_path.read_text())
+    pins = _pyproject_git_pins(pyproject)
+
+    failures: list[str] = []
+    for name, (repo, rev) in sorted(pins.items()):
+        lock_revs = _lock_revs_for_repo(lock, repo)
+        if not lock_revs:
+            failures.append(
+                f"{name}: pyproject.toml pins {repo} @ {rev} in [tool.uv.sources], "
+                f"and uv.lock names that repository nowhere. Run `{RELOCK}`."
+            )
+            continue
+        stale = sorted(r for r in lock_revs if not _agree(r, rev))
+        if stale:
+            failures.append(
+                f"{name}: the pin in pyproject.toml and uv.lock DISAGREE.\n"
+                f"      pyproject.toml  [tool.uv.sources].{name}  rev = {rev}\n"
+                f"      uv.lock         {repo}  rev = {', '.join(stale)}\n"
+                f"      Fix: `{RELOCK}`. Better: re-vendor through "
+                f"`scripts/vendor_snapshot.py {name} <rev>`, which re-locks in "
+                f"the same act so these two cannot diverge."
+            )
+
+    # Third spelling: the vendored snapshot. Same library, different copy.
+    if manifest_path.is_file():
+        manifest = tomllib.loads(manifest_path.read_text())
+        for name, package in sorted(manifest.get("packages", {}).items()):
+            if name not in pins:
+                continue
+            repo, rev = pins[name]
+            vendored = str(package.get("rev", ""))
+            if _norm(str(package.get("repo", repo))) != repo:
+                continue
+            if vendored and not _agree(vendored, rev):
+                failures.append(
+                    f"{name}: the VENDORED SNAPSHOT and the dev pin DISAGREE.\n"
+                    f"      pyproject.toml                     rev = {rev}\n"
+                    f"      src/gen_worker/_vendor/VENDORED.toml  rev = {vendored}\n"
+                    f"      The mint/serving path runs the snapshot and the derive "
+                    f"runs the pin; they are a matched pair (pgw#1457). Re-vendor "
+                    f"through `scripts/vendor_snapshot.py {name} <rev>`."
+                )
+    return failures
+
+
+_SELFTEST_PYPROJECT = """
+[project]
+name = "x"
+version = "0"
+[tool.uv.sources]
+lib = {{ git = "https://example.invalid/org/lib", rev = "{rev}" }}
+"""
+
+_SELFTEST_LOCK = """
+version = 1
+[[package]]
+name = "lib"
+version = "0.1.0"
+source = {{ git = "https://example.invalid/org/lib?rev={rev}#{rev}" }}
+"""
+
+
+def _selftest() -> int:
+    """Prove the check can go red — a guard that cannot fail proves nothing."""
+    import tempfile
+
+    agreeing = "a" * 40
+    divergent = "b" * 40
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "pyproject.toml").write_text(
+            _SELFTEST_PYPROJECT.format(rev=agreeing)
+        )
+
+        (root / "uv.lock").write_text(_SELFTEST_LOCK.format(rev=agreeing))
+        green = check(root)
+        if green:
+            print(f"SELFTEST FAILED: an agreeing tree went red: {green}")
+            return 1
+
+        (root / "uv.lock").write_text(_SELFTEST_LOCK.format(rev=divergent))
+        red = check(root)
+        if not red:
+            print("SELFTEST FAILED: a DIVERGENT tree went green — the check is dead")
+            return 1
+        message = "\n".join(red)
+        for owed in ("pyproject.toml", "uv.lock", agreeing[:8], divergent[:8]):
+            if owed not in message:
+                print(f"SELFTEST FAILED: the verdict never names {owed!r}:\n{message}")
+                return 1
+
+        # And a lock that names the repo nowhere is red too, not silently green.
+        (root / "uv.lock").write_text("version = 1\n")
+        if not check(root):
+            print("SELFTEST FAILED: a lock missing the pin entirely went green")
+            return 1
+
+    print("selftest ok: agreeing tree green, divergent tree red naming both files")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--selftest" in argv:
+        return _selftest()
+
+    root = Path(argv[1]) if len(argv) > 1 else ROOT
+    failures = check(root)
+    if not failures:
+        return 0
+
+    print(
+        "pgw#1477: uv.lock is STALE against pyproject.toml.\n"
+        "\n"
+        "  Every CI job starts with `uv sync --locked`, which dies on this\n"
+        "  BEFORE any gate runs — three red checks, none of them the cause.\n",
+        file=sys.stderr,
+    )
+    for failure in failures:
+        print(f"  - {failure}", file=sys.stderr)
+    print("", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/vendor_snapshot.py
+++ b/scripts/vendor_snapshot.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""pgw#1477: THE ONE WRITER of a vendored package's rev — and it re-locks.
+
+A re-vendor moves the same rev in three places:
+
+  * `src/gen_worker/_vendor/VENDORED.toml`  — the snapshot the mint and the
+    serving path run, plus a per-file sha256 table,
+  * `pyproject.toml` `[tool.uv.sources]`    — the pin the DERIVE resolves from
+    the env it runs in,
+  * `uv.lock`                               — what `uv sync --locked` installs.
+
+Done by hand, the third is forgotten. Twice on 2026-08-19 (`fad60a8b`,
+`3966f323`) that broke `uv sync --locked`, the FIRST step of EVERY job in EVERY
+workflow, on PRs that had touched neither file — and it fails before any gate
+runs, so nothing in the required set could name the cause.
+
+So the three moves are ONE ACT. This script performs it end to end and stages
+every file it touched. `scripts/lint_lock_pin_agreement.py` is the other half:
+it refuses a tree where they disagree, locally and as CI's first step, for
+anyone who edits a pin by hand anyway.
+
+Usage:
+    python3 scripts/vendor_snapshot.py torchcg <rev>
+    python3 scripts/vendor_snapshot.py torchcg <rev> --pins-only
+
+`--pins-only` skips the file copy (use it when the snapshot is already extracted
+by hand, which is required for packages carrying non-mechanical rewrites).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "src" / "gen_worker" / "_vendor" / "VENDORED.toml"
+PYPROJECT = ROOT / "pyproject.toml"
+LOCK = ROOT / "uv.lock"
+
+#: Packages whose `rewrites` are purely mechanical, so this script can re-apply
+#: them and own the file copy too. Everything else (tensorfs: hand-written
+#: pure-Python ports of deleted upstream modules) must be extracted by hand and
+#: re-pinned with `--pins-only`. The prose in VENDORED.toml remains the
+#: authority on WHY each rewrite exists; this is only the executable half.
+MECHANICAL_REWRITES: dict[str, list[tuple[str, str]]] = {
+    # "`from tensorfs import ...` -> `from ..tensorfs import ...`" — upstream's
+    # own dependency, vendored beside it.
+    "torchcg": [(r"(?m)^from tensorfs import ", "from ..tensorfs import ")],
+}
+
+SKIP = {"__pycache__", ".git"}
+
+
+def _run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+    print(f"  $ {' '.join(cmd)}")
+    return subprocess.run(cmd, check=True, **kwargs)  # type: ignore[call-overload,no-any-return]
+
+
+def _files(root: Path) -> list[Path]:
+    return sorted(
+        p
+        for p in root.rglob("*")
+        if p.is_file() and not any(part in SKIP for part in p.relative_to(root).parts)
+    )
+
+
+def _digests(root: Path) -> dict[str, str]:
+    return {
+        str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in _files(root)
+    }
+
+
+def _section(text: str, header: str) -> tuple[int, int]:
+    """Byte span of the `[header]` table, from its line to the next `[` line."""
+    start = text.index(f"\n[{header}]\n") + 1
+    nxt = text.find("\n[", start + 1)
+    return start, len(text) if nxt < 0 else nxt + 1
+
+
+def _replace_rev(text: str, header: str, rev: str) -> str:
+    """Rewrite the FIRST `rev = "..."` inside `[header]`, leaving prose alone."""
+    start, end = _section(text, header)
+    body, count = re.subn(r'(?m)^rev = "[0-9a-f]+"$', f'rev = "{rev}"', text[start:end], count=1)
+    if count != 1:
+        raise SystemExit(f"{header}: expected exactly one `rev = ` line, found {count}")
+    return text[:start] + body + text[end:]
+
+
+def _replace_files_table(text: str, header: str, digests: dict[str, str]) -> str:
+    start, end = _section(text, header)
+    rows = "".join(f'"{path}" = "{sha}"\n' for path, sha in sorted(digests.items()))
+    return text[:start] + f"[{header}]\n" + rows + text[end:]
+
+
+def _extract(repo: str, rev: str, subdir: str, target: Path, package: str) -> None:
+    if package not in MECHANICAL_REWRITES:
+        raise SystemExit(
+            f"{package}: VENDORED.toml declares non-mechanical rewrites for this "
+            f"package, so this script will not overwrite the tree. Extract by "
+            f"hand (`git archive {rev} {subdir} | tar -x`), re-apply the rewrites, "
+            f"then rerun with --pins-only."
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        clone = Path(tmp) / "upstream"
+        _run(["git", "clone", "--quiet", repo, str(clone)])
+        _run(["git", "-C", str(clone), "checkout", "--quiet", rev])
+        staged = Path(tmp) / "staged"
+        staged.mkdir()
+        archive = subprocess.run(
+            ["git", "-C", str(clone), "archive", rev, subdir],
+            check=True,
+            stdout=subprocess.PIPE,
+        ).stdout
+        subprocess.run(["tar", "-x", "-C", str(staged)], input=archive, check=True)
+        source = staged / subdir
+        if not source.is_dir():
+            raise SystemExit(f"{package}: `{subdir}` is not a directory at {rev}")
+
+        for pattern, replacement in MECHANICAL_REWRITES[package]:
+            for path in _files(source):
+                if path.suffix != ".py":
+                    continue
+                text = path.read_text()
+                rewritten = re.sub(pattern, replacement, text)
+                if rewritten != text:
+                    print(f"  rewrite: {path.relative_to(source)}")
+                    path.write_text(rewritten)
+
+        shutil.rmtree(target)
+        shutil.copytree(source, target)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package")
+    parser.add_argument("rev")
+    parser.add_argument(
+        "--pins-only",
+        action="store_true",
+        help="do not touch the vendored files; re-pin, re-digest and re-lock only",
+    )
+    parser.add_argument(
+        "--no-lock",
+        action="store_true",
+        help="skip `uv lock` (for offline dry runs ONLY — it is the whole point)",
+    )
+    args = parser.parse_args(argv[1:])
+
+    manifest_text = MANIFEST.read_text()
+    manifest = tomllib.loads(manifest_text)
+    if args.package not in manifest.get("packages", {}):
+        raise SystemExit(
+            f"{args.package}: not in VENDORED.toml "
+            f"({', '.join(sorted(manifest['packages']))})"
+        )
+    spec = manifest["packages"][args.package]
+    repo, subdir = str(spec["repo"]), str(spec["subdir"])
+    target = MANIFEST.parent / args.package
+
+    print(f"resolving {args.rev} in {repo}")
+    resolved = subprocess.run(
+        ["git", "ls-remote", repo, args.rev],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.split("\t")[0].strip()
+    if not re.fullmatch(r"[0-9a-f]{40}", resolved):
+        # Not a ref — a raw sha. Take it, and let the clone prove it exists.
+        if not re.fullmatch(r"[0-9a-f]{7,40}", args.rev):
+            raise SystemExit(f"{args.rev}: neither a ref on {repo} nor a sha")
+        resolved = args.rev
+    print(f"  -> {resolved}")
+
+    if not args.pins_only:
+        _extract(repo, resolved, subdir, target, args.package)
+        # A short sha given on the command line must be recorded in full.
+        if len(resolved) != 40:
+            with tempfile.TemporaryDirectory() as tmp:
+                clone = Path(tmp) / "u"
+                _run(["git", "clone", "--quiet", repo, str(clone)])
+                resolved = subprocess.run(
+                    ["git", "-C", str(clone), "rev-parse", f"{args.rev}^{{commit}}"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip()
+
+    if len(resolved) != 40:
+        raise SystemExit(
+            f"{resolved}: --pins-only needs the FULL 40-hex rev (a prefix is not "
+            f"a pin; uv writes 40 hex into uv.lock and the two must be comparable)"
+        )
+
+    header = f"packages.{args.package}"
+    manifest_text = _replace_rev(manifest_text, header, resolved)
+    manifest_text = _replace_files_table(
+        manifest_text, f"{header}.files", _digests(target)
+    )
+    MANIFEST.write_text(manifest_text)
+    print(f"VENDORED.toml: {args.package} rev + {len(_digests(target))} digests")
+
+    pyproject_text = PYPROJECT.read_text()
+    pin = re.compile(
+        rf'(?m)^({re.escape(args.package)} = \{{ git = "[^"]+", rev = ")[0-9a-f]+(")'
+    )
+    if pin.search(pyproject_text):
+        PYPROJECT.write_text(pin.sub(rf"\g<1>{resolved}\g<2>", pyproject_text))
+        print(f"pyproject.toml: [tool.uv.sources].{args.package} -> {resolved}")
+    else:
+        print(f"pyproject.toml: no [tool.uv.sources] entry for {args.package} (fine)")
+
+    if args.no_lock:
+        print("uv lock: SKIPPED (--no-lock) — uv.lock is now stale ON PURPOSE")
+    else:
+        _run(["uv", "lock"], cwd=ROOT)
+
+    _run(
+        ["git", "add", "--", str(MANIFEST), str(PYPROJECT), str(LOCK), str(target)],
+        cwd=ROOT,
+    )
+
+    print("\nverifying the three spellings agree:")
+    check = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "lint_lock_pin_agreement.py")],
+        cwd=ROOT,
+    )
+    if check.returncode != 0:
+        return check.returncode
+    print("  ok — pyproject.toml, uv.lock and VENDORED.toml all name", resolved)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -13,10 +13,17 @@
 # (per-file sha256) and separately proves the BEHAVIOUR the pinned rev exists
 # for, so neither fence can pass on a stale or hand-patched tree.
 #
-# To re-vendor: `git archive <rev> <subdir> | tar -x` into the package
-# directory (whose name is the TABLE KEY below, which is upstream's CURRENT
-# package name and not necessarily `subdir`'s last component), re-apply
-# `rewrites`, then regenerate the `files` tables.
+# To re-vendor: `task vendor -- <package> <rev>` (scripts/vendor_snapshot.py).
+# It extracts at the rev, re-applies the mechanical `rewrites`, regenerates the
+# `files` table, and moves the SAME rev in `pyproject.toml`'s `[tool.uv.sources]`
+# and in `uv.lock` — one act, because pgw#1477 is what a hand re-vendor that
+# forgot the third one costs: `uv sync --locked` is the FIRST step of every CI
+# job, and it dies naming neither file. Twice on 2026-08-19, 20 minutes apart.
+# Packages with NON-mechanical rewrites (tensorfs: hand-written pure-Python
+# ports of deleted upstream modules) are extracted by hand — `git archive <rev>
+# <subdir> | tar -x` into the package directory, whose name is the TABLE KEY
+# below (upstream's CURRENT package name, not necessarily `subdir`'s last
+# component) — and then re-pinned with `--pins-only`, which does everything else.
 
 [packages.tensorfs]
 repo = "https://github.com/cozy-creator/tensorfs"
@@ -299,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "6c91b83d"
+rev = "6c91b83d8fb2e45a6d568569dc15884c4d6b26e3"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's

--- a/tests/test_modular_model_index_pgw1481.py
+++ b/tests/test_modular_model_index_pgw1481.py
@@ -54,7 +54,9 @@ def _modularize(source: Path, **overrides: object) -> None:
 
 
 @pytest.fixture(scope="module")
-def modular_source(tmp_path_factory: pytest.TempPathFactory):
+def modular_source(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[Path, type, dict[str, object]]:
     target = tmp_path_factory.mktemp("pgw1481")
     pipeline_cls = build_source(target)
     classic = json.loads((target / "model_index.json").read_text())
@@ -62,7 +64,7 @@ def modular_source(tmp_path_factory: pytest.TempPathFactory):
     return target, pipeline_cls, classic
 
 
-def test_modular_index_loads(modular_source) -> None:
+def test_modular_index_loads(modular_source: tuple[Path, type, dict[str, object]]) -> None:
     """Every component a modular index declares must reach the skeleton.
 
     THE RED ARM: restore ``len(spec) != 2: continue`` in ``skeleton.build`` and

--- a/tests/test_scratch_repo_derives_its_release_pgw1479.py
+++ b/tests/test_scratch_repo_derives_its_release_pgw1479.py
@@ -44,6 +44,7 @@ from gen_worker.request_context import RequestContext
 from gen_worker.hubio.client import (
     COMPILED_GRAPH_NO_RELEASE,
     CommitFile,
+    CommitResult,
     HubClient,
     HubPublishError,
     HubReleaseRequiredError,
@@ -81,7 +82,7 @@ def test_derives_its_release_reads_the_reserved_grammar(ref: str, expected: bool
 # HubClient.publish_v2 — the guard that fired before any HTTP.
 # --------------------------------------------------------------------------
 
-def _publish(destination_repo: str, release: str) -> None:
+def _publish(destination_repo: str, release: str) -> CommitResult:
     """Drive publish_v2 far enough to clear (or trip) the release guard.
 
     The guard is the FIRST thing after the empty-files check, and the next step

--- a/tests/test_scratch_repo_derives_its_release_pgw1479.py
+++ b/tests/test_scratch_repo_derives_its_release_pgw1479.py
@@ -81,7 +81,7 @@ def test_derives_its_release_reads_the_reserved_grammar(ref: str, expected: bool
 # HubClient.publish_v2 — the guard that fired before any HTTP.
 # --------------------------------------------------------------------------
 
-def _publish(destination_repo: str, release: str):
+def _publish(destination_repo: str, release: str) -> None:
     """Drive publish_v2 far enough to clear (or trip) the release guard.
 
     The guard is the FIRST thing after the empty-files check, and the next step


### PR DESCRIPTION
Closes pgw#1477.

`uv sync --locked` is the FIRST step of EVERY job in EVERY workflow. A re-vendor that moved
`pyproject.toml`'s `[tool.uv.sources]` torchcg rev and left `uv.lock` behind therefore killed
`fast gates`, `tests` AND `drift` at install, on PRs that had touched neither file, with a message
naming no file and no rev. Twice on 2026-08-19, twenty minutes apart — and nothing in the required
set could ever have caught it: a gate cannot fail on something it never got far enough to read.

## Which writer each breakage used

Both, the same one: a HAND EDIT of the pin inside a re-vendor. There was no vendor script to fix —
`_vendor/VENDORED.toml`'s prose said `git archive <rev> <subdir> | tar -x`, re-apply the rewrites,
regenerate the digests, and the pin moves were three separate manual edits of which `uv lock` was
the forgettable one. `fad60a8b` (pgw#1460/tcg#58) and `3966f323` (pgw#1478/tcg#61) each touched
`pyproject.toml` + `VENDORED.toml` + the vendored tree and neither touched `uv.lock`.

## Half 1 — the writer re-locks

`scripts/vendor_snapshot.py` (`task vendor -- <package> <rev>`) is now the ONE WRITER of a vendored
rev, and it re-locks in the same act: resolve the rev, extract the subdir, re-apply the declared
mechanical rewrites, regenerate the sha256 table, write the rev into `_vendor/VENDORED.toml` AND
`pyproject.toml`, run `uv lock`, stage all four paths, then re-run the checker on its own output.
Packages whose rewrites are NOT mechanical (tensorfs, whose `planner.py`/`contract.py` are
hand-written ports of deleted upstream modules) are refused the file copy by name and re-pinned
with `--pins-only`, which does everything else.

Proven by a **no-op re-vendor at the rev already vendored**: 39/39 files byte-identical, digest
table unchanged, `uv lock` a no-op. The only diff is `VENDORED.toml`'s rev normalised from 8 hex to
40 — a prefix is not comparable to what uv writes into `uv.lock`.

## Half 2 — the check runs FIRST and fails ALONE

`scripts/lint_lock_pin_agreement.py` runs ahead of uv itself in `fast gates`, `tests`, `drift` and
`publish`, and as the first line of `task lint` (every other line there is a `uv run`, which
silently RE-RESOLVES a stale lock instead of refusing it — so `task lint` was green on exactly the
tree CI dies installing). Stdlib only, no venv, no network, ~30 ms. It reads all THREE spellings of
the rev — `[tool.uv.sources]`, every git URL in `uv.lock`, and the vendored snapshot's — and names
both files and both revs:

```
  - torchcg: the pin in pyproject.toml and uv.lock DISAGREE.
      pyproject.toml  [tool.uv.sources].torchcg  rev = 12c99841f01f9ccba22c279b72bebc30bd7b22d2
      uv.lock         https://github.com/cozy-creator/torchcg  rev = 8e8c5ca6acdb3ed13f94ae6878c8248114ecd9c7
```

`--selftest` runs in `fast gates` and is what makes the green a result: it builds a divergent tree
in a tempdir and fails if the check stays quiet on it.

## Red / green on the REAL divergence

Replayed against actual history (`pyproject.toml` + `uv.lock` + `VENDORED.toml` at each sha):

| commit | verdict |
|---|---|
| `fad60a8b` (occurrence 1) | **RED** — pin `12c99841` vs lock `8e8c5ca6` |
| `3966f323` (occurrence 2) | **RED** — pin `6c91b83d` vs lock `8e8c5ca6` |
| `c16ebf928` ("fixed" occ. 1) | **RED** — its tree was already stale against the re-vendor that landed 7 minutes earlier |
| `bdecee16` (occurrence 2's fix) | green |
| current master `3c123333` | green — **no third breakage; master is clean through the rail** |

Plus a live CI red-proof on a throwaway branch (PR #1044, closed unmerged): `fad60a8b`'s exact
shape on top of this rail, and `fast gates` dies at its FIRST step naming both files instead of
three jobs dying at `uv sync --locked`.