### PR TITLE
pgw#1483/th#2204: the v2 worker ANSWERS the residency goal — ModelStore is constructed, HelloAck.desired_residency has a consumer

### DIFF
--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -31,11 +31,12 @@ from ..redact import sanitize as _sanitize
 from ..topology import current_device_group
 from ..wire_snapshots import resolved_repo_from_snapshot
 from . import cozy_snapshot, disk_gc, disk_telemetry, projection
+from .projection import SNAPSHOTS_DIR
 from . import residency as residency_mod
 from . import staging as staging_mod
 from .cache_paths import tensorhub_cas_dir, tensorhub_fill_source_dir
 from .config_identity import CANONICAL_JSON_MAX_BYTES, canonical_json_digest
-from .cozy_snapshot import _norm_rel_path, delete_blobs
+from .cozy_snapshot import _norm_rel_path, delete_blobs, snapshot_dir_key
 from .download import ensure_local, lookup_provider_for_ref
 from .errors import MissingSnapshotError, UrlExpiredError
 from .hub_client import WorkerResolvedRepo
@@ -1144,6 +1145,75 @@ class ModelStore:
             )
         return snapshot
 
+    async def announce_resident(
+        self, ref: WireRef, snapshot: Optional[pb.Snapshot] = None,
+    ) -> bool:
+        """th#2204: the SATISFIED answer to a residency goal, as a fact.
+
+        A pod booted onto a warm endpoint volume already holds the tree the
+        hub is about to declare. Everything below `ensure_local` would still
+        work — the downloader resolves every object out of the local CAS — but
+        it works by opening a transfer record for a transfer that will move
+        zero bytes, and a fresh process has no banked identity with which to
+        recognise the bytes as its own. That is how th#2204 billed an H100 at
+        $3.29/hr with `no_position_reported`: the pod had the weights and no
+        vocabulary in which to SAY so.
+
+        So this states it directly and cheaply: the tree the goal's digest
+        names either exists on this pod or it does not. When it does, the pod
+        answers with `already_resident` on the position stream and `ON_DISK` on
+        the wire — which is what hub-side placement reads to make the ref
+        DISK-local and dispatch. No record is opened, because there is no
+        transfer to declare.
+
+        Returns True when the answer was given; False means "not resident,
+        fetch it" and the caller falls through to the funnel.
+        """
+        if snapshot is None:
+            snapshot = self._snapshots.get(ref)
+        if snapshot is None or not snapshot.digest:
+            return False
+        digest = str(snapshot.digest).strip()
+        # The tree name is `snapshot_dir_key(digest)`, but the two producers in
+        # this tree disagree about whether the algorithm prefix is part of the
+        # digest (`cozy_snapshot` keeps it, `worker.tree_for` strips it). This
+        # asks the disk instead of picking a side — a residency answer must not
+        # be wrong because two callers spell one digest two ways.
+        bare = digest.split(":", 1)[-1]
+        root = Path(self._cache_dir) / SNAPSHOTS_DIR
+        tree: Optional[Path] = None
+        for key in (snapshot_dir_key(digest), snapshot_dir_key(bare)):
+            candidate = root / key
+            if candidate.is_dir():
+                tree = candidate
+                break
+        if tree is None:
+            existing = self.disk_local_path(ref)
+            if existing is None or not existing.is_dir():
+                return False
+            if existing.name not in (snapshot_dir_key(digest), snapshot_dir_key(bare)):
+                # Resident at a DIFFERENT identity: those are not these bytes,
+                # and calling that satisfied would strand the goal forever.
+                return False
+            tree = existing
+
+        identity = self._snapshot_identity(ref, snapshot)
+        with self._identity_lock:
+            self._disk_identities[ref] = identity
+        if self.residency.tier(ref) is None:
+            # Registers the shared disk tier AND emits the ON_DISK ModelEvent
+            # through Residency's own event path.
+            self.residency.track_disk(ref, tree)
+        else:
+            # Already tracked (boot rescan): the tier transition will not fire
+            # again, so the answer is published as an identity confirmation —
+            # which `replace_desired_snapshots`' epoch bump has just armed.
+            await self._confirm_cached_identity(ref, identity)
+        self._verified.add(ref)
+        self._index.touch(ref)
+        _resident_position(ref, snapshot)
+        return True
+
     async def ensure_local(
         self,
         ref: WireRef,
@@ -1357,9 +1427,20 @@ class ModelStore:
                 # a record opened over RAM/VRAM residency is one that cannot be
                 # closed honestly at all.)
                 resident_tier in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
-                # Disk-resident at EXACTLY the identity being materialized.
+                # Disk-resident at exactly the DIGEST being materialized.
+                #
+                # th#2204: this used to compare the whole identity TUPLE,
+                # `(digest, generation)` — and the generation is the hub's
+                # causal fence for events, not a property of the bytes. Every
+                # HelloAck bumps it, so re-declaring an unchanged goal made the
+                # pod open a DOWNLOADING record for weights it already held,
+                # resolve every object out of the local CAS (zero bytes, so
+                # `_progress` never fires) and leave the hub with the exact
+                # 0-of-N phantom pgw#1485 was written to remove. Measured on the
+                # goal path the moment it had a consumer.
                 or (bool(operation_identity[0])
-                    and banked_disk_identity == operation_identity)
+                    and banked_disk_identity is not None
+                    and banked_disk_identity[0] == operation_identity[0])
             )
             #: True while a hub-side `model_download` record is OPEN for this
             #: materialization and unclosed.

--- a/src/gen_worker/residency_goal.py
+++ b/src/gen_worker/residency_goal.py
@@ -1,0 +1,199 @@
+"""pgw#1483 / th#2204: the v2 worker's consumer of ``HelloAck.desired_residency``.
+
+The hub declares model residency ONCE, in the HelloAck, and then waits. Before
+this module the v2 worker read exactly one field off that ack
+(``file_base_url``) and dropped ``disk_refs``, ``hot`` and ``snapshots`` on the
+floor — the generation was genuinely acked, so the hub logged the goal as
+ACCEPTED while nothing on the pod acted on it. th#2204 measured the consequence
+on a rented H100 at $3.29/hr: `placement declined … reason=model_download_pending
+… download=[no_position_reported]` at 1 Hz for the life of the rental, twice
+punctuated by th#1142's watchdog releasing a reservation whose owner had
+"accepted the goal 6m14s ago with NO DOWNLOAD EVER OPENED" and re-electing the
+same sole worker. **A livelock with no exit and no terminal state.**
+
+The cause was one level below the deleted ``lifecycle.py``: ``ModelStore`` is
+never constructed anywhere in ``src/`` (pgw#1483's census), and
+``WorkerMessage.model_event`` is built INSIDE that class — so the hub was
+waiting for a fact no live object on the pod was capable of stating.
+
+## What this module is, and what it deliberately is NOT
+
+It is a JOIN, not a re-implementation. Every mechanism the reconcile needs
+already shipped and was merely unreachable:
+
+* ``ModelStore.replace_desired_snapshots`` — full-replacement desired identity,
+  and it bumps the republish epoch that forces a re-announce of unchanged bytes.
+* ``ModelStore.ensure_local`` — the one instrumented funnel (pgw#1455's byte
+  positions, pgw#1485's ``already_resident`` phase, lazy record open, terminal
+  close in a ``finally``).
+* ``ModelStore._confirm_cached_identity`` — the SATISFIED answer: a verified
+  cached tree publishes its exact identity as an ``ON_DISK`` ModelEvent without
+  a redundant download. Its docstring already described answering a re-received
+  plan; nothing called it on v2.
+
+So this file owns three things only: **when** to reconcile (a new generation
+arrives), **what order** (declared priority), and **the echo** — the observed
+generation the hub reads back off ``StateDelta`` to tell "answered" from
+"silent". Everything else is delegated.
+
+## The two answers, and why both are words
+
+* **ref already resident** → ``already_resident`` on the ``weight_fetch``
+  position stream plus the ``ON_DISK`` ModelEvent. No download record is
+  opened (pgw#1485: a record is a liability, and one opened for bytes the pod
+  holds can never close honestly). The hub's placement sees DISK locality and
+  DISPATCHES — the wait terminates on a fact, not on a timeout.
+* **ref absent** → the ordinary funnel opens, advances and closes. Positions
+  ride ``weight_fetch`` so th#2191's decline explain can differentiate a
+  progressing fetch from a wedged one.
+
+**Silence is never one of the answers.** A ref that can be neither satisfied
+nor fetched reports ``FAILED`` through the funnel's own terminal path, and the
+generation is still echoed — the hub then knows the pod ANSWERED and failed,
+which is a different state from a pod that never spoke.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict, List, Optional
+
+from .models.refs import WireRef
+from .models.store import ModelStore
+from .pb import worker_scheduler_pb2 as pb
+
+logger = logging.getLogger(__name__)
+
+
+class ResidencyGoal:
+    """Reconciles the hub's declared residency onto this pod's disk.
+
+    One instance per worker. ``apply`` is called from ``on_hello_ack`` and
+    returns immediately: a 134 GB fetch must never run inside the transport's
+    message handler, and a reconnect must be able to supersede a reconcile that
+    is still running.
+    """
+
+    def __init__(self, store: ModelStore) -> None:
+        self._store = store
+        self._task: Optional["asyncio.Task[None]"] = None
+        #: The generation whose reconcile has been ANSWERED — every declared
+        #: ref reached a terminal answer (resident, fetched, or failed).
+        #: Echoed on StateDelta.observed_residency_generation.
+        self.observed_generation: int = 0
+        #: The generation currently being reconciled. Distinct from the one
+        #: above on purpose: a goal in flight is not a goal answered, and
+        #: collapsing them would let the hub read a 134 GB fetch as satisfied.
+        self.accepted_generation: int = 0
+
+    # ---- the HelloAck seam -------------------------------------------------
+
+    def apply(self, desired: Optional[pb.DesiredResidency]) -> None:
+        """Take the hub's goal. Non-blocking; supersedes any live reconcile.
+
+        A goal with generation 0 is the wire's "unset" and is not a goal.
+        """
+        if desired is None:
+            return
+        generation = int(desired.generation or 0)
+        if generation <= 0:
+            return
+        if generation < self.accepted_generation:
+            # An older plan cannot supersede a newer one. The hub is
+            # authoritative on ordering and never rewinds a live generation;
+            # a rewind here would be a replayed frame, not an instruction.
+            logger.warning(
+                "residency goal generation %d is older than the accepted %d; ignored",
+                generation, self.accepted_generation,
+            )
+            return
+
+        snapshots: Dict[WireRef, pb.Snapshot] = {
+            WireRef(str(ref)): snapshot
+            for ref, snapshot in desired.snapshots.items()
+            if str(ref)
+        }
+        refs: List[WireRef] = [
+            WireRef(str(ref)) for ref in desired.disk_refs if str(ref).strip()
+        ]
+        # Full replacement, and it bumps the republish epoch — that is what
+        # makes an unchanged, already-resident ref re-announce instead of
+        # staying silent because nothing changed. The hub re-sending a plan IS
+        # the hub asking to be told again.
+        self._store.replace_desired_snapshots(snapshots, generation=generation)
+        self.accepted_generation = generation
+
+        logger.info(
+            "residency goal accepted: generation=%d disk_refs=%d snapshots=%d",
+            generation, len(refs), len(snapshots),
+        )
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._task = asyncio.create_task(
+            self._reconcile(generation, refs),
+            name=f"residency-goal-{generation}",
+        )
+
+    # ---- the reconcile -----------------------------------------------------
+
+    async def _reconcile(self, generation: int, refs: List[WireRef]) -> None:
+        """Drive every declared ref to a terminal answer, then echo.
+
+        Order is the hub's declared order — ``disk_refs`` is documented as
+        orchestrator priority, and a pod that fetched the 22 MB interpolator
+        before the 134 GB checkpoint would satisfy placement's cheapest
+        precondition last.
+        """
+        answered = 0
+        for ref in refs:
+            try:
+                # THE SATISFIED ANSWER FIRST. A warm pod holds the tree the
+                # goal names; asking the funnel to "fetch" it would open a
+                # transfer record for zero bytes, which is the liability
+                # pgw#1485/th#2205 exist to remove. Ask disk, answer, move on.
+                if await self._store.announce_resident(ref):
+                    answered += 1
+                    logger.info(
+                        "residency already_resident generation=%d ref=%s "
+                        "— answered without opening a transfer",
+                        generation, ref,
+                    )
+                    continue
+                path = await self._store.ensure_local(ref)
+            except asyncio.CancelledError:
+                # A newer generation superseded this one. Say so — a cancelled
+                # reconcile that echoed nothing is exactly the silence this
+                # module exists to remove, and the successor will echo.
+                logger.info(
+                    "residency reconcile generation=%d superseded while on %s",
+                    generation, ref,
+                )
+                raise
+            except Exception as exc:  # noqa: BLE001 — every failure is an ANSWER
+                # ensure_local already emitted the FAILED ModelEvent through
+                # the funnel's terminal path. Nothing is re-emitted here; the
+                # ref is counted as answered because the hub HEARD something.
+                logger.error(
+                    "residency reconcile generation=%d ref=%s failed: %s: %s",
+                    generation, ref, type(exc).__name__, exc,
+                )
+                answered += 1
+                continue
+            answered += 1
+            logger.info(
+                "residency satisfied generation=%d ref=%s at %s", generation, ref, path,
+            )
+
+        self.observed_generation = generation
+        logger.info(
+            "residency goal ANSWERED: generation=%d refs=%d/%d "
+            "— observed_residency_generation now rides every StateDelta",
+            generation, answered, len(refs),
+        )
+
+    # ---- shutdown ----------------------------------------------------------
+
+    def cancel(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -55,6 +55,8 @@ from .models.cache_paths import tensorhub_cache_dir, tensorhub_cas_dir
 from .models.cozy_snapshot import snapshot_dir_key
 from .models.disk_gc import tree_bytes
 from .models.projection import SNAPSHOTS_DIR
+from .models.store import ModelStore
+from .residency_goal import ResidencyGoal
 from .discovery.names import slugify_name
 from . import postmortem
 from .procsplit import is_compute_child
@@ -571,6 +573,25 @@ class Worker:
         boot_mod.mark_once(
             boot_mod.PHASE_SDK_READY, function=",".join(self.functions)
         )
+        # pgw#1483 / th#2204: THE RESIDENCY SEAM. `ModelStore` was never
+        # constructed anywhere in `src/` — and `WorkerMessage.model_event` is
+        # built INSIDE it, so the hub was waiting for a fact no live object on
+        # this pod could state. `_send` is the store's emit: the same wire
+        # every other WorkerMessage rides. `rescan_disk()` is boot-time truth
+        # — on a warm pod with the endpoint volume attached, this is what
+        # turns 134 GB of already-staged bytes into a residency the pod can
+        # ANSWER with instead of re-downloading.
+        self.store = ModelStore(
+            self._send,
+            cache_dir=self.resolver.snapshots_root.parent,
+            vram_budget_bytes=int(budget) or None,
+        )
+        try:
+            self.store.rescan_disk()
+        except Exception as exc:  # noqa: BLE001 — a cold CAS is not a boot failure
+            logger.warning("disk rescan at boot failed: %s: %s", type(exc).__name__, exc)
+        self.residency_goal = ResidencyGoal(self.store)
+
         self.phase = pb.WORKER_PHASE_READY
         self.draining = False
         self.drained = asyncio.Event()
@@ -669,19 +690,35 @@ class Worker:
         free = hostfacts.free_vram_bytes()
         if free is not None:
             delta.free_vram_bytes = int(free)
+        # th#2204: THE ECHO. The hub reads this to tell a pod that ANSWERED the
+        # residency goal from one that never spoke — its own doc calls it
+        # "receipt only", and receipt was precisely the fact missing when
+        # placement re-elected the same silent worker every six minutes at
+        # $3.29/hr. Only a fully reconciled generation is echoed: a goal still
+        # fetching is accepted, not answered, and collapsing the two would let
+        # the hub read a 134 GB transfer as satisfied.
+        observed = int(self.residency_goal.observed_generation)
+        if observed > 0:
+            delta.observed_residency_generation = observed
         return delta
 
     def build_hello(self) -> pb.Hello:
         # NO `resources`: the split parent measures the silicon in a process
         # that imported no tenant code and stamps every relayed Hello, so
         # anything measured here would be replaced before the hub saw it.
-        # NO `models`/`lifecycle_snapshot`: this build carries no residency
-        # ledger and no intent registry, and an invented one is worse than an
-        # absent one.
+        # NO `lifecycle_snapshot`: this build carries no intent registry, and
+        # an invented one is worse than an absent one.
+        # `models` IS carried now (pgw#1483): the store's residency snapshot is
+        # this pod's BOOT BASELINE, replayed hub-side through
+        # ApplyModelResidency. On a warm pod with the endpoint volume attached
+        # this is the cheapest possible answer to th#2204 — the hub learns the
+        # 134 GB is already here before it ever declares a goal, so the park
+        # never happens rather than being unparked later.
         return pb.Hello(
             protocol_version=PROTOCOL_VERSION,
             worker_id=self.worker_id,
             release_id=self.release_id,
+            models=self.store.residency_snapshot(),
             state=self._state_delta(),
             in_flight=[
                 pb.InFlightJob(request_id=rid, attempt=att)
@@ -705,6 +742,14 @@ class Worker:
         # RECONNECT, and "process start -> hello" measured on the third
         # reconnect of a six-hour-old worker is not a boot number.
         boot_mod.mark_once(boot_mod.PHASE_HELLO)
+        # pgw#1483 / th#2204: TAKE THE RESIDENCY GOAL. This must sit ABOVE the
+        # `file_base_url` early return below — a session with no file API is a
+        # hub-side fact that has nothing to do with weights, and putting the
+        # residency consumer under that return would reproduce this issue's
+        # silence on exactly the pods least able to explain it. Non-blocking:
+        # a 134 GB fetch reconciles on its own task while the transport keeps
+        # reading.
+        self.residency_goal.apply(ack.desired_residency)
         if self.functions:
             # THE cold-boot number: the hub has acked a Hello advertising these
             # functions, so from this instant it may dispatch to this pod.

--- a/tests/test_residency_goal.py
+++ b/tests/test_residency_goal.py
@@ -142,6 +142,72 @@ def test_a_goal_for_a_resident_ref_is_ANSWERED_and_opens_no_record(
         origin.close()
 
 
+def test_a_FRESH_process_on_a_warm_volume_answers_its_FIRST_goal(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """th#2204's pod, reproduced: the bytes outlive the process.
+
+    Pod orq6abdjo28it6 booted onto network volume 5u85rpu7m2, which already held
+    all 134 GB of `tensorhub/minimax-h3:serve-narrowed`. Its FIRST residency goal
+    was for weights it already had, and it was a brand-new process with no banked
+    identity to recognise them by — which is why the resident short-circuits
+    inside the funnel could not save it and why it needed a fetch it could not
+    perform. It answered nothing, and the hub re-elected it for 13 minutes.
+
+    So: stage through one store, destroy it, and boot a SECOND store on the same
+    CAS root. The volume is the only thing that survives.
+    """
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        snapshot = _pb_snapshot(files)
+        cas = tmp_path / "endpoint-volume-cas"
+
+        async def stage() -> None:
+            wire = _Wire()
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            goal = ResidencyGoal(_store(wire, cas))
+            goal.apply(_goal(1, _REF, snapshot))
+            await _drain(goal)
+
+        asyncio.run(stage())
+
+        warm = _Wire()
+
+        async def boot() -> None:
+            store = _store(warm, cas)
+            activity.bind_sink(warm.send, asyncio.get_running_loop())
+            store.rescan_disk()  # boot-time truth, exactly as the Worker does
+            goal = ResidencyGoal(store)
+            # Generation 1 again: the hub does not know this pod ever existed.
+            goal.apply(_goal(1, _REF, snapshot))
+            await _drain(goal)
+            assert goal.observed_generation == 1, (
+                "the pod must ANSWER its first goal; an unanswered goal is what "
+                "placement re-elected the same sole worker over, at $3.29/hr"
+            )
+
+        asyncio.run(boot())
+
+        phases = [u.phase for u in warm.positions()]
+        assert phases == [PHASE_ALREADY_RESIDENT], (
+            f"a warm volume answers, it does not fetch; position stream said {phases}")
+        states = [e.state for e in warm.model_events]
+        assert pb.MODEL_STATE_DOWNLOADING not in states, (
+            f"nothing to transfer, so nothing to declare; got {states}")
+        assert pb.MODEL_STATE_ON_DISK in states, (
+            "without this the hub has no residency for the ref and parks forever — "
+            f"the measured livelock; got {states}"
+        )
+        assert warm.open_download_records() == {}
+    finally:
+        origin.close()
+
+
 def test_a_goal_for_an_absent_ref_OPENS_the_instrumented_funnel(
     tmp_path: Path, _fine_cadence: Any
 ) -> None:

--- a/tests/test_residency_goal.py
+++ b/tests/test_residency_goal.py
@@ -1,4 +1,6 @@
-"""pgw#1483 / th#2204: the v2 worker ANSWERS the hub's residency goal.
+"""The v2 worker ANSWERS the hub's residency goal.
+
+# pgw#1483 / th#2204: `HelloAck.desired_residency` had no consumer on v2.
 
 th#2204 measured the absence on a live rented H100 at $3.29/hr: the hub sent
 `HelloAck(desired_generation=3 disk=2 hot=0 resolutions=0)`, the worker acked the

--- a/tests/test_residency_goal_pgw1483.py
+++ b/tests/test_residency_goal_pgw1483.py
@@ -1,0 +1,280 @@
+"""pgw#1483 / th#2204: the v2 worker ANSWERS the hub's residency goal.
+
+th#2204 measured the absence on a live rented H100 at $3.29/hr: the hub sent
+`HelloAck(desired_generation=3 disk=2 hot=0 resolutions=0)`, the worker acked the
+generation, and then nothing on the pod ever acted — `placement declined …
+reason=model_download_pending … download=[no_position_reported]` at 1 Hz for the
+life of the rental, twice interrupted by th#1142 releasing a reservation whose
+owner had "accepted the goal 6m14s ago with NO DOWNLOAD EVER OPENED" and
+re-electing the same sole worker.
+
+These drive the REAL consumer over the REAL `ModelStore` funnel against a real
+trickling HTTP origin and a real CAS — the harness pgw#1455 built and pgw#1485
+extended. $0, no GPU, no pod.
+
+Two arms, and they are the two answers the hub must be able to tell apart:
+
+* **goal names an already-resident ref** → the SATISFIED answer. An
+  `already_resident` row on the `weight_fetch` position stream, an `ON_DISK`
+  ModelEvent so hub-side placement sees DISK locality and dispatches, and NO
+  download record (pgw#1485: a record opened for bytes the pod holds can never
+  close honestly).
+* **goal names an absent ref** → the funnel opens, positions advance, the
+  record closes. This is pgw#1485's control, re-run through the goal consumer
+  rather than through a bare `ensure_local`, because the thing under test is
+  the JOIN and a join can be wrong in either direction.
+
+The echo is asserted in both: `observed_generation` only advances once every
+declared ref reached a terminal answer. A goal still fetching is ACCEPTED, not
+ANSWERED, and the hub reads those two states differently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker import activity
+from gen_worker.models.refs import WireRef
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.residency_goal import ResidencyGoal
+from gen_worker.weight_position import MIB, PHASE_ALREADY_RESIDENT
+
+# The pgw#1455/#1485 harness: `tests` is on `pythonpath` (pyproject), so this is
+# the same real origin, real CAS, real ModelStore every position test uses.
+from test_weight_position import (  # type: ignore[import-not-found]
+    OBJECT_BYTES,
+    OBJECTS,
+    _Origin,
+    _Wire,
+    _pb_snapshot,
+    _store,
+)
+
+_REF = WireRef("acme/model-a")
+
+
+def _goal(generation: int, ref: WireRef, snapshot: pb.Snapshot) -> pb.DesiredResidency:
+    """The hub's wire form, built exactly as `hello_ack.go` builds it:
+    `disk_refs` in orchestrator priority order and `snapshots` keyed by ref."""
+    desired = pb.DesiredResidency(generation=generation, disk_refs=[str(ref)])
+    desired.snapshots[str(ref)].CopyFrom(snapshot)
+    return desired
+
+
+async def _drain(goal: ResidencyGoal) -> None:
+    """Let the reconcile task and the activity sink's `create_task` hops run."""
+    task = goal._task  # the lane under test owns its task; nothing else does
+    assert task is not None, "apply() created no reconcile task"
+    await task
+    for _ in range(8):
+        await asyncio.sleep(0)
+
+
+def test_a_goal_for_a_resident_ref_is_ANSWERED_and_opens_no_record(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """th#2204's own shape: a WARM pod whose weights are already on the
+    attached volume.
+
+    Before this, the worker acked the generation and did nothing — no download,
+    no event, no position — so the hub's `no_position_reported` was the honest
+    reading of a genuine silence, and placement had nothing that could ever
+    terminate the wait.
+    """
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        snapshot = _pb_snapshot(files)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            # Generation 1 stages the bytes — this is the COLD arm and it is
+            # here so the resident arm is measured on a pod that genuinely
+            # holds them, not on a mocked residency.
+            goal = ResidencyGoal(store)
+            goal.apply(_goal(1, _REF, snapshot))
+            await _drain(goal)
+            assert goal.observed_generation == 1
+
+            # Everything the cold generation said is now history; the resident
+            # generation must speak for itself.
+            wire.updates.clear()
+            wire.model_events.clear()
+
+            # Generation 2: the identical goal, re-declared. This is the warm
+            # re-dispatch / reconnect the hub performs on every HelloAck.
+            goal.apply(_goal(2, _REF, snapshot))
+            await _drain(goal)
+            assert goal.observed_generation == 2
+
+        asyncio.run(run())
+
+        phases = [u.phase for u in wire.positions()]
+        assert PHASE_ALREADY_RESIDENT in phases, (
+            "a goal naming a ref the pod already holds must ANSWER with the "
+            f"satisfied fact; the position stream said {phases}"
+        )
+        states = [e.state for e in wire.model_events]
+        assert pb.MODEL_STATE_DOWNLOADING not in states, (
+            "the pod holds these bytes: declaring a transfer opens a hub-side "
+            f"liability that can never close honestly; got {states}"
+        )
+        assert pb.MODEL_STATE_ON_DISK in states, (
+            "the satisfied answer must reach the hub as residency, or placement "
+            "still sees a pod that said nothing and parks forever "
+            f"(th#2204, $3.29/hr); got {states}"
+        )
+        assert wire.open_download_records() == {}, (
+            "a resident ref must leave no open download record")
+    finally:
+        origin.close()
+
+
+def test_a_goal_for_an_absent_ref_OPENS_the_instrumented_funnel(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """pgw#1485's control, driven through the goal consumer.
+
+    The fix must not buy silence-on-resident by making the consumer refuse to
+    fetch: an absent ref still opens, advances and closes, with positions.
+    """
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        snapshot = _pb_snapshot(files)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            goal = ResidencyGoal(store)
+            goal.apply(_goal(7, _REF, snapshot))
+            # Not answered until the transfer reaches a terminal answer: a goal
+            # in flight is ACCEPTED, and the hub must not read a 134 GB fetch
+            # as satisfied.
+            assert goal.observed_generation == 0
+            assert goal.accepted_generation == 7
+            await _drain(goal)
+            assert goal.observed_generation == 7
+
+        asyncio.run(run())
+
+        states = [e.state for e in wire.model_events]
+        assert pb.MODEL_STATE_DOWNLOADING in states, (
+            f"an absent ref must declare its transfer; got {states}")
+        assert pb.MODEL_STATE_ON_DISK in states
+        assert wire.open_download_records() == {}
+        steps = [r.step for r in wire.positions()]
+        assert steps and steps[-1] == (OBJECTS * OBJECT_BYTES) // MIB, (
+            f"the funnel's byte positions must advance to the whole; got {steps}")
+        assert steps[-1] > steps[0]
+    finally:
+        origin.close()
+
+
+def test_a_generation_bump_over_UNCHANGED_bytes_declares_no_transfer(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """The defect this lane found by measuring, not by reading.
+
+    pgw#1485's resident pre-check compared the whole identity TUPLE
+    `(digest, generation)`. The generation is the hub's causal fence for
+    EVENTS, not a property of the bytes, and every HelloAck bumps it — so
+    re-declaring an unchanged goal made the pod open a `DOWNLOADING` record
+    for weights it already held, resolve every object out of the local CAS
+    (zero bytes moved, so `_progress` never fires once) and hand the hub the
+    exact `0 of N bytes @ 0.00/s` phantom that th#2205 measured for 1h54m and
+    th#2204 measured as a placement livelock.
+
+    Driven through `ensure_local` deliberately, BELOW `announce_resident`, so
+    the predicate is proved on its own rather than through the fast path.
+    """
+    origin = _Origin()
+    try:
+        blobs = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        files = [(p, b, origin.put(b)) for p, b in blobs]
+        snapshot = _pb_snapshot(files)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            store.replace_desired_snapshots({_REF: snapshot}, generation=1)
+            await store.ensure_local(_REF)
+            for _ in range(8):
+                await asyncio.sleep(0)
+            wire.updates.clear()
+            wire.model_events.clear()
+            # Same bytes, same digest, next generation — the ordinary reconnect.
+            store.replace_desired_snapshots({_REF: snapshot}, generation=2)
+            await store.ensure_local(_REF)
+            for _ in range(8):
+                await asyncio.sleep(0)
+
+        asyncio.run(run())
+
+        states = [e.state for e in wire.model_events]
+        assert pb.MODEL_STATE_DOWNLOADING not in states, (
+            "a generation bump moved no bytes: declaring a transfer here opens "
+            "the 0-of-N hub row that parks placement and vetoes idle retire; "
+            f"got {states}"
+        )
+        phases = [u.phase for u in wire.positions()]
+        assert PHASE_ALREADY_RESIDENT in phases, (
+            f"the unchanged bytes must be reported as resident; got {phases}")
+    finally:
+        origin.close()
+
+
+def test_an_unset_or_rewound_generation_is_not_a_goal(tmp_path: Path) -> None:
+    """Generation 0 is the wire's "unset", and the hub never rewinds a live
+    generation — a rewind on the wire is a replayed frame, not an instruction.
+    Neither may start a reconcile, because either would make the echo lie."""
+    wire = _Wire()
+    store = _store(wire, tmp_path / "cas")
+    goal = ResidencyGoal(store)
+
+    goal.apply(None)
+    assert goal._task is None
+    goal.apply(pb.DesiredResidency(generation=0, disk_refs=[str(_REF)]))
+    assert goal._task is None
+    assert goal.accepted_generation == 0
+
+    async def run() -> None:
+        goal.apply(pb.DesiredResidency(generation=5))
+        await _drain(goal)
+        assert goal.observed_generation == 5
+        # A stale frame arriving after generation 5 must not reopen it.
+        goal.apply(pb.DesiredResidency(generation=4))
+        assert goal.accepted_generation == 5
+
+    asyncio.run(run())
+
+
+@pytest.fixture
+def _fine_cadence(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """pgw#1455's stride/floor make a 9 MiB fixture emit one row; the position
+    mechanics are asserted in `test_weight_position.py` and re-asserted here,
+    so the cadence is tightened the same way it is there."""
+    import gen_worker.weight_position as wp
+
+    monkeypatch.setattr(wp, "STRIDE_MIB", 1)
+    monkeypatch.setattr(wp, "MIN_INTERVAL_S", 0.0)
+    return None


### PR DESCRIPTION
pgw#1483/th#2204: the v2 worker ANSWERS the residency goal — ModelStore is constructed, HelloAck.desired_residency has a consumer, and `already_resident` is about the BYTES not the generation

th#2204 measured this on a rented H100 at $3.29/hr, two full cycles: a warm pod
whose weights were already on the attached volume accepted the residency goal,
opened no download, and was re-elected forever — `model_download_pending` with
`no_position_reported`, nothing that could ever finish.

pgw#1483's census found the cause one level below the deleted `lifecycle.py`:
`ModelStore` is NEVER CONSTRUCTED anywhere in src/, and
`WorkerMessage.model_event` is built INSIDE that class — so the hub was waiting
for a fact no live object on the pod was capable of stating.

This is a JOIN, not a re-implementation. Every mechanism already shipped and was
merely unreachable: replace_desired_snapshots (full-replacement identity + the
republish epoch), ensure_local (pgw#1455 positions, pgw#1485's already_resident
phase, lazy open, terminal close in a finally), _confirm_cached_identity (the
satisfied answer, whose own docstring described answering a re-received plan).

- residency_goal.ResidencyGoal: when to reconcile, in what order, and the echo.
  apply() is non-blocking — a 134 GB fetch must never run inside the transport's
  message handler — and a newer generation supersedes a live reconcile.
- Worker constructs a live ModelStore on self._send, rescans disk at boot, takes
  the goal in on_hello_ack ABOVE the file_base_url early return, and carries
  Hello.models so a warm pod's residency reaches the hub before any goal is even
  declared.
- StateDelta.observed_residency_generation is ECHOED. The hub already reads it
  (connect_worker.go:1657) and its doc calls it receipt-only — receipt was
  exactly the fact missing when placement re-elected the same silent worker every
  six minutes. Only a fully reconciled generation is echoed: a goal still
  fetching is ACCEPTED, not ANSWERED, and collapsing the two would let the hub
  read a 134 GB transfer as satisfied.
- ModelStore.announce_resident: the SATISFIED answer as a fact. A fresh process
  on a warm volume has no banked identity to recognise its own bytes with, so it
  asks disk directly — and answers already_resident + ON_DISK without opening a
  transfer record for a transfer that would move zero bytes.

FOUND BY MEASURING, and it is a live defect in pgw#1485's own predicate:
already_resident compared the whole identity TUPLE (digest, generation). The
generation is the hub's causal fence for EVENTS, not a property of the bytes,
and every HelloAck bumps it — so re-declaring an unchanged goal made the pod open
a DOWNLOADING record for weights it already held, resolve every object out of
the local CAS (zero bytes, so _progress never fires once) and hand the hub the
exact 0-of-N phantom th#2205 measured for 1h54m and th#2204 measured as a
placement livelock. Now compared on digest.

Red/green, $0, no GPU, on the production ModelStore funnel over a real trickling
HTTP origin and a real CAS (the pgw#1455/#1485 harness):

  goal for a resident ref is ANSWERED, opens no record  | pass | RED with the
                                                        |      | consumer disarmed
  goal for an absent ref OPENS the funnel with positions| pass | RED likewise
  a generation bump over unchanged bytes declares no    | pass | RED with the
    transfer                                            |      | tuple compare back
  unset/rewound generation is not a goal                | pass | —

Every red arm flips a CONDITION, never cuts lines: the module still parses, the
test still executes, and the failure is the assertion claimed.

Neighbours green: test_weight_position (9), test_model_residency,
test_snapshot_residency_progress_pgw1289, test_component_digests_v2_th1303,
test_cancel_at_grant_pgw845, test_managed_tier_fill_source,
test_store_corruption_pgw1283, test_snapshot_disk_headroom_pgw1263 (40 passed).
ruff + mypy clean on the changed files.

Observed and NOT fixed here, because fixing it blind would be worse than naming
it: the two producers of a snapshot tree name disagree about the algorithm
prefix. `cozy_snapshot` writes `snapshots/sha256:<hex>` while `worker.tree_for`
strips the prefix and looks for `snapshots/<hex>`. `announce_resident` asks disk
for BOTH spellings rather than picking a side; whether the asymmetry is live in
production depends on the hub's `ModelSnapshot.Digest` format and wants one
measurement on a real pod.
