### PR TITLE
pgw#1488: traces just trace — contracts stop gating, and lanes=() stops silently disabling compile

### DIFF
--- a/changelog.d/pgw1488-traces-just-trace.md
+++ b/changelog.d/pgw1488-traces-just-trace.md
@@ -1,0 +1,34 @@
+- **A trace no longer needs a contract document, and an empty lane tuple no longer disables
+  compilation in silence.** Paul's ruling ("A NORMAL TRACE MUST JUST WORK"): point the tracer at
+  the endpoint's model and payloads, trace, compile, run. Two things stood in the way and both
+  are gone.
+
+  **Contracts are metadata, not a gate.** A model class that names no tensorfs contract used to
+  be refused by name at publish — *"omits lanes= and its model type has no canonical contract
+  yet"* — which cost the anima lane a throwaway one-tensor contract document invented purely to
+  be ALLOWED to run `torch.export`. Such a class now gets a DERIVED lane, `derived.<model
+  type>@1`, computed the same way at trace and at serve so both address the same row, and its
+  load dtype comes from the checkpoint itself when no contract states one. A contract document
+  attaches to the produced artifacts later, as fleet naming/pricing metadata.
+
+  **Nothing rekeys.** A lane handle is a NAME: `cg-graph-v1` hashes the canonical trace plus its
+  ingress and passes, `cg-key-v1` is (graph, sm, toolchain), and the contract string is in
+  neither. Measured, not argued — a fixture identical to another but for its emptied `lanes=`
+  derives byte-identical graph hashes under a different lane name, and re-locking the real sd1.5
+  endpoint reproduces its document digest exactly.
+
+  **Eager-forever is now a word, with a reason.** `eager_only="<why>"` on the class header, the
+  mandatory-reason pattern `self_loading=` already uses. `lanes=()` no longer means it: an
+  absent lane declaration says "no layout contract stated", and that traces. This closes
+  pgw#1469, where `ctx.compile` under `lanes=()` was byte-identical-digest dead code — `load`
+  was never called, so nothing observed the mark and the author got a green lock proving
+  nothing. A compile mark under `eager_only=` is now a declaration refusal, read statically from
+  the AST with no author code run.
+
+  Every outcome `lock` can reach is printed as one word — `traced`,
+  `traced-no-compile-targets`, `eager-by-declaration`, `weightless` — and carried in its JSON
+  summary. Silence is not a posture.
+
+- **`gen-worker lock --check`** — the freshness gate for a lock that is committed source. It
+  re-derives only when the inputs moved, compares the DOCUMENT (an input that moves without
+  moving the output is not drift), writes nothing either way, and exits 1 on real drift.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -822,7 +822,10 @@ sibling of `ctx.load(...)`:
 ```python
 from gen_worker import LlamaServer, LoadContext, Model, entrypoint
 
-class QwenMtpModel(Model[Qwen36MtpGguf], lanes=()):
+class QwenMtpModel(
+    Model[Qwen36MtpGguf],
+    eager_only="llama-server owns the weights and the graph",
+):
     def load(self, ctx: LoadContext[Qwen36MtpGguf]) -> None:
         self.engine = ctx.engine(LlamaServer(
             n_ctx=32768,
@@ -838,9 +841,17 @@ async def chat(ctx, payload: ChatIn, model: QwenMtpModel) -> AsyncIterator[...]:
             ...
 ```
 
-`lanes=()` is the honest declaration here: an engine-hosted model performs no
-pytorch streaming load, so `ctx.lane` has nothing to answer and raises by
-design.
+`eager_only="<why>"` is the honest declaration here: an engine-hosted model
+performs no pytorch streaming load and compiles nothing, so `ctx.lane` has
+nothing to answer and raises by design.
+
+**It is the ONLY way to say that (pgw#1488).** An absent lane declaration —
+`lanes=()`, or no `lanes=` at all — means "this class states no layout
+contract", and a class that states none still TRACES, under a lane identity
+derived from the model type. Contract documents are fleet metadata that
+attaches to the produced artifacts; they are never a precondition for
+producing them. The reason is mandatory for the same reason `self_loading=`'s
+is: eager-forever costs throughput and the class should say why.
 
 The spec is a DECLARATION — engine + flags, and nothing else. The checkpoint
 tree, the port, the environment and the supervision are the platform's half:

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -71,6 +71,13 @@ def add_subparser(sub: Any) -> None:
         help="write the discovery blocks and no [derive] — the bake-time shape",
     )
     parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the committed lock is current and WRITE NOTHING; exit 1 "
+             "on drift. The freshness gate for CI (endpoint.lock is source, "
+             "committed beside the endpoint, and a stale one is a wrong build)",
+    )
+    parser.add_argument(
         "-o", "--out",
         default="",
         help=f"lock path (default: <endpoint_dir>/{el.LOCK_FILENAME})",
@@ -99,7 +106,7 @@ def _checkpoint_tree(args: argparse.Namespace) -> tuple[Optional[Path], str]:
 
 
 def run_lock(args: argparse.Namespace) -> int:
-    from ..discovery.discover import discover_manifest, prime_sys_path
+    from ..discovery.discover import discover_manifest
     from ..discovery.project import load_project_config
 
     root = Path(args.endpoint_dir).resolve()
@@ -165,6 +172,32 @@ def run_lock(args: argparse.Namespace) -> int:
         _say(f"lock: ignoring unusable saved trace: {exc}")
         existing = None
 
+    if args.check:
+        # endpoint.lock is SOURCE: it is committed beside the endpoint and a
+        # stale one builds the wrong thing. The gate is cheap in the common
+        # case ON PURPOSE — the inputs digest is the derive's own definition of
+        # "would this trace differently", computed in milliseconds, so CI can
+        # run it on every push. Only when the inputs MOVED does it pay for a
+        # re-derive, and then it compares the produced document against the
+        # committed one: an input that changed without changing the output is
+        # not drift, and reporting it as drift would train people to ignore
+        # this check.
+        if existing is None:
+            _say(f"error: {out} has no saved trace to check — run `gen-worker lock`")
+            return 2
+        if existing.inputs_digest == want and existing.trace_device == device:
+            _say(f"lock --check: {out} is current (inputs unchanged)")
+            print(json.dumps({
+                "lock": str(out), "check": "current",
+                "document_digest": existing.document_digest,
+            }))
+            return 0
+        _say("lock --check: inputs moved — re-deriving to see whether the "
+             "document moved with them")
+        return _check_by_rederive(
+            config, root, out, existing, tree, lockfile, graph_cas_root, device,
+        )
+
     cas = ws.local_cas(graph_cas_root)
     reuse = el.derive_is_reusable(
         existing,
@@ -203,34 +236,10 @@ def run_lock(args: argparse.Namespace) -> int:
             "say so rather than emit an empty document."
         )
 
-    prime_sys_path(root)
-    try:
-        module = importlib.import_module(config.main)
-    except Exception as exc:  # noqa: BLE001
-        _say(f"error: failed to import {config.main!r}: {exc}")
+    traced = _trace(config, root, tree, lockfile, graph_cas_root, device)
+    if traced is None:
         return 1
-
-    from ..release.derive import DeriveError, derive_release
-
-    _say(
-        f"lock: trace device is {device}-class"
-        + ("" if device == "cuda" else " — CPU-class graphs are NOT servable on "
-                                       "a GPU; a cuda mint refuses by name")
-    )
-    started = time.monotonic()
-    try:
-        result = derive_release(
-            module,
-            checkpoint_dir=tree if tree is not None else root,
-            graph_cas=graph_cas_root,
-        )
-    except DeriveError as exc:
-        _say(f"error: derive: {exc}")
-        return 1
-    elapsed = time.monotonic() - started
-
-    for warning in result.warnings:
-        _say(f"warning: {warning}")
+    result, elapsed = traced
 
     interface_v, _document_v = el.torchcg_format_versions()
     block = el.DeriveBlock(
@@ -246,12 +255,7 @@ def run_lock(args: argparse.Namespace) -> int:
 
     graphs = sum(len(h) for h in result.lane_graphs.values())
     programs = el.program_digests(json.loads(result.document))
-    for lane, hashes in result.lane_graphs.items():
-        _say(f"lock: lane {lane}: {len(hashes)} specialization(s)")
-    if result.eager_permanent:
-        why = ("no model class — weightless endpoint, nothing to compile"
-               if result.weightless else "no lanes — eager-permanent by declaration")
-        _say(f"lock: {result.endpoint}: {why}")
+    _say_posture(result)
     _say(
         f"lock: traced {graphs} specialization(s), {len(programs)} exported "
         f"program(s) in the CAS at {graph_cas_root} ({elapsed:.1f}s)"
@@ -261,6 +265,7 @@ def run_lock(args: argparse.Namespace) -> int:
         "lock": str(out),
         "derive": "traced",
         "endpoint": result.endpoint,
+        "posture": _posture(result),
         "document_digest": result.digest,
         "trace_device": device,
         "specializations": graphs,
@@ -268,6 +273,150 @@ def run_lock(args: argparse.Namespace) -> int:
         "seconds": round(elapsed, 1),
     }))
     return 0
+
+
+#: The compile posture of a derived endpoint — ONE WORD, always printed
+#: (pgw#1488). Silence used to be a posture: `lanes=()` disabled compilation
+#: with no output at all, and a missing contract document refused to trace at
+#: all. Both are states now, and both are named.
+POSTURE_EAGER_BY_DECLARATION = "eager-by-declaration"
+POSTURE_WEIGHTLESS = "weightless"
+POSTURE_NO_COMPILE_TARGETS = "traced-no-compile-targets"
+POSTURE_TRACED = "traced"
+
+
+def _posture(result: Any) -> str:
+    if result.eager_only:
+        return POSTURE_EAGER_BY_DECLARATION
+    if result.weightless:
+        return POSTURE_WEIGHTLESS
+    if not result.lane_graphs:
+        return POSTURE_NO_COMPILE_TARGETS
+    return POSTURE_TRACED
+
+
+def _say_posture(result: Any) -> None:
+    """State what this endpoint compiles, and why, in the author's words."""
+
+    for lane, hashes in result.lane_graphs.items():
+        _say(f"lock: lane {lane}: {len(hashes)} specialization(s)")
+    for lane in result.derived_lanes:
+        _say(
+            f"lock: lane {lane}: identity DERIVED from the model class — this "
+            f"endpoint declares no layout contract, so the trace named the "
+            f"lane itself. A contract document ATTACHES to these artifacts "
+            f"later as fleet metadata; it was never needed to produce them."
+        )
+    posture = _posture(result)
+    if posture == POSTURE_EAGER_BY_DECLARATION:
+        _say(
+            f"lock: {result.endpoint}: {posture} — eager_only="
+            f"{result.eager_only!r}. Nothing was traced because the author "
+            f"said so."
+        )
+    elif posture == POSTURE_WEIGHTLESS:
+        _say(
+            f"lock: {result.endpoint}: {posture} — no model class, nothing to "
+            f"compile"
+        )
+    elif posture == POSTURE_NO_COMPILE_TARGETS:
+        _say(
+            f"lock: {result.endpoint}: {posture} — the trace RAN and load() "
+            f"marked no module via ctx.compile(), so there is nothing to "
+            f"compile (lane(s): "
+            f"{', '.join(result.unmarked_lanes) or 'none'}). Mark a module to "
+            f"compile it; declare eager_only=\"<why>\" to state that this is "
+            f"permanent."
+        )
+
+
+def _trace(
+    config: Any,
+    root: Path,
+    tree: Optional[Path],
+    lockfile: Path,
+    graph_cas_root: Path,
+    device: str,
+) -> Optional[tuple[Any, float]]:
+    """Import the author's module and derive it. ``None`` = said why, failed."""
+
+    from ..discovery.discover import prime_sys_path
+    from ..release.derive import DeriveError, derive_release
+
+    prime_sys_path(root)
+    try:
+        module = importlib.import_module(config.main)
+    except Exception as exc:  # noqa: BLE001
+        _say(f"error: failed to import {config.main!r}: {exc}")
+        return None
+
+    _say(
+        f"lock: trace device is {device}-class"
+        + ("" if device == "cuda" else " — CPU-class graphs are NOT servable on "
+                                       "a GPU; a cuda mint refuses by name")
+    )
+    started = time.monotonic()
+    try:
+        result = derive_release(
+            module,
+            checkpoint_dir=tree if tree is not None else root,
+            graph_cas=graph_cas_root,
+        )
+    except DeriveError as exc:
+        _say(f"error: derive: {exc}")
+        return None
+    elapsed = time.monotonic() - started
+    for warning in result.warnings:
+        _say(f"warning: {warning}")
+    return result, elapsed
+
+
+def _check_by_rederive(
+    config: Any,
+    root: Path,
+    out: Path,
+    existing: el.DeriveBlock,
+    tree: Optional[Path],
+    lockfile: Path,
+    graph_cas_root: Path,
+    device: str,
+) -> int:
+    """``--check``'s expensive arm: does the committed DOCUMENT still hold?
+
+    Inputs moving is not drift — a comment, a retimed dependency, a new tracer
+    that emits the same graphs all move the inputs digest and change nothing
+    anyone builds. Only the document decides, so only the document is compared,
+    and NOTHING IS WRITTEN either way: `--check` is a question.
+    """
+
+    traced = _trace(config, root, tree, lockfile, graph_cas_root, device)
+    if traced is None:
+        return 1
+    result, elapsed = traced
+    _say_posture(result)
+    drifted = result.digest != existing.document_digest
+    if drifted:
+        _say(
+            f"lock --check: DRIFT — {out} carries document "
+            f"{existing.document_digest} and this tree derives "
+            f"{result.digest} ({elapsed:.1f}s). The committed lock does not "
+            f"describe this endpoint; re-run `gen-worker lock` and commit it."
+        )
+    else:
+        _say(
+            f"lock --check: {out} is current — the inputs moved, the document "
+            f"did not ({elapsed:.1f}s)"
+        )
+    print(json.dumps({
+        "lock": str(out),
+        "check": "drift" if drifted else "current",
+        "endpoint": result.endpoint,
+        "posture": _posture(result),
+        "committed_document_digest": existing.document_digest,
+        "derived_document_digest": result.digest,
+        "seconds": round(elapsed, 1),
+    }))
+    return 1 if drifted else 0
 
 
 __all__ = ["add_subparser", "run_lock"]

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -195,7 +195,7 @@ def run_lock(args: argparse.Namespace) -> int:
         _say("lock --check: inputs moved — re-deriving to see whether the "
              "document moved with them")
         return _check_by_rederive(
-            config, root, out, existing, tree, lockfile, graph_cas_root, device,
+            config, root, out, existing, tree, graph_cas_root, device,
         )
 
     cas = ws.local_cas(graph_cas_root)
@@ -236,7 +236,7 @@ def run_lock(args: argparse.Namespace) -> int:
             "say so rather than emit an empty document."
         )
 
-    traced = _trace(config, root, tree, lockfile, graph_cas_root, device)
+    traced = _trace(config, root, tree, graph_cas_root, device)
     if traced is None:
         return 1
     result, elapsed = traced
@@ -334,7 +334,6 @@ def _trace(
     config: Any,
     root: Path,
     tree: Optional[Path],
-    lockfile: Path,
     graph_cas_root: Path,
     device: str,
 ) -> Optional[tuple[Any, float]]:
@@ -377,7 +376,6 @@ def _check_by_rederive(
     out: Path,
     existing: el.DeriveBlock,
     tree: Optional[Path],
-    lockfile: Path,
     graph_cas_root: Path,
     device: str,
 ) -> int:
@@ -389,7 +387,7 @@ def _check_by_rederive(
     and NOTHING IS WRITTEN either way: `--check` is a question.
     """
 
-    traced = _trace(config, root, tree, lockfile, graph_cas_root, device)
+    traced = _trace(config, root, tree, graph_cas_root, device)
     if traced is None:
         return 1
     result, elapsed = traced

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -8,6 +8,16 @@ instrumented discovery, and stamp the observed graph set -- plus the lane
 contracts and the model type's checkpoint-defaults schema -- as the static
 release metadata document.
 
+**A contract is METADATA, never a gate** (Paul, 2026-08-19, "A NORMAL TRACE
+MUST JUST WORK"; pgw#1488). A model class that names no tensorfs contract is
+traced under a DERIVED lane identity — ``derived.<model type>@1``, computed
+identically here and at serve — and its load dtype comes from the checkpoint
+when no contract states one. Nothing rekeys: ``cg-graph-v1`` hashes the
+canonical trace plus ingress plus passes, so the lane's NAME never entered
+graph identity, and a lane that declares a contract publishes exactly the
+bytes it always did. Eager-forever is the class header's ``eager_only=``
+declaration, with a reason, and never an inference from an empty lane tuple.
+
 **Coverage is auto-enumerated -- inputs AND bindings** (Paul rulings,
 2026-08-19/20; ``ctx.is_trace`` is DELETED from the author surface, so author
 code is trace-oblivious and arm coverage is entirely the derive's job):
@@ -64,6 +74,8 @@ from ..serving.entrypoints import ENTRYPOINT_ATTR
 from ..serving.model import (
     Model,
     ModelDeclarationError,
+    eager_only_reason,
+    is_derived_lane,
     lane_handle,
     model_lanes,
     model_requires,
@@ -128,6 +140,15 @@ class ReleaseDeriveResult:
     #: Distinct from eager-permanent, which holds a model and compiles none —
     #: both land on "no lanes", and a log that conflates them lies.
     weightless: bool = False
+    #: pgw#1488: the class's DECLARED eager-forever reason (``eager_only=``).
+    #: Non-empty means no trace was attempted and the author said why.
+    eager_only: str = ""
+    #: Lanes whose identity was DERIVED (no contract declared). Their handles
+    #: read ``derived.*``; contract metadata attaches to the artifacts later.
+    derived_lanes: tuple[str, ...] = ()
+    #: Lanes that TRACED and found nothing marked via ``ctx.compile``. Zero
+    #: graphs because the author marked zero modules — measured, not assumed.
+    unmarked_lanes: tuple[str, ...] = ()
 
     @property
     def eager_permanent(self) -> bool:
@@ -287,10 +308,18 @@ def _assert_weights_free(torch: Any, program: Any) -> None:
         )
 
 
-def _lane_model_class(module: ModuleType) -> Optional[type]:
-    """The ONE lanes-declaring Model subclass in the module, or None."""
+def _lane_model_class(module: ModuleType) -> tuple[Optional[type], str]:
+    """``(the ONE traced Model subclass or None, the eager_only reason)``.
+
+    pgw#1488: every model class has a lane unless it declares
+    ``eager_only="<reason>"``, so "which class do we trace" is now the same
+    question as "which class is not declared eager". A module whose only model
+    class IS eager-declared answers ``(None, reason)`` — the same shape the
+    eager-permanent path always had, plus the author's own words for it.
+    """
 
     found: list[type] = []
+    eager: list[tuple[type, str]] = []
     for value in vars(module).values():
         if not (
             inspect.isclass(value)
@@ -299,31 +328,37 @@ def _lane_model_class(module: ModuleType) -> Optional[type]:
             and getattr(value, "__module__", None) == module.__name__
         ):
             continue
+        reason = eager_only_reason(value)
+        if reason:
+            eager.append((value, reason))
+            continue
         try:
             lanes = model_lanes(value)
             # pgw#1391: `model_lanes` hands back the lane OBJECTS without
-            # reading them, so a class that omitted `lanes=` and fell through
-            # to a canonical contract with no tensorfs document got this far
-            # silently. Reading each lane's handle and dtype here is what makes
-            # the publish path refuse it, through the SAME conversion.
+            # reading them, so a class whose lane is a CONTRACT still has to
+            # have that contract read here. A derived lane has nothing to
+            # read — it carries no document by construction, which is the
+            # whole point — so it is not put through the contract check.
             from ..serving.model import lane_dtype
 
             for lane in lanes:
+                if is_derived_lane(lane):
+                    continue
                 lane_dtype(lane, where=f"class {value.__qualname__!r}")
         except ModelDeclarationError as exc:
-            # Omitted lanes with no canonical contract (tensorfs#111 not
-            # shipped): the class cannot state its lanes — refuse loudly,
-            # never silently treat it as eager.
             raise DeriveError(str(exc)) from exc
         if lanes:
             found.append(value)
     if len(found) > 1:
         raise DeriveError(
-            f"module {module.__name__!r} declares lanes on "
-            f"{[cls.__name__ for cls in found]!r}; a release derives ONE "
-            f"model class"
+            f"module {module.__name__!r} has more than one compilable model "
+            f"class ({[cls.__name__ for cls in found]!r}); a release derives "
+            f"ONE. An auxiliary model that another slot drives and that "
+            f"compiles nothing declares "
+            f"eager_only=\"<why>\" on its class header — that is the "
+            f"declaration, and it is not an empty lanes tuple."
         )
-    return found[0] if found else None
+    return (found[0] if found else None, eager[0][1] if eager and not found else "")
 
 
 @dataclass(frozen=True)
@@ -972,6 +1007,13 @@ def _contract_document(
     stand-in — travels stamp-only with a WARNING naming it, never silently.
     """
 
+    if is_derived_lane(lane):
+        # pgw#1488: a DERIVED lane has no contract and never claimed one. The
+        # honest row is no document — the artifacts exist under the derived
+        # identity and a contract, when someone authors one, ATTACHES to them
+        # as fleet metadata. That is a later step, not a precondition.
+        return None
+
     claimed = False
     for attribute in ("document", "as_dict", "to_dict"):
         value = getattr(lane, attribute, None)
@@ -1038,6 +1080,12 @@ def _resolve_lane(torchcg: ModuleType, cls: type, lane: Any) -> Any:
     """
 
     handle = lane_contract_handle(f"class {cls.__name__!r}", lane)
+    if is_derived_lane(lane):
+        # pgw#1488: no contract, so no contract dtype. The precision comes
+        # from the CHECKPOINT, resolved inside the load context (which is the
+        # one place that holds the tree) so the trace and the serve read the
+        # same source. `LaneRef` carries the handle; dtype stays open here.
+        return torchcg.LaneRef(handle, dtype=None)
     try:
         # tensorfs#113's `dtype` is a PROPERTY that RAISES on a contract
         # declaring none (minimax.h3-dit-diffusers today), so this is a try,
@@ -1063,7 +1111,7 @@ def _derive_lane(
     checkpoint_dir: Path,
     warnings: list[str],
     program_sink: Optional[Any] = None,
-) -> Any:
+) -> Optional[Any]:
     """One lane's instrumented runs, merged across defaults variants.
 
     Per variant: fresh model, ``load`` (defaults variants change what
@@ -1121,10 +1169,20 @@ def _derive_lane(
                     f"session: {type(exc).__name__}: {exc}"
                 ) from exc
             if not load_ctx.marked_modules:
+                if is_derived_lane(lane):
+                    # pgw#1488. The trace RAN — the model loaded under the
+                    # hollow session and the author marked no module, which is
+                    # an observation, not a failure. Zero graphs is the honest
+                    # answer and the caller prints it as one. The refusal below
+                    # stays for a lane the author DECLARED: declaring a lane is
+                    # saying "graphs key here", and then compiling nothing is a
+                    # contradiction only the author can resolve.
+                    return None
                 raise DeriveError(
                     f"lane {handle!r}: load() marked nothing via ctx.compile(). "
                     f"A lane-declaring model compiles SOMETHING; a model that "
-                    f"wants eager-forever declares no lanes instead."
+                    f"wants eager-forever declares "
+                    f"eager_only=\"<why>\" instead."
                 )
             modules = _named_marked_modules(model, load_ctx.marked_modules)
 
@@ -1271,10 +1329,12 @@ def derive_release(
     except EnvIdentityError as exc:
         raise DeriveError(str(exc)) from exc
 
-    cls = _lane_model_class(module)
+    cls, eager_only = _lane_model_class(module)
     endpoint_name = f"{module.__name__}:{cls.__name__ if cls else ''}".rstrip(":")
 
     lanes: list[Any] = []
+    derived_lanes: list[str] = []
+    unmarked_lanes: list[str] = []
     lane_contracts: dict[str, Any] = {}
     entrypoints: dict[str, Any] = {}
     warnings: list[str] = []
@@ -1316,6 +1376,15 @@ def derive_release(
                 torchcg, cls, lane, plans, checkpoint_dir, warnings,
                 program_sink=program_sink,
             )
+            if lane_graphs is None:
+                # Traced, nothing marked (pgw#1488). No lane row: an empty one
+                # would claim a keyed graph set that does not exist.
+                unmarked_lanes.append(
+                    lane_contract_handle(f"class {cls.__name__!r}", lane)
+                )
+                continue
+            if is_derived_lane(lane):
+                derived_lanes.append(lane_graphs.contract)
             lanes.append(lane_graphs)
             entry: dict[str, Any] = {
                 "stamp": lane_graphs.contract,
@@ -1329,6 +1398,13 @@ def derive_release(
                 # states none.
                 "digest": _contract_digest(lane),
             }
+            if is_derived_lane(lane):
+                # pgw#1488: `document: null` is a BUG on a declared contract
+                # (pgw#1391) and the HONEST state on a derived one. The reader
+                # cannot tell those apart from a null, so the producer says
+                # which it is. Written only on the derived branch, so every
+                # contract-declaring release keeps its bytes exactly.
+                entry["derived"] = True
             # ie#740 placement floor for THIS lane, read off the class header
             # (`requires=`). Absent = undeclared, and the platform default is
             # what the deployment gets — the honest state, never an invented
@@ -1375,6 +1451,9 @@ def derive_release(
         # declared zero model slots. An eager-permanent module also has no
         # lane class, but its entrypoints carry slots and derive no plan.
         weightless=cls is None and bool(plans),
+        eager_only=eager_only,
+        derived_lanes=tuple(derived_lanes),
+        unmarked_lanes=tuple(unmarked_lanes),
     )
 
 

--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -85,7 +85,7 @@ class TraceLoadContext:
         # `torch.bfloat16`; diffusers refuses the string with a warning and
         # silently loads fp32, so this read decides the precision the whole
         # trace runs at.
-        dtype = _lane_torch_dtype(self.lane)
+        dtype = _lane_torch_dtype(self.lane, checkpoint_dir=self.checkpoint_dir)
         try:
             loaded = from_pretrained(self.checkpoint_dir, torch_dtype=dtype)
         except TypeError as exc:

--- a/src/gen_worker/serving/checkpoint_dtype.py
+++ b/src/gen_worker/serving/checkpoint_dtype.py
@@ -10,9 +10,10 @@ The checkpoint is the answer. Two sources, in order of how directly they know:
 1. the root config's ``torch_dtype``/``dtype`` (``model_index.json`` for a
    diffusers pipeline, ``config.json`` for a bare module) — what the packager
    SAID;
-2. the safetensors headers — what the tensors ARE. Headers are read as headers
-   (an 8-byte length and a JSON blob at the front of the file), so this costs
-   a few KB and never opens a weight.
+2. the safetensors headers — what the tensors ARE, read through
+   ``models.safetensors_header.read_header``, the ONE header reader in this
+   repo (bounded length, projection-stub aware). Headers are headers, so this
+   costs a few KB and never opens a weight.
 
 (1) leads because a packager who states a dtype is stating the serving
 intent — an fp32 file saved from a bf16 recipe is real. (2) is the fallback
@@ -28,13 +29,9 @@ precision a derived lane runs at.
 from __future__ import annotations
 
 import json
-import logging
-import struct
 from collections import Counter
 from pathlib import Path
 from typing import Any, Optional
-
-_LOG = logging.getLogger("gen_worker.serving.checkpoint_dtype")
 
 #: safetensors dtype spellings -> torch attribute names.
 _ST_DTYPES = {
@@ -48,10 +45,6 @@ _ST_DTYPES = {
 
 #: Root config files, most specific first.
 _CONFIGS = ("model_index.json", "config.json")
-
-#: Header prefix cap. A safetensors header is JSON metadata; anything past
-#: this is a corrupt or hostile file, not a header we want in memory.
-_MAX_HEADER = 100 * 1024 * 1024
 
 
 def torch_dtype(name: Any) -> Any:
@@ -89,21 +82,25 @@ def _config_dtype(tree: Path) -> Any:
 
 
 def _header_dtypes(path: Path) -> Counter[str]:
-    """The floating dtype tally of one safetensors file's header."""
+    """The floating dtype tally of one safetensors file's header.
+
+    Through `read_header`, never a second hand-rolled reader: the declared
+    header length comes off the file and sizes an allocation, and this repo
+    keeps exactly one bound on that (pgw#1013). It is also the only reader
+    that knows a projection stub from a real file.
+    """
+
+    from ..models.safetensors_header import read_header
 
     tally: Counter[str] = Counter()
     try:
-        with path.open("rb") as handle:
-            raw = handle.read(8)
-            if len(raw) != 8:
-                return tally
-            length = struct.unpack("<Q", raw)[0]
-            if length <= 0 or length > _MAX_HEADER:
-                return tally
-            header = json.loads(handle.read(length).decode("utf-8"))
-    except (OSError, ValueError, struct.error):
-        return tally
-    if not isinstance(header, dict):
+        header = read_header(
+            path,
+            why="a lane with no contract takes its load dtype from the "
+                "checkpoint, and a header that reads as empty would silently "
+                "become the loader's default precision instead",
+        )
+    except Exception:  # noqa: BLE001 - a dtype PROBE never kills a load
         return tally
     for name, entry in header.items():
         if name == "__metadata__" or not isinstance(entry, dict):

--- a/src/gen_worker/serving/checkpoint_dtype.py
+++ b/src/gen_worker/serving/checkpoint_dtype.py
@@ -1,0 +1,145 @@
+"""What dtype a checkpoint IS, for a lane that declares none (pgw#1488).
+
+A layout contract states its load dtype, and a class that declares a contract
+lane reads it there. A class that declares NO contract still has to load at
+some precision, and the trace's precision is graph identity — a bf16 trace and
+an fp32 trace are different graphs, so "whatever happens" is not an answer.
+
+The checkpoint is the answer. Two sources, in order of how directly they know:
+
+1. the root config's ``torch_dtype``/``dtype`` (``model_index.json`` for a
+   diffusers pipeline, ``config.json`` for a bare module) — what the packager
+   SAID;
+2. the safetensors headers — what the tensors ARE. Headers are read as headers
+   (an 8-byte length and a JSON blob at the front of the file), so this costs
+   a few KB and never opens a weight.
+
+(1) leads because a packager who states a dtype is stating the serving
+intent — an fp32 file saved from a bf16 recipe is real. (2) is the fallback
+because it cannot be absent, and it is the only source for the many
+checkpoints that ship raw ``.safetensors`` with no config at all. ``None``
+means neither source spoke, and the author's loader keeps its own default.
+
+Both ends of the pipeline read this: the trace (``TraceLoadContext.load``) and
+the serve (``LoadContext``). One function, so they cannot disagree about the
+precision a derived lane runs at.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import struct
+from collections import Counter
+from pathlib import Path
+from typing import Any, Optional
+
+_LOG = logging.getLogger("gen_worker.serving.checkpoint_dtype")
+
+#: safetensors dtype spellings -> torch attribute names.
+_ST_DTYPES = {
+    "BF16": "bfloat16",
+    "F16": "float16",
+    "F32": "float32",
+    "F64": "float64",
+    "F8_E4M3": "float8_e4m3fn",
+    "F8_E5M2": "float8_e5m2",
+}
+
+#: Root config files, most specific first.
+_CONFIGS = ("model_index.json", "config.json")
+
+#: Header prefix cap. A safetensors header is JSON metadata; anything past
+#: this is a corrupt or hostile file, not a header we want in memory.
+_MAX_HEADER = 100 * 1024 * 1024
+
+
+def torch_dtype(name: Any) -> Any:
+    """A dtype SPELLING (safetensors or torch) as a real ``torch.dtype``."""
+
+    import torch
+
+    if name is None or isinstance(name, torch.dtype):
+        return name
+    if not isinstance(name, str):
+        return None
+    spelled = _ST_DTYPES.get(name.upper(), name.lower())
+    if spelled.startswith("torch."):
+        spelled = spelled[len("torch."):]
+    candidate = getattr(torch, spelled, None)
+    return candidate if isinstance(candidate, torch.dtype) else None
+
+
+def _config_dtype(tree: Path) -> Any:
+    for name in _CONFIGS:
+        path = tree / name
+        if not path.is_file():
+            continue
+        try:
+            config = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(config, dict):
+            continue
+        for key in ("torch_dtype", "dtype"):
+            resolved = torch_dtype(config.get(key))
+            if resolved is not None:
+                return resolved
+    return None
+
+
+def _header_dtypes(path: Path) -> Counter[str]:
+    """The floating dtype tally of one safetensors file's header."""
+
+    tally: Counter[str] = Counter()
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(8)
+            if len(raw) != 8:
+                return tally
+            length = struct.unpack("<Q", raw)[0]
+            if length <= 0 or length > _MAX_HEADER:
+                return tally
+            header = json.loads(handle.read(length).decode("utf-8"))
+    except (OSError, ValueError, struct.error):
+        return tally
+    if not isinstance(header, dict):
+        return tally
+    for name, entry in header.items():
+        if name == "__metadata__" or not isinstance(entry, dict):
+            continue
+        spelling = entry.get("dtype")
+        if isinstance(spelling, str) and spelling.upper() in _ST_DTYPES:
+            tally[spelling.upper()] += 1
+    return tally
+
+
+def _tensor_dtype(tree: Path) -> Any:
+    """The dominant floating dtype across the tree's safetensors headers.
+
+    Every shard is read (headers only) rather than just the first: a pipeline
+    keeps its text encoder and its VAE beside the denoiser, and the file that
+    happens to sort first is not the one that decides the recipe. The majority
+    of DECLARED TENSORS wins, which is the denoiser in every real checkpoint.
+    """
+
+    tally: Counter[str] = Counter()
+    for path in sorted(tree.rglob("*.safetensors")):
+        tally.update(_header_dtypes(path))
+    if not tally:
+        return None
+    return torch_dtype(tally.most_common(1)[0][0])
+
+
+def checkpoint_dtype(tree: Optional[Path]) -> Any:
+    """The dtype ``tree`` advertises, or ``None`` when it advertises none."""
+
+    if tree is None:
+        return None
+    path = Path(tree)
+    if not path.is_dir():
+        return None
+    return _config_dtype(path) or _tensor_dtype(path)
+
+
+__all__ = ["checkpoint_dtype", "torch_dtype"]

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -80,12 +80,19 @@ def _torch_dtype_from_name(name: str) -> Any:
     return candidate if isinstance(candidate, torch.dtype) else None
 
 
-def _lane_torch_dtype(lane: Any) -> Any:
+def _lane_torch_dtype(lane: Any, *, checkpoint_dir: Any = None) -> Any:
     """The lane's load dtype as a REAL ``torch.dtype``, or None.
 
     Shared by both eager bridges (`serving/context.py` and
     `release/trace_context.py`) so the two cannot drift — pgw#1447 already
     proved they drift when they are two copies.
+
+    ``checkpoint_dir`` (pgw#1488) is the fallback source for a lane that
+    declares no dtype — a DERIVED lane, which by construction has no contract
+    to read one from. Precision is graph identity, so "no answer" is not an
+    outcome the trace can take: the checkpoint's own dtype is read instead
+    (``serving.checkpoint_dtype``). Both bridges pass their tree, so the trace
+    and the serve resolve the SAME precision for the same lane.
 
     Prefers ``Contract.torch_dtype`` (the object) over ``Contract.dtype`` (the
     spelling). Every non-AttributeError read is treated as "this contract
@@ -94,8 +101,10 @@ def _lane_torch_dtype(lane: Any) -> Any:
     protective arm, kept identical and applied to BOTH spellings, since a
     dtype-less document raises the same way whichever attribute is asked for.
     """
+    from .checkpoint_dtype import checkpoint_dtype
+
     if lane is None:
-        return None
+        return checkpoint_dtype(checkpoint_dir)
     for attr in ("torch_dtype", "dtype"):
         try:
             value = getattr(lane, attr)
@@ -106,7 +115,7 @@ def _lane_torch_dtype(lane: Any) -> Any:
                 "ctx.load: lane %r declares no load dtype; the eager bridge "
                 "takes the checkpoint's own", lane,
             )
-            return None
+            return checkpoint_dtype(checkpoint_dir)
         if value is None:
             continue
         if isinstance(value, str):
@@ -118,9 +127,9 @@ def _lane_torch_dtype(lane: Any) -> Any:
                 "torch dtype; loading in the checkpoint's own precision "
                 "(pgw#1448)", lane, value,
             )
-            return None
+            return checkpoint_dtype(checkpoint_dir)
         return value
-    return None
+    return checkpoint_dtype(checkpoint_dir)
 
 
 def _rejected_torch_dtype(exc: TypeError) -> bool:
@@ -485,7 +494,7 @@ class LoadContext(Generic[MT_co]):
         FLEET CONSEQUENCE: any timing ever taken through this bridge was fp32
         timing and must be re-baselined, not compared.
         """
-        return _lane_torch_dtype(self._lane)
+        return _lane_torch_dtype(self._lane, checkpoint_dir=self.checkpoint_dir)
 
     def engine(self, spec: Any) -> Any:
         """Boot the EXTERNAL engine that serves this checkpoint — the one

--- a/src/gen_worker/serving/loader.py
+++ b/src/gen_worker/serving/loader.py
@@ -48,8 +48,8 @@ class LoadedEndpoint:
 
     def lane(self, model_cls: type, contract: str = "") -> Any:
         """The active lane for one model class: the deploy's pick by
-        contract handle, or the single declared lane. ``None`` for an
-        explicit eager-permanent (``lanes=()``) model. Ambiguity refuses —
+        contract handle, or the single declared lane. ``None`` only for a
+        model that declares ``eager_only="<why>"`` (pgw#1488). Ambiguity refuses —
         a multi-lane model's active lane is the deploy's pick, never a
         default."""
         lanes = self.lanes_of(model_cls)

--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -24,8 +24,13 @@ typed skeleton, not a toolbox; nothing else goes on it without a Paul ruling.
 
 from __future__ import annotations
 
+import ast
+import inspect
+import re
+import textwrap
 import typing
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:  # keep the base import-weightless
@@ -43,6 +48,16 @@ REQUIRES_ATTR = "__cozy_requires__"
 #: hatch, and the pipeline-level twin of `Slot(layouts_undeclarable=)`, which
 #: says the same thing one level down about the BYTES.
 SELF_LOADING_ATTR = "__cozy_self_loading__"
+#: pgw#1488 (Paul: "A NORMAL TRACE MUST JUST WORK"). The author's REASON that
+#: this model is served EAGER FOREVER. It is the ONLY way to be eager: an
+#: absent lane declaration means "I state no layout contract", which now
+#: TRACES under a derived identity instead of silently disabling compilation.
+EAGER_ONLY_ATTR = "__cozy_eager_only__"
+
+#: Producer namespace of a DERIVED lane handle. Reserved: a tensorfs contract
+#: is named after the model that publishes it, so nothing real is ever called
+#: ``derived.*`` and a reader can tell the two apart at a glance.
+DERIVED_LANE_PRODUCER = "derived"
 
 
 class ModelDeclarationError(TypeError):
@@ -168,6 +183,101 @@ def lane_dtype(lane: Any, *, where: str) -> Any:
             f"None is not an answer."
         )
     return dtype
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedLane:
+    """The lane of a model class that states NO layout contract (pgw#1488).
+
+    Paul's ruling: *"Traces should just trace."* A contract document is fleet
+    METADATA — a name, a price, a published layout — and metadata cannot be a
+    precondition for producing the artifacts it describes. So a class that
+    names no contract still has exactly one lane; its handle is derived from
+    the model type, deterministically, and the same derivation runs at trace
+    and at serve so both ends address the same row.
+
+    Nothing is lost by deriving it. A lane handle is a NAME, not a key: graph
+    identity is ``cg-graph-v1`` (the canonical trace + ingress + passes) and
+    artifact identity is ``cg-key-v1`` (graph + sm + toolchain), and the
+    contract string appears in neither. That is why a contract-declaring class
+    keeps every byte it had — the handle it publishes is unchanged — while a
+    contract-less class stops being refused.
+
+    ``dtype`` is None here on purpose and is NOT a gap: with no contract the
+    load dtype is the CHECKPOINT's own (``serving.checkpoint_dtype``), read at
+    the two places that hold a checkpoint tree.
+    """
+
+    stamp: str
+    dtype: Any = None
+
+
+def _slug(name: str) -> str:
+    """A class name as a contract-handle path segment."""
+    text = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return text or "model"
+
+
+def derived_lane(cls: type) -> DerivedLane:
+    """The derived lane of ``cls`` — the same answer on every machine."""
+
+    return DerivedLane(
+        stamp=f"{DERIVED_LANE_PRODUCER}.{_slug(model_type(cls).__name__)}@1"
+    )
+
+
+def is_derived_lane(lane: Any) -> bool:
+    """Whether this lane's identity was derived rather than declared."""
+
+    return isinstance(lane, DerivedLane)
+
+
+def eager_only_reason(cls: type) -> str:
+    """The class's declared eager-forever REASON, or ``""``."""
+
+    return str(getattr(cls, EAGER_ONLY_ATTR, "") or "").strip()
+
+
+def _calls_ctx_compile(fn: Any) -> bool:
+    """Whether ``load`` calls ``ctx.compile(...)`` — statically, by AST.
+
+    pgw#1469 measured the mirror of the refusal that already existed: a lane
+    with no compile mark refuses, but a compile mark with no lane was SILENT —
+    ``load`` was never called at all, so nothing observed the mark, and the
+    author got a green lock with a byte-identical document. Under pgw#1488 the
+    unmarked case traces by default, so the only way to reach that silence is
+    to declare ``eager_only=`` AND mark a target, and this is what makes that
+    contradiction a refusal for free: no author code runs, no model loads.
+
+    Parsed rather than grepped — the string ``ctx.compile`` appears in comments
+    and docstrings that say a model deliberately does NOT compile, and a
+    substring check would refuse exactly the classes that documented
+    themselves best.
+    """
+
+    try:
+        source = textwrap.dedent(inspect.getsource(fn))
+    except (OSError, TypeError):  # exec'd/builtin source is not readable
+        return False
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:  # pragma: no cover - dedent of a nested def
+        return False
+    definition = tree.body[0] if tree.body else None
+    if not isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return False
+    # The ctx parameter: `load(self, ctx)`, the ruled signature (pgw#1382).
+    names = {argument.arg for argument in definition.args.args[1:2]}
+    for node in ast.walk(definition):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "compile"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in names
+        ):
+            return True
+    return False
 
 
 def _parse_lanes(
@@ -338,8 +448,14 @@ class Model(Generic[MT]):
         class SdxlModel(Model[SDXL], lanes=(contracts.SDXL_DIFFUSERS_BF16,)):
             def load(self, ctx: LoadContext[SDXL]) -> None: ...
 
-    ``lanes=`` omitted means one lane — the model type's canonical contract;
-    ``lanes=()`` states eager-permanent explicitly.
+    ``lanes=`` omitted (or ``lanes=()``) means the author states NO layout
+    contract: the class gets its model type's canonical contract when one is
+    published, and otherwise a DERIVED lane (:class:`DerivedLane`) — either
+    way it TRACES. Eager-forever is a separate declaration and never an
+    inference from an absent one::
+
+        class RifeModel(Model[Rife], eager_only="frame interpolation runs "
+                        "eager; there is no compile target"): ...
 
     The MAPPING form declares each lane together with what that lane needs of
     a machine, in the ie#740 grammar — one line, one place::
@@ -366,12 +482,14 @@ class Model(Generic[MT]):
     __cozy_lanes__: ClassVar[tuple[Any, ...] | None] = None
     __cozy_requires__: ClassVar[dict[str, Any]] = {}
     __cozy_self_loading__: ClassVar[str] = ""
+    __cozy_eager_only__: ClassVar[str] = ""
 
     def __init_subclass__(
         cls,
         *,
         lanes: tuple[Any, ...] | Mapping[Any, Any] | None = None,
         self_loading: str | None = None,
+        eager_only: str | None = None,
         **kwargs: Any,
     ) -> None:
         if "requires" in kwargs:
@@ -404,6 +522,42 @@ class Model(Generic[MT]):
                     "this declaration replaces."
                 )
             cls.__cozy_self_loading__ = reason
+        if eager_only is not None:
+            # pgw#1488 fix (3). Same mandatory-reason pattern as
+            # `self_loading=`, for the same reason: this is the ONE state in
+            # which nothing is compiled, ever, and a state that costs the
+            # fleet performance has to say why in the header where anyone
+            # reviewing the class will read it.
+            if not isinstance(eager_only, str):
+                raise ModelDeclarationError(
+                    f"{cls.__qualname__}: eager_only= must be a string reason, "
+                    f"got {type(eager_only).__name__}"
+                )
+            eager_reason = eager_only.strip()
+            if not eager_reason:
+                raise ModelDeclarationError(
+                    f"{cls.__qualname__}: eager_only= needs a REASON. Say why "
+                    "this model compiles NOTHING, ever — measured no win, no "
+                    "compilable module, an auxiliary model another slot "
+                    "drives. Eager-forever is the one posture that costs the "
+                    "fleet throughput silently, so it states its case."
+                )
+            if lanes:
+                raise ModelDeclarationError(
+                    f"{cls.__qualname__}: eager_only= and a non-empty lanes= "
+                    "contradict each other — a declared lane exists to key "
+                    "compiled graphs, and this class compiles none. Keep one."
+                )
+            if _calls_ctx_compile(cls.__dict__.get("load")):
+                raise ModelDeclarationError(
+                    f"{cls.__qualname__}: eager_only="
+                    f"{eager_reason!r} while load() marks a compile target "
+                    "via ctx.compile(). That mark can never produce a graph — "
+                    "pgw#1469 measured exactly this pair going through as a "
+                    "green lock with a byte-identical document. Drop the mark, "
+                    "or drop eager_only= and let the lock trace."
+                )
+            cls.__cozy_eager_only__ = eager_reason
         super().__init_subclass__(**kwargs)
         if Model in cls.__bases__ and _declared_model_type(cls) is None and not any(
             isinstance(parameter, TypeVar)
@@ -422,25 +576,25 @@ class Model(Generic[MT]):
         # The lanes this class actually serves, and their floors, from the ONE
         # `lanes=` declaration — or the model type's canonical contract when
         # `lanes=` is omitted (which declares no floor).
-        if lanes is not None:
+        if lanes:
             contracts, floors = _parse_lanes(cls, lanes)
             cls.__cozy_lanes__ = contracts
             cls.__cozy_requires__ = floors
-        elif declared is not None:
-            # pgw#1391: OMITTING `lanes=` IS THE se#757 TRAP, so it is checked
-            # here too. `model_lanes()` falls through to the model type's
-            # `canonical_contract`, and the class that declares nothing is
-            # exactly the one that used to claim `sd15.diffusers-bf16@1` — a
-            # document that existed nowhere — all the way into a published
-            # manifest. Validating the fall-through target at declaration is
-            # what makes discovery refuse it, because discovery IMPORTS the
-            # author module: the guarantee rides on `__init_subclass__` rather
-            # than on any particular consumer remembering to enumerate lanes.
-            # (pgw#1394 deleted discovery's `_lane_stamps` for good reasons;
-            # this seam is why that deletion costs the fence nothing.)
-            canonical = getattr(declared, "canonical_contract", None)
-            if canonical is not None:
-                lane_dtype(canonical, where=f"{cls.__qualname__} (lanes= omitted)")
+        elif lanes is not None:
+            # `lanes=()` — the author states no contract, which is what an
+            # omitted `lanes=` says too. pgw#1488 collapses the two: neither is
+            # eager-forever, and both fall through to `model_lanes`.
+            cls.__cozy_lanes__ = ()
+            cls.__cozy_requires__ = {}
+        # pgw#1391 VALIDATED the omitted-`lanes=` fall-through HERE and refused
+        # a canonical contract tensorfs publishes no readable document for.
+        # pgw#1488 deletes that refusal rather than moving it: the fall-through
+        # can no longer strand anyone, because `model_lanes` answers a DERIVED
+        # lane when the canonical contract is missing or unreadable. The se#757
+        # trap it was built for — a class silently CLAIMING a stamp that names
+        # no document — is closed by the same change from the other side: an
+        # unreadable contract is not borrowed at all, so no false stamp can be
+        # published, and the class traces under a handle that says `derived.`.
 
     # -- lifecycle hooks (the load/unload contract, pgw#1382) ---------------
 
@@ -477,22 +631,52 @@ def model_type(cls: type) -> type:
 
 
 def model_lanes(cls: type) -> tuple[Any, ...]:
-    """The model class's lanes — declared, or the model type's canonical
-    contract when ``lanes=`` was omitted. ``()`` is explicit eager-permanent."""
+    """The model class's lanes. ``()`` ONLY for ``eager_only=`` (pgw#1488).
+
+    Three states, each a word rather than an inference:
+
+    * ``eager_only="<reason>"`` -> ``()``. Nothing is traced, nothing compiled,
+      and the reason travels to whoever asks why.
+    * ``lanes=<contracts>`` -> exactly those. Unchanged, byte for byte: a
+      contract-declaring class publishes the handle it always did.
+    * ``lanes=()`` -> a DERIVED lane. The author stated no contract, so none is
+      borrowed — and it TRACES, which is the whole of fix (3): an empty tuple
+      used to disable compilation with no output whatsoever.
+    * ``lanes=`` omitted -> the model type's canonical contract when tensorfs
+      publishes a readable one (the convenience that spelling exists for),
+      else a DERIVED lane. This is fix (1): a missing contract document stops
+      being a reason to refuse to trace.
+
+    The old refusal ("omits lanes= and its model type has no canonical contract
+    yet (tensorfs#111); declare lanes= explicitly, or lanes=() for
+    eager-permanent") is DELETED. It cost anima a throwaway one-tensor contract
+    document, invented purely to be allowed to run torch.export, and its own
+    suggested remedy (``lanes=()``) silently disabled compilation instead.
+    """
 
     declared_type = model_type(cls)  # also validates cls
+    if eager_only_reason(cls):
+        return ()
     lanes = getattr(cls, LANES_ATTR, None)
-    if lanes is not None:
+    if lanes:
         return tuple(lanes)
+    if lanes is not None:
+        # `lanes=()` WRITTEN OUT: the author states no contract for this class,
+        # so none is borrowed — not even the model type's canonical one, which
+        # would publish a layout claim the author never made. It traces under
+        # its own derived name.
+        return (derived_lane(cls),)
     canonical = getattr(declared_type, "canonical_contract", None)
-    if canonical is None:
-        raise ModelDeclarationError(
-            f"{cls.__qualname__} omits lanes= and its model type "
-            f"{declared_type.__name__} has no canonical contract yet "
-            "(tensorfs#111); declare lanes= explicitly, or lanes=() for "
-            "eager-permanent"
-        )
-    return (canonical,)
+    if canonical is not None:
+        try:
+            lane_dtype(canonical, where=f"{cls.__qualname__} (lanes= omitted)")
+        except ModelDeclarationError:
+            # A canonical contract that cannot state its own load dtype is not
+            # a lane; borrowing its stamp would publish a claim about a layout
+            # nobody can read. Derive instead — and say `derived.` in the name.
+            return (derived_lane(cls),)
+        return (canonical,)
+    return (derived_lane(cls),)
 
 
 def model_requires(cls: type) -> dict[str, Any]:
@@ -505,12 +689,18 @@ def model_requires(cls: type) -> dict[str, Any]:
 
 
 __all__ = [
+    "DERIVED_LANE_PRODUCER",
     "DTYPELESS_UPSTREAM_LANES",
+    "EAGER_ONLY_ATTR",
     "LANES_ATTR",
     "LaneContract",
     "MODEL_TYPE_ATTR",
     "Model",
     "REQUIRES_ATTR",
+    "DerivedLane",
+    "derived_lane",
+    "eager_only_reason",
+    "is_derived_lane",
     "model_requires",
     "ModelDeclarationError",
     "lane_handle",

--- a/tests/fixtures/serving_engine_endpoint/src/serving_engine_fixture/main.py
+++ b/tests/fixtures/serving_engine_endpoint/src/serving_engine_fixture/main.py
@@ -58,7 +58,7 @@ class FakePipeline:
 
 class GgufModel(
     Model[SDXL],
-    lanes=(),
+    eager_only="an external llama.cpp server owns the weights and the graph",
     self_loading="served by llama-server, which self-loads a GGUF; the "
                  "block-quantized container is the external-binary class "
                  "the streaming engine refuses by design",
@@ -80,7 +80,7 @@ class GgufModel(
 
 class VllmModel(
     Model[SDXL],
-    lanes=(),
+    eager_only="an external vLLM server owns the weights and the graph",
     self_loading="served by vLLM, which self-loads the checkpoint directory; "
                  "ctx.load is never called",
 ):
@@ -93,7 +93,10 @@ class VllmModel(
         ))
 
 
-class PytorchModel(Model[SDXL], lanes=()):
+class PytorchModel(
+    Model[SDXL],
+    eager_only="the fixture's in-process arm compiles nothing",
+):
     """THE CONTROL: boots no engine, so the census must not name it."""
 
     def load(self, ctx: LoadContext[SDXL]) -> None:

--- a/tests/fixtures/serving_engine_host_endpoint/src/serving_engine_host_fixture/main.py
+++ b/tests/fixtures/serving_engine_host_endpoint/src/serving_engine_host_fixture/main.py
@@ -50,7 +50,7 @@ class StandInSpec(EngineSpec, frozen=True, kw_only=True):
 
 class StandInModel(
     Model[SDXL],
-    lanes=(),
+    eager_only="an external engine process owns the weights and the graph",
     self_loading="served by an external engine process over HTTP",
 ):
     def load(self, ctx: LoadContext[SDXL]) -> None:

--- a/tests/fixtures/serving_rt_endpoint/src/serving_rt_fixture/main.py
+++ b/tests/fixtures/serving_rt_endpoint/src/serving_rt_fixture/main.py
@@ -48,7 +48,10 @@ class Out(msgspec.Struct):
     served_by: str
 
 
-class SlowModel(Model[SDXL], lanes=()):
+class SlowModel(
+    Model[SDXL],
+    eager_only="a residency/lifecycle fixture: it compiles nothing by design",
+):
     """Eager-permanent; ``load`` builds cheap state, work is gauged."""
 
     def load(self, ctx: LoadContext[SDXL]) -> None:
@@ -73,11 +76,13 @@ class SlowModel(Model[SDXL], lanes=()):
         ORDER.append(f"unload:{type(self).__name__}")
 
 
-class OtherModel(SlowModel, lanes=()):
+class OtherModel(SlowModel, eager_only="second residency key, same posture"):
     pass
 
 
-class BrokenUnloadModel(SlowModel, lanes=()):
+class BrokenUnloadModel(
+    SlowModel, eager_only="unload-failure fixture; compiles nothing"
+):
     def unload(self, ctx: LoadContext[SDXL]) -> None:
         ORDER.append("unload:BrokenUnloadModel")
         raise RuntimeError("author unload bug — must not pin the eviction")

--- a/tests/release_fixtures/derived_twin_endpoint.py
+++ b/tests/release_fixtures/derived_twin_endpoint.py
@@ -1,0 +1,123 @@
+"""tiny_endpoint's TWIN, identical but for the LANE DECLARATION (pgw#1488).
+
+Every line below is `tiny_endpoint.py`'s, with one difference: the model class
+declares `lanes=()` — no layout contract at all — where the original names
+`TINY_DIFFUSERS_FP32`. So the two derives run the same code, the same
+payload enumeration and the same precision, and differ only in what the lane
+is CALLED.
+
+That is the wire-compatibility measurement the ruling needs. `cg-graph-v1` is
+a content hash of the canonical trace plus its ingress and passes, and
+`cg-key-v1` is (graph, sm, toolchain): the contract handle is in NEITHER. The
+test asserts what that predicts — byte-identical graph hashes across the two
+fixtures, under two different lane names — which is why declaring a contract
+can be made optional without rekeying a single existing artifact.
+"""
+
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import (
+    Adapter,
+    DistillationAdapter,
+    ImageAsset,
+    LoadContext,
+    Model,
+    RequestContext,
+    ValidationError,
+    entrypoint,
+)
+from gen_worker.models import SDXL
+
+
+class Size(StrEnum):
+    SMALL = "small"
+    LARGE = "large"
+
+
+_BUCKETS: dict[Size, int] = {Size.SMALL: 32, Size.LARGE: 64}
+
+
+class GenerateInput(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    # LARGE deliberately: the payload DEFAULT differs from enum declaration
+    # order, so pgw#1384's default-first document ordering is observable.
+    size: Size = Size.LARGE
+    guidance_scale: float | None = None
+    num_inference_steps: int | None = None
+
+
+class TurboInput(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    size: Size = Size.SMALL
+
+
+class ImageOutput(msgspec.Struct):
+    image: ImageAsset
+    model_used: str
+
+
+class TinyModel(Model[SDXL], lanes=()):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+        self.defaults = ctx.defaults()
+
+
+def _run(model: TinyModel, ctx: Any, *, steps: int, guidance: float,
+         side: int, prompt: str) -> ImageAsset:
+    with torch.inference_mode():
+        result = model.pipe(
+            prompt=prompt,
+            num_inference_steps=steps,
+            guidance_scale=guidance,
+            width=side,
+            height=side,
+            callback_on_step_end=ctx.step_callback(steps),
+            output_type="pil",
+        )
+    return ctx.save_image(result.images[0], format="png")
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: GenerateInput, model: TinyModel,
+             turbo: DistillationAdapter | None,
+             loras: list[Adapter]) -> ImageOutput:
+    """Contract-file shape: ctx-first order, platform-injected adapter slots.
+
+    A riding distillation adapter (or a cfg-off checkpoint) serves the
+    guidance-free batch-1 arm -- the derive's binding enumeration reaches it
+    without any real adapter bytes.
+    """
+    ctx.raise_if_cancelled()
+    d = model.defaults
+    if turbo is not None and not d.cfg:
+        raise ValidationError(
+            "this checkpoint is already distilled; a distillation adapter "
+            "cannot be stacked on it"
+        )
+    config = turbo.defaults if turbo is not None else d
+    distilled = not config.cfg
+    steps = config.steps.resolve(payload.num_inference_steps or 16, ctx)
+    guidance = 0.0 if distilled else d.guidance.resolve(payload.guidance_scale, ctx)
+    image = _run(model, ctx, steps=int(steps), guidance=guidance,
+                 side=_BUCKETS[payload.size], prompt=payload.prompt.strip())
+    return ImageOutput(image=image, model_used=ctx.checkpoint_ref)
+
+
+@entrypoint
+def generate_turbo(ctx: RequestContext, payload: TurboInput,
+                   model: TinyModel) -> ImageOutput:
+    ctx.raise_if_cancelled()
+    image = _run(model, ctx, steps=2, guidance=0.0,
+                 side=_BUCKETS[payload.size], prompt=payload.prompt.strip())
+    return ImageOutput(image=image, model_used=ctx.checkpoint_ref)

--- a/tests/release_fixtures/eager_endpoint.py
+++ b/tests/release_fixtures/eager_endpoint.py
@@ -1,4 +1,9 @@
-"""A lanes=() module: eager-permanent, stated by an explicit empty document."""
+"""An `eager_only=` module: eager-permanent, DECLARED, with the reason.
+
+pgw#1488: `lanes=()` no longer says this. An absent lane declaration means
+"no layout contract stated", which traces; eager-forever is its own word and
+carries the author's reason for it.
+"""
 
 from __future__ import annotations
 
@@ -17,8 +22,11 @@ class Out(msgspec.Struct):
     echoed: str
 
 
-class EagerModel(Model[Any], lanes=()):
-    """lanes=() -> nothing compiles, ever; the document says so."""
+class EagerModel(
+    Model[Any],
+    eager_only="the fixture's subject IS the no-compile document",
+):
+    """eager_only= -> nothing compiles, ever; the document says so."""
 
 
 @entrypoint

--- a/tests/release_fixtures/unmarked_endpoint.py
+++ b/tests/release_fixtures/unmarked_endpoint.py
@@ -1,0 +1,43 @@
+"""No contract, no eager declaration, no compile mark: it TRACES anyway.
+
+pgw#1488's middle state. `Whatever` is a model type with no canonical
+contract, so before this change the derive refused the class outright ("omits
+lanes= and its model type has no canonical contract yet"); the remedy the
+refusal named — `lanes=()` — then disabled compilation with no output at all.
+
+Now the lane is DERIVED, `load` runs, and the honest answer is recorded: the
+author marked nothing, so there is nothing to compile. Zero graphs measured,
+not assumed.
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+
+
+class Whatever(msgspec.Struct):
+    """A model type with no canonical contract — tensorfs publishes none."""
+
+    steps: int = 4
+
+
+class In(msgspec.Struct):
+    text: str
+
+
+class Out(msgspec.Struct):
+    echoed: str
+
+
+class UnmarkedModel(Model[Whatever]):
+    """No `lanes=`, no `ctx.compile` — and no refusal."""
+
+    def load(self, ctx: LoadContext[Whatever]) -> None:
+        self.loaded = True
+
+
+@entrypoint
+def analyze(ctx: RequestContext, payload: In, model: UnmarkedModel) -> Out:
+    return Out(echoed=payload.text)

--- a/tests/test_endpoint_lock_gate.py
+++ b/tests/test_endpoint_lock_gate.py
@@ -1,5 +1,8 @@
 """`gen-worker lock` as a COMMITTED SOURCE artifact: deterministic, checkable.
 
+pgw#1488: the lock is committed beside the endpoint, so it must serialize
+deterministically and `--check` must be able to say whether it is stale.
+
 endpoint.lock lives in git beside the endpoint, so two properties matter that
 did not matter when it was scratch output:
 

--- a/tests/test_engine_runtime_binding.py
+++ b/tests/test_engine_runtime_binding.py
@@ -167,7 +167,9 @@ def test_the_lock_census_names_the_engine_runtime(declarations: Any) -> None:
 # --------------------------------------------------------------------------
 
 
-class UnmarkedGgufModel(Model[SDXL], lanes=()):
+class UnmarkedGgufModel(
+    Model[SDXL], eager_only="an external engine owns the weights and the graph"
+):
     """Engine-hosted and NOT marked — the mistake a migrating author makes.
 
     An engine-hosted model is self-loading by construction, so this class is

--- a/tests/test_lock_check_pgw1488.py
+++ b/tests/test_lock_check_pgw1488.py
@@ -1,0 +1,200 @@
+"""`gen-worker lock` as a COMMITTED SOURCE artifact: deterministic, checkable.
+
+endpoint.lock lives in git beside the endpoint, so two properties matter that
+did not matter when it was scratch output:
+
+* **determinism** — locking twice writes the same bytes, or every diff is
+  noise and nobody reads them;
+* **`--check`** — the freshness gate. It answers "does this committed lock
+  still describe this tree" and WRITES NOTHING, so CI can run it on a
+  read-only checkout. The cheap arm is the inputs digest (milliseconds); only
+  when the inputs moved does it pay for a re-derive, and then it compares the
+  DOCUMENT, because an input that moved without moving the output is not
+  drift and reporting it as drift trains people to ignore the check.
+
+Integration through the real CLI against a real endpoint project on disk — no
+mocks. The endpoint declares NO layout contract and marks NO compile target,
+which is deliberate on both counts: it is pgw#1488's traced-by-default state
+(before this change the derive refused the class outright), and it keeps the
+gate's own test off the export path so a lock/`--check` regression cannot hide
+behind a torch failure.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+
+MAIN = '''
+from __future__ import annotations
+
+import msgspec
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+
+
+class Unlaned(msgspec.Struct):
+    """A model type with no canonical contract."""
+
+    steps: int = 4
+
+
+class In(msgspec.Struct):
+    text: str
+{extra_field}
+
+class Out(msgspec.Struct):
+    echoed: str
+
+
+class UnlanedModel(
+    Model[Unlaned],
+    self_loading="a lock/--check gate fixture: there is no pipeline at all",
+):
+    """No `lanes=`, no contract, no ctx.compile — and it locks."""
+
+    def load(self, ctx: LoadContext[Unlaned]) -> None:
+        self.ready = True
+
+
+@entrypoint
+def analyze(ctx: RequestContext, payload: In, model: UnlanedModel) -> Out:
+    return Out(echoed=payload.text)
+'''
+
+
+def _write_endpoint(root: Path, *, extra_field: str = "") -> None:
+    package = root / "src" / "lockcheck_fixture"
+    package.mkdir(parents=True, exist_ok=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "main.py").write_text(
+        MAIN.format(extra_field=extra_field), encoding="utf-8"
+    )
+    (root / "endpoint.toml").write_text(
+        'schema_version = 1\nmain = "lockcheck_fixture.main"\n', encoding="utf-8"
+    )
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "lockcheck-fixture"\nversion = "0"\n\n'
+        '[tool.gen_worker]\nmain = "lockcheck_fixture.main"\n',
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def endpoint(tmp_path: Path) -> Path:
+    root = tmp_path / "endpoint"
+    _write_endpoint(root)
+    return root
+
+
+@pytest.fixture()
+def checkpoint(tmp_path: Path) -> Path:
+    tree = tmp_path / "checkpoint"
+    tree.mkdir()
+    (tree / "config.json").write_text(
+        json.dumps({"torch_dtype": "bfloat16"}), encoding="utf-8"
+    )
+    return tree
+
+
+def _lock(
+    endpoint: Path, checkpoint: Path, graph_cas: Path, *extra: str
+) -> tuple[int, dict]:
+    """One `gen-worker lock` invocation — as a PROCESS, deliberately.
+
+    In-process would import the author module once and keep it in
+    `sys.modules`, so every later "the source changed" arm would be measuring
+    a module that never changed. The CLI is a process in production and the
+    gate has to be tested as one.
+    """
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "gen_worker.cli", "lock", str(endpoint),
+         "--checkpoint", str(checkpoint), "--graph-cas", str(graph_cas), *extra],
+        capture_output=True, text=True, check=False,
+    )
+    summary = json.loads(completed.stdout) if completed.stdout.strip() else {}
+    return completed.returncode, summary
+
+
+def test_lock_is_deterministic_and_check_gates_on_the_document(
+    endpoint: Path,
+    checkpoint: Path,
+    tmp_path: Path,
+) -> None:
+    graph_cas = tmp_path / "graph-cas"
+    lock = endpoint / "endpoint.lock"
+
+    code, summary = _lock(endpoint, checkpoint, graph_cas)
+    assert code == 0
+    first = lock.read_bytes()
+    assert summary["derive"] == "traced"
+    # pgw#1488: the trace RAN on a contract-less class and found nothing
+    # marked. That is a posture with a name, not silence.
+    assert summary["posture"] == "traced-no-compile-targets"
+    assert summary["specializations"] == 0
+
+    # Determinism: the same tree locks to the same BYTES. (The re-run reuses
+    # the saved trace and REWRITES the file, so a non-deterministic
+    # serialization shows up right here.)
+    code, summary = _lock(endpoint, checkpoint, graph_cas)
+    assert code == 0
+    assert lock.read_bytes() == first
+    assert summary["derive"] == "reused"
+
+    # --check, cheap arm: inputs unchanged, nothing re-derived...
+    code, summary = _lock(endpoint, checkpoint, graph_cas, "--check")
+    assert code == 0
+    assert summary["check"] == "current"
+    # ...and NOTHING IS WRITTEN.
+    assert lock.read_bytes() == first
+
+    # An input moves without moving the output: a comment. --check re-derives
+    # and passes, because the document is what the endpoint IS.
+    source = endpoint / "src" / "lockcheck_fixture" / "main.py"
+    source.write_text(
+        source.read_text(encoding="utf-8") + "\n# a comment moves the inputs\n",
+        encoding="utf-8",
+    )
+    code, result = _lock(endpoint, checkpoint, graph_cas, "--check")
+    assert code == 0
+    assert result["check"] == "current"
+    assert result["committed_document_digest"] == result["derived_document_digest"]
+    assert lock.read_bytes() == first
+
+
+def test_check_goes_red_on_a_stale_committed_lock(
+    endpoint: Path,
+    checkpoint: Path,
+    tmp_path: Path,
+) -> None:
+    """The gate's whole job: a lock that no longer describes the endpoint."""
+
+    graph_cas = tmp_path / "graph-cas"
+    lock = endpoint / "endpoint.lock"
+    assert _lock(endpoint, checkpoint, graph_cas)[0] == 0
+    before = lock.read_bytes()
+
+    # A REAL change to what this endpoint IS: the entrypoint's payload gains a
+    # field, so the published envelope schema — and the document with it —
+    # differs from the committed one.
+    _write_endpoint(endpoint, extra_field="    drifted: bool = False\n")
+
+    code, result = _lock(endpoint, checkpoint, graph_cas, "--check")
+    assert code == 1
+    assert result["check"] == "drift"
+    assert result["committed_document_digest"] != result["derived_document_digest"]
+    # A gate does not fix what it finds.
+    assert lock.read_bytes() == before
+
+
+def test_check_refuses_when_there_is_no_lock_to_check(
+    endpoint: Path, checkpoint: Path, tmp_path: Path
+) -> None:
+    assert _lock(endpoint, checkpoint, tmp_path / "graph-cas", "--check")[0] == 2

--- a/tests/test_lock_check_pgw1488.py
+++ b/tests/test_lock_check_pgw1488.py
@@ -198,3 +198,58 @@ def test_check_refuses_when_there_is_no_lock_to_check(
     endpoint: Path, checkpoint: Path, tmp_path: Path
 ) -> None:
     assert _lock(endpoint, checkpoint, tmp_path / "graph-cas", "--check")[0] == 2
+
+
+# --------------------------------------------------------------------------
+# The derived lane's load dtype: the CHECKPOINT decides, because no contract
+# is there to. Precision is graph identity, so "whatever the loader defaults
+# to" is not an answer a trace can take.
+# --------------------------------------------------------------------------
+
+
+def _safetensors(path: Path, dtypes: dict[str, int]) -> None:
+    """A real safetensors file: 8-byte length, JSON header, no payload read."""
+
+    import struct
+
+    header: dict[str, object] = {}
+    offset = 0
+    for spelling, count in dtypes.items():
+        for index in range(count):
+            header[f"w{spelling}{index}"] = {
+                "dtype": spelling, "shape": [1], "data_offsets": [offset, offset + 2],
+            }
+            offset += 2
+    blob = json.dumps(header).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob + b"\0" * offset)
+
+
+def test_a_derived_lane_takes_its_dtype_from_the_checkpoint(tmp_path: Path) -> None:
+    import torch
+
+    from gen_worker.serving.checkpoint_dtype import checkpoint_dtype
+
+    assert checkpoint_dtype(None) is None
+    assert checkpoint_dtype(tmp_path / "nowhere") is None
+
+    # No config at all — the many checkpoints that ship raw shards. The
+    # MAJORITY of declared tensors decides, not the file that sorts first:
+    # a pipeline keeps its text encoder and VAE beside the denoiser.
+    tree = tmp_path / "raw"
+    tree.mkdir()
+    _safetensors(tree / "a-encoder.safetensors", {"F32": 2})
+    _safetensors(tree / "b-denoiser.safetensors", {"BF16": 9})
+    assert checkpoint_dtype(tree) is torch.bfloat16
+
+    # A stated dtype leads: the packager is stating serving intent, and an
+    # fp32 file saved from a bf16 recipe is a real thing.
+    (tree / "model_index.json").write_text(
+        json.dumps({"_class_name": "X", "torch_dtype": "float16"}), encoding="utf-8"
+    )
+    assert checkpoint_dtype(tree) is torch.float16
+
+    # Nothing readable anywhere is None — the loader keeps its own default,
+    # stated rather than invented.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert checkpoint_dtype(empty) is None

--- a/tests/test_model_authoring.py
+++ b/tests/test_model_authoring.py
@@ -114,6 +114,12 @@ def test_fixture_imports_clean_and_extracts_the_declared_surface() -> None:
     }
 
 
+def _sdxl_contract() -> Any:
+    from gen_worker._vendor.tensorfs import contracts
+
+    return contracts.SDXL_DIFFUSERS_BF16
+
+
 def test_model_header_declarations_and_refusals() -> None:
     with pytest.raises(ModelDeclarationError, match=r"Model\[SDXL\]"):
         type("Bare", (Model,), {})
@@ -126,11 +132,61 @@ def test_model_header_declarations_and_refusals() -> None:
         class StringLane(Model[SDXL], lanes=("sdxl.diffusers-bf16@1",)):
             pass
 
-    class EagerPermanent(Model[SDXL], lanes=()):
+    # pgw#1488. `lanes=()` is NO LONGER eager-permanent: it says "this class
+    # states no layout contract", and a class that states none still traces —
+    # under a DERIVED lane, named after the model type so both the trace and
+    # the serve address the same row. No contract is borrowed (not even SDXL's
+    # canonical one): borrowing would publish a layout claim nobody made.
+    class NoContractDeclared(Model[SDXL], lanes=()):
+        pass
+
+    (derived,) = model_lanes(NoContractDeclared)
+    assert lane_handle(derived) == "derived.sdxl@1"
+    assert derived.dtype is None  # the checkpoint's own dtype decides
+    assert model_type(NoContractDeclared) is SDXL
+
+    # Eager-forever is a DECLARATION with a mandatory reason, mirroring
+    # `self_loading=` — never an inference from an empty tuple.
+    class EagerPermanent(
+        Model[SDXL], eager_only="the fixture compiles nothing on purpose"
+    ):
         pass
 
     assert model_lanes(EagerPermanent) == ()
     assert model_type(EagerPermanent) is SDXL
+
+    with pytest.raises(ModelDeclarationError, match="eager_only= needs a REASON"):
+        class BlankEager(Model[SDXL], eager_only="   "):
+            pass
+
+    with pytest.raises(ModelDeclarationError, match="must be a string reason"):
+        class UnreasonedEager(Model[SDXL], eager_only=True):  # type: ignore[arg-type]
+            pass
+
+    with pytest.raises(ModelDeclarationError, match="contradict each other"):
+        class BothWays(
+            Model[SDXL],
+            lanes={_sdxl_contract(): None},
+            eager_only="but it also declares a lane",
+        ):
+            pass
+
+    # pgw#1469's gap, closed statically: a compile mark under an eager-forever
+    # declaration can never produce a graph, and used to pass as a green lock
+    # with a byte-identical document.
+    with pytest.raises(ModelDeclarationError, match="can never produce a graph"):
+        class MarkedButEager(Model[SDXL], eager_only="measured no win"):
+            def load(self, ctx: object) -> None:
+                ctx.compile(object())  # type: ignore[attr-defined]
+
+    # ...and the same words in a DOCSTRING are not a mark. A class that
+    # documents "no ctx.compile here" is the best-behaved one on the fleet and
+    # a substring check would refuse exactly it.
+    class DocumentedEager(Model[SDXL], eager_only="compute-bound; measured no win"):
+        def load(self, ctx: object) -> None:
+            """No ctx.compile(): torch.compile measured no win here."""
+
+    assert model_lanes(DocumentedEager) == ()
 
     class OmittedLanes(Model[SDXL]):
         pass

--- a/tests/test_release_derive.py
+++ b/tests/test_release_derive.py
@@ -172,6 +172,66 @@ def test_a_no_lane_endpoint_stamps_the_explicit_eager_marker(
     assert document["checkpoint_defaults_schema"] is None
 
 
+def test_a_contractless_endpoint_traces_under_a_derived_lane(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    """pgw#1488 fix (1) + (3): no contract, no `lanes=`, and it still traces.
+
+    The twin fixture is `tiny_endpoint` with its `lanes=` emptied and nothing
+    else changed, so this is a controlled measurement rather than an
+    assertion about a second endpoint: SAME graphs, DIFFERENT lane name.
+    A contract handle is a name, not a key — which is the whole argument for
+    letting a contract be optional without rekeying anything that exists.
+    """
+
+    declared = tmp_path / "declared.json"
+    derived = tmp_path / "derived.json"
+    assert _derive("tiny_endpoint", config_only_tree, declared) == 0
+    assert _derive("derived_twin_endpoint", config_only_tree, derived) == 0
+
+    (contract_lane,) = json.loads(declared.read_bytes())["graphs"]["lanes"]
+    document = json.loads(derived.read_bytes())
+    (derived_lane,) = document["graphs"]["lanes"]
+
+    assert contract_lane["contract"] == "tiny.diffusers-fp32@1"
+    assert derived_lane["contract"] == "derived.sdxl@1"
+    assert [record["graph"] for record in derived_lane["graphs"]] == [
+        record["graph"] for record in contract_lane["graphs"]
+    ]
+    assert len(derived_lane["graphs"]) == 4
+
+    # The lane row says WHICH KIND of identity it carries. `document: null` is
+    # a bug on a declared contract (pgw#1391) and the honest state on a derived
+    # one, and a reader cannot tell those apart from a null alone.
+    row = document["lane_contracts"]["derived.sdxl@1"]
+    assert row == {"stamp": "derived.sdxl@1", "document": None, "digest": "",
+                   "derived": True}
+
+
+def test_an_unmarked_endpoint_traces_and_reports_nothing_to_compile(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    """The middle state: traced, and the author marked no compile target.
+
+    Before pgw#1488 this endpoint could not be derived at all — its model type
+    has no canonical contract, so the derive refused the class by name, and the
+    remedy that refusal named (`lanes=()`) silently disabled compilation. Now
+    `load` RUNS and zero graphs is a measurement.
+    """
+
+    out = tmp_path / "unmarked.json"
+    assert _derive("unmarked_endpoint", config_only_tree, out) == 0
+    document = json.loads(out.read_bytes())
+    assert document["graphs"]["lanes"] == []
+    assert document["lane_contracts"] == {}
+    # It is NOT weightless and NOT eager-by-declaration: the entrypoint's
+    # envelope is published exactly as a compiled endpoint's is.
+    assert set(document["entrypoints"]) == {"analyze"}
+    assert document["entrypoints"]["analyze"]["model_slots"] == {
+        "model": "UnmarkedModel"
+    }
+
+
 def test_binding_enumeration_reaches_adapter_and_cfg_arms(
     config_only_tree: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_weightless_entrypoints.py
+++ b/tests/test_weightless_entrypoints.py
@@ -165,7 +165,7 @@ def test_derive_renders_an_envelope_with_no_model_field(
     assert "model" not in json.dumps(schema)
 
     # "No lanes" has two causes and the log may not conflate them: a model
-    # held eagerly (lanes=()) vs NO MODEL AT ALL.
+    # held eagerly (`eager_only=`) vs NO MODEL AT ALL.
     assert result.eager_permanent and result.weightless
 
     sys.path.insert(0, str(FIXTURES))
@@ -176,6 +176,10 @@ def test_derive_renders_an_envelope_with_no_model_field(
     finally:
         sys.path.remove(str(FIXTURES))
     assert eager.eager_permanent and not eager.weightless
+    # pgw#1488: eager-by-DECLARATION carries the author's reason, and the
+    # reason is the difference between this and "traced, nothing marked".
+    assert eager.eager_only.startswith("the fixture's subject")
+    assert not result.eager_only
     assert json.loads(eager.document)["entrypoints"] == {}
 
 


### PR DESCRIPTION
Paul's ruling, **"A NORMAL TRACE MUST JUST WORK"** (DESIGN-RULINGS 2026-08-19), fixes (1) and (3). Fix (2) — the fakification shim / device-class removal — belongs to a sibling lane and is untouched here.

## Fix 1 — a contract document is METADATA, not a gate

A model class naming no tensorfs contract was refused by name at publish (*"omits lanes= and its model type has no canonical contract yet"*), which cost the anima lane a throwaway one-tensor contract document invented purely to be ALLOWED to run `torch.export`. Such a class now gets a **derived lane** — `derived.<model type>@1`, computed identically at trace and at serve so both address the same row — and its load dtype comes from the checkpoint itself (`serving/checkpoint_dtype.py`: the packager's stated `torch_dtype`, else the dominant dtype across the safetensors **headers**, else the loader's own default). Contract attachment becomes a later step.

**Nothing rekeys, and that is measured rather than argued.** `cg-graph-v1` hashes the canonical trace plus ingress plus passes; `cg-key-v1` is (graph, sm, toolchain). The contract string is in neither — it is a NAME. The new `derived_twin_endpoint` fixture is `tiny_endpoint` with its `lanes=` emptied and nothing else changed, and the two derive **byte-identical graph hashes under two different lane names**.

## Fix 3 (pgw#1469) — eager-forever is a word, with a reason

`eager_only="<why>"` on the class header, the mandatory-reason pattern `self_loading=` already uses. `lanes=()` no longer means it: an absent lane declaration says "no layout contract stated", and that traces. This closes the gap pgw#1469 measured — `ctx.compile` under `lanes=()` was byte-identical-digest dead code, because `_derive_lane` was never reached, so `load()` never ran and nothing observed the mark. A compile mark under `eager_only=` is now a declaration refusal read from the **AST** (never a substring: the classes that document "no ctx.compile here" are the best-behaved ones and a grep would refuse exactly them). No author code runs.

Every `lock` outcome is one printed word, in the JSON summary too: `traced` / `traced-no-compile-targets` / `eager-by-declaration` / `weightless`.

## Also: `gen-worker lock --check`

The freshness gate for a lock that is now committed source. Cheap arm is the inputs digest (ms, so CI can run it per push); only a moved input pays for a re-derive, and then the **document** decides — an input that moves without moving the output is not drift, and calling it drift teaches people to ignore the gate. Writes nothing either way; exit 1 on drift, 2 with no lock to check.

## Evidence — execution, both arms

| arm | at master | at this branch |
|---|---|---|
| anima with NO contract document anywhere | `error: derive: AnimaModel omits lanes= and its model type Anima has no canonical contract yet` (exit 1) | traces under `derived.anima@1` |
| sd1.5, the real endpoint, real checkpoint | document `adc3e8c2…0d8f09ae`, 14 specializations, lane `sd15.diffusers-bf16@1` | same document digest — no rekey |

Plus `tests/test_lock_check_pgw1488.py` (lock determinism + `--check` current/drift/no-lock, through the real CLI as a process) and `tests/test_release_derive.py` (the twin's identical graph hashes; the traced-nothing-marked posture). mypy (src + tests) and ruff (src) clean.

## Fleet consequence

`serverless-endpoints` has two `lanes=()` classes (`wan-2.2` and `minimax-h3`, both `RifeModel`). They must become `eager_only=`; branch `788-eager-only-rife` is pushed and **rides the gen-worker pin bump**, since `eager_only=` does not exist at their pinned rev. Tracked as se#788.

Tracker: pgw#1488.