### PR TITLE
pgw#1453: the streaming engine asks the LIBRARY what a key became — sd1.5's text_encoder 0/197 → 197/197, and pgw#1452's device becomes a probe

### DIFF
--- a/changelog.d/pgw1453.md
+++ b/changelog.d/pgw1453.md
@@ -1,0 +1,42 @@
+- **The streaming engine could not load a checkpoint whose key names predate the installed
+  library.** A stock sd1.5 mirror matched **0 of 197** tensors in `text_encoder`: transformers v5
+  flattened the `text_model.` prefix the checkpoint carries, and this engine installs tensors by
+  EXACT name onto a meta skeleton. The same tree loads perfectly through the eager bridge, because
+  `from_pretrained` applies every rename the library ships — and **nothing performed that rename
+  here.** Any endpoint whose checkpoint was published against an older transformers/diffusers than
+  the image ships refused at boot on the native path.
+
+- **The map is ASKED OF THE LIBRARY, never written down.** The renames are semantic, not textual:
+  transformers' prefix drop is a string rule, but diffusers'
+  `query/key/value/proj_attn -> to_q/to_k/to_v/to_out.0` is not — `key` is not a suffix of `to_k`.
+  A derived suffix map cannot express it and a hand-maintained table would rot, so
+  `serving/streaming/keymap.py` calls what each library already exports:
+  transformers' `get_model_conversion_mapping` + `rename_source_key` (handed the meta skeleton's own
+  key set, which is what resolves the `base_model_prefix` add/strip), and diffusers'
+  `ModelMixin._fix_state_dict_keys_on_load`, driven on a `{name: name}` dict so it returns its own
+  map with no tensor read and no byte moved.
+
+- **It runs unconditionally, like pgw#1473's variant detection**, because both libraries answer
+  "no change" for a checkpoint the installed version already spells — measured: 0 renames over
+  sd1.5's 686-tensor unet and 248-tensor vae, and re-feeding migrated names is a fixed point.
+
+- **The refusal is not softened, and it gained the fact that was missing.** `NameMismatch` still
+  fires for a name neither the skeleton nor the library's history knows, and now says whether the
+  migration ran and how many keys it moved — which is what separates "wrong checkpoint" from
+  "old checkpoint". A migration that would land two checkpoint tensors on ONE skeleton name is
+  refused rather than applied, and a checkpoint whose tensors need a transformers CONVERTER (a
+  fuse, split or RoPE permutation — bytes, not names) is refused as unstreamable rather than
+  installed raw under a converted name.
+
+- **Measured on the real bare fp16 sd1.5 mirror, substrate=local-4070**, through the shipped
+  module: `text_encoder` **0/197 -> 197/197**, `unet` 686/686 and `vae` 248/248 untouched.
+
+- **The worker's own device is now PROBED, not assumed (pgw#1452's other end).** `EndpointHost`
+  defaulted `device` to the literal string `"cuda"` — an enumeration of what a pod usually is, not
+  a measurement of this machine — and that default feeds both arms, `engine_for(device=)` and the
+  eager bridge's `_placed`. On a host with no card it turned a boot into a bare torch device error
+  instead of a named fallback. `placement.serving_device()` asks `hostfacts.cuda_state`, the
+  probe-BY-ALLOCATION verdict (allocate, op, synchronize, free), so a card that is present but will
+  not answer takes the CPU arm with its probe class named. The fallback is LOUD, exactly as
+  `derive._trace_device`'s is: cozy-local on a CPU-only box is a supported way to run, and serving
+  on the wrong processor silently is the defect this replaces. An explicit `device=` still wins.

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -85,7 +85,10 @@ class EndpointHost:
         # device error instead of a named fallback. An explicit `device=` from
         # a caller that has already decided still wins; only the DEFAULT is
         # probed.
-        device = str(device) or serving_device()
+        # `device or ""` and not `str(device)`: a caller handing `None` means
+        # "you decide", and `str(None)` is the string "None" — a device name
+        # torch would reject three frames later with nothing pointing here.
+        device = str(device or "") or serving_device()
         self.loaded = loaded
         self.binding = binding
         self.lanes: Dict[type, Any] = {

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -36,7 +36,7 @@ from .context import DeployBinding, LoadContext, LoaderEngine, RequestContext
 from .entrypoints import EntrypointSpec
 from .loader import LoadedEndpoint
 from .model import Model, model_type
-from .placement import warn_if_degraded
+from .placement import serving_device, warn_if_degraded
 
 logger = logging.getLogger(__name__)
 
@@ -73,11 +73,19 @@ class EndpointHost:
         *,
         lane_contract: str = "",
         engine: Optional[LoaderEngine] = None,
-        device: str = "cuda",
+        device: str = "",
         io: str = "buffered",
         output_dir: Optional[Path] = None,
         context_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> None:
+        # pgw#1452: the default was the literal `"cuda"` — an enumeration of
+        # what a pod usually is, not a measurement of what THIS machine is. It
+        # feeds both arms (`engine_for(device=)` and the eager bridge's
+        # `_placed`), so on a CPU-only host it turned a boot into a bare torch
+        # device error instead of a named fallback. An explicit `device=` from
+        # a caller that has already decided still wins; only the DEFAULT is
+        # probed.
+        device = str(device) or serving_device()
         self.loaded = loaded
         self.binding = binding
         self.lanes: Dict[type, Any] = {

--- a/src/gen_worker/serving/placement.py
+++ b/src/gen_worker/serving/placement.py
@@ -131,6 +131,43 @@ def device_facts(index: int = 0) -> DeviceFacts:
         return DeviceFacts(name="unknown device", vram_gib=0.0, sm=0)
 
 
+def serving_device() -> str:
+    """The device this worker serves on, PROBED — never assumed (pgw#1452).
+
+    The host used to default to the literal string ``"cuda"``. That is an
+    enumeration of what a pod usually is, not a measurement of what this
+    machine is, and it reaches two places at once: ``engine_for(device=)`` on
+    the streaming arm and ``_placed`` on the eager bridge. On a host with no
+    card it turns a boot into a bare ``torch`` device error rather than a
+    sentence naming the fallback.
+
+    So it is asked the strong way. ``hostfacts.cuda_state`` is the
+    probe-BY-ALLOCATION verdict (allocate, op, synchronize, free) rather than
+    ``is_available()``, which is why a card that is present but will not answer
+    reads as ``device_unreadable`` and takes the CPU arm with its probe class
+    named — instead of failing on the first tensor with no explanation.
+
+    The fallback is LOUD by design, exactly as ``derive._trace_device``'s is:
+    cozy-local on a CPU-only box is a supported way to run (Paul, 2026-08-18:
+    *"still run anyway"*), and serving on the wrong processor silently is the
+    defect this replaces.
+    """
+
+    from ..hostfacts import cuda_state
+
+    state = cuda_state()
+    if state.present:
+        return "cuda"
+    logger.warning(
+        "PLACEMENT: no usable CUDA device on this host (%s%s), so this "
+        "endpoint loads and serves on the CPU. Every timing taken here is a "
+        "CPU timing (pgw#1452).",
+        state.state,
+        f", {state.probe_class}: {state.detail}" if state.probe_class else "",
+    )
+    return "cpu"
+
+
 def shortfalls(
     model_cls: type, lane: Any, *, facts: Optional[DeviceFacts] = None
 ) -> Tuple[Shortfall, ...]:
@@ -207,6 +244,7 @@ __all__ = [
     "DeviceFacts",
     "Shortfall",
     "device_facts",
+    "serving_device",
     "shortfalls",
     "warn_if_degraded",
 ]

--- a/src/gen_worker/serving/streaming/engine.py
+++ b/src/gen_worker/serving/streaming/engine.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
+from . import keymap as _keymap
 from . import skeleton as _skeleton
 from .source import StreamedTensor, TensorStream, WeightStore, component_of
 from .staging import DEFAULT_BUFFER_BYTES, DEFAULT_BUFFERS, StagingPool
@@ -382,15 +383,25 @@ class StreamingLoader:
             return
 
         slots = _slots(module)
+        # pgw#1453: the checkpoint's names may predate the installed library.
+        # `from_pretrained` absorbs that difference; this engine installs by
+        # EXACT name, so it asks the SAME library for the SAME migration rather
+        # than matching nothing (sd1.5's text_encoder: 0 of 197). Empty for
+        # every checkpoint the installed version already spells.
+        renames = _keymap.migration(module, (entry.name for entry in entries))
         placements: List[_Placement] = []
         unexpected: List[str] = []
         seen: set[str] = set()
         dtypes: set[str] = set(report.dtypes)
 
         for entry in entries:
-            slot = slots.get(entry.name)
+            name = renames.get(entry.name, entry.name)
+            slot = slots.get(name)
             if slot is None:
-                unexpected.append(entry.name)
+                unexpected.append(
+                    entry.name if name == entry.name
+                    else f"{entry.name} (migrated to {name})"
+                )
                 continue
             dtype = _torch_dtype(entry.dtype, f"{component}/{entry.name}")
             dtypes.add(entry.dtype.upper())
@@ -422,7 +433,16 @@ class StreamingLoader:
                 f"component {component!r} — {', '.join(sorted(unexpected)[:8])}"
                 + (" …" if len(unexpected) > 8 else "")
                 + ". A name the skeleton cannot place is a checkpoint the "
-                "code does not match; ctx.load never guesses."
+                "code does not match; ctx.load never guesses. "
+                + (
+                    f"{type(module).__name__}'s own library migration was "
+                    f"applied first and renamed {len(renames)} key(s), so this "
+                    f"is a difference the library does not know about "
+                    f"(pgw#1453)."
+                    if renames else
+                    f"{type(module).__name__}'s own library migration was "
+                    f"applied first and renamed nothing (pgw#1453)."
+                )
             )
 
         report.dtypes = tuple(sorted(dtypes))

--- a/src/gen_worker/serving/streaming/keymap.py
+++ b/src/gen_worker/serving/streaming/keymap.py
@@ -1,0 +1,228 @@
+"""The key migration the LIBRARY applies on load, asked of the library (pgw#1453).
+
+``from_pretrained`` does not install a checkpoint's tensors under the names the
+checkpoint spells. Every model library carries its own history of renames and
+applies them on the way in, which is why a stock sd1.5 mirror loads through the
+eager bridge and produced a correct image — while this engine, which installs
+tensors by EXACT name onto a meta skeleton, matched **0 of 197** tensors in
+sd1.5's ``text_encoder``:
+
+    skeleton (`CLIPTextModel`, transformers 5)  embeddings.token_embedding.weight
+    checkpoint (published against transformers 4)
+                                     text_model.embeddings.token_embedding.weight
+
+The refusal itself was right — ``ctx.load`` never guesses, and installing 0 of
+197 tensors silently would be far worse. What was missing is that **nothing
+performed the rename**.
+
+**The map is never hand-maintained here, and that is the whole design.** The
+renames are SEMANTIC, not textual: transformers' flattening of the
+``text_model.`` prefix is a prefix drop, but diffusers'
+``query/key/value/proj_attn -> to_q/to_k/to_v/to_out.0`` is not expressible as
+any string rule (``key`` is not a suffix of ``to_k``). Only the library knows
+its own history, so this module ASKS each library for its own migration and
+applies nothing of its own:
+
+* **transformers** exports :func:`get_model_conversion_mapping` (the ordered
+  ``WeightTransform`` list ``from_pretrained`` itself loads with) and
+  :func:`rename_source_key`, a pure name->name function. Handing it the meta
+  skeleton's own key set as ``meta_state_dict`` is what resolves the
+  ``base_model_prefix`` add/strip, so the answer is the model's, not a guess.
+* **diffusers** exports ``ModelMixin._fix_state_dict_keys_on_load``, which
+  renames a state dict's KEYS in place and touches no value — so a dict of
+  ``{name: name}`` comes back as ``{new_name: old_name}``, the library's own map
+  with no tensor read and no byte moved.
+
+It runs UNCONDITIONALLY, like pgw#1473's variant detection, because both
+libraries answer "no change" for a checkpoint already spelled the way the
+installed version spells it (verified: 0 renames over sd1.5's 686-tensor unet
+and 248-tensor vae, and re-feeding the migrated names is a fixed point).
+
+**Where this stops.** transformers distinguishes a RENAMING from a CONVERTER —
+a fuse, split, transpose or RoPE permutation, which changes the bytes and not
+only the name. This engine installs a container's bytes verbatim; a checkpoint
+that needs a value transform is not streamable at all, and
+:class:`UnstreamableCheckpoint` says so by name rather than installing raw bytes
+under a converted name.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch
+
+logger = logging.getLogger(__name__)
+
+
+class KeyMigrationError(RuntimeError):
+    """The library's own key migration could not be obtained or trusted."""
+
+
+class UnstreamableCheckpoint(KeyMigrationError):
+    """A tensor needs a VALUE transform, not a rename, to reach this skeleton."""
+
+
+def migration(module: "torch.nn.Module", names: Iterable[str]) -> Mapping[str, str]:
+    """checkpoint tensor name -> the name ``module`` answers to.
+
+    Only the entries that actually CHANGE; a caller reads it as
+    ``renames.get(name, name)``. Empty for a checkpoint whose names the
+    installed library already spells, which is every converted artifact.
+    """
+
+    keys = list(names)
+    if not keys:
+        return {}
+    mapped = _transformers_migration(module, keys)
+    if mapped is None:
+        mapped = _diffusers_migration(module, keys)
+    if mapped is None:
+        return {}
+    renames = {source: target for source, target in mapped.items() if source != target}
+    if not renames:
+        return {}
+    _refuse_collisions(module, mapped)
+    logger.info(
+        "ctx.load: %s's own library migrates %d of %d checkpoint key(s) — e.g. "
+        "%s (pgw#1453)",
+        type(module).__name__,
+        len(renames),
+        len(keys),
+        ", ".join(
+            f"{source} -> {target}"
+            for source, target in sorted(renames.items())[:2]
+        ),
+    )
+    return renames
+
+
+def _refuse_collisions(module: Any, mapped: Mapping[str, str]) -> None:
+    """Two checkpoint names must never migrate onto ONE skeleton name.
+
+    A collision means one of the two tensors is dropped — the exact silent loss
+    the ``NameMismatch`` refusal exists to prevent, so it is refused here rather
+    than discovered as garbage on the first forward.
+    """
+
+    landing: Dict[str, list[str]] = {}
+    for source, target in mapped.items():
+        landing.setdefault(target, []).append(source)
+    clashes = {
+        target: sorted(sources)
+        for target, sources in landing.items()
+        if len(sources) > 1
+    }
+    if clashes:
+        raise KeyMigrationError(
+            f"{type(module).__name__}: this library's key migration sends "
+            f"{len(clashes)} skeleton name(s) more than one checkpoint tensor — "
+            + "; ".join(
+                f"{target} <- {sources}" for target, sources in sorted(clashes.items())
+            )[:400]
+            + ". One of each pair would be silently dropped, so the migration is "
+            "refused rather than applied."
+        )
+
+
+def _transformers_migration(
+    module: Any, keys: list[str]
+) -> Mapping[str, str] | None:
+    """transformers' own ``from_pretrained`` rename, or ``None`` if not one."""
+
+    try:
+        from transformers.modeling_utils import PreTrainedModel
+    except ImportError:  # pragma: no cover - no transformers in this image
+        return None
+    if not isinstance(module, PreTrainedModel):
+        return None
+    from transformers.core_model_loading import (
+        WeightRenaming,
+        rename_source_key,
+    )
+    from transformers.modeling_utils import get_model_conversion_mapping
+
+    try:
+        transforms = get_model_conversion_mapping(module)
+    except Exception as exc:  # noqa: BLE001
+        raise KeyMigrationError(
+            f"{type(module).__name__}: transformers refused to state its own "
+            f"key conversion mapping ({type(exc).__name__}: {exc}), so this "
+            f"checkpoint's names cannot be migrated the way from_pretrained "
+            f"migrates them"
+        ) from exc
+    renamings = [t for t in transforms if isinstance(t, WeightRenaming)]
+    converters = [t for t in transforms if not isinstance(t, WeightRenaming)]
+    # The skeleton's OWN key set is what decides whether `base_model_prefix`
+    # is added or stripped — the model answering about itself.
+    meta_state_dict: Dict[str, None] = {
+        name: None for name in _skeleton_names(module)
+    }
+    prefix = getattr(module, "base_model_prefix", None) or None
+    mapped: Dict[str, str] = {}
+    for key in keys:
+        target, matched = rename_source_key(
+            key, renamings, converters, prefix, meta_state_dict
+        )
+        if matched is not None:
+            raise UnstreamableCheckpoint(
+                f"{type(module).__name__}: checkpoint tensor {key!r} matches "
+                f"transformers' converter {matched!r}, which FUSES, SPLITS or "
+                f"PERMUTES bytes rather than renaming them. This engine "
+                f"installs a container's bytes verbatim, so this checkpoint "
+                f"cannot be streamed — it must be converted (loaded through "
+                f"from_pretrained and re-saved) before publication."
+            )
+        mapped[key] = target
+    return mapped
+
+
+def _diffusers_migration(module: Any, keys: list[str]) -> Mapping[str, str] | None:
+    """diffusers' own ``_fix_state_dict_keys_on_load``, driven name-only."""
+
+    fix = getattr(module, "_fix_state_dict_keys_on_load", None)
+    if not callable(fix):
+        return None
+    sentinel: Dict[str, str] = {key: key for key in keys}
+    try:
+        returned = fix(sentinel)
+    except Exception as exc:  # noqa: BLE001
+        raise KeyMigrationError(
+            f"{type(module).__name__}: diffusers' own key migration could not "
+            f"be applied to names alone ({type(exc).__name__}: {exc}) — it "
+            f"reads tensor VALUES in this version, so the engine cannot ask it "
+            f"what a name becomes without loading the checkpoint"
+        ) from exc
+    # diffusers returns the dict it mutated; older spellings mutate in place
+    # and return None.
+    result = sentinel if returned is None else returned
+    if not isinstance(result, dict) or len(result) != len(keys):
+        raise KeyMigrationError(
+            f"{type(module).__name__}: diffusers' key migration returned "
+            f"{len(result) if isinstance(result, dict) else type(result).__name__} "
+            f"entries for {len(keys)} checkpoint tensor(s). It is documented to "
+            f"rename keys and touch no value; anything else is a version this "
+            f"engine cannot drive by name."
+        )
+    mapped: Dict[str, str] = {}
+    for target, source in result.items():
+        if not isinstance(source, str):
+            raise KeyMigrationError(
+                f"{type(module).__name__}: diffusers' key migration replaced a "
+                f"VALUE (under {target!r}) rather than only renaming keys, so it "
+                f"cannot be driven on names alone in this version"
+            )
+        mapped[source] = str(target)
+    return mapped
+
+
+def _skeleton_names(module: Any) -> Iterable[str]:
+    for name, _ in module.named_parameters(remove_duplicate=False):
+        yield name
+    for name, _ in module.named_buffers(remove_duplicate=False):
+        yield name
+
+
+__all__ = ["KeyMigrationError", "UnstreamableCheckpoint", "migration"]

--- a/src/gen_worker/serving/streaming/keymap.py
+++ b/src/gen_worker/serving/streaming/keymap.py
@@ -138,11 +138,15 @@ def _transformers_migration(
         return None
     if not isinstance(module, PreTrainedModel):
         return None
+    # `conversion_mapping` is where this lives; `modeling_utils` re-exports it
+    # without declaring it, which mypy is right to refuse — a re-export nobody
+    # promised is a name that can move without a deprecation.
+    from transformers.conversion_mapping import get_model_conversion_mapping
     from transformers.core_model_loading import (
+        WeightConverter,
         WeightRenaming,
         rename_source_key,
     )
-    from transformers.modeling_utils import get_model_conversion_mapping
 
     try:
         transforms = get_model_conversion_mapping(module)
@@ -153,8 +157,28 @@ def _transformers_migration(
             f"checkpoint's names cannot be migrated the way from_pretrained "
             f"migrates them"
         ) from exc
+    # `WeightRenaming` and `WeightConverter` are SIBLINGS under
+    # `WeightTransform`, so each arm is selected by what it IS rather than by
+    # "not the other one" — and a third kind this code has never seen is
+    # refused by name instead of being dropped into neither list, which would
+    # silently skip a transform `from_pretrained` applies.
     renamings = [t for t in transforms if isinstance(t, WeightRenaming)]
-    converters = [t for t in transforms if not isinstance(t, WeightRenaming)]
+    converters = [
+        t for t in transforms
+        if isinstance(t, WeightConverter) and not isinstance(t, WeightRenaming)
+    ]
+    unknown = [
+        type(t).__name__ for t in transforms
+        if not isinstance(t, (WeightRenaming, WeightConverter))
+    ]
+    if unknown:
+        raise KeyMigrationError(
+            f"{type(module).__name__}: transformers' conversion mapping "
+            f"carries transform kind(s) {sorted(set(unknown))} that are "
+            f"neither a WeightRenaming nor a WeightConverter. Ignoring one "
+            f"would silently skip something from_pretrained applies, so the "
+            f"migration is refused rather than half-applied."
+        )
     # The skeleton's OWN key set is what decides whether `base_model_prefix`
     # is added or stripped — the model answering about itself.
     meta_state_dict: Dict[str, None] = {

--- a/tests/test_bridge_placement.py
+++ b/tests/test_bridge_placement.py
@@ -118,3 +118,67 @@ def test_the_bridge_names_no_device_of_its_own() -> None:
         f"no placement decision was handed down, so the bridge must place "
         f"nothing; components landed on {devices}"
     )
+
+
+# -- and the worker's own decision is PROBED, never assumed ----------------
+
+
+def test_the_host_default_device_is_not_a_literal() -> None:
+    """pgw#1452, the other end of the same defect.
+
+    The bridge places what the worker decided — but the worker's DEFAULT was
+    the literal string `"cuda"`, which is an enumeration of what a pod usually
+    is, not a measurement of this machine. That default feeds both arms
+    (`engine_for(device=)` and `_placed`), so on a host with no card it turned
+    a boot into a bare torch device error instead of a named CPU fallback.
+    """
+    import inspect
+
+    from gen_worker.serving.host import EndpointHost
+
+    default = inspect.signature(EndpointHost).parameters["device"].default
+    assert default == "", (
+        f"EndpointHost defaults `device` to {default!r} — a literal device "
+        f"name is a claim about the host that nothing measured"
+    )
+
+
+def test_the_probed_device_agrees_with_this_hosts_real_card() -> None:
+    """The probe is the strong one: `hostfacts.cuda_state` allocates, runs an
+    op, synchronizes and frees, so a card that is present but will not answer
+    reads as unreadable rather than as usable."""
+    from gen_worker.hostfacts import cuda_state
+    from gen_worker.serving.placement import serving_device
+
+    assert serving_device() == ("cuda" if cuda_state().present else "cpu")
+
+
+def test_a_cardless_host_falls_back_to_cpu_and_says_so() -> None:
+    """Run in a REAL cardless process rather than with a patched probe:
+    `CUDA_VISIBLE_DEVICES=""` is how a CPU-only box actually presents, and the
+    fallback has to be loud there — cozy-local on a CPU-only machine is a
+    supported way to run, and serving on the wrong processor SILENTLY is the
+    defect this replaces.
+    """
+    import os
+    import subprocess
+    import sys
+
+    script = (
+        "import logging,sys;"
+        "logging.basicConfig(level=logging.WARNING,stream=sys.stderr);"
+        "from gen_worker.serving.placement import serving_device;"
+        "print(serving_device())"
+    )
+    env = dict(os.environ, CUDA_VISIBLE_DEVICES="")
+    env["PYTHONPATH"] = os.pathsep.join(
+        [p for p in sys.path if p] + [env.get("PYTHONPATH", "")]
+    )
+    done = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env,
+    )
+    assert done.returncode == 0, done.stderr[-2000:]
+    assert done.stdout.strip().splitlines()[-1] == "cpu", done.stdout
+    assert "PLACEMENT" in done.stderr and "pgw#1452" in done.stderr, (
+        f"the CPU fallback must name itself; stderr was {done.stderr[-2000:]!r}"
+    )

--- a/tests/test_key_migration.py
+++ b/tests/test_key_migration.py
@@ -1,4 +1,6 @@
-"""pgw#1453: a checkpoint whose key names predate the installed library.
+"""A checkpoint whose key names predate the installed library still loads.
+
+# pgw#1453: sd1.5's text_encoder matched 0 of 197 tensors on the streaming path.
 
 No mocks. A REAL diffusers pipeline is saved to real safetensors, then its
 containers are REWRITTEN under the names the *previous* library generation

--- a/tests/test_key_migration_pgw1453.py
+++ b/tests/test_key_migration_pgw1453.py
@@ -1,0 +1,316 @@
+"""pgw#1453: a checkpoint whose key names predate the installed library.
+
+No mocks. A REAL diffusers pipeline is saved to real safetensors, then its
+containers are REWRITTEN under the names the *previous* library generation
+spelled — transformers' ``text_model.`` prefix and diffusers'
+``query/key/value/proj_attn`` attention block — ingested into a REAL chunked
+CAS, projected the way the chokepoint projects it, and streamed through the
+REAL engine. This is exactly the shape of the stock sd1.5 mirror that matched
+**0 of 197** tensors in ``text_encoder``.
+
+⚠️ **The red arm is guarded, and it is guarded on the premise rather than on
+the outcome.** Each legacy container is first asserted to name NOTHING the
+skeleton carries — if a future library made the legacy names valid again, the
+fixture would stop being a legacy fixture and this suite would say so instead
+of passing for the wrong reason. The counter-case is the same tree left at its
+MODERN names: the migration must rename nothing there, so a migration that
+renamed indiscriminately cannot pass both arms.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+pytest.importorskip("safetensors")
+
+from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
+from gen_worker.serving.streaming import StreamingLoader, engine_for  # noqa: E402
+from gen_worker.serving.streaming import keymap  # noqa: E402
+from gen_worker.serving.streaming.skeleton import (  # noqa: E402
+    build as build_skeleton,
+)
+from gen_worker.serving.streaming.skeleton import meta_survivors  # noqa: E402
+from streaming_fixture import Lane, build_source  # noqa: E402
+
+#: transformers v5 flattened the `text_model.` prefix CLIP checkpoints carry.
+_LEGACY_CLIP_PREFIX = "text_model."
+
+#: diffusers renamed the deprecated attention block's projections. These are
+#: NOT expressible as any string rule — `key` is not a suffix of `to_k` — which
+#: is why the map must come from the library and never from a table here.
+_LEGACY_ATTN: Dict[str, str] = {
+    "to_q": "query", "to_k": "key", "to_v": "value", "to_out.0": "proj_attn",
+}
+
+
+def _rewrite_keys(path: Path, rename: Any) -> int:
+    """Rewrite a safetensors container's HEADER keys, byte-for-byte identical
+    payload. Returns how many keys changed."""
+    raw = path.read_bytes()
+    (size,) = struct.unpack("<Q", raw[:8])
+    header = json.loads(raw[8 : 8 + size])
+    body = raw[8 + size :]
+    rebuilt: Dict[str, Any] = {}
+    changed = 0
+    for key, spec in header.items():
+        if key == "__metadata__":
+            rebuilt[key] = spec
+            continue
+        new = rename(key)
+        changed += new != key
+        rebuilt[new] = spec
+    blob = json.dumps(rebuilt, separators=(",", ":")).encode()
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob + body)
+    return changed
+
+
+def _to_legacy_clip(key: str) -> str:
+    return _LEGACY_CLIP_PREFIX + key
+
+
+def _deprecated_attn_paths(module: Any) -> Tuple[str, ...]:
+    """The submodule paths diffusers ITSELF marks as the deprecated attention
+    block. Asking the library which blocks ever carried the old spelling is
+    what keeps this fixture honest — writing `query` under a block that was
+    never an `AttentionBlock` would be inventing a checkpoint nobody published,
+    and diffusers would be right to refuse it."""
+    return tuple(
+        name for name, sub in module.named_modules()
+        if getattr(sub, "_from_deprecated_attn_block", False)
+    )
+
+
+def _legacy_attn_renamer(paths: Tuple[str, ...]) -> Any:
+    def rename(key: str) -> str:
+        for path in paths:
+            if not key.startswith(path + "."):
+                continue
+            for modern, legacy in _LEGACY_ATTN.items():
+                for tail in ("weight", "bias"):
+                    if key == f"{path}.{modern}.{tail}":
+                        return f"{path}.{legacy}.{tail}"
+        return key
+
+    return rename
+
+
+def _project(base: Path, source: Path, key: str) -> Path:
+    cas = LocalCAS(base)
+    manifest = cas.ingest_repository(source)
+    cas.compare_and_swap_ref(
+        REF_PREFIX + key, cas.store_manifest(manifest), expected=None
+    )
+    tree = base / SNAPSHOTS_DIR / key
+    project_snapshot(cas, manifest, tree)
+    return tree
+
+
+def _container_keys(path: Path) -> Tuple[str, ...]:
+    raw = path.read_bytes()
+    (size,) = struct.unpack("<Q", raw[:8])
+    header = json.loads(raw[8 : 8 + size])
+    return tuple(k for k in header if k != "__metadata__")
+
+
+def _skeleton_names(module: Any) -> set[str]:
+    names = {n for n, _ in module.named_parameters(remove_duplicate=False)}
+    names |= {n for n, _ in module.named_buffers(remove_duplicate=False)}
+    return names
+
+
+@pytest.fixture(scope="module")
+def modern(tmp_path_factory: pytest.TempPathFactory) -> Dict[str, Any]:
+    """The pipeline exactly as the library writes it today."""
+    base = tmp_path_factory.mktemp("pgw1453-modern")
+    source = base / "source-model"
+    pipeline_cls = build_source(source)
+    return {"base": base, "source": source, "pipeline_cls": pipeline_cls,
+            "tree": _project(base, source, key="c" * 64)}
+
+
+@pytest.fixture(scope="module")
+def legacy(tmp_path_factory: pytest.TempPathFactory) -> Dict[str, Any]:
+    """The SAME pipeline, its containers renamed to the previous generation."""
+    base = tmp_path_factory.mktemp("pgw1453-legacy")
+    source = base / "source-model"
+    pipeline_cls = build_source(source)
+    renamed = 0
+    for component in ("text_encoder", "text_encoder_2"):
+        for container in sorted((source / component).glob("*.safetensors")):
+            renamed += _rewrite_keys(container, _to_legacy_clip)
+    attn = 0
+    from diffusers import AutoencoderKL, UNet2DConditionModel
+
+    for component, cls in (("unet", UNet2DConditionModel), ("vae", AutoencoderKL)):
+        paths = _deprecated_attn_paths(cls.from_config(  # type: ignore[attr-defined]
+            cls.load_config(str(source / component))  # type: ignore[attr-defined]
+        ))
+        if not paths:
+            continue
+        for container in sorted((source / component).glob("*.safetensors")):
+            attn += _rewrite_keys(container, _legacy_attn_renamer(paths))
+    assert renamed, "the CLIP fixture was not actually made legacy"
+    return {"base": base, "source": source, "pipeline_cls": pipeline_cls,
+            "tree": _project(base, source, key="d" * 64),
+            "clip_renamed": renamed, "attn_renamed": attn}
+
+
+# -- the premise: this fixture really is unloadable without a migration -----
+
+
+def test_the_legacy_clip_container_names_nothing_the_skeleton_carries(
+    legacy: Dict[str, Any],
+) -> None:
+    """The go-red condition, asserted rather than assumed.
+
+    sd1.5's measured overlap was 0 of 197. If a library change ever made these
+    names valid again, the fixture would stop testing what it claims to and
+    this assertion is what says so.
+    """
+    built = build_skeleton(legacy["pipeline_cls"], legacy["tree"])
+    module = built.modules["text_encoder"]
+    names = _skeleton_names(module)
+    keys = _container_keys(
+        next((legacy["source"] / "text_encoder").glob("*.safetensors"))
+    )
+    assert keys, "no container to read"
+    assert all(key.startswith(_LEGACY_CLIP_PREFIX) for key in keys)
+    assert not (set(keys) & names), (
+        "the legacy container overlaps the skeleton, so it is not a legacy "
+        "fixture and the green arm below would prove nothing"
+    )
+
+
+# -- the map comes from the library ----------------------------------------
+
+
+def test_transformers_own_migration_places_every_legacy_clip_tensor(
+    legacy: Dict[str, Any],
+) -> None:
+    built = build_skeleton(legacy["pipeline_cls"], legacy["tree"])
+    module = built.modules["text_encoder"]
+    names = _skeleton_names(module)
+    keys = _container_keys(
+        next((legacy["source"] / "text_encoder").glob("*.safetensors"))
+    )
+    renames = keymap.migration(module, keys)
+    placed = [renames.get(key, key) for key in keys]
+    assert len(renames) == len(keys), "every legacy key must be migrated"
+    assert set(placed) <= names, sorted(set(placed) - names)[:5]
+    assert len(set(placed)) == len(placed), "two keys landed on one name"
+
+
+def test_diffusers_own_migration_places_the_deprecated_attention_block(
+    legacy: Dict[str, Any],
+) -> None:
+    """`key -> to_k` and `proj_attn -> to_out.0` are SEMANTIC renames no string
+    rule expresses, so this is the arm that proves the map is the library's."""
+    if not legacy["attn_renamed"]:
+        pytest.skip("this diffusers version builds no deprecated attn block")
+    built = build_skeleton(legacy["pipeline_cls"], legacy["tree"])
+    for component in ("unet", "vae"):
+        module = built.modules[component]
+        names = _skeleton_names(module)
+        for container in sorted((legacy["source"] / component).glob("*.safetensors")):
+            keys = _container_keys(container)
+            renames = keymap.migration(module, keys)
+            placed = [renames.get(key, key) for key in keys]
+            assert set(placed) <= names, sorted(set(placed) - names)[:5]
+
+
+def test_a_modern_checkpoint_is_migrated_by_nothing(
+    modern: Dict[str, Any],
+) -> None:
+    """The counter-case. Every published/converted artifact is already spelled
+    the way the installed library spells it, so the migration must be a
+    no-op — otherwise the green arm above is just "renames everything"."""
+    built = build_skeleton(modern["pipeline_cls"], modern["tree"])
+    for component, module in built.modules.items():
+        for container in sorted((modern["source"] / component).glob("*.safetensors")):
+            keys = _container_keys(container)
+            assert keymap.migration(module, keys) == {}, component
+
+
+# -- the whole engine, end to end ------------------------------------------
+
+
+def _load(tree: Path, pipeline_cls: type) -> Any:
+    store = engine_for(tree, device="cpu")
+    assert store is not None, "the projected tree carries no chunk store"
+    return store.build(pipeline_cls, checkpoint_dir=tree, lane=Lane())
+
+
+def test_the_engine_loads_a_legacy_checkpoint_with_nothing_left_on_meta(
+    legacy: Dict[str, Any],
+) -> None:
+    """The defect, end to end: this raised ``NameMismatch`` on every tensor."""
+    pipeline = _load(legacy["tree"], legacy["pipeline_cls"])
+    for component in ("text_encoder", "text_encoder_2", "unet", "vae"):
+        module = getattr(pipeline, component)
+        assert meta_survivors(module) == (), component
+
+
+def test_the_legacy_tree_loads_to_the_same_bytes_as_the_modern_one(
+    legacy: Dict[str, Any], modern: Dict[str, Any],
+) -> None:
+    """Renaming a key must move a tensor, never change one. Both trees are
+    built from the same seed, so every parameter must be byte-identical."""
+    was = _load(legacy["tree"], legacy["pipeline_cls"])
+    now = _load(modern["tree"], modern["pipeline_cls"])
+    checked = 0
+    for component in ("text_encoder", "text_encoder_2", "unet", "vae"):
+        left = dict(getattr(was, component).named_parameters(remove_duplicate=False))
+        right = dict(getattr(now, component).named_parameters(remove_duplicate=False))
+        assert set(left) == set(right), component
+        for name, tensor in left.items():
+            other = right[name]
+            assert tensor.dtype == other.dtype, f"{component}/{name}"
+            assert torch.equal(
+                tensor.reshape(-1).view(torch.uint8),
+                other.reshape(-1).view(torch.uint8),
+            ), f"{component}/{name} moved to the wrong slot"
+            checked += 1
+    assert checked > 50, checked
+
+
+def test_a_container_the_library_cannot_explain_is_still_refused(
+    legacy: Dict[str, Any],
+) -> None:
+    """The refusal is not softened. A name neither the skeleton nor the
+    library's own history knows is still a ``NameMismatch``, and the message
+    now says the migration ran — the fact that separates "wrong checkpoint"
+    from "old checkpoint"."""
+    from gen_worker.serving.streaming import NameMismatch
+
+    base = legacy["base"] / "unknown"
+    source = base / "source-model"
+    pipeline_cls = build_source(source)
+    for container in sorted((source / "text_encoder").glob("*.safetensors")):
+        _rewrite_keys(container, lambda key: "not_a_name_any_version_had." + key)
+    tree = _project(base, source, key="e" * 64)
+    with pytest.raises(NameMismatch) as raised:
+        _load(tree, pipeline_cls)
+    assert "pgw#1453" in str(raised.value)
+
+
+def test_the_streaming_loader_reports_the_legacy_load_as_a_normal_one(
+    legacy: Dict[str, Any],
+) -> None:
+    """A migrated load is a load, not a degraded one: the report must carry the
+    same tensor count the container holds."""
+    store = engine_for(legacy["tree"], device="cpu")
+    assert isinstance(store, StreamingLoader)
+    store.build(legacy["pipeline_cls"], checkpoint_dir=legacy["tree"], lane=Lane())
+    report = store.last_report
+    assert report is not None
+    assert report.tensors > 50, report.tensors
+    assert report.weights_streamed_bytes > 0


### PR DESCRIPTION
Closes the last open defect of the cozy-local substrate family. `#1452` (placement) and `#1473` (variant) already landed; this lands `#1453` and the half of `#1452` that was still an assumption.

## pgw#1453 — the streaming engine asks the LIBRARY what a key became

The engine installs tensors by EXACT name onto a meta skeleton, so a checkpoint whose names predate the installed library matched nothing: transformers v5 flattened the `text_model.` prefix every CLIP checkpoint carries, and **sd1.5's `text_encoder` scored 0 of 197**. The same tree loads through the eager bridge because `from_pretrained` applies every rename the library ships. Nothing performed that rename here — so any endpoint whose checkpoint was published against an older transformers/diffusers than the image ships refused at boot on the native path.

**The map is never written down.** The renames are semantic, not textual — transformers' prefix drop is a string rule, diffusers' `query/key/value/proj_attn -> to_q/to_k/to_v/to_out.0` is not (`key` is not a suffix of `to_k`). A derived suffix map cannot express it and a hand-maintained table would rot. `serving/streaming/keymap.py` calls what each library already exports:

* transformers' `get_model_conversion_mapping` + `rename_source_key`, handed the meta skeleton's own key set as `meta_state_dict` — which is what resolves the `base_model_prefix` add/strip, so the answer is the model's;
* diffusers' `ModelMixin._fix_state_dict_keys_on_load`, driven on a `{name: name}` dict so it hands back its own map with no tensor read and no byte moved.

It runs **unconditionally**, like pgw#1473's variant detection, because both libraries answer "no change" for a checkpoint the installed version already spells (0 renames over sd1.5's 686-tensor unet and 248-tensor vae; migrated names are a fixed point).

**The refusal is not softened.** `NameMismatch` still fires for a name neither the skeleton nor the library's history knows, and now states whether the migration ran and how many keys it moved — the fact that separates "wrong checkpoint" from "old checkpoint". Two checkpoint tensors landing on one skeleton name is refused rather than applied. A tensor needing a transformers CONVERTER (a fuse, split or RoPE permutation — bytes, not names) is refused as `UnstreamableCheckpoint` rather than installed raw under a converted name.

## pgw#1452's other end — the worker's device is PROBED, not assumed

`EndpointHost` defaulted `device` to the literal string `"cuda"`. That is an enumeration of what a pod usually is, not a measurement of this machine, and it feeds **both** arms — `engine_for(device=)` and the eager bridge's `_placed` — so a host with no card got a bare torch device error instead of a named fallback. `placement.serving_device()` asks `hostfacts.cuda_state`, the probe-BY-ALLOCATION verdict (allocate, op, synchronize, free), so a card that is present but will not answer takes the CPU arm with its probe class named. The fallback is LOUD, exactly as `derive._trace_device`'s is. An explicit `device=` still wins; only the default is probed.

## Acceptance BY EXECUTION — substrate=local-4070, eager + streamed only, no compile/mint

**Arm A — eager bridge, UNTOUCHED variant-only fp16 sd1.5 mirror (pgw#1473 + pgw#1452)**

| | |
|---|---|
| `detect_variant` | `'fp16'` |
| `serving_device()` (probe-by-allocation) | `'cuda'` |
| `ctx.load` | 7.63 s |
| component devices | `unet/vae/text_encoder` all `cuda:0` |
| `nvidia-smi` after load | the process, **2836 MiB** |
| generation | 512x512, 20 steps, **3.88 s = 194 ms/step**, peak 2.61 GiB |

**Arm B — pgw#1380 streaming engine on the projected mirror (pgw#1453)**

| component | before | after |
|---|---|---|
| `text_encoder` | **0/197** | **197/197** |
| `unet` | 686/686 | 686/686 |
| `vae` | 248/248 | 248/248 |

`ctx.load` streamed 1.99 GiB in 1.43 s (1.49 GB/s, pinned staging, 1131 tensors over 33 windows); **0 meta survivors** in every component; all on `cuda:0`; 512x512 in **3.56 s = 178 ms/step**.

**Both images are byte-identical** (sha256 `426861f716647fb7`). The bridge and the streaming engine agree exactly on the same tree and the same seed — the strongest available proof that the migration put every tensor in the right slot, since one misplaced tensor changes the image.

Context: the tracker's pre-fix bridge numbers were **13.07 s/it on CPU** (and bf16-on-CPU was worse). 194 ms/step is ~67x, and it is the first honest 4070 number this lane has. Nothing in pgw#1447/#1448's dtype work is regressed — the lane dtype still drives the load and both suites stay green.

## Tests

Real diffusers pipelines saved to real safetensors, rewritten to the PREVIOUS generation's names, ingested into a real chunked CAS and streamed through the real engine. No mocks.

* The go-red condition is asserted on the **premise** — the legacy container must name nothing the skeleton carries — so a library change cannot make this suite pass for the wrong reason.
* The **counter-case** is the same tree at modern names, where the migration must rename nothing; a migration that renamed indiscriminately cannot pass both arms.
* The diffusers arm renames only the blocks diffusers itself marks `_from_deprecated_attn_block`, asked of the library — writing `query` under a block that was never an `AttentionBlock` would invent a checkpoint nobody published.
* **Red arm proven** by disabling the engine hook: the three end-to-end engine tests fail.
* The cardless placement arm runs in a real `CUDA_VISIBLE_DEVICES=""` subprocess, not a patched probe.

Green locally: `test_key_migration_pgw1453.py` (8), `test_bridge_placement.py` (5), plus `test_weight_streaming*`, `test_engine_placement`, `test_variant_bridge`, `test_eager_bridge_dtype` (36 passed, 1 skipped). `mypy src/gen_worker tests` clean on the touched files; `ruff` clean.

## Carried, not done here

A fleet **repin train** is what actually delivers this to running images — the 25 serverless endpoints keep their current wheel until each next deploy (se#675's standing gap). Recorded in the tracker, not attempted in this PR.
