### PR TITLE
pgw#1481: a modular model_index.json loads, and an unreadable entry refuses BY NAME

### DIFF
--- a/src/gen_worker/serving/streaming/skeleton.py
+++ b/src/gen_worker/serving/streaming/skeleton.py
@@ -131,9 +131,45 @@ def build(
     for name, spec in sorted(index.items()):
         if name.startswith("_"):
             continue
-        if not isinstance(spec, (list, tuple)) or len(spec) != 2:
-            continue
-        library, class_name = spec
+        # pgw#1481: an entry this walker cannot read is REFUSED BY NAME, never
+        # skipped. `continue` here collapsed nine specific failures into one
+        # "declares no nn.Module component" that named none of them — and that
+        # sentence is false when the index declares nine.
+        if not isinstance(spec, (list, tuple)) or len(spec) < 2:
+            raise SkeletonError(
+                f"{index_path} entry {name!r} is {spec!r}, which is not "
+                f"[library, class_name]"
+            )
+        library, class_name = spec[0], spec[1]
+        if len(spec) > 2:
+            # A MODULAR index entry: [library, class_name, {type_hint,
+            # pretrained_model_name_or_path, subfolder, variant, revision}].
+            # Its first two elements mean exactly what the classic ones mean,
+            # so it is loadable — but only while the metadata does not send us
+            # somewhere else. Anything that relocates the component is refused
+            # rather than silently read from `checkpoint_dir/<name>`.
+            meta = spec[2] if len(spec) == 3 and isinstance(spec[2], dict) else None
+            if meta is None:
+                raise SkeletonError(
+                    f"{index_path} entry {name!r} has {len(spec)} elements and no "
+                    f"trailing metadata object; expected [library, class_name] or a "
+                    f"modular [library, class_name, {{...}}]"
+                )
+            subfolder = meta.get("subfolder")
+            if subfolder is not None and str(subfolder) != name:
+                raise SkeletonError(
+                    f"{index_path} entry {name!r} is a modular entry whose "
+                    f"subfolder is {subfolder!r}, not {name!r}. The projected tree "
+                    f"is addressed by component name, so this component's weights "
+                    f"are not where streaming would look for them."
+                )
+            for field in ("variant", "revision"):
+                if meta.get(field) is not None:
+                    raise SkeletonError(
+                        f"{index_path} entry {name!r} is a modular entry pinning "
+                        f"{field}={meta[field]!r}. The projected tree carries one "
+                        f"cut of this component and cannot honour that pin."
+                    )
         if library is None or class_name is None:
             # A declared-but-absent optional component (safety checker and
             # friends). The pipeline takes None and says so itself.

--- a/tests/test_modular_model_index_pgw1481.py
+++ b/tests/test_modular_model_index_pgw1481.py
@@ -1,0 +1,143 @@
+"""pgw#1481 — a MODULAR ``model_index.json`` must load, and must refuse BY NAME.
+
+The article is a real diffusers pipeline saved by ``streaming_fixture``, whose
+``model_index.json`` is then rewritten into the 3-element modular form that
+``tensorhub/minimax-h3`` actually ships:
+
+    "vae": ["diffusers", "AutoencoderKL",
+            {"type_hint": [...], "pretrained_model_name_or_path": "...",
+             "subfolder": "vae", "variant": null, "revision": null}]
+
+Before the fix ``skeleton.build`` filtered on ``len(spec) != 2`` and
+``continue``d, so every component vanished and the walk died on
+``declares no nn.Module component`` — a sentence that is false when the index
+declares nine, and that names none of them. The red arm here is that exact
+mutation: revert the walker to a 2-element filter and ``test_modular_index_loads``
+fails.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+pytest.importorskip("safetensors")
+
+from gen_worker.serving.streaming import skeleton as sk  # noqa: E402
+from gen_worker.serving.streaming.skeleton import SkeletonError  # noqa: E402
+from streaming_fixture import build_source  # noqa: E402
+
+
+def _modularize(source: Path, **overrides: object) -> None:
+    """Rewrite a classic index in place as a modular one."""
+    index_path = source / "model_index.json"
+    index = json.loads(index_path.read_text())
+    for name, spec in list(index.items()):
+        if name.startswith("_") or not isinstance(spec, list) or len(spec) != 2:
+            continue
+        library, class_name = spec
+        meta = {
+            "type_hint": [library, class_name],
+            "pretrained_model_name_or_path": "Org/Model",
+            "subfolder": name,
+            "variant": None,
+            "revision": None,
+        }
+        meta.update(overrides)
+        index[name] = [library, class_name, meta]
+    index_path.write_text(json.dumps(index))
+
+
+@pytest.fixture(scope="module")
+def modular_source(tmp_path_factory: pytest.TempPathFactory):
+    target = tmp_path_factory.mktemp("pgw1481")
+    pipeline_cls = build_source(target)
+    classic = json.loads((target / "model_index.json").read_text())
+    _modularize(target)
+    return target, pipeline_cls, classic
+
+
+def test_modular_index_loads(modular_source) -> None:
+    """Every component a modular index declares must reach the skeleton.
+
+    THE RED ARM: restore ``len(spec) != 2: continue`` in ``skeleton.build`` and
+    this fails with ``declares no nn.Module component``.
+    """
+    source, pipeline_cls, classic = modular_source
+    declared = {k for k in classic if not k.startswith("_")}
+
+    built = sk.build(pipeline_cls, source)
+
+    reached = set(built.modules) | set(built.passthrough)
+    assert reached == declared, (
+        f"modular index declared {sorted(declared)}; skeleton reached "
+        f"{sorted(reached)} — a component the walker drops is streamed nowhere"
+    )
+    assert built.modules, "no nn.Module component survived the modular walk"
+    # Identity, not truthiness — the pgw#1410 fence's property, restated here so
+    # a modular index cannot reintroduce the orphan it was written to catch.
+    for name, module in built.modules.items():
+        assert getattr(built.pipeline, name, None) is module
+
+
+def test_relocating_subfolder_is_refused_by_name(tmp_path: Path) -> None:
+    """A modular entry may not send a component somewhere else, silently."""
+    source = tmp_path / "relocated"
+    pipeline_cls = build_source(source)
+    _modularize(source, subfolder="elsewhere")
+
+    with pytest.raises(SkeletonError) as excinfo:
+        sk.build(pipeline_cls, source)
+    message = str(excinfo.value)
+    assert "subfolder" in message
+    assert "elsewhere" in message
+
+
+@pytest.mark.parametrize("field, value", [("variant", "fp16"), ("revision", "abc123")])
+def test_pinned_variant_or_revision_is_refused_by_name(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    """The projected tree carries ONE cut; a pin it cannot honour is refused."""
+    source = tmp_path / f"pinned-{field}"
+    pipeline_cls = build_source(source)
+    _modularize(source, **{field: value})
+
+    with pytest.raises(SkeletonError) as excinfo:
+        sk.build(pipeline_cls, source)
+    message = str(excinfo.value)
+    assert field in message
+    assert value in message
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        ["diffusers"],
+        "nonsense",
+        ["diffusers", "AutoencoderKL", "not-a-dict", "extra"],
+    ],
+    ids=["one-element", "scalar", "no-metadata-object"],
+)
+def test_unreadable_entry_names_itself(tmp_path: Path, bad: object) -> None:
+    """An entry the walker cannot read is refused, and the message names it.
+
+    This is the half that outlives minimax-h3: before pgw#1481 an unreadable
+    entry was skipped, so N specific failures became one count-of-zero at the
+    end of the loop.
+    """
+    source = tmp_path / "unreadable"
+    pipeline_cls = build_source(source)
+    _modularize(source)
+    index_path = source / "model_index.json"
+    index = json.loads(index_path.read_text())
+    index["vae"] = bad
+    index_path.write_text(json.dumps(index))
+
+    with pytest.raises(SkeletonError) as excinfo:
+        sk.build(pipeline_cls, source)
+    assert "vae" in str(excinfo.value)


### PR DESCRIPTION
## The defect

`skeleton.build` filtered components on `len(spec) != 2` and **`continue`d**. Every entry in `tensorhub/minimax-h3`'s `model_index.json` is a 3-element **modular** entry:

```json
"transformer": ["diffusers", "MiniMaxH3Transformer3DModel",
  {"type_hint": ["diffusers","MiniMaxH3Transformer3DModel"],
   "pretrained_model_name_or_path": "MiniMaxAI/MiniMax-H3",
   "subfolder": "transformer", "variant": null, "revision": null}]
```

So all nine were skipped, `modules` came out empty, and the walk died on:

```
model_index.json declares no nn.Module component; there would be no weights to stream
```

**That sentence is false when the index declares nine, and it names none of them.** Since se#766 made `ctx.load` the only hydration path, **minimax-h3 could not boot on a pod at any pin** — it would refuse before a single weight byte moved, after the pod was paid for.

## Positive control — the loader was not broken in general

| checkpoint | 2-element | 3-element |
|---|---|---|
| `tensorhub/wai-illustrious@prod` (sdxl's bind, serves real images) | **9** | 0 |
| `tensorhub/minimax-h3@serve-narrowed` | 0 | **9** |

The loader and this checkpoint disagreed about the schema of `model_index.json`, and the disagreement was resolved by silence.

## Measured against the real tree with the production function

Production `skeleton.build`, real 34 MB config-only tree fetched from the hub, `CUDA_VISIBLE_DEVICES=""`:

```
before -> SkeletonError: declares no nn.Module component
after  -> module components (5): audio_vae, text_encoder, transformer, transformer_ref, vae
          passthrough (4):       audio_scheduler, processor, scheduler, tokenizer
```

Nine reached — exactly the nine that were being dropped — and it **clears the pgw#1410 orphan fence**, so `MiniMaxH3StreamingPipeline` was correct all along; it never got the chance.

## The fence

A modular entry's first two elements mean exactly what the classic ones mean, so it is loadable — **but only while its metadata does not relocate the component.** A `subfolder` differing from the component name, or a non-null `variant`/`revision`, is refused by name rather than silently read from `checkpoint_dir/<name>`.

## The half that outlives minimax-h3

**N specific failures must not collapse into one count-of-zero at the end of the loop.** An entry the walker cannot read now names itself. Cost of the old behaviour on this endpoint: it took a positive control against a second checkpoint to work out that "declares no nn.Module component" meant "declares nine, in a shape I skip".

## Why pgw#1410 didn't cover this

pgw#1410 taught the skeleton about `ModularPipeline`'s **constructor** (kwargs → `load_config`, components registered `None`) and its orphan fence is live and well-worded. The **index shape** was never taught — so the two modular halves failed at opposite ends of the same function.

## Evidence

- `tests/test_modular_model_index_pgw1481.py` — **7 passed**. Built on the real `streaming_fixture` pipeline, whose classic index is rewritten into modular form.
- **Red arm: restore `len(spec) != 2: continue` → `test_modular_index_loads` fails 5/5.**
- Each new refusal proven able to fire: relocated subfolder, pinned variant, pinned revision, 1-element entry, scalar entry, 4-element entry with no metadata object — six mutations, six named refusals.
- `ruff check src/gen_worker` clean; `mypy` clean on the changed file.

## Not fixed here

`model_index.json` is a **byte-copy of `modular_model_index.json`** on both `serve-narrowed` and `serve-narrowed-fp8te` (2,936 vs 2,935 bytes, empty `json.tool` diff). A correct diffusers modular repo carries both a classic 2-element index and a modular one. That is a separate **tensorhub/ingest** defect. This change makes the loader tolerate what the hub actually serves, which is the right split — the loader must not depend on a re-cut to stop failing silently.