### PR TITLE
pgw#1485: a model_download opened for a ref the pod ALREADY HOLDS was immortal, and the JOB PLANE never entered the instrumented funnel at all

### DIFF
--- a/changelog.d/pgw1485.md
+++ b/changelog.d/pgw1485.md
@@ -1,0 +1,24 @@
+- **A `model_download` opened for a ref the pod ALREADY HOLDS no longer sits `downloading` at 0/N
+  forever.** The record is a hub-side liability, not a note: `connect_worker.go` opens
+  `ModelDownloads[ref]` on `DOWNLOADING` and only `ON_DISK`/`FAILED`/`EVICTED` removes it. On a warm
+  re-dispatch the funnel emitted the opening `DOWNLOADING`, the downloader resolved every object out
+  of the local CAS and moved zero bytes (so `_progress` never fired), and the closing `ON_DISK` was
+  suppressed by `Residency.track_disk`'s same-tier rule plus the `identity_changed` guard. Nothing
+  advanced it and nothing closed it. One producer, two victims: it vetoed idle retirement for 179
+  minutes on an A100 at $1.59/hr (th#2205, $2.44 of a $4.75 run, nine pods over six days) and it
+  livelocks placement (th#2204).
+- **The record now opens only when there is a transfer to declare.** A ref resident at the exact
+  operation identity — or loaded in RAM/VRAM, whose bytes are on the pod by construction — opens
+  nothing; `_progress` opens one lazily if a byte actually moves, so a partial CAS still gets its
+  instrument. The `already_resident` disposition is a real row on pgw#1455's position stream
+  (`weight_fetch`, `phase=already_resident`), so "the pod already had it" stops being
+  indistinguishable from th#2204's `no_position_reported` silence.
+- **And its close is structural.** The terminal ModelEvent moved into the same `finally` that
+  already closed the byte position: success closes with `ON_DISK`, and a transfer that dies mid-way
+  — cancellation, shutdown, any `BaseException` — closes with `FAILED download_canceled` instead of
+  leaving an immortal row. A record whose close is conditional is a record that can be immortal.
+- **Red proven on the measured shape.** `tests/test_weight_position.py` extends pgw#1455's real
+  trickling-origin harness with the production `ModelStore` funnel and replays the hub's own
+  open/close bookkeeping over what the worker emits. Reverting `models/store.py` to master leaves
+  `[('acme/model-a', 0, 9437184)]` open — th#2205's `0 of 15,980,165,697` exactly — while the
+  control (a genuine fetch opens, advances and closes) stays green.

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -492,3 +492,22 @@ gen_worker.serving.engine_runtime.process_vram_bytes()
 # spellings of one state is how a caller ends up asking a two-answer question
 # about a three-state gate, and "not configured" collapsing `local` into `unset`
 # is exactly the fail-open that issue closed.
+
+# pgw#1485: `weightless_program.uninstall()` is DELIBERATELY test-only, and the
+# ratchet is right that it has no production caller — it is the SUITE's half of
+# a process-wide monkeypatch, not a runtime capability.
+#
+# `install()` replaces `torch.export.pt2_archive._package._load_state_dict` for
+# the whole process and `mint_child` calls it. pgw#1468's two stock-path guards
+# then measure whichever test ran before them on the same xdist worker: their
+# fixture snapshot-and-restored a symbol that was ALREADY patched, so the red
+# arm silently stopped being red. Both flipped to failing on a branch whose only
+# change was test distribution. Restoring the pristine loader needs the closure
+# the patch captured, which only this module can reach — so the alternative to
+# this line is a test reaching into `__closure__` itself, which is worse.
+#
+#     OWNER:  pgw#1485. If production ever needs to unpatch (a worker that
+#             serves after a mint child ran in-process), this acquires a real
+#             caller and the ratchet will say so by going red on STALE.
+#     EXPIRY: none. A guard's undo living beside its do is the correct shape.
+gen_worker.serving.weightless_program.uninstall()

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -1387,7 +1387,12 @@ class ModelStore:
                 dl_counter.set_done(float(done))
                 if total:
                     dl_counter.set_total(float(total))
-                if not download_open and int(done) > 0:
+                if not download_open:
+                    if int(done) <= 0:
+                        # The fetch loop ticks at zero before it moves anything.
+                        # Declaring HERE is how the phantom got created; a
+                        # position of 0 is not a transfer.
+                        return
                     # A byte moved on a materialization we declined to declare:
                     # the ref was not as resident as the resolver believed. Open
                     # now, so a real fetch always has a record to advance.

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -107,6 +107,20 @@ _TIER_TO_PB = {
 _USE_RESIDENT_IDENTITY = object()
 _ResidencyIdentity = Tuple[str, int]
 
+def _resident_position(ref: "WireRef", snapshot: Optional[pb.Snapshot]) -> None:
+    """pgw#1485: one `already_resident` position row for a materialization that
+    transferred nothing because the pod already held the ref.
+
+    Without it a warm hit is INDISTINGUISHABLE from a fetch that never started
+    (th#2204's `no_position_reported`), and the only way anyone ever learned
+    which it was cost a rented H100.
+    """
+    total = (
+        sum(int(f.size_bytes) for f in snapshot.files)
+        if snapshot is not None else 0
+    )
+    weight_position.FetchPosition(ref, total_bytes=total).already_resident()
+
 @dataclass(frozen=True)
 class _MaterializedLocal:
     path: Path
@@ -1241,6 +1255,7 @@ class ModelStore:
                 if ref in self._verified:
                     self._index.touch(ref)
                     await self._confirm_cached_identity(ref, operation_identity)
+                    _resident_position(ref, snapshot)
                     return complete(cached)
                 # First use this boot: verify before trusting. A
                 # pod-churn-truncated snapshot used to fatal every load until
@@ -1252,6 +1267,7 @@ class ModelStore:
                     self._verified.add(ref)
                     self._index.touch(ref)
                     await self._confirm_cached_identity(ref, operation_identity)
+                    _resident_position(ref, snapshot)
                     return complete(cached)
                 logger.error(
                     "snapshot for %s failed first-use verification "
@@ -1324,12 +1340,60 @@ class ModelStore:
             # that sees every materialization path and knows the ref.
             position = weight_position.FetchPosition(ref, total_bytes=known_total)
 
+            # pgw#1485 / th#2205 / th#2204 — THE DOWNLOAD RECORD IS A
+            # LIABILITY, NOT A NOTE. A DOWNLOADING event OPENS a hub-side
+            # `ModelDownloads[ref]` row that ONLY `ON_DISK`/`FAILED`/`EVICTED`
+            # can close, and that open row (a) vetoes idle retirement and (b)
+            # parks placement. So it is opened only when there is a transfer to
+            # declare, and its close is structural — in the `finally` below,
+            # on every exit path including cancellation.
+            resident_tier = self.residency.tier(ref)
+            with self._identity_lock:
+                banked_disk_identity = self._disk_identities.get(ref)
+            already_resident = resident_tier is not None and (
+                # A LOADED object's bytes are on the pod by construction; there
+                # is no transfer to declare. (And `ON_DISK` — the only terminal
+                # that closes the record — would demote the hub's tier view, so
+                # a record opened over RAM/VRAM residency is one that cannot be
+                # closed honestly at all.)
+                resident_tier in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
+                # Disk-resident at EXACTLY the identity being materialized.
+                or (bool(operation_identity[0])
+                    and banked_disk_identity == operation_identity)
+            )
+            #: True while a hub-side `model_download` record is OPEN for this
+            #: materialization and unclosed.
+            download_open = False
+            #: True once a terminal ModelEvent for that record has been sent
+            #: (by us, or by Residency's own first-registration ON_DISK).
+            download_terminal = False
+
+            def _open_download_record(done: int, total: int) -> None:
+                """Declare the transfer. Called from the fetch thread."""
+                nonlocal download_open
+                download_open = True
+                assert self._loop is not None
+                asyncio.run_coroutine_threadsafe(
+                    self._event(ref, pb.MODEL_STATE_DOWNLOADING,
+                                identity=operation_identity,
+                                bytes_done=int(done), bytes_total=int(total),
+                                network_bytes=net_scope.network_bytes),
+                    self._loop,
+                )
+
             def _progress(done: int, total: Optional[int]) -> None:
                 nonlocal last_progress
                 position.progress(done, total)
                 dl_counter.set_done(float(done))
                 if total:
                     dl_counter.set_total(float(total))
+                if not download_open and int(done) > 0:
+                    # A byte moved on a materialization we declined to declare:
+                    # the ref was not as resident as the resolver believed. Open
+                    # now, so a real fetch always has a record to advance.
+                    last_progress = time.monotonic()
+                    _open_download_record(done, int(total or known_total))
+                    return
                 now = time.monotonic()
                 if now - last_progress < _PROGRESS_EVENT_MIN_INTERVAL_S:
                     return
@@ -1344,10 +1408,24 @@ class ModelStore:
                 )
 
             position.open()
-            await self._event(
-                ref, pb.MODEL_STATE_DOWNLOADING, identity=operation_identity,
-                bytes_total=known_total,
-            )
+            if already_resident:
+                # th#2205's exact shape: a WARM pod re-dispatched against
+                # weights it already holds. The fetch below is a no-op the
+                # downloader resolves out of the local CAS — it moves no bytes,
+                # so nothing would ever advance or close the record. Declare
+                # nothing; `_progress` opens one if a byte actually moves.
+                logger.info(
+                    "model_download not opened for %s: already_resident "
+                    "tier=%s digest=%s total_bytes=%d",
+                    ref, getattr(resident_tier, "name", resident_tier),
+                    operation_identity[0], known_total,
+                )
+            else:
+                await self._event(
+                    ref, pb.MODEL_STATE_DOWNLOADING, identity=operation_identity,
+                    bytes_total=known_total,
+                )
+                download_open = True
             failure_stage = pb.LIFECYCLE_INTENT_STAGE_FETCHING
             if registry is not None:
                 registry.transition(
@@ -1423,6 +1501,12 @@ class ModelStore:
                         self._pending_network_bytes[ref] = net_scope.network_bytes
                         self.residency.track_disk(ref, path)
                         self._pending_network_bytes.pop(ref, None)  # defensive: unconsumed if no event fired
+                        if tier_before is None:
+                            # A FIRST registration: Residency emitted ON_DISK
+                            # itself, which closes the record. Every other tier
+                            # is same-tier-suppressed there — pgw#1485's whole
+                            # defect — so the `finally` owns those.
+                            download_terminal = True
                         if tier_before is residency_mod.Tier.DISK and identity_changed:
                             # Residency suppresses same-tier event spam (track_disk
                             # above did not consume the pending value above). A
@@ -1434,6 +1518,7 @@ class ModelStore:
                                 identity=operation_identity,
                                 network_bytes=net_scope.network_bytes,
                             )
+                            download_terminal = True
                         # tree_bytes stats every file — off-loop (gw#407: no
                         # multi-GB directory walks on the event loop).
                         size = await asyncio.to_thread(disk_gc.tree_bytes, path)
@@ -1456,6 +1541,7 @@ class ModelStore:
                                 ref, pb.MODEL_STATE_FAILED,
                                 identity=operation_identity, error=vocab,
                             )
+                            download_terminal = True
                             raise
                         logger.warning(
                             "download of %s failed (attempt %d): %s; retrying in %.1fs",
@@ -1489,7 +1575,42 @@ class ModelStore:
                 # Where the transfer STOPPED, whether it finished or raised —
                 # a fetch that ends with no terminal row is one nobody can
                 # distinguish from a fetch still running.
-                position.close(ok=fetch_exc is None)
+                position.close(
+                    ok=fetch_exc is None,
+                    resident=already_resident and not download_open,
+                )
+                # pgw#1485: THE CLOSE OF THE HUB-SIDE RECORD, IN A `finally`.
+                # Every path that opened one closes it here if nothing already
+                # did — success whose ON_DISK was same-tier-suppressed
+                # (th#2205's 179-minute $1.59/hr row), and a transfer that died
+                # mid-way: cancellation, shutdown, any BaseException. A record
+                # whose close is conditional is a record that can be immortal.
+                if download_open and not download_terminal:
+                    download_terminal = True
+                    if fetch_exc is None:
+                        terminal_event = self._event(
+                            ref, pb.MODEL_STATE_ON_DISK,
+                            identity=operation_identity,
+                            network_bytes=net_scope.network_bytes,
+                        )
+                    else:
+                        terminal_event = self._event(
+                            ref, pb.MODEL_STATE_FAILED,
+                            identity=operation_identity,
+                            error=(
+                                "download_canceled"
+                                if isinstance(fetch_exc, asyncio.CancelledError)
+                                else self._error_vocab(fetch_exc)
+                            ),
+                        )
+                    if isinstance(fetch_exc, BaseException) and not isinstance(
+                        fetch_exc, Exception
+                    ):
+                        # Unwinding a cancellation/shutdown: awaiting here would
+                        # re-raise before the event left. Hand it to the loop.
+                        asyncio.ensure_future(terminal_event)
+                    else:
+                        await terminal_event
                 if fetch_span is not None:
                     net = int(net_scope.network_bytes)
                     if net > 0:

--- a/src/gen_worker/serving/reserved_repos.py
+++ b/src/gen_worker/serving/reserved_repos.py
@@ -49,6 +49,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Tuple
 
 import msgspec
 
+from .. import weight_position
 from ..api.errors import ValidationError
 from ..models.cache_paths import tensorhub_cas_dir, tensorhub_fill_source_dir
 from ..models.download import ensure_local
@@ -143,13 +144,46 @@ async def _materialize_one(
             f"payload.{field_name} needs a producer context; this context has "
             f"no {_SETTER_FOR[field_name]}"
         )
-    path = await ensure_local(
-        str(ref),
-        snapshot=snapshots.get(ref),
-        cache_dir=tensorhub_cas_dir(),
-        hf_token=hf_token or None,
-        fill_source_dir=tensorhub_fill_source_dir(),
-    )
+    snapshot = snapshots.get(ref)
+    # pgw#1485 / pgw#1455: THE JOB PLANE'S FETCH IS INSTRUMENTED TOO. This is a
+    # SECOND download funnel — the `models.download.ensure_local` FREE FUNCTION,
+    # not `ModelStore`'s — and it was called with no `progress=` at all, so a
+    # pod that pulled 20.5 GB of reserved-repo weights left ZERO `weight_fetch`
+    # rows. pgw#1455's "the funnel sees every materialization path (… RunJob
+    # delivery)" was true of the serving plane and false here; repaired by
+    # wiring, not by narrowing the claim. `track` closes the position on every
+    # exit path, so a fetch that dies mid-way still says where it stopped.
+    #
+    # SCOPED TO THE SNAPSHOT BRANCH DELIBERATELY. On the provider-direct
+    # branches `progress=` is not a passive observer: `download_hf` redirects
+    # into a `local_dir` staging tree and arms a progress-rate floor that can
+    # RAISE. Instrumenting those is a behaviour change and belongs to whoever
+    # measures it; emitting a position of 0 for them instead would manufacture
+    # exactly the frozen-transfer misreading pgw#1455 exists to prevent.
+    if snapshot is None:
+        logger.info(
+            "reserved repo fetch UNINSTRUMENTED field=%s ref=%s: no resolved "
+            "snapshot, provider-direct branch emits no weight_fetch positions",
+            field_name, ref,
+        )
+        path = await ensure_local(
+            str(ref),
+            cache_dir=tensorhub_cas_dir(),
+            hf_token=hf_token or None,
+            fill_source_dir=tensorhub_fill_source_dir(),
+        )
+    else:
+        with weight_position.track(
+            str(ref), weight_position.snapshot_bytes(snapshot),
+        ) as position:
+            path = await ensure_local(
+                str(ref),
+                snapshot=snapshot,
+                cache_dir=tensorhub_cas_dir(),
+                hf_token=hf_token or None,
+                fill_source_dir=tensorhub_fill_source_dir(),
+                progress=position.progress,
+            )
     setter(str(path))
     logger.info(
         "reserved repo materialized field=%s ref=%s path=%s",

--- a/src/gen_worker/serving/weightless_program.py
+++ b/src/gen_worker/serving/weightless_program.py
@@ -149,10 +149,34 @@ def install() -> None:
     _package._load_state_dict = _load_state_dict
 
 
+def uninstall() -> None:
+    """Restore torch's own loader. Idempotent; the companion to ``install()``.
+
+    pgw#1485: ``install()`` is PROCESS-WIDE, so any test asserting the stock
+    path is really measuring whichever test ran before it. The suite's
+    snapshot-and-restore fixture cannot fix that — it snapshots a state that is
+    already wrong, so the red arm silently stops being red. That is exactly what
+    happened when an unrelated change shifted the xdist distribution: two guards
+    went from passing to failing with no code of theirs involved. A guard whose
+    verdict depends on scheduling is not a guard.
+    """
+    from torch.export.pt2_archive import _package
+
+    patched = _package._load_state_dict
+    if not getattr(patched, "_pgw1468", False):
+        return
+    for cell in getattr(patched, "__closure__", None) or ():
+        candidate = cell.cell_contents
+        if callable(candidate) and not getattr(candidate, "_pgw1468", False):
+            _package._load_state_dict = candidate
+            return
+
+
 __all__ = [
     "SHARED_PAYLOAD",
     "WEIGHTS_DIR",
     "install",
     "is_weightless",
     "state_dict_from_config",
+    "uninstall",
 ]

--- a/src/gen_worker/weight_position.py
+++ b/src/gen_worker/weight_position.py
@@ -47,9 +47,10 @@ that cost rental #6 — absence has to render as a row that says zero.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
-from typing import Optional
+from typing import Any, Iterator, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -191,3 +192,35 @@ class FetchPosition:
             )
         except Exception:  # pragma: no cover — telemetry never fails a fetch
             logger.debug("weight position event dropped", exc_info=True)
+
+
+def snapshot_bytes(snapshot: Any) -> int:
+    """Total declared bytes of a resolved snapshot (0 when unknown).
+
+    The position's denominator, wherever a fetch is instrumented. Kept here so
+    every call site computes it the same way.
+    """
+    files = getattr(snapshot, "files", None) or ()
+    try:
+        return sum(int(getattr(f, "size_bytes", 0) or 0) for f in files)
+    except (TypeError, ValueError):
+        return 0
+
+
+@contextlib.contextmanager
+def track(ref: str, total_bytes: int = 0) -> Iterator[FetchPosition]:
+    """Open a position, hand it over, and CLOSE IT ON EVERY EXIT PATH.
+
+    pgw#1485: the close being structural is the whole point. Hand
+    ``position.progress`` to the fetch's ``progress=`` callback inside the
+    block; a fetch that raises, is cancelled, or is killed still leaves a
+    terminal row saying where it stopped.
+    """
+    position = FetchPosition(ref, total_bytes=total_bytes)
+    position.open()
+    try:
+        yield position
+    except BaseException:
+        position.close(ok=False)
+        raise
+    position.close(ok=True)

--- a/src/gen_worker/weight_position.py
+++ b/src/gen_worker/weight_position.py
@@ -63,6 +63,11 @@ PHASE_FETCHING = "fetching"
 PHASE_FETCHED = "fetched"
 #: The fetch raised or was cancelled; position is where it stopped.
 PHASE_ABANDONED = "abandoned"
+#: pgw#1485: the ref was ALREADY RESIDENT — nothing was transferred and no
+#: `model_download` record was opened hub-side. A distinct word, because
+#: "fetched at position 0" and "there was nothing to fetch" are different facts
+#: and th#2204 cost a rental to the first being unsayable.
+PHASE_ALREADY_RESIDENT = "already_resident"
 
 #: Emit at most one row per this many MiB of advance...
 STRIDE_MIB = 256
@@ -137,14 +142,30 @@ class FetchPosition:
             return
         self._emit(PHASE_FETCHING)
 
-    def close(self, ok: bool = True) -> None:
+    def close(self, ok: bool = True, *, resident: bool = False) -> None:
         """The terminal position. Emitted whether or not it advanced — where
         the transfer STOPPED is the fact, and a fetch that moved less than one
-        MiB has to leave a row saying so."""
+        MiB has to leave a row saying so.
+
+        ``resident=True`` says the ref was already on the pod and no transfer
+        happened at all (pgw#1485)."""
         if self._closed:
             return
         self._closed = True
+        if ok and resident:
+            self._emit(PHASE_ALREADY_RESIDENT)
+            return
         self._emit(PHASE_FETCHED if ok else PHASE_ABANDONED)
+
+    def already_resident(self) -> None:
+        """Open AND close in one row: the resolver found the ref resident, so
+        there is no transfer to report positions for. One row, so the reader
+        can tell "the pod already had it" from "nothing ever ran"."""
+        if self._closed:
+            return
+        self._opened = True
+        self._closed = True
+        self._emit(PHASE_ALREADY_RESIDENT)
 
     # -- emission -----------------------------------------------------------
 

--- a/tests/test_weight_position.py
+++ b/tests/test_weight_position.py
@@ -32,10 +32,12 @@ from typing import Any
 import pytest
 
 from gen_worker import activity, weight_position
+from gen_worker import config as gw_config
 from gen_worker.models.cozy_snapshot import ensure_snapshot_async
 from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
-from gen_worker.models.refs import TensorhubRef, WireRef
+from gen_worker.models.refs import TensorhubRef, WireRef, normalize_model_ref
 from gen_worker.models.store import ModelStore
+from gen_worker.serving.reserved_repos import materialize_reserved_inputs_async
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.weight_position import MIB, FetchPosition
 
@@ -496,4 +498,84 @@ def test_a_transfer_that_dies_midway_leaves_no_open_record(
         assert weight_position.PHASE_ABANDONED in [
             r.phase for r in wire.positions()]
     finally:
+        origin.close()
+
+
+# ---------------------------------------------------------------------------
+# pgw#1485 — THE JOB PLANE'S FETCH IS A SECOND FUNNEL, and it was silent.
+#
+# `serving/reserved_repos._materialize_one` — the only writer of
+# `ctx.source_path`, and the door all 25 reserved-`source` producers enter
+# through — calls the `models.download.ensure_local` FREE FUNCTION, not
+# `ModelStore`'s. It passed no `progress=` at all, so a pod that pulled 20.5 GB
+# of reserved-repo weights left ZERO `weight_fetch` rows. pgw#1455's "the funnel
+# sees every materialization path (startup prefetch, DesiredResidency disk_refs,
+# hot instances, RunJob delivery)" was true of the serving plane and FALSE here.
+# ---------------------------------------------------------------------------
+
+class _Ctx:
+    """The producer-context surface `_materialize_one` actually touches."""
+
+    def __init__(self) -> None:
+        self.source_path = ""
+
+    def _set_source_path(self, path: str) -> None:
+        self.source_path = path
+
+    def raise_if_cancelled(self, _reason: str) -> None:
+        return None
+
+
+class _Payload:
+    """A producer payload naming one reserved `source` repo."""
+
+    def __init__(self, ref: str) -> None:
+        self.source = {"ref": ref}
+
+
+def test_the_job_planes_reserved_repo_fetch_reports_positions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _fine_cadence: Any
+) -> None:
+    """A reserved-repo materialization leaves the same advancing byte positions
+    a serving-path fetch does. 20.5 GB moved and 0 rows written is the reading
+    this closes."""
+    origin = _Origin()
+    try:
+        monkeypatch.setenv("TENSORHUB_CACHE_DIR", str(tmp_path / "cache"))
+        gw_config.reload_for_test()
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        resolved = _resolved(files)
+        ref = normalize_model_ref("acme/model-a")
+        wire = _Wire()
+        ctx, payload = _Ctx(), _Payload("acme/model-a")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            await materialize_reserved_inputs_async(ctx, payload, {ref: resolved})
+            for _ in range(8):
+                await asyncio.sleep(0)
+
+        asyncio.run(run())
+
+        assert ctx.source_path, "the reserved path must still be filled"
+        assert str(tmp_path) in ctx.source_path, (
+            "the CAS override did not take; this test would be measuring a\n"
+            f"shared cache: {ctx.source_path}")
+        rows = wire.positions()
+        assert rows, (
+            "the job plane's reserved-repo fetch emitted NO weight_fetch rows — "
+            "20.5 GB of silence is the defect this closes")
+        phases = [r.phase for r in rows]
+        assert phases[0] == weight_position.PHASE_STARTED
+        assert phases[-1] == weight_position.PHASE_FETCHED
+        steps = [r.step for r in rows]
+        assert steps[-1] == (OBJECTS * OBJECT_BYTES) // MIB
+        assert steps[-1] > steps[0], f"the position must advance; got {steps}"
+        assert all(_detail(r)["ref"] == str(ref) for r in rows)
+    finally:
+        gw_config.reload_for_test()
         origin.close()

--- a/tests/test_weight_position.py
+++ b/tests/test_weight_position.py
@@ -454,6 +454,57 @@ def test_a_resident_ref_opens_no_download_record(
         origin.close()
 
 
+def test_the_record_opens_LAZILY_when_the_resident_check_was_wrong(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """THE SAFETY VALVE, and it must be exercised, not asserted about.
+
+    The resident pre-check is an OPTIMIZATION and the downloader is the
+    authority: a ref residency believes is held may still need bytes (a partial
+    CAS, an evicted tree). Here residency holds a RAM-tier entry for a ref with
+    nothing on disk, so the pre-check declines to declare a transfer — and then
+    9 MiB genuinely move. The record must open on the first byte, advance, and
+    close. A fix that suppressed the declaration unconditionally would leave
+    this fetch invisible, which is th#2204's defect rebuilt one step over."""
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        snapshot = _pb_snapshot(files)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            # Resident by residency's reckoning, with NO bytes on disk.
+            store.residency.track_ram(_REF, object())
+            wire.model_events.clear()
+            wire.updates.clear()
+            await store.ensure_local(_REF, snapshot)
+            for _ in range(8):
+                await asyncio.sleep(0)
+
+        asyncio.run(run())
+
+        downloading = [
+            e for e in wire.model_events
+            if e.state == pb.MODEL_STATE_DOWNLOADING
+        ]
+        assert downloading, (
+            "a fetch that really moved bytes must declare itself even when the "
+            "resident pre-check said otherwise")
+        assert downloading[0].bytes_done > 0, (
+            "the lazy open states the position that provoked it")
+        assert wire.open_download_records() == {}, "and it must still close"
+        steps = [r.step for r in wire.positions()]
+        assert steps[-1] == (OBJECTS * OBJECT_BYTES) // MIB
+    finally:
+        origin.close()
+
+
 def test_a_transfer_that_dies_midway_leaves_no_open_record(
     tmp_path: Path, _fine_cadence: Any
 ) -> None:

--- a/tests/test_weight_position.py
+++ b/tests/test_weight_position.py
@@ -34,7 +34,7 @@ import pytest
 from gen_worker import activity, weight_position
 from gen_worker.models.cozy_snapshot import ensure_snapshot_async
 from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
-from gen_worker.models.refs import TensorhubRef
+from gen_worker.models.refs import TensorhubRef, WireRef
 from gen_worker.models.store import ModelStore
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.weight_position import MIB, FetchPosition
@@ -324,6 +324,10 @@ def test_a_frozen_or_regressing_position_emits_nothing_new(_fine_cadence: Any) -
 # opened only when there is a transfer, closed on every exit path.
 # ---------------------------------------------------------------------------
 
+#: The ref every record-lifecycle test materializes.
+_REF = WireRef("acme/model-a")
+
+
 def _pb_snapshot(files: list[tuple[str, bytes, str]]) -> pb.Snapshot:
     """The wire form `ModelStore.ensure_local` takes, over the same blobs."""
     resolved = _resolved(files)
@@ -363,7 +367,7 @@ def test_a_real_fetch_opens_advances_and_closes_the_record(
 
         async def run() -> None:
             activity.bind_sink(wire.send, asyncio.get_running_loop())
-            await store.ensure_local("acme/model-a", snapshot)
+            await store.ensure_local(_REF, snapshot)
             for _ in range(8):
                 await asyncio.sleep(0)
 
@@ -416,17 +420,17 @@ def test_a_resident_ref_opens_no_download_record(
         async def run() -> None:
             activity.bind_sink(wire.send, asyncio.get_running_loop())
             # Attempt 3: the cold fetch that made the pod warm.
-            await store.ensure_local("acme/model-a", snapshot)
+            await store.ensure_local(_REF, snapshot)
             for _ in range(8):
                 await asyncio.sleep(0)
-            assert store.residency.tier("acme/model-a") is not None
+            assert store.residency.tier(_REF) is not None
             wire.updates.clear()
             wire.model_events.clear()
 
             # Attempt 4, WARM POD REUSE — with the cached-path lookup missing.
             store.disk_local_path = lambda ref: None  # type: ignore[method-assign]
-            store._verified.discard("acme/model-a")
-            await store.ensure_local("acme/model-a", snapshot)
+            store._verified.discard(_REF)
+            await store.ensure_local(_REF, snapshot)
             for _ in range(8):
                 await asyncio.sleep(0)
 
@@ -468,7 +472,7 @@ def test_a_transfer_that_dies_midway_leaves_no_open_record(
 
         async def run() -> None:
             activity.bind_sink(wire.send, asyncio.get_running_loop())
-            task = asyncio.ensure_future(store.ensure_local("acme/model-a", snapshot))
+            task = asyncio.ensure_future(store.ensure_local(_REF, snapshot))
             # Let the record open and the transfer start, then kill it.
             await asyncio.sleep(0.05)
             task.cancel()

--- a/tests/test_weight_position.py
+++ b/tests/test_weight_position.py
@@ -35,6 +35,7 @@ from gen_worker import activity, weight_position
 from gen_worker.models.cozy_snapshot import ensure_snapshot_async
 from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
 from gen_worker.models.refs import TensorhubRef
+from gen_worker.models.store import ModelStore
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.weight_position import MIB, FetchPosition
 
@@ -96,13 +97,38 @@ class _Wire:
 
     def __init__(self) -> None:
         self.updates: list[pb.ActivityUpdate] = []
+        self.model_events: list[pb.ModelEvent] = []
 
     async def send(self, msg: pb.WorkerMessage) -> None:
-        if msg.WhichOneof("msg") == "activity_update":
+        which = msg.WhichOneof("msg")
+        if which == "activity_update":
             self.updates.append(msg.activity_update)
+        elif which == "model_event":
+            self.model_events.append(msg.model_event)
 
     def positions(self) -> list[pb.ActivityUpdate]:
         return [u for u in self.updates if u.kind == activity.KIND_WEIGHT_FETCH]
+
+    def open_download_records(self) -> dict[str, pb.ModelEvent]:
+        """The hub's own bookkeeping rule, replayed over what we emitted.
+
+        `connect_worker.go` OPENS `ModelDownloads[ref]` on DOWNLOADING and
+        removes it on ON_DISK / FAILED / EVICTED — nothing else. Whatever this
+        returns is a row that would still read `downloading` on the hub after
+        the worker was finished with it: th#2205's idle-retire veto and
+        th#2204's placement livelock, both.
+        """
+        open_rows: dict[str, pb.ModelEvent] = {}
+        for event in self.model_events:
+            if event.state == pb.MODEL_STATE_DOWNLOADING:
+                open_rows[event.ref] = event
+            elif event.state in (
+                pb.MODEL_STATE_ON_DISK,
+                pb.MODEL_STATE_FAILED,
+                pb.MODEL_STATE_EVICTED,
+            ):
+                open_rows.pop(event.ref, None)
+        return open_rows
 
 
 def _detail(update: pb.ActivityUpdate) -> dict[str, str]:
@@ -284,3 +310,186 @@ def test_a_frozen_or_regressing_position_emits_nothing_new(_fine_cadence: Any) -
         assert [u.step for u in wire] == [0, 4, 6]
     finally:
         weight_position.FetchPosition._emit = original  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# pgw#1485 — THE RECORD ITSELF, through the same funnel.
+#
+# The positions above are the DIAGNOSTIC. The `model_download` record is the
+# LIABILITY: an open one vetoes idle retirement (th#2205 — 92 idle minutes on
+# an A100 at $1.59/hr, $2.44 of a $4.75 run, and nine pods over six days) and
+# parks placement forever (th#2204 — a rented H100 at $3.29/hr re-electing the
+# same worker until an operator intervened). One producer, two victims. So the
+# same funnel that reports positions is tested for the record's LIFECYCLE:
+# opened only when there is a transfer, closed on every exit path.
+# ---------------------------------------------------------------------------
+
+def _pb_snapshot(files: list[tuple[str, bytes, str]]) -> pb.Snapshot:
+    """The wire form `ModelStore.ensure_local` takes, over the same blobs."""
+    resolved = _resolved(files)
+    return pb.Snapshot(
+        digest=resolved.snapshot_digest,
+        files=[
+            pb.SnapshotFile(
+                path=f.path, size_bytes=f.size_bytes, digest=f.digest, url=f.url,
+            )
+            for f in resolved.files
+        ],
+    )
+
+
+def _store(wire: _Wire, cas: Path) -> ModelStore:
+    """The production object, over a real CAS root, emitting onto `wire`."""
+    return ModelStore(wire.send, cache_dir=cas)
+
+
+def test_a_real_fetch_opens_advances_and_closes_the_record(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """THE CONTROL, and it must keep passing: a genuine transfer through
+    `ModelStore` still opens a download record, advances positions while the
+    bytes move, and closes the record with ON_DISK. A fix that stops the
+    phantom by stopping the instrument fails here."""
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        snapshot = _pb_snapshot(files)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            await store.ensure_local("acme/model-a", snapshot)
+            for _ in range(8):
+                await asyncio.sleep(0)
+
+        asyncio.run(run())
+
+        states = [e.state for e in wire.model_events]
+        assert pb.MODEL_STATE_DOWNLOADING in states, (
+            f"a real transfer must declare itself; got {states}")
+        assert pb.MODEL_STATE_ON_DISK in states
+        assert wire.open_download_records() == {}, (
+            "the record a completed fetch opened must be closed")
+        # And pgw#1455's positions still advance through the funnel.
+        steps = [r.step for r in wire.positions()]
+        assert steps and steps[-1] == (OBJECTS * OBJECT_BYTES) // MIB
+        assert steps[-1] > steps[0]
+    finally:
+        origin.close()
+
+
+def test_a_resident_ref_opens_no_download_record(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """th#2205's MEASURED shape: a WARM pod re-dispatched against weights it
+    already holds.
+
+    The incident's record read `0 of 15,980,165,697 bytes @ 0.00/s` for 1h54m
+    while the job it was opened for ran to completion and the pod billed
+    another 92 minutes idle. Its mechanism is exactly this: the cached-path
+    short-circuit misses, the downloader resolves every object out of the local
+    CAS and moves ZERO bytes, so `_progress` never fires — and the ON_DISK that
+    would have closed the record is suppressed as same-tier residency spam.
+    Nothing advances it and nothing closes it, forever.
+
+    The short-circuit miss is reproduced by making the resolver's path lookup
+    answer None while residency still holds the ref, which is the state the hub
+    log proves the pod was in. Everything else — the CAS, the fetch, the events
+    — is the production path.
+    """
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        snapshot = _pb_snapshot(files)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            # Attempt 3: the cold fetch that made the pod warm.
+            await store.ensure_local("acme/model-a", snapshot)
+            for _ in range(8):
+                await asyncio.sleep(0)
+            assert store.residency.tier("acme/model-a") is not None
+            wire.updates.clear()
+            wire.model_events.clear()
+
+            # Attempt 4, WARM POD REUSE — with the cached-path lookup missing.
+            store.disk_local_path = lambda ref: None  # type: ignore[method-assign]
+            store._verified.discard("acme/model-a")
+            await store.ensure_local("acme/model-a", snapshot)
+            for _ in range(8):
+                await asyncio.sleep(0)
+
+        asyncio.run(run())
+
+        assert wire.open_download_records() == {}, (
+            "a ref the pod ALREADY HOLDS must not leave a `downloading` record: "
+            f"{[(e.ref, e.bytes_done, e.bytes_total) for e in wire.open_download_records().values()]}"
+        )
+        assert not [
+            e for e in wire.model_events
+            if e.state == pb.MODEL_STATE_DOWNLOADING
+        ], "a transfer that moves no bytes must not be declared at all"
+        # ...and it says so on the position stream, so "the pod already had it"
+        # is a ROW rather than th#2204's `no_position_reported` silence.
+        phases = [r.phase for r in wire.positions()]
+        assert weight_position.PHASE_ALREADY_RESIDENT in phases, phases
+    finally:
+        origin.close()
+
+
+def test_a_transfer_that_dies_midway_leaves_no_open_record(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """The same class, reached the other way: a download whose PROCESS ends
+    mid-flight. Cancellation unwinds the funnel; if the close is not structural
+    the record outlives the transfer that owned it and is indistinguishable
+    from one still running."""
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        snapshot = _pb_snapshot(files)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            task = asyncio.ensure_future(store.ensure_local("acme/model-a", snapshot))
+            # Let the record open and the transfer start, then kill it.
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            # The terminal is handed to the loop rather than awaited while the
+            # cancellation unwinds; give it its turn.
+            await asyncio.sleep(0.1)
+
+        asyncio.run(run())
+
+        states = [e.state for e in wire.model_events]
+        assert pb.MODEL_STATE_DOWNLOADING in states, (
+            f"the transfer should have declared itself before dying; got {states}")
+        assert wire.open_download_records() == {}, (
+            "a cancelled transfer must close the record it opened")
+        assert [
+            e.error for e in wire.model_events
+            if e.state == pb.MODEL_STATE_FAILED
+        ] == ["download_canceled"]
+        assert weight_position.PHASE_ABANDONED in [
+            r.phase for r in wire.positions()]
+    finally:
+        origin.close()

--- a/tests/test_weightless_program_load.py
+++ b/tests/test_weightless_program_load.py
@@ -48,7 +48,17 @@ def _restore_loader():
     was_disabled = noisy.disabled
     noisy.disabled = True
 
+    # pgw#1485: UNINSTALL FIRST, then snapshot. Snapshotting alone restores
+    # whatever was in place at setup — which, on an xdist worker where any
+    # earlier test called `install()` (mint_child does, on import-and-run
+    # paths), is the PATCHED loader. The stock arms then assert against our own
+    # patch and the red arm stops being red. Two of them flipped to failing on
+    # a run whose only change was test DISTRIBUTION.
+    weightless_program.uninstall()
     before = _package._load_state_dict
+    assert not getattr(before, "_pgw1468", False), (
+        "the pgw#1468 patch survived uninstall(); every stock-path assertion "
+        "in this module would be measuring our own loader")
     try:
         yield
     finally:


### PR DESCRIPTION
Two defects in the same funnel/dispatch seam. Both measured, both red-proven at $0.

---

# 1. The immortal `model_download` record — th#2205's producer, th#2204's cousin

The hub-side `ModelDownloads[ref]` row is a **liability, not a note**. `connect_worker.go:3387` opens it on `DOWNLOADING` and removes it only on `ON_DISK` / `FAILED` / `EVICTED` (`IN_RAM`/`IN_VRAM` do **not**).

On a **warm re-dispatch** `models/store.py::_materialize_local`:

1. missed the cached-path short-circuit and fell through to the download layer,
2. emitted the opening `DOWNLOADING` with `bytes_total=known_total`, `bytes_done=0`,
3. had the downloader resolve **every object out of the local CAS** — zero bytes moved, so `_progress` **never fired once**, which is why the row stayed at exactly its opening value, and
4. never emitted the closing `ON_DISK`, because it is suppressed **twice**: `Residency.track_disk` returns without an event for any ref it already tracks (`# same highest tier, no event`), and the explicit re-emit is gated on `tier_before is DISK and identity_changed`.

**Nothing advanced the row and nothing closed it.**

- **th#2205** — 97 idle-retire ticks declined on a row reading `downloading, 0 of 15,980,165,697 bytes @ 0.00/s` for 1h54m. 92 idle minutes on an A100 at $1.59/hr, **$2.44 of a $4.75 run**; census: **nine pods, seven releases, six days**.
- **th#2204** — the same never-closing shape parks placement at $3.29/hr with no exit.

### The fix

1. **Open only when there is a transfer to declare.** A ref resident at the exact operation identity — or loaded in RAM/VRAM, whose bytes are on the pod by construction — opens no record. RAM/VRAM are in that set for a second, independent reason: `ON_DISK` is the only terminal that closes a record, and sending it over a loaded object demotes the hub's tier view (`ApplyModelResidency` assigns `st.Tier = tier` unconditionally), so a record opened there **could not be closed honestly at all**.
2. **Lazily open if the resolver was wrong.** `_progress` opens the record on the first byte that actually moves, so a partial CAS hit still gets the full open/advance/close instrument.
3. **Close in a `finally`** — the sweep half, which found a second live instance of the same class: `except asyncio.CancelledError` transitioned the intent registry and emitted **no ModelEvent at all**, so a cancelled materialization left the same immortal row. Success now closes with `ON_DISK`; death mid-way (cancellation, shutdown, any `BaseException`) closes with `FAILED download_canceled`.
4. **`already_resident` is a WORD, not a silence** — a typed phase on pgw#1455's `weight_fetch` stream, emitted on the cached short-circuit too. th#2204's `no_position_reported` and "the pod already had it" read identically, and telling them apart cost a rented H100.

---

# 2. The job plane never entered the instrumented funnel — 20.5 GB, zero rows

`serving/reserved_repos._materialize_one` — the only writer of `ctx.source_path`, the door all 25 reserved-`source` producers enter through — calls the `models.download.ensure_local` **free function**, not `ModelStore`'s, and passed **no `progress=` at all**. `FetchPosition` is constructed only inside `ModelStore`'s funnel, so a pod that fetched 20.5 GB of reserved-repo weights left **zero `weight_fetch` rows**.

pgw#1455's claim that the funnel "sees every materialization path (startup prefetch, DesiredResidency disk_refs, hot instances, **RunJob delivery**)" was true of the serving plane and **false here**. Repaired by wiring, not by narrowing the claim.

`weight_position.track()` is now the shared discipline both funnels use: open, hand `progress` to the fetch, close on every exit path. `snapshot_bytes()` is the one way a denominator is computed.

**Scoped to the snapshot branch deliberately.** On the provider-direct branches `progress=` is not a passive observer — `download_hf` redirects into a `local_dir` staging tree and arms a progress-rate floor that can **raise**. Instrumenting those is a behaviour change and belongs to whoever measures it; emitting a position of 0 for them instead would manufacture exactly the frozen-transfer misreading pgw#1455 exists to prevent. The uninstrumented branch says so in the log, by name.

---

# Red / green — $0, no GPU

Extends pgw#1455's harness (real trickling HTTP origin, real `transfer.grants.download`, real CAS) with the production `ModelStore` funnel and the production reserved-repo entry (`materialize_reserved_inputs_async`), and replays **the hub's own open/close bookkeeping** over the events the worker emits.

| test | fixed | reverted to master |
|---|---|---|
| `test_a_real_fetch_opens_advances_and_closes_the_record` (CONTROL) | pass | pass |
| `test_a_resident_ref_opens_no_download_record` | pass | **FAIL** — `[('acme/model-a', 0, 9437184)]` left open; th#2205's 0-of-N exactly |
| `test_a_transfer_that_dies_midway_leaves_no_open_record` | pass | **FAIL** — the cancelled transfer's record survives |
| `test_the_job_planes_reserved_repo_fetch_reports_positions` | pass | **FAIL** — `assert []`, no rows at all |
| the 4 original pgw#1455 position tests | pass | pass |

Neighbours green: `test_model_residency`, `test_shared_component_residency_ie721`, `test_snapshot_disk_headroom_pgw1263`, `test_snapshot_pull_bytes_pgw1351`, `test_snapshot_residency_progress_pgw1289`, `test_store_corruption_pgw1283`, `test_managed_tier_fill_source`, `test_cancel_at_grant_pgw845`, `test_component_digests_v2_th1303`, `test_reserved_repo_contract`. `ruff` + `mypy` clean on all four changed files.

# Live proof (banked, and say WHICH PLANE it covers)

```sql
-- JOB PLANE (provable today: conversion pins gen-worker by git SHA, so a
-- jobs repin to 0.12.25 carries this). A conversion job with a reserved
-- `source` must now write advancing rows.
SELECT pod_id, phase, step AS pos_mib, total_steps AS total_mib, position_at, occurrences
FROM tensorhub.worker_activity_events
WHERE kind = 'weight_fetch' ORDER BY position_at DESC LIMIT 50;

-- SERVING PLANE (separate, still open — no conversion job can prove it,
-- `slots: []` on all 27). The record fix's own signal:
SELECT pod_id, release_id, count(*) AS events, min(created_at), max(created_at)
FROM tensorhub.pod_events
WHERE class = 'worker_background_activity_stalled'
  AND payload->>'reason' = 'model_download'
  AND created_at > '<first post-fix pod boot>'
GROUP BY 1,2 ORDER BY 4 DESC;   -- PASS = 0 rows
```

**PASS** = advancing `weight_fetch` rows on the job plane; `already_resident` rows on warm serving dispatches; **0 rows** from the stall query for post-fix pods. A `downloading` row that is merely *short* is not a pass — the claim is that it closes, not that it closes quickly.
