### PR TITLE
pgw#1472: "the environment" had TWO producers and no single meaning — one definition, over the INSTALLED set

### DIFF
--- a/changelog.d/pgw1472.md
+++ b/changelog.d/pgw1472.md
@@ -1,35 +1,45 @@
 - **The env-identity closure had two producers and no single meaning, so a locally derived document
-  was adoptable by nothing — including the local serve it exists for.** `gen-worker lock` stamps the
-  endpoint's `uv.lock`; a serving process restated `importlib.metadata`. Those are incomparable by
-  construction, for three independent reasons measured against `sd15/uv.lock` and its own venv: PEP
-  503 name spelling (**10 packages** on that one endpoint agree only after normalization), the PEP
-  440 local version segment (`torch 2.13.0` in a lock vs `2.13.0+cu129` installed — a lock cannot
-  state it and an installed CUDA wheel always has one), and platform-conditional lock entries
-  (`colorama` will never install on Linux). `assert_exact_env` then demanded exact equality.
+  was adoptable by nothing — including the local serve it exists for.** `gen-worker lock` stamped the
+  endpoint's `uv.lock`; `release derive` and every serving pod stated the INSTALLED set. Those are
+  incomparable by construction, for three independent reasons measured against `sd15/uv.lock` and its
+  own venv: PEP 503 name spelling (**10 packages** on that one endpoint agree only after
+  normalization), the PEP 440 local version segment (`torch 2.13.0` in a lock vs `2.13.0+cu129`
+  installed — a lock cannot state it and an installed CUDA wheel always has one), and
+  platform-conditional lock entries (`colorama` will never install on Linux). `assert_exact_env` then
+  demanded exact equality and called the difference "a build-system bug surfacing".
 
-- **`gen_worker.env_identity` is now the ONE definition**, and `release/derive.py` reads it rather
-  than carrying its own. Proven byte-stable across the move: sd15's document closure still hashes to
-  `40471a90…`, so no document ever stamped is rekeyed.
+- **RULED: the closure is over the INSTALLED SET AS OBSERVED BY A RUNNING PROCESS**, and
+  `gen_worker.env_identity.env_closure()` / `env_closure_hash()` is the one function that computes
+  it. It is the only definition every party can restate — the publish-time derive, the mint child and
+  the serving pod are three different processes by design (pgw#1367) and all three run inside the
+  release image. **A lockfile closure is restatable by no running process at all**, and in the
+  general case it does not even name one package set: pgw's own `uv.lock` resolves `torch` to BOTH
+  `2.13.0` and `2.13.0+cu130`, because uv forks the resolution per index marker.
 
-- **`python -m gen_worker.serving` states this boot's identity from the endpoint's own `uv.lock`** —
-  the same file `gen-worker lock` hashed — so the two ends finally name one source. `--env-lockfile`
-  overrides it and `--env-lockfile=-` forces the installed set, which is what a release-image derive
-  stamps and therefore the right answer on a pod. **Production is deliberately untouched**: the
-  builder passes no `--lockfile`, so the fleet is installed-at-both-ends today and landing the
-  worker half alone would break it. That migration is sequenced separately.
+- **`gen-worker release derive --lockfile` is DELETED**, with `derive_release(lockfile=)` and the
+  reader behind it. A flag that switched the SOURCE of an identity is what gave `closure` two
+  meanings; there is now no way to ask for the other one. `gen-worker lock` stops stamping the
+  lockfile — the local end that was broken — and every consumer (boot adopt, the adopt session, the
+  serve host, the derive-reuse key) reaches the same function.
 
-- **installed-vs-lock is a typed DRIFT SIGNAL, never the gate.** Normalized on both sides so it
-  reports real divergence instead of spelling — a signal that fires on `PyYAML` vs `pyyaml` is
-  measuring itself. Printed at boot with a count before the examples.
+- **The derive-reuse key now folds `env_closure_hash()` instead of the `uv.lock` file digest** — a
+  second latent bug the one-definition rule made visible. A reuse carries the saved `[derive]` block
+  through untouched, closure included, so an env that moved without its lock moving handed back a
+  document stamped with a closure the process could no longer restate.
 
-- **A permanent adoption refusal is now a countable STATE.** `sink_for` swallows every failure into
+- **A lockfile survives as an explicitly DIFFERENT named thing.** `lockfile_packages` reads it,
+  `closure_drift` compares it against the installed set as a typed signal, normalized on both sides
+  so it reports real divergence instead of spelling — a signal that fires on `PyYAML` vs `pyyaml` is
+  measuring itself. Printed at boot and by `gen-worker lock`, with the count before the examples.
+  **Never a gate**, and nothing calls it env identity.
+
+- **Production is untouched and stays green.** `derive_runner.go` passes no `--lockfile`, so the
+  fleet has been installed-at-both-ends all along; this ruling costs zero migration, where
+  lockfile-at-both-ends would have meant moving a two-repo build path in lockstep.
+
+- **A permanent adoption refusal is a countable STATE.** `sink_for` swallows every failure into
   eager-forever, which is right as a boot policy and wrong as an observability one: an unconditional
   refusal is indistinguishable from a correct one, and that is exactly how this defect could have
   made every boot eager while looking healthy. `PERMANENT_REFUSALS` names the set in code (a fence
-  asserts every member is actually emitted), `ServeAdoption.refusal_permanent` is readable off the
-  object, and the count remains `phase IN PERMANENT_REFUSALS` on the existing typed wire field —
-  no new proto field is invented by a serving module.
-
-- **Measured end to end on this box's 4070**, through the real CLI with no harness:
-  `adopt: env identity stated from sd15/uv.lock (87 packages)`, `14 adopted, 0 holes`, and an image
-  whose sha256 is byte-identical to the one the compiled proof produced earlier.
+  asserts every member is actually emitted) and `ServeAdoption.refusal_permanent` is readable off the
+  object.

--- a/src/gen_worker/cli/endpoint_lock.py
+++ b/src/gen_worker/cli/endpoint_lock.py
@@ -163,11 +163,11 @@ def torchcg_format_versions() -> tuple[int, int]:
 def tracer_digest() -> str:
     """A fingerprint of the CODE THAT TRACES: torchcg plus gen_worker's derive.
 
-    The env closure (``uv.lock``) is the right identity when both are resolved
-    from the lockfile — but the cozy-local shape Paul asked for runs them off
-    ``PYTHONPATH`` from working trees, where the lockfile mentions neither. In
-    that shape a tracer change is invisible to the closure, so a saved trace
-    would be reused across a fix that changes what tracing MEANS.
+    The env closure covers both when both are INSTALLED — but the cozy-local
+    shape Paul asked for runs them off ``PYTHONPATH`` from working trees, where
+    no distribution names them. In that shape a tracer change is invisible to
+    the closure, so a saved trace would be reused across a fix that changes
+    what tracing MEANS.
 
     That is not hypothetical: tcg#57 changed the hollow session's default
     device and pgw#1465 deleted the meta demotion. Both alter the emitted
@@ -260,7 +260,6 @@ def inputs_digest(
     module_name: str,
     checkpoint_ref: str,
     trace_device: str,
-    lockfile: Optional[Path],
     extra: Iterable[str] = (),
 ) -> str:
     """Hash everything the derive READS. Unchanged inputs => skippable re-run.
@@ -269,9 +268,13 @@ def inputs_digest(
     digest is that it can be computed in milliseconds before deciding whether to
     spend ~165s; a digest over outputs could only be checked after paying.
 
-    ``lockfile`` (``uv.lock``) is the env-identity closure — torch's version
-    changes what a trace means, so a lock derived under a different closure is
-    not reusable even when the author source is byte-identical.
+    The env input is ``env_closure_hash()`` — the SAME value the reused document
+    carries stamped (pgw#1472). This field used to be the `uv.lock` file digest,
+    which was wrong in a way only the one-definition rule makes visible: a reuse
+    carries the saved ``[derive]`` block through UNTOUCHED, closure included, so
+    an env that moved without its lock moving would have handed back a document
+    stamped with a closure this process no longer restates — unadoptable, and
+    silently.
     """
     h = hashlib.sha256()
 
@@ -287,14 +290,17 @@ def inputs_digest(
     # instead of a silently-misread document.
     field("interface_v", str(interface_v))
     field("document_v", str(document_v))
-    # The tracer's own source. See `tracer_digest`: in the cozy-local shape the
-    # lockfile does not mention torchcg or gen_worker, so this is the only thing
-    # standing between a tracer fix and a silently-reused pre-fix graph set.
+    # The tracer's own source. See `tracer_digest`: in the cozy-local shape
+    # neither torchcg nor gen_worker is an installed distribution, so this is
+    # the only thing standing between a tracer fix and a silently-reused
+    # pre-fix graph set.
     field("tracer", tracer_digest())
     field("module", module_name)
     field("checkpoint_ref", checkpoint_ref)
     field("trace_device", trace_device)
-    field("lockfile", _file_digest(lockfile) if lockfile and lockfile.is_file() else "")
+    from ..env_identity import env_closure_hash
+
+    field("env_closure", env_closure_hash())
     for path in source_files(root):
         field(f"src:{path.relative_to(root).as_posix()}", _file_digest(path))
     for item in extra:

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -142,14 +142,20 @@ def run_lock(args: argparse.Namespace) -> int:
 
     device = ws.trace_device()
     graph_cas_root = Path(args.graph_cas).resolve() if args.graph_cas else ws.graph_cas_root()
-    lockfile = root / "uv.lock"
+    from ..env_identity import describe_lockfile_drift, lockfile_beside
+
+    # pgw#1472: a lockfile is a DIAGNOSTIC here and nothing else. The identity
+    # this run stamps is `env_closure_hash()` of the process doing the tracing,
+    # which is also what invalidates a saved trace (`inputs_digest`).
+    lockfile = lockfile_beside(root)
+    if lockfile is not None:
+        _say(f"lock: {describe_lockfile_drift(lockfile)}")
 
     want = el.inputs_digest(
         root=root,
         module_name=config.main,
         checkpoint_ref=ref_text,
         trace_device=device,
-        lockfile=lockfile if lockfile.is_file() else None,
     )
 
     existing: Optional[el.DeriveBlock]
@@ -216,7 +222,6 @@ def run_lock(args: argparse.Namespace) -> int:
         result = derive_release(
             module,
             checkpoint_dir=tree if tree is not None else root,
-            lockfile=lockfile if lockfile.is_file() else None,
             graph_cas=graph_cas_root,
         )
     except DeriveError as exc:

--- a/src/gen_worker/cli/release.py
+++ b/src/gen_worker/cli/release.py
@@ -44,12 +44,10 @@ def add_subparser(sub: Any) -> None:
         help="CONFIG-ONLY checkpoint tree the author's load path resolves "
         "(subset snapshot; weights never transit the derive)",
     )
-    derive.add_argument(
-        "--lockfile",
-        default=None,
-        help="uv.lock to hash as the env-identity closure (default: the "
-        "installed distribution set of THIS env)",
-    )
+    # pgw#1472 DELETED `--lockfile`. A document's env closure is the installed
+    # set of the process that derives it, always — the one definition a mint
+    # child and a serving pod can also restate. A flag that switched the
+    # SOURCE of an identity gave `closure` two meanings and no single one.
     derive.add_argument(
         "--graph-cas",
         default=None,
@@ -90,7 +88,6 @@ def _run_derive(args: argparse.Namespace) -> int:
         result = derive_release(
             module,
             checkpoint_dir=checkpoint,
-            lockfile=Path(args.lockfile).resolve() if args.lockfile else None,
             graph_cas=Path(args.graph_cas).resolve() if args.graph_cas else None,
         )
     except DeriveError as exc:

--- a/src/gen_worker/env_identity.py
+++ b/src/gen_worker/env_identity.py
@@ -1,36 +1,41 @@
-"""ONE definition of "what environment is this", for both ends (pgw#1472).
+"""ONE definition of "what environment is this", for every party (pgw#1472).
 
-A release document's `closure` is a hash of a package set, and the serving side
-must be able to RESTATE it or adoption refuses. So the two ends have to name
-the same set with the same spelling — and until this module existed they did
-not:
+A release document's `closure` is the env half of the compile identity. The
+publish-time derive stamps it, the mint child folds it into the ck1 key
+alongside `env_seal`, and a serving pod must RESTATE it or adoption refuses.
+pgw#1367's trace-once-at-publish architecture makes those three DIFFERENT
+processes by design, so the value has exactly one job: **be restatable to the
+same string by any of them.** Two spellings of it fragment the whole
+[release x sm] serving table.
 
-* `gen-worker lock` stamps the endpoint's `uv.lock` (`release/derive.py`);
-* a serving process restates `importlib.metadata` (`installed_closure()`).
+**Ruled: the closure is over the INSTALLED SET AS OBSERVED BY A RUNNING
+PROCESS**, computed by :func:`env_closure` / :func:`env_closure_hash` and by
+nothing else. It is the only definition every party CAN restate: the derive
+runs inside the release image, the mint child runs inside it, the serving pod
+runs inside it. A lockfile closure is restatable by no running process at all —
+which is the defect this module exists to have ended.
 
-Those are incomparable, and not by a little. Measured against
-`serverless-endpoints/sd15/uv.lock` and its own venv, THREE independent reasons
-they can never be equal:
+This reverses the 2026-08-19 coordinator ruling (*"lockfile at both ends"*).
+Three measured facts decided it:
 
-1. **Name spelling.** uv normalizes to PEP 503; `importlib.metadata` reports the
-   DECLARED name. Ten packages on that one endpoint agree only after
-   normalization: `pyyaml`/`PyYAML`, `huggingface-hub`/`huggingface_hub`,
-   `typing-extensions`/`typing_extensions`, and seven more.
-2. **The local version segment.** A lock says `torch = "2.13.0"`; every
-   installed CUDA wheel says `2.13.0+cu129`. A lock cannot state it and an
-   installed distribution always has one.
-3. **Platform-conditional entries.** `colorama` is in that lock and will never
-   install on Linux — a lock enumerates the resolution for every marker, an
-   install enumerates one platform.
+1. **A lockfile is not readable as a closure at all in the general case.** pgw's
+   own `uv.lock` resolves `torch` to BOTH `2.13.0` and `2.13.0+cu130` — uv forks
+   the resolution per index marker. There is no single "the lock's package set".
+2. **`env_seal` — the OTHER axis of the same compile key — is already
+   installed-observed** (it digests the torch/triton tree on disk). Making
+   `closure` a lockfile hash would leave one key folding two contradictory
+   answers to "which environment".
+3. **Production already does it.** `derive_runner.go` passes no `--lockfile`, so
+   the fleet stamps `installed_closure()` inside the release image and the pod
+   restates it from that same image. The migration cost of the alternative was
+   moving a currently-green fleet; the cost of this one is zero.
 
-**Ruled (2026-08-19): the LOCKFILE is the identity at both ends.** The
-weights-free derive can only ever state the lock, and the lock is the one
-artifact mint and serve pods share by construction. This module is that single
-source, so a second copy cannot drift from it.
-
-**And the comparison installed-vs-lock is a DRIFT SIGNAL, never a gate.** It is
-normalized on both sides precisely so it reports real divergence instead of
-spelling — a signal that fires on `PyYAML` vs `pyyaml` is measuring itself.
+A lockfile is still a useful DIFFERENT thing, and it is spelled differently
+here on purpose (the th#2137 lesson: never two names for one authority):
+:func:`lockfile_packages` reads it, :func:`closure_drift` compares it against
+the installed set as a **typed drift signal that is never a gate**, normalized
+on both sides so it reports real divergence instead of PEP 503 spelling and PEP
+440 local segments. Nothing in this module calls a lockfile "env identity".
 """
 
 from __future__ import annotations
@@ -41,15 +46,54 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
-#: What `uv` writes beside a project, and therefore what `gen-worker lock`
-#: hashed. Named once so the CLI and the serve runner cannot disagree.
+#: What `uv` writes beside a project. Named once so every reader of a lockfile
+#: — all of them diagnostics — spells the filename the same way.
 LOCKFILE_NAME = "uv.lock"
 
 _SEPARATORS = re.compile(r"[-_.]+")
 
 
 class EnvIdentityError(ValueError):
-    """A lockfile cannot be read, or states no resolved packages."""
+    """The installed set cannot be observed, or a lockfile cannot be read."""
+
+
+# --- THE definition --------------------------------------------------------
+
+
+def env_closure() -> dict[str, str]:
+    """`{name: version}` of the distributions THIS process can import.
+
+    The one measurement of "which environment am I". Called by the derive that
+    stamps a document, by the boot that restates it, and by the reuse key that
+    decides whether a saved trace still describes this env — so that all three
+    are one function and cannot drift apart.
+    """
+
+    from ._vendor.torchcg.graph_identity import GraphIdentityError, installed_closure
+
+    try:
+        return installed_closure()
+    except GraphIdentityError as exc:
+        raise EnvIdentityError(f"cannot observe this process's env: {exc}") from exc
+
+
+def env_closure_hash() -> str:
+    """The 64-hex env closure of this process — the stamped/restated value.
+
+    `closure_hash` canonicalizes names the way package indexes compare them, so
+    this is stable across the `PyYAML`/`pyyaml` spelling that `importlib` and
+    `uv` disagree on.
+    """
+
+    from ._vendor.torchcg.graph_identity import GraphIdentityError, closure_hash
+
+    try:
+        return closure_hash(env_closure())
+    except GraphIdentityError as exc:
+        raise EnvIdentityError(f"cannot state this process's env identity: {exc}") from exc
+
+
+# --- lockfiles: a different thing, deliberately named differently ----------
 
 
 def normalize_name(name: str) -> str:
@@ -71,20 +115,22 @@ def normalize_version(version: str) -> str:
     against `+cu130` is exactly the kind of difference a compiled artifact
     cares about. But a lockfile CANNOT express it — uv records the version and
     the wheel URL separately — so a comparison that keeps it can only ever
-    report a difference that is not one. The local segment is recoverable from
-    the artifact's own requirements manifest, which is where the compiled side
-    checks it.
+    report a difference that is not one. Identity does not go through here: it
+    is `env_closure_hash`, which keeps the local segment because an installed
+    distribution can state it.
     """
 
     return str(version).split("+", 1)[0]
 
 
-def closure_entries_from_lockfile(lockfile: Path | str) -> dict[str, str]:
-    """`{name: version}` for every package a `uv.lock` resolves.
+def lockfile_packages(lockfile: Path | str) -> dict[str, str]:
+    """`{name: version}` for every package a `uv.lock` resolves — a DIAGNOSTIC.
 
-    Verbatim names and versions: this is the hashed identity, so normalization
-    must NOT happen here — it would change every closure hash ever stamped.
-    Normalization belongs to the DRIFT comparison, which is not an identity.
+    Explicitly NOT an env identity and never hashed into one. A lock enumerates
+    the resolution for every marker, so on any real multi-index project it does
+    not even name one set: pgw's own lock resolves `torch` to `2.13.0` under one
+    marker and `2.13.0+cu130` under another. That fork is reported here, per
+    package, instead of being collapsed into a number nobody could restate.
     """
 
     path = Path(lockfile)
@@ -93,6 +139,7 @@ def closure_entries_from_lockfile(lockfile: Path | str) -> dict[str, str]:
     except (OSError, tomllib.TOMLDecodeError) as exc:
         raise EnvIdentityError(f"cannot read lockfile {path}: {exc}") from exc
     entries: dict[str, str] = {}
+    forked: dict[str, set[str]] = {}
     for package in parsed.get("package", ()):
         name = package.get("name")
         version = package.get("version")
@@ -100,23 +147,20 @@ def closure_entries_from_lockfile(lockfile: Path | str) -> dict[str, str]:
             continue
         known = entries.get(name)
         if known is not None and known != version:
-            raise EnvIdentityError(
-                f"lockfile {path} resolves {name!r} to both {known!r} and "
-                f"{version!r}; a release env has ONE resolved closure"
-            )
+            forked.setdefault(name, {known}).add(version)
         entries[name] = version
     if not entries:
         raise EnvIdentityError(f"lockfile {path} states no resolved packages")
+    for name, versions in forked.items():
+        # Recorded, not raised: this reader feeds a drift report, and a report
+        # that dies on the very property that killed lockfile-as-identity is
+        # useless exactly where it is most informative.
+        entries[name] = "/".join(sorted(versions))
     return entries
 
 
 def lockfile_beside(endpoint_dir: Path | str) -> Path | None:
-    """The endpoint's own `uv.lock`, or `None` — never a guess elsewhere.
-
-    This is the SAME file `gen-worker lock` hashes for the document it writes,
-    which is the whole point: a locally derived document and a local serve now
-    read one file rather than two sources.
-    """
+    """The endpoint's own `uv.lock`, or `None` — never a guess elsewhere."""
 
     candidate = Path(endpoint_dir) / LOCKFILE_NAME
     return candidate if candidate.is_file() else None
@@ -124,10 +168,10 @@ def lockfile_beside(endpoint_dir: Path | str) -> Path | None:
 
 @dataclass(frozen=True, slots=True)
 class DriftRow:
-    """One package on which the installed set and the stated closure differ."""
+    """One package on which the installed set and a lockfile differ."""
 
     name: str
-    #: ``missing`` (stated, not installed), ``extra`` (installed, not stated),
+    #: ``missing`` (locked, not installed), ``extra`` (installed, not locked),
     #: ``version`` (both, different versions). A closed vocabulary.
     kind: str
     stated: str = ""
@@ -144,10 +188,12 @@ class DriftRow:
 def closure_drift(
     installed: Mapping[str, str], stated: Mapping[str, str]
 ) -> tuple[DriftRow, ...]:
-    """How far the running env is from the one the release states.
+    """How far the running env is from what a lockfile resolves. NEVER a gate.
 
-    NORMALIZED on both sides, so every row is a real divergence. Sorted by name
-    so two runs of the same pair produce the same report.
+    NORMALIZED on both sides, so every row is a real divergence rather than a
+    spelling. Sorted by name so two runs of the same pair produce the same
+    report. Adoption does not consult this: identity is `env_closure_hash` and
+    this is the signal that tells an operator the image drifted from its lock.
     """
 
     live = {normalize_name(n): normalize_version(v) for n, v in installed.items()}
@@ -182,14 +228,35 @@ def describe_drift(rows: tuple[DriftRow, ...], *, limit: int = 8) -> str:
     return f"{len(rows)} package(s) differ ({head}): {shown}{more}"
 
 
+def describe_lockfile_drift(lockfile: Path | str) -> str:
+    """The drift line a boot or a lock run prints. Never raises, never gates."""
+
+    try:
+        stated = lockfile_packages(lockfile)
+    except EnvIdentityError as exc:
+        return f"lockfile drift unavailable: {exc}"
+    try:
+        installed = env_closure()
+    except EnvIdentityError as exc:  # pragma: no cover - a dead env
+        return f"lockfile drift unavailable: {exc}"
+    summary = describe_drift(closure_drift(installed, stated))
+    return (
+        f"installed-vs-{Path(lockfile)} ({len(stated)} locked, "
+        f"{len(installed)} installed): {summary or 'none'}"
+    )
+
+
 __all__ = [
     "LOCKFILE_NAME",
     "DriftRow",
     "EnvIdentityError",
     "closure_drift",
-    "closure_entries_from_lockfile",
     "describe_drift",
+    "describe_lockfile_drift",
+    "env_closure",
+    "env_closure_hash",
     "lockfile_beside",
+    "lockfile_packages",
     "normalize_name",
     "normalize_version",
 ]

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -173,7 +173,7 @@ def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
     goes into a tensorfs ``LocalCAS`` and only its digest travels in the
     release document, beside the cg-graph-v1 hash and the ingress spec.
     Portability needs no new fence: an ExportedProgram is torch-coupled and
-    the document's own lockfile closure pins torch -- the same validity rule
+    the document's own env closure pins torch -- the same validity rule
     compiled artifacts already live under.
     """
 
@@ -911,23 +911,6 @@ def _unique_component(instance: Any, name: str, component: Any) -> bool:
     return seen <= 1
 
 
-def _closure_entries_from_lockfile(lockfile: Path) -> dict[str, str]:
-    """The lockfile closure, from the ONE definition (pgw#1472).
-
-    Kept as a name here because callers and fences reference it, but the body
-    moved to :mod:`gen_worker.env_identity`: the SERVING side has to restate
-    this exact set or adoption refuses, and a second implementation of "what
-    packages are we" is precisely how the two ends came to disagree.
-    """
-
-    from ..env_identity import EnvIdentityError, closure_entries_from_lockfile
-
-    try:
-        return closure_entries_from_lockfile(lockfile)
-    except EnvIdentityError as exc:
-        raise DeriveError(str(exc)) from exc
-
-
 def _defaults_schema(model_type: Optional[type]) -> Optional[dict[str, Any]]:
     """msgspec JSON Schema of the class-header model type's Defaults.
 
@@ -1266,18 +1249,27 @@ def derive_release(
     module: ModuleType,
     *,
     checkpoint_dir: Path,
-    lockfile: Optional[Path] = None,
     graph_cas: Optional[Path] = None,
 ) -> ReleaseDeriveResult:
-    """Derive the release metadata document for one endpoint module."""
+    """Derive the release metadata document for one endpoint module.
+
+    The document's `closure` is THIS process's installed set (pgw#1472,
+    :func:`gen_worker.env_identity.env_closure_hash`) — there is no second
+    source and no flag that picks one. The derive runs inside the release
+    image, so the mint child and the serving pod restate the same value from
+    the same image; a stamp that any of the three cannot restate is an
+    unadoptable release.
+    """
 
     torchcg = _torchcg()
     program_sink = _program_sink(graph_cas)
 
-    if lockfile is not None:
-        closure = torchcg.closure_hash(_closure_entries_from_lockfile(lockfile))
-    else:
-        closure = torchcg.closure_hash(torchcg.installed_closure())
+    from ..env_identity import EnvIdentityError, env_closure_hash
+
+    try:
+        closure = env_closure_hash()
+    except EnvIdentityError as exc:
+        raise DeriveError(str(exc)) from exc
 
     cls = _lane_model_class(module)
     endpoint_name = f"{module.__name__}:{cls.__name__ if cls else ''}".rstrip(":")

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -29,7 +29,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
 
 import msgspec
 
@@ -143,12 +143,12 @@ def _parser() -> argparse.ArgumentParser:
                              "`release.compiled_graphs`")
     parser.add_argument("--sm", default="", help="this GPU's sm (e.g. sm_89)")
     parser.add_argument(
-        "--env-lockfile", default="",
-        help="uv.lock stating this boot's env identity (pgw#1472). Default: "
-             "the endpoint's own uv.lock when it has one, which is the SAME "
-             "file `gen-worker lock` hashed into the document being adopted. "
-             "`--env-lockfile=-` forces the installed distribution set "
-             "instead, which is what a release-image derive stamps.")
+        "--drift-lockfile", default="",
+        help="uv.lock to DIAGNOSE this env against (pgw#1472). Default: the "
+             "endpoint's own uv.lock when it has one; `-` skips the report. "
+             "This is a drift signal and never an identity: env identity is "
+             "the installed set of this process, the one thing the derive, "
+             "the mint child and this pod can all restate.")
     parser.add_argument("--artifacts-dir", default=".compiled-graphs")
     parser.add_argument("--mint", action="store_true",
                         help="after boot, fill this (lane x sm)'s holes "
@@ -255,58 +255,29 @@ def _toolchain() -> Mapping[str, str]:
     return dict(toolchain_digest())
 
 
-def _stated_env(
-    args: argparse.Namespace, document: Any
-) -> "Optional[Mapping[str, str]]":
-    """This boot's env identity, from the SAME source the document was stamped
-    from (pgw#1472).
+def _report_env_drift(args: argparse.Namespace, document: Any) -> None:
+    """Print how far this image drifted from its lock. NEVER a gate (pgw#1472).
 
-    `gen-worker lock` hashes the endpoint's `uv.lock`; a serving process
-    otherwise restates `importlib.metadata`, and the two are incomparable by
-    construction (PEP 503 spelling, PEP 440 local segments, platform-conditional
-    lock entries). So a locally derived document was adoptable by NOTHING —
-    including the local serve it exists for. Reading the endpoint's own lock
-    here is what makes `gen-worker lock` and this runner agree.
-
-    `None` means "no lock offered": the adopt session falls back to the
-    installed set, which is what a release-image derive stamps and therefore
-    the right answer on a pod.
-
-    The comparison between the two is a DRIFT REPORT and never a gate — it is
-    printed, normalized, and then ignored.
+    This boot's env identity is not chosen here and cannot be: it is
+    `env_closure_hash()` of this process, the one definition the publish-time
+    derive, the mint child and this pod all restate. What a lockfile is good
+    for is telling an operator that the image stopped matching what it claims
+    to have been built from — a typed signal, printed and then ignored.
     """
     if document is None:
-        return None
-    from ..env_identity import (
-        EnvIdentityError,
-        closure_drift,
-        closure_entries_from_lockfile,
-        describe_drift,
-        lockfile_beside,
-    )
+        return
+    from ..env_identity import describe_lockfile_drift, env_closure_hash, lockfile_beside
 
-    given = str(args.env_lockfile or "").strip()
+    given = str(args.drift_lockfile or "").strip()
     if given == "-":
-        return None  # the operator asked for the installed set, explicitly
+        return
     lockfile = Path(given) if given else lockfile_beside(args.endpoint_dir)
-    if lockfile is None:
-        return None
-    try:
-        stated = closure_entries_from_lockfile(lockfile)
-    except EnvIdentityError as exc:
-        raise SystemExit(f"--env-lockfile: {exc}")
-
-    from .._vendor.torchcg.graph_identity import installed_closure
-
-    drift = closure_drift(installed_closure(), stated)
-    summary = describe_drift(drift)
+    line = describe_lockfile_drift(lockfile) if lockfile is not None else "no lockfile"
     print(
-        f"adopt: env identity stated from {lockfile} "
-        f"({len(stated)} packages); installed-vs-lock drift: "
-        f"{summary or 'none'}",
+        f"adopt: env identity {env_closure_hash()[:16]}... (installed set of "
+        f"this process); {line}",
         file=sys.stderr,
     )
-    return stated
 
 
 def _serve_envelopes(args: argparse.Namespace, loaded: Any) -> int:
@@ -382,7 +353,7 @@ def main(argv: list[str] | None = None) -> int:
         loaded, binding, lane_contract=args.lane, output_dir=Path(args.output_dir)
     )
     store, document = _adoption_source(args, loaded.module_name)
-    installed = _stated_env(args, document)
+    _report_env_drift(args, document)
     # No `loader=`: pgw#1460. The byte-identical raw `aoti_load_package` that
     # used to sit here discarded the record and armed a WEIGHTLESS package with
     # an empty constant buffer. `torchcg.serve.aoti_loader` (tcg#58) is the
@@ -391,7 +362,6 @@ def main(argv: list[str] | None = None) -> int:
     host.setup(
         store=store, document=document, sm=args.sm,
         artifacts_dir=Path(args.artifacts_dir),
-        installed=installed,
     )
     if host.adoption is not None:
         report: dict[str, Any] = {

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -184,7 +184,7 @@ class EndpointHost:
         """
         from .._vendor.torchcg import EnvironmentMismatch
         from .._vendor.torchcg.adopt import AdoptSession
-        from .._vendor.torchcg.graph_identity import installed_closure
+        from ..env_identity import env_closure
 
         started = time.monotonic()
 
@@ -219,7 +219,10 @@ class EndpointHost:
             from .model import lane_handle
 
             lane_contract = lane_handle(self.lanes[lane_bearing[0]])
-            installed_map = dict(installed) if installed is not None else installed_closure()
+            # pgw#1472: `installed=` is a TEST seam. Production has exactly one
+            # answer — this process's own installed set, via the one function
+            # the publish-time derive also stamped from.
+            installed_map = dict(installed) if installed is not None else env_closure()
             try:
                 session = AdoptSession(
                     store,

--- a/src/gen_worker/serving/hub_store.py
+++ b/src/gen_worker/serving/hub_store.py
@@ -250,6 +250,11 @@ class HubGraphStore:
         # call — swallowing it made their handlers dead code and left every
         # unstamped pod reporting the drift reason.
         answer = self._resolve()
+        # `env_lockfile_hash` is the HUB's field name and it is a misnomer:
+        # the hub echoes the derive document's `closure`, which is the derive
+        # process's INSTALLED set, never a lockfile hash (pgw#1472 — one
+        # definition, and this wire spelling is owed a rename in tensorhub's
+        # th#2133 schema). Read under the name it actually carries.
         closure = str(answer.get("env_lockfile_hash") or "")
         lanes: list[dict[str, Any]] = []
         if not answer.get("empty") and answer.get("lane_stamped"):

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -292,7 +292,7 @@ class ServeAdoption:
 
     def _build(self, lane: Any) -> None:
         from .._vendor.torchcg.adopt import AdoptSession
-        from .._vendor.torchcg.graph_identity import installed_closure
+        from ..env_identity import env_closure
         from .mint_store import worker_store
         from .hub_store import (
             BrokerReleaseGraphTransport,
@@ -326,8 +326,11 @@ class ServeAdoption:
         if getattr(document, "eager_permanent", False):
             self._refuse("eager_permanent", "the release document is eager-permanent")
             return
+        # pgw#1472: `_installed` is a TEST seam. Production has exactly one
+        # answer — this process's own installed set, via the one function the
+        # publish-time derive also stamped from.
         installed = (
-            self._installed if self._installed is not None else installed_closure()
+            self._installed if self._installed is not None else env_closure()
         )
         # ONE store for both directions: the adopt reads through it (local CAS
         # before the hub, so a restarted pod adopts what it already minted) and

--- a/tests/test_env_identity.py
+++ b/tests/test_env_identity.py
@@ -1,20 +1,26 @@
-"""pgw#1472: the two ends of the env identity must name the same set.
+"""pgw#1472: the env-identity closure has ONE definition and one producer.
 
-The defect this file fences is not "a hash was wrong". It is that the PUBLISH
-side hashed a `uv.lock` and the SERVE side hashed `importlib.metadata`, and
-those two are incomparable by construction — so a locally derived document was
-adoptable by nothing, including the local serve it exists for.
+The defect this file fences is not "a hash was wrong". It is that "the
+environment" had TWO producers and no single meaning: `gen-worker lock` stamped
+a document from the LOCKFILE while `release derive` and the pod stated the
+INSTALLED set — and a lockfile closure is restatable by no running process at
+all. pgw#1367 makes publish, mint and serve three different processes by
+design, so a value none of them can agree on fragments the whole
+[release x sm] serving table.
 
 ⚠️ **Why no existing test could fail on it.** Every adopt test builds its
 document from the same `installed=` mapping it then audits against, so the two
 sources are ONE dict by construction. The fixture made the bug unrepresentable.
-The cases here therefore work from a REAL `uv.lock` on disk and from a real
-`importlib.metadata` reading, because that difference is the whole subject.
+The cases here therefore work from REAL lockfiles on disk, from a real
+`importlib.metadata` reading, and from a real FRESH SUBPROCESS — because
+"restatable by another process" is the whole subject.
 """
 
 from __future__ import annotations
 
-import tomllib
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -22,12 +28,17 @@ import pytest
 from gen_worker.env_identity import (
     EnvIdentityError,
     closure_drift,
-    closure_entries_from_lockfile,
     describe_drift,
+    describe_lockfile_drift,
+    env_closure,
+    env_closure_hash,
     lockfile_beside,
+    lockfile_packages,
     normalize_name,
     normalize_version,
 )
+
+ROOT = Path(__file__).resolve().parents[1]
 
 LOCK = """\
 version = 1
@@ -53,26 +64,131 @@ def lockfile(tmp_path: Path) -> Path:
     return path
 
 
-def test_the_lockfile_reader_keeps_names_and_versions_VERBATIM(lockfile: Path) -> None:
-    """The identity is hashed from this, so normalizing here would silently
-    rekey every document ever stamped."""
+# -- RED: the two old producers cannot agree on ONE environment -------------
 
-    entries = closure_entries_from_lockfile(lockfile)
+
+def test_RED_the_two_old_paths_disagree_on_THIS_VERY_ENV(tmp_path: Path) -> None:
+    """The issue's own repro, run against the env the test is running in.
+
+    A lockfile written to state EXACTLY what is installed still hashes to a
+    different closure, for reasons no build can fix: `uv` normalizes names to
+    PEP 503 while `importlib.metadata` reports the DECLARED name, and a lock
+    cannot carry the PEP 440 local segment (`+cu129`) that every installed CUDA
+    wheel has. Two producers, one environment, two answers.
+    """
+
+    from gen_worker._vendor.torchcg.graph_identity import closure_hash
+
+    installed = env_closure()
+    # The most generous lockfile imaginable: uv's own spelling of this exact
+    # installed set, which is the best any real `uv.lock` could ever do.
+    as_uv_would_write_it = {
+        normalize_name(name): normalize_version(version)
+        for name, version in installed.items()
+    }
+    path = tmp_path / "uv.lock"
+    path.write_text(
+        "version = 1\n"
+        + "".join(
+            f'\n[[package]]\nname = "{n}"\nversion = "{v}"\n'
+            for n, v in sorted(as_uv_would_write_it.items())
+        )
+    )
+    assert closure_hash(lockfile_packages(path)) != env_closure_hash()
+
+
+def test_RED_a_real_lockfile_does_not_even_NAME_one_package_set() -> None:
+    """pgw's own `uv.lock` resolves `torch` twice — the killer fact.
+
+    uv forks the resolution per index marker, so `torch` is `2.13.0` under one
+    and `2.13.0+cu130` under another. There is no "the lock's closure" to hash;
+    the old reader raised on exactly this, which is how a lockfile identity
+    fails CLOSED on the one repo that most needs it.
+    """
+
+    entries = lockfile_packages(ROOT / "uv.lock")
+    assert "/" in entries["torch"], entries["torch"]
+
+
+# -- GREEN: the one function restates identically from a fresh process ------
+
+
+def test_GREEN_a_FRESH_PROCESS_restates_the_same_value() -> None:
+    """The property the whole architecture rests on.
+
+    Publish, mint and serve are three processes (pgw#1367). The identity they
+    fold into the ck1 key must survive that boundary, so it is measured across
+    a real subprocess fence rather than by calling the function twice.
+    """
+
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "import json,sys;sys.path.insert(0,%r);"
+         "from gen_worker.env_identity import env_closure_hash;"
+         "print(json.dumps(env_closure_hash()))" % str(ROOT / "src")],
+        capture_output=True, text=True, check=True,
+    )
+    assert json.loads(proc.stdout) == env_closure_hash()
+
+
+def test_GREEN_every_party_reaches_the_one_function_and_not_a_second_copy() -> None:
+    """The derive, the boot host and the adopt session must not each observe
+    the env their own way — that is how two spellings were born the first
+    time. Asserted by RESOLVING their imports, not by grepping for a name."""
+
+    src = ROOT / "src" / "gen_worker"
+    for relative in (
+        "release/derive.py",
+        "serving/host.py",
+        "serving/serve_adoption.py",
+        "serving/__main__.py",
+        "cli/endpoint_lock.py",
+        "cli/lock.py",
+        "cli/release.py",
+    ):
+        assert "installed_closure" not in (src / relative).read_text(), (
+            f"{relative} observes the env itself; it must go through "
+            f"gen_worker.env_identity.env_closure"
+        )
+
+
+def test_CONTROL_one_bumped_package_is_a_DIFFERENT_env() -> None:
+    """The control that the value still discriminates.
+
+    A restatable identity that returned a constant would pass every test
+    above. Bump exactly one real package's version and the closure must move.
+    """
+
+    from gen_worker._vendor.torchcg.graph_identity import closure_hash
+
+    installed = env_closure()
+    victim = sorted(installed)[0]
+    bumped = dict(installed, **{victim: installed[victim] + ".99"})
+    assert closure_hash(bumped) != env_closure_hash()
+
+
+# -- the lockfile is a DIFFERENT named thing, and only a diagnostic ---------
+
+
+def test_the_lockfile_reader_keeps_names_and_versions_VERBATIM(lockfile: Path) -> None:
+    entries = lockfile_packages(lockfile)
     assert entries == {"torch": "2.13.0", "PyYAML": "6.0.3", "colorama": "0.4.6"}
 
 
-def test_a_lockfile_resolving_one_package_twice_refuses(tmp_path: Path) -> None:
+def test_a_forked_lockfile_REPORTS_the_fork_instead_of_dying(tmp_path: Path) -> None:
+    """A drift report that raises on the very property that killed
+    lockfile-as-identity is useless exactly where it is most informative."""
+
     path = tmp_path / "uv.lock"
-    path.write_text(LOCK + '\n[[package]]\nname = "torch"\nversion = "2.12.0"\n')
-    with pytest.raises(EnvIdentityError, match="ONE resolved closure"):
-        closure_entries_from_lockfile(path)
+    path.write_text(LOCK + '\n[[package]]\nname = "torch"\nversion = "2.13.0+cu130"\n')
+    assert lockfile_packages(path)["torch"] == "2.13.0/2.13.0+cu130"
 
 
-def test_an_empty_lockfile_refuses_rather_than_hashing_nothing(tmp_path: Path) -> None:
+def test_an_empty_lockfile_refuses_rather_than_reporting_nothing(tmp_path: Path) -> None:
     path = tmp_path / "uv.lock"
     path.write_text("version = 1\n")
     with pytest.raises(EnvIdentityError, match="no resolved packages"):
-        closure_entries_from_lockfile(path)
+        lockfile_packages(path)
 
 
 def test_lockfile_beside_finds_the_endpoints_own_and_never_guesses(
@@ -80,9 +196,6 @@ def test_lockfile_beside_finds_the_endpoints_own_and_never_guesses(
 ) -> None:
     assert lockfile_beside(lockfile.parent) == lockfile
     assert lockfile_beside(tmp_path / "elsewhere") is None
-
-
-# -- the drift signal -------------------------------------------------------
 
 
 def test_drift_does_not_fire_on_SPELLING(lockfile: Path) -> None:
@@ -93,25 +206,22 @@ def test_drift_does_not_fire_on_SPELLING(lockfile: Path) -> None:
     of the rows.
     """
 
-    stated = closure_entries_from_lockfile(lockfile)
+    stated = lockfile_packages(lockfile)
     installed = {"torch": "2.13.0", "pyyaml": "6.0.3", "colorama": "0.4.6"}
     assert closure_drift(installed, stated) == ()
 
 
 def test_drift_does_not_fire_on_the_LOCAL_VERSION_SEGMENT(lockfile: Path) -> None:
-    """A lock cannot state `+cu129`; an installed CUDA wheel always has one."""
-
-    stated = closure_entries_from_lockfile(lockfile)
+    stated = lockfile_packages(lockfile)
     installed = {"torch": "2.13.0+cu129", "PyYAML": "6.0.3", "colorama": "0.4.6"}
     assert closure_drift(installed, stated) == ()
 
 
 def test_drift_DOES_fire_on_a_real_difference_and_names_it(lockfile: Path) -> None:
-    stated = closure_entries_from_lockfile(lockfile)
+    stated = lockfile_packages(lockfile)
     installed = {"torch": "2.12.0+cu129", "PyYAML": "6.0.3", "extra-thing": "1.0"}
     rows = closure_drift(installed, stated)
-    kinds = {(r.name, r.kind) for r in rows}
-    assert kinds == {
+    assert {(r.name, r.kind) for r in rows} == {
         ("colorama", "missing"),
         ("extra-thing", "extra"),
         ("torch", "version"),
@@ -120,6 +230,13 @@ def test_drift_DOES_fire_on_a_real_difference_and_names_it(lockfile: Path) -> No
     assert "3 package(s) differ" in summary
     assert "torch 2.13.0 != 2.12.0" in summary
     assert describe_drift(()) == ""
+
+
+def test_the_drift_line_never_raises_on_an_unreadable_lock(tmp_path: Path) -> None:
+    """It is a signal, not a gate: an absent or broken lock reports, it does
+    not stop a boot."""
+
+    assert "unavailable" in describe_lockfile_drift(tmp_path / "nope.lock")
 
 
 @pytest.mark.parametrize(
@@ -131,44 +248,13 @@ def test_pep503_name_normalization(raw: str, want: str) -> None:
     assert normalize_name(raw) == want
 
 
-def test_local_version_segment_is_stripped_and_nothing_else_is() -> None:
+def test_local_version_segment_is_stripped_for_DRIFT_and_kept_for_IDENTITY() -> None:
     assert normalize_version("2.13.0+cu129") == "2.13.0"
     assert normalize_version("2.13.0rc1") == "2.13.0rc1"
-
-
-# -- the end-to-end property, against the REAL producer ---------------------
-
-
-def test_the_derive_and_the_serve_runner_hash_the_SAME_source(
-    lockfile: Path,
-) -> None:
-    """The whole issue, as one assertion.
-
-    `release/derive.py` stamps a document's closure from a lockfile; the serve
-    runner states this boot's identity from one. If those two ever stop being
-    the same function, a locally derived document becomes adoptable by nothing
-    again — silently, because `sink_for` turns the refusal into eager-forever.
-    """
-
-    from gen_worker.release.derive import _closure_entries_from_lockfile
-
-    assert _closure_entries_from_lockfile(lockfile) == closure_entries_from_lockfile(
-        lockfile
-    )
-
-
-def test_a_real_endpoint_lock_hashes_to_a_stable_closure(tmp_path: Path) -> None:
-    """Guards the MOVE itself: the reader now lives in `env_identity`, and if
-    the move had changed a single byte of its output every document ever
-    stamped would have been rekeyed."""
-
+    # Identity does NOT go through normalize_version: `+cu129` vs `+cu130` is
+    # exactly the difference a compiled artifact cares about.
     from gen_worker._vendor.torchcg.graph_identity import closure_hash
 
-    path = tmp_path / "uv.lock"
-    path.write_text(LOCK)
-    entries = closure_entries_from_lockfile(path)
-    # Recomputed from the parsed TOML, independently of the reader under test.
-    parsed = tomllib.loads(LOCK)
-    expected = {p["name"]: p["version"] for p in parsed["package"]}
-    assert entries == expected
-    assert closure_hash(entries) == closure_hash(expected)
+    assert closure_hash({"torch": "2.13.0+cu129"}) != closure_hash(
+        {"torch": "2.13.0+cu130"}
+    )

--- a/tests/test_release_derive.py
+++ b/tests/test_release_derive.py
@@ -204,27 +204,48 @@ def test_binding_enumeration_reaches_adapter_and_cfg_arms(
     assert "refused by the author's own validation" in stderr
 
 
-def test_lockfile_closure_is_the_env_identity(
+def test_the_derive_stamps_THIS_PROCESSS_INSTALLED_SET_and_has_no_other_source(
     config_only_tree: Path, tmp_path: Path
 ) -> None:
+    """pgw#1472: one definition, and the CLI cannot be asked for another.
+
+    The document's closure has to be restatable by the mint child and by the
+    serving pod, which are different processes in different runs. The only
+    thing all three can measure is the installed set, so the derive states it —
+    and the `--lockfile` flag that used to switch the SOURCE is gone, because a
+    flag that changes what an identity MEANS gives it no meaning.
+    """
+
+    from gen_worker.env_identity import env_closure_hash
+
+    out = tmp_path / "derived.json"
+    assert _derive("tiny_endpoint", config_only_tree, out) == 0
+    assert json.loads(out.read_bytes())["graphs"]["closure"] == env_closure_hash()
+
     lockfile = tmp_path / "uv.lock"
     lockfile.write_text(
         'version = 1\n\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
-        '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
     )
-    out_locked = tmp_path / "locked.json"
-    out_installed = tmp_path / "installed.json"
-    assert _derive(
-        "tiny_endpoint", config_only_tree, out_locked, "--lockfile", str(lockfile)
-    ) == 0
-    assert _derive("tiny_endpoint", config_only_tree, out_installed) == 0
-    locked = json.loads(out_locked.read_bytes())
-    installed = json.loads(out_installed.read_bytes())
-    assert locked["graphs"]["closure"] != installed["graphs"]["closure"]
-    # Env identity never leaks into GRAPH identity: same graphs either way.
-    assert [record["graph"] for lane in locked["graphs"]["lanes"] for record in lane["graphs"]] == [
-        record["graph"] for lane in installed["graphs"]["lanes"] for record in lane["graphs"]
+    with pytest.raises(SystemExit) as refusal:
+        _derive(
+            "tiny_endpoint", config_only_tree, tmp_path / "no.json",
+            "--lockfile", str(lockfile),
+        )
+    assert refusal.value.code != 0
+
+
+def test_env_identity_never_leaks_into_GRAPH_identity(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    first = tmp_path / "a.json"
+    second = tmp_path / "b.json"
+    assert _derive("tiny_endpoint", config_only_tree, first) == 0
+    assert _derive("tiny_endpoint", config_only_tree, second) == 0
+    a, b = json.loads(first.read_bytes()), json.loads(second.read_bytes())
+    graphs = lambda d: [  # noqa: E731
+        r["graph"] for lane in d["graphs"]["lanes"] for r in lane["graphs"]
     ]
+    assert graphs(a) == graphs(b)
 
 
 # --- the sys.path priming the derive shares with discovery -------------------


### PR DESCRIPTION
A release document's `closure` is the env half of the compile identity: the publish-time derive stamps it, the mint child folds it into the ck1 key beside `env_seal`, and a serving pod must restate it or adoption refuses. pgw#1367's trace-once-at-publish architecture makes those three **different processes by design**, so the value has exactly one job — be restatable to the same string by any of them.

It had **two producers** instead. `gen-worker lock` stamped the endpoint's `uv.lock`; `release derive` and every pod stated the installed set. Same environment, two answers, incomparable for three measured reasons (PEP 503 spelling, the PEP 440 local segment a lock cannot carry, platform-conditional lock entries). Every document this box produced was adoptable by **nothing**, including the local serve it exists for — and `sink_for` turns that refusal into eager-forever, so the pod looks healthy.

## The one definition

**The closure is over the INSTALLED SET AS OBSERVED BY A RUNNING PROCESS**, computed by `gen_worker.env_identity.env_closure()` / `env_closure_hash()` and by nothing else. It is the only definition every party CAN restate — derive, mint child and serving pod all run inside the release image.

This **reverses** the coordinator's `lockfile-at-both-ends` ruling. Three facts decided it, two of which the reversed rationale did not have:

1. **A lockfile does not name ONE package set in the general case.** pgw's own `uv.lock` resolves `torch` to *both* `2.13.0` and `2.13.0+cu130` — uv forks the resolution per index marker — and the old reader RAISED on it. Lockfile identity fails closed on the repo that most needs it.
2. **`env_seal` — the OTHER env axis of the SAME ck1 key — is already installed-observed.** Lockfile-at-both-ends left one compile key folding two contradictory answers to "which environment".
3. **"The weightless derive can only ever state the lock" is false**, and it was the load-bearing premise. Weightless means no model *weights*; the derive runs inside the release image with every package installed. Production has been stamping `installed_closure()` all along (`derive_runner.go` passes no `--lockfile`), so this costs **zero migration** where the alternative moved a green two-repo build path in lockstep.

## Consumer audit — every reader of both old spellings

| site | old spelling | disposition |
|---|---|---|
| `release/derive.py` `derive_release(lockfile=)` | lockfile-closure OR installed, by flag | branch + parameter **deleted**; always `env_closure_hash()` |
| `release/derive.py::_closure_entries_from_lockfile` | lockfile-closure | **deleted** (no callers) |
| `cli/release.py` `--lockfile` | lockfile-closure | flag **deleted** — a flag that switches the SOURCE of an identity gives it no meaning |
| `cli/lock.py` (the local producer, the broken end) | lockfile-closure | stops passing a lockfile; prints the drift line instead |
| `cli/endpoint_lock.py::inputs_digest(lockfile=)` | `uv.lock` FILE digest as the derive-REUSE key | → `env_closure_hash()`. **A second latent bug the one-definition rule made visible**: a reuse carries the saved `[derive]` block through untouched, closure included, so an env that moved without its lock moving handed back a document stamped with a closure the process no longer restates |
| `serving/__main__.py::_stated_env` | lockfile-closure as the boot's identity | → `_report_env_drift()`; identity is never chosen here |
| `serving/__main__.py` `--env-lockfile` | forced lockfile identity | → `--drift-lockfile`, diagnostic only |
| `serving/host.py::setup` | `installed_closure()` direct | routed through `env_closure()`; `installed=` is now explicitly a TEST seam |
| `serving/serve_adoption.py::_build` | `installed_closure()` direct | same |
| `_vendor/torchcg/requirements.assert_exact_env` | takes `installed` from its caller | unchanged, already correct — its caller now has one source |
| `serving/hub_store.py` `env_lockfile_hash` | hub WIRE field name | pass-through of the document's `closure`; read renamed + commented. **Owed:** the tensorhub-side rename (th#2133/th#2132 columns + JSON) — a misnomer for an installed-set hash |
| `_vendor/torchcg/{graph_identity,document}.py` docstrings | "lockfile's resolved closure" | prose only; vendored files are sha256-fenced, so **owed as a torchcg PR + re-vendor** |

A lockfile survives as an explicitly **different named thing**: `lockfile_packages` reads it, `closure_drift` compares it against the installed set as a typed signal, normalized on both sides so it reports real divergence instead of spelling. Printed at boot and by `gen-worker lock`, **never a gate**, and nothing calls it env identity (th#2137: no second spelling of one authority).

## Red / green, measured on this box (no GPU)

* **RED** `test_RED_the_two_old_paths_disagree_on_THIS_VERY_ENV` — a lockfile written to state *exactly* the installed set, in uv's own spelling, still hashes differently. Against sd15: installed `fb48fc6c…` (103 pkgs) vs `serverless-endpoints/sd15/uv.lock` `40471a90…` (87 pkgs), 43 drift rows — the issue's own numbers.
* **RED** `test_RED_a_real_lockfile_does_not_even_NAME_one_package_set` — pgw's `uv.lock` forks `torch`.
* **GREEN** `test_GREEN_a_FRESH_PROCESS_restates_the_same_value` — identical across a real subprocess fence. Measured across a process boundary, not by calling the function twice, because *restatable by another process* IS the property.
* **GREEN** the derive stamps exactly `env_closure_hash()`; `--lockfile` is a CLI error.
* **CONTROL** `test_CONTROL_one_bumped_package_is_a_DIFFERENT_env` — bump one real package's version and the closure moves. A restatable identity that returned a constant would pass every green above.
* **FENCE** `test_GREEN_every_party_reaches_the_one_function_and_not_a_second_copy` — no first-party producer/consumer file may name `installed_closure` itself.

Local: `tests/test_env_identity.py` (18) + `tests/test_release_derive.py` + `test_serving_adopt_first` + `test_adopt_refusal_permanence` + `test_self_mint_wiring` + `test_vendored_snapshot_pgw1310` green; `lint_fence_symbols`, `lint_unreached_surface`, `lint_serving_process_compiles`, `lint_serve_role_closure`, `lint_config_reads`, `lint_mypy_ratchet`, ruff on the diff all clean.

No serverless-endpoints repin obligation: no sibling repo passes `--lockfile` or `--env-lockfile`, and `lint_author_derive` runs `gen-worker release derive` in the endpoint's own env, which is exactly what the one definition wants.
