### PR TITLE
pgw#1486: ask the offload ladder BEFORE placing, and obey the answer

### DIFF
--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -285,3 +285,14 @@ CI-SKIPPED tests/test_engine_placement.py|this host's nvml is version-mismatched
 # pre-populate that cache, so the row is a CI fact rather than a defect, and the
 # property it guards is measured on an authoring box that has the model.
 CI-SKIPPED tests/test_bridge_placement.py|hf-internal-testing/tiny-stable-diffusion-pipe is not in the local hf cache (<path>)
+
+# pgw#1486: the VRAM-fit suite's fixture skip, and it is the SAME fact as the
+# `test_bridge_placement.py` row above — both build the real tiny SD pipeline,
+# because the properties under test are things that happen to what
+# `from_pretrained` returns, and a hand-built double that never calls it could
+# not catch either defect. CI runners do not pre-populate the HF cache.
+# The load-bearing proof for this suite is not CI: it is the local 4070 run
+# recorded in the tracker (master puts 7.14 GiB on a 7.62 GiB card and OOMs;
+# the fix engages `model_offload` pre-placement, 0.51 GiB resident, and serves),
+# plus the red arm in a detached master worktree where 4 of the 6 cases fail.
+CI-SKIPPED tests/test_vram_fit.py|hf-internal-testing/tiny-stable-diffusion-pipe is not in the local hf cache (<path>)

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import gc
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
@@ -1550,6 +1551,77 @@ def _report_offload_engaged(
     )
 
 
+_execution_device_fallback_installed = False
+
+
+def install_execution_device_fallback() -> bool:
+    """Make ``pipeline.device`` never answer ``meta``. Idempotent.
+
+    ``enable_sequential_cpu_offload`` leaves every module on the meta device,
+    so diffusers' ``DiffusionPipeline.device`` — a PUBLIC property, and the one
+    thing endpoint code is told to ask — answers ``meta``. Endpoint code that
+    builds a generator on it then dies with ``RuntimeError: META device type
+    not an accelerator`` BEFORE any image. Measured on the real sdxl endpoint
+    at 1024^2 (pgw#1486): the bottom rung of this ladder, the one whose whole
+    job is "always works", did not work at all.
+
+    The endpoint is not at fault and must not be the fix. The worker tells
+    authors *"PLACEMENT is decided here, by the worker, never by author code"*
+    and `ctx.load`'s contract is that they never name a device — so asking the
+    pipeline where it lives is the documented-correct thing to do, and
+    `_execution_device` is a private diffusers attribute no endpoint should
+    reach for. The rung that breaks the answer repairs the answer, once, for
+    every endpoint.
+
+    Patching a foreign class is the same shape as ``host_move_guard``'s patch
+    of ``torch.nn.Module.to``, for the same reason: the call site is in author
+    code this worker does not own and cannot edit.
+    """
+    global _execution_device_fallback_installed
+    if _execution_device_fallback_installed:
+        return True
+    try:
+        from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+    except Exception:  # pragma: no cover - no diffusers, nothing to patch
+        return False
+
+    original_getter = DiffusionPipeline.device.fget  # type: ignore[attr-defined]
+    # `_execution_device` ENDS in `return self.device` when no component
+    # carries an accelerate hook — so a pipeline parked on `meta` with no hooks
+    # (a derive shell, a half-armed rung) would recurse until the stack blew.
+    # The guard is thread-local because two loads may run concurrently and a
+    # flag on the pipeline would have to survive diffusers' own `__setattr__`,
+    # which treats attribute names as component registrations.
+    reentry = threading.local()
+
+    def device(self: Any) -> Any:
+        got = original_getter(self)
+        if getattr(got, "type", None) != "meta":
+            return got
+        if getattr(reentry, "active", False):
+            return got
+        reentry.active = True
+        try:
+            # diffusers' own accelerate-aware answer to the same question:
+            # where the next forward will actually run.
+            resolved = self._execution_device
+        except Exception:  # pragma: no cover - upstream shape changed
+            return got
+        finally:
+            reentry.active = False
+        # No hook to read: `meta` really is the honest answer, and inventing a
+        # device here would send tensors somewhere the weights are not.
+        return got if getattr(resolved, "type", None) == "meta" else resolved
+
+    DiffusionPipeline.device = property(device)  # type: ignore[method-assign,assignment]
+    _execution_device_fallback_installed = True
+    _LOG.info(
+        "low_vram: `pipeline.device` now falls back to the execution device "
+        "when an offload rung parks modules on `meta` (pgw#1486)"
+    )
+    return True
+
+
 def apply_low_vram_config(
     pipeline: Any,
     *,
@@ -1630,6 +1702,11 @@ def apply_low_vram_config(
         setattr(pipeline, _COZY_MODE_ATTR, "vae_only")
         log.info("low_vram: vae_only applied (%s)", _applied_summary(applied))
         return applied
+
+    # Every rung from here down parks modules off the execution device, and
+    # some park them on `meta`. Repair `pipeline.device` BEFORE any of them
+    # arms, so no endpoint ever observes the meta answer (pgw#1486).
+    install_execution_device_fallback()
 
     cuda_ok = cuda_ready()
 
@@ -1761,6 +1838,7 @@ _RESIDENT_MODES = ("off", "vae_only")
 
 __all__ = [
     "apply_low_vram_config",
+    "install_execution_device_fallback",
     "low_vram_mode",
     "rearm_offload",
     "place_pipeline",

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -243,6 +243,10 @@ class LoadContext(Generic[MT_co]):
         #: means none was handed down — a bare `LoadContext(...)` places
         #: nothing, exactly as before.
         self._device = str(device or "")
+        #: The offload rung `_placed` engaged for this load, or "" for "the
+        #: ladder was never consulted" (pgw#1486). Read by `compile()`, which
+        #: may not arm a compiled graph over hook-managed weights.
+        self._engaged_rung = ""
 
     @property
     def checkpoint_dir(self) -> Path:
@@ -359,19 +363,94 @@ class LoadContext(Generic[MT_co]):
         was handed. An empty `_device` places nothing, so a bare
         `LoadContext(...)` and any caller that never had a placement decision
         behave exactly as before.
+
+        pgw#1486: the placement decision is now a FIT decision, and the order
+        is the whole point. `models.memory.select_auto_mode` nets the
+        requirement against `estimate_cuda_resident_gb(pipeline)` (pgw#1025,
+        correct: a pipeline must not be charged twice for bytes already on the
+        card) — so asking it AFTER a full `.to(device)` makes the requirement
+        net to zero, "it fits" trivially true, and the ladder answers its most
+        memory-hungry rung for a pipeline that is about to OOM. Measured on one
+        SDXL pipeline object at 1024^2 on a 7.62 GiB card: `model_offload`
+        asked before placement, `vae_only` asked after. The second OOMs.
         """
         if not self._device:
             return pipeline
         to = getattr(pipeline, "to", None)
         if not callable(to):
             return pipeline
+        from ..models.rung import touches_host_ram
+
+        mode = self._fit_rung(pipeline)
+        if mode and touches_host_ram(mode):
+            # The rung armed accelerate's hooks and OWNS placement from here:
+            # each component is onloaded for its own forward and evicted after.
+            # A `.to(device)` now would either undo the hooks or re-land the
+            # very bytes the rung just moved off — which is the OOM.
+            logger.info(
+                "ctx.load: %r engaged pre-placement; the rung places its own "
+                "components (pgw#1486)", mode,
+            )
+            return pipeline
         logger.info(
             "ctx.load: placing the bridged pipeline on %s — the worker's "
-            "decision, inherited (pgw#1452)", self._device,
+            "decision, inherited (pgw#1452); fit rung %r",
+            self._device, mode or "not consulted",
         )
         moved = to(self._device)
         # diffusers returns self; some component-wise `.to` return None.
         return pipeline if moved is None else moved
+
+    def _fit_rung(self, pipeline: P) -> str:
+        """Ask the shipped offload ladder which rung this pipeline needs,
+        while it is still on the host, and engage it.
+
+        Returns the engaged mode, or `""` when the ladder was not consulted at
+        all (no CUDA target, or the ladder could not read the pipeline). `""`
+        is deliberately distinct from `"off"`: "nobody asked" and "asked, and
+        the answer was full residency" are different facts, and only the
+        second licenses the unconditional placement below.
+
+        EAGER-BRIDGE SCOPE, stated here rather than inferred. The streaming
+        engine returns before `_placed` is ever reached and streams weights
+        onto the device itself; giving it a fit rung is a separate mechanism
+        (it would have to choose per-component destinations mid-stream, not
+        re-place a built pipeline). And this is an ADMISSION check, never a
+        catch-and-retry: an OOM inside a compiled graph is not catchable — it
+        is process death (pgw#1255 leg 2) — so the only honest place to decide
+        is before the weights land.
+        """
+        try:
+            import torch
+
+            if torch.device(self._device).type != "cuda":
+                return ""
+        except Exception:
+            return ""
+        from ..api.errors import HostRamMoveRefusedError
+
+        try:
+            from ..models.memory import apply_low_vram_config
+
+            applied = apply_low_vram_config(pipeline, mode="auto")
+        except HostRamMoveRefusedError:
+            # The guard did its job: this host cannot hold what the rung wanted
+            # to move. Re-raising is right — the alternative is placing the
+            # whole pipeline on a card that already refused it.
+            raise
+        except Exception as exc:
+            # A ladder that cannot read this pipeline must not stop it loading.
+            # Placement then proceeds exactly as it did before pgw#1486, which
+            # is the behaviour every non-diffusers `ctx.load` caller has today.
+            logger.warning(
+                "ctx.load: the offload ladder could not size this pipeline "
+                "(%s: %s); placing it whole, as before (pgw#1486)",
+                type(exc).__name__, exc,
+            )
+            return ""
+        mode = str(applied.get("mode") or "")
+        self._engaged_rung = mode
+        return mode
 
     def _lane_dtype(self) -> Any:
         """The lane's load dtype, or None when the contract declares none.
@@ -488,6 +567,25 @@ class LoadContext(Generic[MT_co]):
         (local runs, the eager bridge) it returns ``target`` untouched —
         marking is always safe."""
         if self._compile_sink is None:
+            return target
+        from ..models.rung import touches_host_ram
+
+        if touches_host_ram(self._engaged_rung):
+            # pgw#1486, the ADMISSION half. An offload rung hands each
+            # component's weights to accelerate, which onloads them for a
+            # forward and frees the device copy after — so the device pointers
+            # a compiled graph binds its constants to are dangling by the
+            # second call. That is not an OOM to catch; it is a use-after-free,
+            # and on the compiled path it is the SIGSEGV that takes the whole
+            # worker down (pgw#1255 leg 2). Serving eager here is a real
+            # degradation and is therefore said out loud, not logged at debug.
+            logger.warning(
+                "ctx.compile: serving EAGER for %s — the %r offload rung is "
+                "engaged, and a compiled graph cannot bind constants to "
+                "weights accelerate moves between host and device per forward "
+                "(pgw#1486). Fit the model on the card to get compiled speed.",
+                type(target).__name__, self._engaged_rung,
+            )
             return target
         return self._compile_sink(target)
 

--- a/src/gen_worker/serving/placement.py
+++ b/src/gen_worker/serving/placement.py
@@ -69,9 +69,12 @@ class Shortfall:
             return (
                 f"DEGRADED PLACEMENT: {self.device} has {self.actual:.1f} GiB "
                 f"of VRAM, but lane {self.lane} declares a floor of "
-                f"{self.declared:.1f} GiB. Running anyway — the residency "
-                f"ladder will engage host offload rungs, so expect a HEAVY "
-                f"slowdown (minutes where seconds are normal), not a failure. "
+                f"{self.declared:.1f} GiB. Running anyway — the load asks the "
+                f"offload ladder whether this pipeline fits BEFORE placing it "
+                f"and engages a host-offload rung when it does not, naming "
+                f"that rung in the log. Expect a HEAVY slowdown (minutes "
+                f"where seconds are normal) rather than a failure; if no rung "
+                f"is named, nothing was offloaded and it fit. "
                 f"A declared floor is a buying hint and a warning, never "
                 f"permission: any model runs on any machine."
             )

--- a/tests/test_offload_ladder_pgw1486.py
+++ b/tests/test_offload_ladder_pgw1486.py
@@ -1,0 +1,257 @@
+"""The offload ladder is consulted BEFORE placement, and its answer is obeyed.
+
+pgw#1486, measured on a real 7.62 GiB RTX 4070 against the real sdxl endpoint at
+1024^2 CFG batch-2. The do-nothing baseline OOMs in 1.74 s inside the unet;
+`enable_model_cpu_offload()` alone serves the same request in 26.8 s at a
+6.41 GiB peak with an image out. The ladder that picks exactly that rung has
+shipped in `models/memory.py` for months and had ZERO callers on the v2 serve
+path — and calling it in the wrong ORDER does not help, it inverts the answer:
+
+    select_auto_mode  PRE-placement -> "model_offload"   (serves)
+    select_auto_mode POST-placement -> "vae_only"        (OOMs)
+
+because `select_auto_mode` nets the requirement against
+`estimate_cuda_resident_gb(pipeline)` (pgw#1025, deliberate and correct: a
+pipeline must not be charged twice for bytes already on the card), and
+`_placed` had already made every byte resident.
+
+So the property under test is an ORDERING one, and it is written that way: not
+"the ladder was called" but "the ladder was called while nothing was resident".
+That is checkable with no GPU at all, which is why it runs on every runner
+rather than only where the defect was found.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from diffusers import StableDiffusionPipeline  # noqa: E402
+
+from gen_worker.models import memory as gwmem  # noqa: E402
+from gen_worker.serving.context import DeployBinding, LoadContext  # noqa: E402
+
+#: The same real tiny pipeline `test_bridge_placement.py` uses. The defect was
+#: in what happens to the object `from_pretrained` returns, so a hand-built
+#: double that never calls it could not have caught it.
+FIXTURE = "hf-internal-testing/tiny-stable-diffusion-pipe"
+
+
+def _local_snapshot() -> Path:
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    repo = "models--" + FIXTURE.replace("/", "--")
+    for snapshot in sorted(Path(HF_HUB_CACHE).glob(f"{repo}/snapshots/*")):
+        if (snapshot / "model_index.json").is_file():
+            return snapshot
+    pytest.skip(f"{FIXTURE} is not in the local HF cache ({HF_HUB_CACHE})")
+
+
+def _ctx(device: str) -> "LoadContext[Any]":
+    binding = DeployBinding(
+        checkpoint_ref="ckpt:tiny@fixture", checkpoint_dir=_local_snapshot()
+    )
+    return LoadContext(binding=binding, device=device)
+
+
+def _recording_to(moved: List[Any]) -> Any:
+    """A `.to` that records where it was asked to go and moves nothing.
+
+    The contract under test is "the bridge does not move an offloaded
+    pipeline", and that is observable as a CALL — so the assertions run on
+    runners with no CUDA device, which is where this suite mostly lives.
+    """
+    def to(self: Any, *args: Any, **kwargs: Any) -> Any:
+        moved.append(args)
+        return self
+
+    return to
+
+
+def test_the_ladder_is_asked_while_the_pipeline_is_still_on_the_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE RED ARM. At master `apply_low_vram_config` is never called at all,
+    so `asked_with_resident` stays empty and this fails on the first assert.
+
+    The second assert is the half that a "did we call the ladder?" test would
+    miss entirely: calling it one line later still compiles, still logs, and
+    still returns a mode — and that mode is the one that OOMs.
+    """
+    asked_with_resident: List[float] = []
+    real = gwmem.apply_low_vram_config
+
+    def recording(pipeline: Any, **kwargs: Any) -> Any:
+        asked_with_resident.append(gwmem.estimate_cuda_resident_gb(pipeline))
+        return real(pipeline, **kwargs)
+
+    monkeypatch.setattr(gwmem, "apply_low_vram_config", recording)
+    pipe = StableDiffusionPipeline.from_pretrained(_local_snapshot())
+    # The real `.to` is stubbed so the ORDERING question is answerable on a
+    # runner with no CUDA device — which is most of them, and the property is
+    # not a CUDA property.
+    monkeypatch.setattr(type(pipe), "to", lambda self, *a, **k: self)
+
+    _ctx("cuda")._placed(pipe)
+
+    assert asked_with_resident, (
+        "the offload ladder was never consulted on the eager bridge — this is "
+        "the pgw#1486 defect: 1785 lines of correct ladder with no caller, and "
+        "an SDXL pipeline that OOMs on a card it fits with one rung engaged"
+    )
+    assert asked_with_resident[0] == 0.0, (
+        f"the ladder was consulted with {asked_with_resident[0]:.2f} GiB "
+        f"already resident on the card. `select_auto_mode` nets the "
+        f"requirement against what is already there (pgw#1025), so asking it "
+        f"after placement makes every pipeline 'fit' and selects the most "
+        f"memory-hungry rung — measured as model_offload -> vae_only on SDXL"
+    )
+
+
+def test_an_offload_rung_places_its_own_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the ladder answers an offload rung, `_placed` must NOT then move
+    the pipeline to the device.
+
+    The `.to(device)` is the whole defect: it re-lands exactly the bytes the
+    rung just moved off the card. Asserted on the CALL rather than on resulting
+    device placement so it runs without a GPU — the contract is "the bridge
+    does not move it", and that is what is observable everywhere.
+    """
+    armed: List[str] = []
+    def arming(pipeline: Any, **kwargs: Any) -> Any:
+        armed.append("model_offload")
+        return {"mode": "model_offload"}
+
+    monkeypatch.setattr(gwmem, "apply_low_vram_config", arming)
+    moved: List[Any] = []
+    ctx = _ctx("cuda")
+    pipe = StableDiffusionPipeline.from_pretrained(_local_snapshot())
+    monkeypatch.setattr(type(pipe), "to", _recording_to(moved))
+
+    ctx._placed(pipe)
+
+    assert armed == ["model_offload"], "the rung was not engaged"
+    assert not moved, (
+        f"an offload rung was engaged and the bridge moved the pipeline to the "
+        f"device anyway ({moved}) — that re-lands the very weights the rung "
+        f"just evicted, which is the OOM pgw#1486 exists to remove"
+    )
+
+
+def test_a_resident_rung_still_places_the_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The counter-case, so the assertion above cannot pass by never placing
+    anything: a pipeline that FITS is still placed on the device, exactly as
+    pgw#1452 requires."""
+    monkeypatch.setattr(gwmem, "select_auto_mode", lambda **_: "off")
+    moved: List[Any] = []
+    ctx = _ctx("cuda")
+    pipe = StableDiffusionPipeline.from_pretrained(_local_snapshot())
+    monkeypatch.setattr(type(pipe), "to", _recording_to(moved))
+
+    ctx._placed(pipe)
+
+    assert moved == [("cuda",)], (
+        f"the ladder said this pipeline fits, so the worker's placement "
+        f"decision must still be applied; moves seen: {moved}"
+    )
+
+
+def test_a_ladder_that_cannot_size_the_pipeline_does_not_block_the_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every non-diffusers `ctx.load` caller reaches this path too. A ladder
+    that raises on an object it cannot read must degrade to the pre-pgw#1486
+    behaviour — place it whole — never refuse the load."""
+    def explode(pipeline: Any, **kwargs: Any) -> Any:
+        raise TypeError("this is not a diffusers pipeline")
+
+    monkeypatch.setattr(gwmem, "apply_low_vram_config", explode)
+    moved: List[Any] = []
+    ctx = _ctx("cuda")
+    pipe = StableDiffusionPipeline.from_pretrained(_local_snapshot())
+    monkeypatch.setattr(type(pipe), "to", _recording_to(moved))
+
+    ctx._placed(pipe)
+
+    assert moved == [("cuda",)]
+
+
+def test_compile_will_not_arm_over_hook_managed_weights() -> None:
+    """The ADMISSION half. Under an offload rung accelerate moves a module's
+    weights on and off the device per forward, so a compiled graph's bound
+    constants dangle — a use-after-free, which on the compiled path is the
+    uncatchable SIGSEGV (pgw#1255 leg 2), not an OOM anyone can retry."""
+    sink_calls: List[Any] = []
+    def sink(target: Any) -> Any:
+        sink_calls.append(target)
+        return "ARMED"
+
+    ctx: "LoadContext[Any]" = LoadContext(
+        binding=DeployBinding(checkpoint_ref="r", checkpoint_dir=Path(".")),
+        compile_sink=sink,
+    )
+    module = torch.nn.Linear(2, 2)
+
+    ctx._engaged_rung = ""
+    assert ctx.compile(module) == "ARMED", (
+        "with no offload rung engaged, marking must reach torchcg unchanged — "
+        "otherwise this guard has silently disabled compilation everywhere"
+    )
+    assert sink_calls == [module]
+
+    ctx._engaged_rung = "model_offload"
+    assert ctx.compile(module) is module, (
+        "an offload rung is engaged and `ctx.compile` still armed a compiled "
+        "graph over weights accelerate relocates every forward"
+    )
+    assert len(sink_calls) == 1, "the sink must not be reached under a rung"
+
+
+def test_pipeline_device_never_answers_meta_to_endpoint_code() -> None:
+    """The bottom rung's own defect. `enable_sequential_cpu_offload` parks
+    modules on `meta`, so `pipeline.device` — the public property endpoint code
+    is told to ask, because `ctx.load`'s contract is that authors never name a
+    device — answered `meta`, and `torch.Generator(device=pipe.device)` died
+    with "META device type not an accelerator" before any image.
+
+    Both directions are asserted, because the fallback must not INVENT a device
+    for a pipeline that is genuinely on meta with nothing to onload to.
+    """
+    pipe = StableDiffusionPipeline.from_pretrained(_local_snapshot())
+    assert gwmem.install_execution_device_fallback()
+
+    # EVERY module, not just the big three: `DiffusionPipeline.device` reports
+    # the first module it finds, so a leftover cpu-resident safety checker
+    # would hide the meta answer and make this test pass for the wrong reason.
+    for component in pipe.components.values():
+        if isinstance(component, torch.nn.Module):
+            component.to("meta")
+
+    # No accelerate hook anywhere: `meta` is the honest answer, and the
+    # fallback must terminate rather than recurse through `_execution_device`,
+    # which itself ends in `return self.device`.
+    assert pipe.device.type == "meta"
+
+    class _Hook:
+        execution_device = torch.device("cpu")
+
+    # Every module, because that is what `enable_sequential_cpu_offload` does
+    # and what diffusers' `_execution_device` requires: it bails to
+    # `self.device` on the FIRST component it finds without a hook.
+    for component in pipe.components.values():
+        if isinstance(component, torch.nn.Module):
+            component._hf_hook = _Hook()
+    assert pipe.device.type == "cpu", (
+        "a hook names where the next forward runs, so `pipeline.device` must "
+        "report that and not `meta` — this is what the sdxl endpoint's "
+        "`torch.Generator(device=model.pipe.device)` builds on"
+    )

--- a/tests/test_vram_fit.py
+++ b/tests/test_vram_fit.py
@@ -73,6 +73,7 @@ def _recording_to(moved: List[Any]) -> Any:
     return to
 
 
+# pgw#1486: the ladder is consulted before placement, not after.
 def test_the_ladder_is_asked_while_the_pipeline_is_still_on_the_host(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -113,6 +114,7 @@ def test_the_ladder_is_asked_while_the_pipeline_is_still_on_the_host(
     )
 
 
+# pgw#1486: an offload rung owns placement; the bridge must not re-move it.
 def test_an_offload_rung_places_its_own_components(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -145,6 +147,7 @@ def test_an_offload_rung_places_its_own_components(
     )
 
 
+# pgw#1452: a pipeline that fits is still placed where the worker said.
 def test_a_resident_rung_still_places_the_pipeline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -165,6 +168,7 @@ def test_a_resident_rung_still_places_the_pipeline(
     )
 
 
+# pgw#1486: a ladder that cannot size an object never refuses the load.
 def test_a_ladder_that_cannot_size_the_pipeline_does_not_block_the_load(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -185,6 +189,7 @@ def test_a_ladder_that_cannot_size_the_pipeline_does_not_block_the_load(
     assert moved == [("cuda",)]
 
 
+# pgw#1486: admission check — no compiled graph over relocating weights.
 def test_compile_will_not_arm_over_hook_managed_weights() -> None:
     """The ADMISSION half. Under an offload rung accelerate moves a module's
     weights on and off the device per forward, so a compiled graph's bound
@@ -216,6 +221,7 @@ def test_compile_will_not_arm_over_hook_managed_weights() -> None:
     assert len(sink_calls) == 1, "the sink must not be reached under a rung"
 
 
+# pgw#1486: the bottom rung parked modules on `meta` and broke `pipe.device`.
 def test_pipeline_device_never_answers_meta_to_endpoint_code() -> None:
     """The bottom rung's own defect. `enable_sequential_cpu_offload` parks
     modules on `meta`, so `pipeline.device` — the public property endpoint code


### PR DESCRIPTION
`models/memory.py` has shipped a correct offload ladder for months with **zero callers on the v2 serve path** — `serving/context._placed` moved every eager-loaded pipeline to CUDA unconditionally.

Measured on a 7.62 GiB RTX 4070 against the real `serverless-endpoints/sdxl` endpoint, 1024² CFG batch-2, 25 steps, one rung per process:

| rung | outcome | wall s | peak device GiB | image |
|---|---|---|---|---|
| do-nothing baseline | 💥 OOM in the unet | 1.74 | 7.59 / 7.62 | — |
| the shipped `mode="auto"` ladder | 💥 OOM — it picks `vae_only` | 1.34 | 7.61 | — |
| **`enable_model_cpu_offload()` alone** | ✅ | **26.8** | **6.41** | yes |
| `sequential_cpu_offload` | ✅ | 131.5 | **2.89** | yes |

## Calling the ladder later does not fix it — it inverts the answer

`select_auto_mode` nets the requirement against `estimate_cuda_resident_gb` (pgw#1025, deliberate: no pipeline is charged twice for bytes already on the card). Once `_placed` has made everything resident the requirement nets to zero, "it fits" is trivially true, and the ladder returns its most memory-hungry rung. On one SDXL pipeline object:

```
select_auto_mode  PRE-placement -> "model_offload"   (serves)
select_auto_mode POST-placement -> "vae_only"        (OOMs)
```

So the fix is **ordering**, and the test is an ordering test: not "the ladder was called" but "the ladder was called while nothing was resident" — no GPU needed, runs on every runner.

## Also here, all three found by running it

- **`ctx.compile` will not arm over hook-managed weights.** Accelerate relocates a module's weights per forward, so a compiled graph's bound constants dangle — a use-after-free, which on the compiled path is the uncatchable SIGSEGV (pgw#1255 leg 2), not an OOM anything can retry. An admission check; deliberately no catch-and-retry anywhere here.
- **The bottom rung was unreachable.** `enable_sequential_cpu_offload` parks modules on `meta`, so `pipeline.device` answered `meta` and the sdxl endpoint's `torch.Generator(device=model.pipe.device)` died before any image. The endpoint is doing exactly what `ctx.load`'s contract tells authors to do, so the worker repairs the answer once rather than teaching 20+ endpoints a private diffusers attribute. Carries a thread-local re-entry guard — `_execution_device` itself ends in `return self.device`, so a hookless meta pipeline would otherwise recurse until the stack blew.
- **The `DEGRADED PLACEMENT` banner** promised *"the residency ladder will engage host offload rungs … not a failure"*, and then no rung engaged and it WAS a failure. It now states what the code does and names the evidence to look for.

## Scope and evidence

Eager bridge only, stated in code: the streaming engine returns before `_placed` and places weights itself.

**Red-verified in a throwaway detached master worktree at `a58e4b32` — 4 of the 6 new cases fail there**, the two that pass being the deliberate counter-cases (a fitting pipeline is still placed; a ladder that cannot size an object never blocks the load). mypy + ruff clean; 89 adjacent tests green.

Tracker: pgw#1486.