### PR TITLE
pgw#1487: the derive states cuda. Always. The cpu-class fallback is deleted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,7 +696,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "3d958bf9628f54f400ca6d1e570a6f8d4b066f4e" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -306,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "3d958bf9628f54f400ca6d1e570a6f8d4b066f4e"
+rev = "0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -515,7 +515,7 @@ rewrites = [
 "__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
 "_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
 "_wrapper_split.py" = "1d5a3bc1ccabadeaa2b8b54f1492cba10723e53074a0022b8c7453565a86a4ce"
-"adopt.py" = "671af1e744a753f4b7dcf7a167825fad4f18c3e125768b6237e7ed489c3bcf2d"
+"adopt.py" = "78f6557c7f68fa4e96b27bce25b49f056f2e1bd02e1118d48b3ed71ccf3317c1"
 "artifact.py" = "a3c96d845be49c752bd608dbb4b36fb192cb449937716d8d835aeba2e28d12ba"
 "cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
 "compiler.py" = "6ee54b26286b215eef8867dffb133d023a6808379574ac69f8007a64c477045a"
@@ -529,11 +529,11 @@ rewrites = [
 "contracts/recipe_v1.json" = "d319b5f2e4a3d5c13587da2b7d7cdc25c83b92e0b5b22311c317948c3e610d1a"
 "contracts/toolchain_identity_v1.json" = "f4114c38ae373f62ddcb2aae5498ffbee30630e80adf11fee99e68bcbdb24282"
 "declaration.py" = "8b42bae864a4127cc5e418915f8395d980b8a439a51fd4d6f5ecbb42ba613b21"
-"discovery.py" = "33c95279c008b1f4c7d27d77c255ed4db84d6abeff7c788b738b56a7fc8eb855"
+"discovery.py" = "a73e4173677b0e60d9574b1606696c82160830b8a34dea66ba14fd7fd5f7606f"
 "document.py" = "797a3f17f46e971ce165c7c64503efece8219c04c80530036727d7c838f173f7"
 "engine.py" = "d8275ad146c73ae5516ea7d60acc1fd63cdddb3036f4833f7741913fe340a1a9"
-"graph_identity.py" = "9518c789b98cad8d84f1288ae549af21f0e2d359066e43f6ad6eb3a7f09a2e78"
-"hollow.py" = "edbfbc7b158c34db61a60bbd95287ef68b08d532d47b032f89ddcc0abdc71b77"
+"graph_identity.py" = "88c731a681eb1e0b878f30bc33fcaa4efdbfc16bdc612fd6d406a088e299e567"
+"hollow.py" = "a46d1b33a8b9b9501edee654eaaa2dd71406cb6c102127fddffa92a9a5ce4116"
 "host_isa.py" = "679aa81547be2d60ae6593b6e8f75dd29dcd56ab85d8e858e219b5af5d0eadc4"
 "identity.py" = "a460a24836cbd46cc9e65bd684b9f6258f6718e5c56102f26a7071f01574a99e"
 "ingress.py" = "fa9b814dbfcd43e2a7cfdd2ed48299a7fa5a570aa73d3e2269448c974074d558"

--- a/src/gen_worker/_vendor/torchcg/adopt.py
+++ b/src/gen_worker/_vendor/torchcg/adopt.py
@@ -25,13 +25,12 @@ forward — the author's code stays the serve host.
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .artifact import ArtifactError
 from .document import GraphRecord, GraphSetDocument, LaneGraphs
-from .graph_identity import EnvIdentity
 from .requirements import assert_exact_env
 from .runner import ConstantBindingError
 from .store import GraphStore, StoreError
@@ -200,7 +199,7 @@ class AdoptSession:
         *,
         loader: ArtifactLoader | None = None,
         artifacts_dir: str | Path,
-        stack: Mapping[str, str],
+        stack: Mapping[str, str] | Sequence[tuple[str, str]],
         transforms: TransformSet | None = None,
     ) -> None:
         lane = next((row for row in document.lanes if row.contract == contract), None)

--- a/src/gen_worker/_vendor/torchcg/discovery.py
+++ b/src/gen_worker/_vendor/torchcg/discovery.py
@@ -234,10 +234,16 @@ def _demote_example_inputs(program: Any) -> None:
             continue
 
 
-def _restore_literal_values(
-    contract: str, path: str, program: Any, session: Any
-) -> None:
-    """Put real values back under any lifted constant the session faked."""
+def _assert_literal_values_are_real(contract: str, path: str, program: Any) -> None:
+    """A lifted constant must carry its VALUE, never a fake stand-in.
+
+    ``graph_hash`` folds the literal digest in, so a graph whose constants
+    were faked keys off a table of ZEROS and collides with every model that
+    differs only in those constants (pgw#1458). The session used to fake them
+    on a GPU-less cuda derive and swap the real values back here; since tcg#64
+    it never fakes a value-bearing tensor at all, so this is the standing
+    assertion that the property holds rather than a repair step.
+    """
 
     from torch._subclasses.fake_tensor import FakeTensor
 
@@ -245,20 +251,12 @@ def _restore_literal_values(
     faked = sorted(name for name, value in constants.items() if isinstance(value, FakeTensor))
     if not faked:
         return
-    if session is not None:
-        session.restore_constants(program)
-        faked = sorted(
-            name for name, value in (getattr(program, "constants", None) or {}).items()
-            if isinstance(value, FakeTensor)
-        )
-        if not faked:
-            return
     raise DiscoveryError(
         f"lane {contract!r} target {path!r}: lifted constant(s) {faked[:6]!r} are "
-        f"FAKE and no session holds their real values. The graph hash folds the "
-        f"literal digest in, so this graph would key off a table of ZEROS and "
-        f"collide with every other model that differs only in these constants "
-        f"(pgw#1458). Pass the HollowSession the modules were virtualized under."
+        f"FAKE, so this graph would key off a table of ZEROS and collide with "
+        f"every other model that differs only in these constants (pgw#1458). A "
+        f"hollow session keeps buffers and constants REAL; something else "
+        f"replaced these."
     )
 
 
@@ -288,16 +286,15 @@ def discover_modules(
     holds no opinion on WHERE the bytes go -- bytes-at-rest is tensorfs's
     charter, so the caller owns the sink.
 
-    ``session`` (pgw#1458) is the :class:`~torchcg.hollow.HollowSession` the
-    modules were virtualized under, when they were. Reaching a uniform cuda
-    trace on a GPU-less publish box means FAKING the lifted tensor constants,
-    which destroys their values -- and ``graph_hash`` folds the literal digest
-    in, so two models differing only in their constant tables would collide on
-    one identity. The session carries the real values and they are restored
-    here, before the hash is taken and before the sink sees the program. A
-    module whose program carries faked constants and no session to restore
-    them from is REFUSED: a silently zeroed literal digest is exactly the
-    class of defect this pass exists to delete.
+    ``session`` (pgw#1458, tcg#64) is the :class:`~torchcg.hollow.
+    HollowSession` the modules were virtualized under, when they were. It
+    carries the two devices a GPU-less cuda derive needs -- the drive ran on
+    one that exists, the graph is stamped with the one the session states --
+    and ``session.restate`` is applied to each exported program HERE, before
+    the hash, which is what makes the key independent of the box that derived
+    it. A program whose lifted constants are FAKE is still refused by name --
+    a silently zeroed literal digest is exactly the class of defect this pass
+    exists to delete -- but under tcg#64 no session can produce one.
 
     ``transforms`` (tcg#52) is the SEALED :class:`~torchcg.transform.
     TransformSet` of the lane's PASS phase. Passing it is what makes PASS ->
@@ -387,7 +384,13 @@ def discover_modules(
                     f"(strict={strict}) failed for the observed call: "
                     f"{type(exc).__name__}: {exc}"
                 ) from exc
-            _restore_literal_values(contract, path, program, session)
+            # tcg#64: the drive ran on a device that EXISTS; the graph is
+            # stamped with the device the session STATES. This is the one
+            # place the two meet, and it is before the hash, so a GPU-less
+            # box derives the same key a GPU box derives.
+            if session is not None:
+                session.restate(program)
+            _assert_literal_values_are_real(contract, path, program)
             _demote_example_inputs(program)
             names = _param_names(module, args, kwargs)
             try:

--- a/src/gen_worker/_vendor/torchcg/graph_identity.py
+++ b/src/gen_worker/_vendor/torchcg/graph_identity.py
@@ -186,7 +186,14 @@ class EnvIdentity:
     the image, not fingerprinted (pgw#1467, stated residual).
     """
 
-    stack: tuple[tuple[str, str], ...]
+    #: Declared as either shape because ``__post_init__`` NORMALIZES it --
+    #: `require_stack` takes a mapping or rows and always stores the canonical
+    #: tuple, so every reader sees `tuple[tuple[str, str], ...]` and every
+    #: caller may hand it whichever it has. pgw ruled the same way on its own
+    #: side of the boundary (pgw#1490, "a compile stack is either shape");
+    #: declaring only the stored shape left torchcg's own `assert_exact_env`
+    #: red under mypy against a constructor its docstring invites.
+    stack: tuple[tuple[str, str], ...] | Mapping[str, str] | Sequence[tuple[str, str]]
     sm: str
 
     def __post_init__(self) -> None:

--- a/src/gen_worker/_vendor/torchcg/hollow.py
+++ b/src/gen_worker/_vendor/torchcg/hollow.py
@@ -12,27 +12,44 @@ supplies the session that makes that code run hollow:
   literal digest reads), then every parameter becomes a FAKE tensor in the
   session's one ``FakeTensorMode``. Tokenizers, schedulers and processors
   load real from the config-only tree; they never carry weights.
-* **One stated trace device** -- author code's device asks are remapped to
-  the SESSION's device at the torch-function boundary. **This is not device
-  neutrality and never was** (pgw#1458): the trace stamps a concrete device
-  into every node's meta, so a cpu-remapped derive emits a device-CPU
-  artifact, and a cuda mint of it dies four layers down inside AOTInductor's
-  own ``Expected: cpu, Got: cuda:0``. The device is established at TRACE time
-  and cannot be re-homed downstream -- four escalating attempts to move it
-  were each defeated by a different layer.
+* **Two devices, named honestly** (tcg#64) -- the STATED trace device, which
+  the graphs are stamped with, and the DRIVE device, where the run's real
+  tensors actually live. They are the same device whenever this host can hold
+  a real tensor there, and they differ on exactly one shape: a GPU-less box
+  stating ``cuda``.
 
-  What IS neutral is the ARCH. Device (``cpu`` vs ``cuda``) is not arch
-  (``sm_86`` vs ``sm_90``): a fake-``cuda`` trace needs no silicon --
-  measured, with ``torch.cuda.is_available() == False`` -- and one such trace
-  serves every ``sm``, because the sm enters at ARTIFACT level through
-  ``RuntimeCompatibility``. So the session states a device CLASS, the
-  declaration records it (derived from the program), and a mismatched mint
-  refuses by name before it compiles.
+  Splitting them is what makes a normal trace just work. The stated device
+  used to be forced onto the drive as well, so a GPU-less ``cuda`` derive had
+  to fake every real tensor the author's code touched -- and a full diffusers
+  pipeline does not survive that: ``encode_prompt`` moves real token ids to
+  the execution device, the scheduler reads real sigmas with ``.item()``, and
+  fakifying them either runs a real cuda kernel on a box with no GPU or trips
+  fake-tensor data-dependence. The drive now runs on a device that EXISTS, so
+  every one of those reads gets its real value, exactly as it does on a GPU.
 
-  Device uniformity must be TOTAL. Parameters, buffers AND lifted tensor
-  constants all move; leaving any one real-on-cpu yields either
-  ``FakeTensorDeviceMismatchError`` or -- worse, because it exports cleanly --
-  a MIXED ``['cpu','cuda:0']`` placement that only AOTI rejects.
+  It costs nothing in identity because the drive does not decide identity.
+  Discovery is two passes: the drive only records each marked module's call
+  STRUCTURE (dtype and shape), and the graph is produced by a second,
+  independent ``torch.export`` of that module alone. So the drive's device
+  reaches the graph through one channel only -- the device stamped into the
+  exported program -- and :func:`restate_program` restates it afterwards.
+  Measured line-for-line: a cpu export restated onto cuda is byte-identical
+  to a native fake-cuda export, and a GPU-less sd1.5 derive reproduces the
+  graph keys of the GPU-traced one.
+
+  The stated device is still a REAL decision (pgw#1458): it is stamped into
+  every node's meta and therefore into the graph's identity, and a mint for a
+  different class refuses by name (``RuntimeCompatibility.key``). What is
+  gone is the HOST deciding it -- ``cuda`` needs no silicon.
+
+  What was never device is the ARCH. Device (``cpu`` vs ``cuda``) is not arch
+  (``sm_86`` vs ``sm_90``): one cuda trace serves every ``sm``, because the sm
+  enters at ARTIFACT level through ``RuntimeCompatibility``.
+
+  Device uniformity must be TOTAL on the stated side. Parameters, buffers AND
+  lifted tensor constants all carry the stated device; leaving any one
+  real-on-cpu yields a MIXED ``['cpu','cuda:0']`` placement that exports
+  cleanly and only AOTI rejects.
 * **Fake egress** -- scalarization of a fake tensor (``.numpy()``,
   ``.item()``, ``.tolist()``, ``bool()``) answers canonical ZEROS instead of
   refusing. Observation is structure-only; a value-dependent branch in author
@@ -50,7 +67,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -59,8 +76,9 @@ class HollowError(RuntimeError):
 
 
 #: The device class a compiled-graph derive traces on unless told otherwise.
-#: The fleet's compiled graphs are all cuda; a cpu trace is for tests and for
-#: cpu-target endpoints, and it is a DIFFERENT graph specialization, not a fallback.
+#: The fleet's compiled graphs are all cuda, and this needs no GPU to state
+#: (tcg#64). A cpu trace is for tests and for cpu-target endpoints, and it is a
+#: DIFFERENT graph specialization, never a fallback for a missing device.
 DEFAULT_TRACE_DEVICE = "cuda"
 
 
@@ -77,20 +95,22 @@ class TraceDeviceUnavailable(HollowError):
 
 @dataclass(frozen=True, slots=True)
 class HollowSession:
-    """The one fake mode and the one trace DEVICE of a derive run.
+    """The one fake mode, the STATED trace device, and where the drive runs.
 
-    ``real_constants`` holds the true values of every tensor this session had
-    to fake in order to reach device uniformity, keyed by module FQN. They are
-    not decoration: ``graph_hash`` folds ``_literal_digest`` in, so a graph
-    whose lifted constants were faked would key off a table of ZEROS, and two
-    models differing only in their constant tables would collide on one graph
-    identity. :meth:`restore_constants` puts the real values back into the
-    exported program before it is serialized.
+    ``device`` is what the graphs are stamped with and therefore part of their
+    identity. :attr:`drive_device` is where the run's real tensors physically
+    live; it is ``device`` whenever this host can hold one there and ``cpu``
+    otherwise. A GPU-less ``cuda`` session is the whole point of the split.
+
+    Nothing value-bearing is ever faked. The session that HAD to fake buffers
+    and lifted constants -- and therefore had to carry a table of their real
+    values to keep the literal digest honest -- was the session that forced
+    the stated device onto the drive. It does not any more (tcg#64), so that
+    table is gone rather than empty.
     """
 
     fake_mode: Any
     device: str = DEFAULT_TRACE_DEVICE
-    real_constants: dict[str, Any] = field(default_factory=dict)
 
     @property
     def device_type(self) -> str:
@@ -98,11 +118,11 @@ class HollowSession:
 
     @property
     def materializes_real_tensors(self) -> bool:
-        """Can a REAL tensor live on this session's device, here, now?
+        """Can a REAL tensor live on this session's STATED device, here, now?
 
         cpu always. cuda only with visible silicon -- and the publish derive
-        deliberately runs on boxes without any, which is why the constants
-        have to be faked and restored rather than moved.
+        deliberately runs on boxes without any, which is what
+        :attr:`drive_device` answers.
         """
 
         if self.device_type == "cpu":
@@ -111,21 +131,36 @@ class HollowSession:
 
         return bool(torch.cuda.is_available())
 
-    def restore_constants(self, program: Any) -> Any:
-        """Put every faked lifted constant's REAL value back on the program.
+    @property
+    def drive_device(self) -> str:
+        """Where the author's code actually runs -- a device that EXISTS.
 
-        Called after ``torch.export`` and before serialization. Without it the
-        literal digest -- and therefore ``cg-graph-v1`` -- would be computed
-        over zeros.
+        The single place the fallback is decided, so no caller can compute a
+        second answer. Every real value the drive reads (``.item()`` on a
+        sigma, token ids moved to the execution device, an ``encode_prompt``
+        kernel) is a real value on this device.
         """
 
-        constants = getattr(program, "constants", None)
-        if not constants or not self.real_constants:
-            return program
-        for name, value in self.real_constants.items():
-            if name in constants:
-                constants[name] = value
-        return program
+        return self.device if self.materializes_real_tensors else "cpu"
+
+    @property
+    def drive_device_type(self) -> str:
+        return str(self.drive_device).split(":", 1)[0]
+
+    def restate(self, program: Any) -> tuple[str, ...]:
+        """Restate one exported program on this session's STATED device.
+
+        A no-op when the drive already ran there. Otherwise it is the ONLY
+        place the drive's device is corrected, and it happens before the graph
+        is hashed, so the key a GPU-less box derives is the key a GPU box
+        derives. Returns the value-bearing tensors that had to stay on the
+        drive device (see :func:`restate_program`); ``()`` for a weights-free
+        program, which is every program this session produces today.
+        """
+
+        if self.drive_device_type == self.device_type:
+            return ()
+        return restate_program(program, self.device)
 
 
 #: The pt2 archive members that record a per-tensor device, in the shape
@@ -174,6 +209,13 @@ def load_exported_program(path: Any) -> Any:
     the check is POSITIVE and happens first: read the archive's own recorded
     devices and say the sentence. Everything downstream of the load is
     developer-box-and-pod-only (pgw has no GPU CI lane), and this is the line.
+
+    The loaded program is then restated onto its own GRAPH's device (tcg#64).
+    That is a no-op for a weights-free program, which is fake all the way
+    through and therefore uniform already. It matters for the one case that is
+    not: a value-bearing buffer a GPU-less derive could not move stayed real
+    on cpu under a cuda graph, and this -- running where the device exists --
+    is where it lands.
     """
 
     import torch
@@ -187,7 +229,28 @@ def load_exported_program(path: Any) -> Any:
             f"CPU-side check must read the recorded placement "
             f"(exported_program_devices) instead of loading the blob."
         )
-    return torch.export.load(str(path))
+    program = torch.export.load(str(path))
+    graph_device = program_graph_device(program)
+    if graph_device is not None:
+        restate_program(program, graph_device)
+    return program
+
+
+def program_graph_device(program: Any) -> Any:
+    """The device an exported program's GRAPH is stated on, or ``None``.
+
+    The graph's device -- not the state dict's -- is the one that entered
+    ``cg-graph-v1`` and the one AOTI compiles for.
+    """
+
+    import torch
+
+    for node in program.graph_module.graph.nodes:
+        value = node.meta.get("val")
+        for item in value if isinstance(value, (list, tuple)) else [value]:
+            if isinstance(item, torch.Tensor):
+                return item.device
+    return None
 
 
 def _numpy_dtype(dtype: Any) -> Any:
@@ -270,23 +333,23 @@ def _tensor_attributes(submodule: Any) -> list[tuple[str, Any]]:
 
 
 def virtualize_parameters(module: Any, session: HollowSession, *, dtype: Any = None) -> None:
-    """Move every tensor of ``module`` onto the session's ONE trace device.
+    """Move every tensor of ``module`` onto the session's DRIVE device.
 
     ``dtype`` restates the author's ``torch_dtype=`` ask: floating parameters
     take it, integer parameters keep their own -- exactly what a real
     ``from_pretrained(torch_dtype=...)`` load produces.
 
     Parameters are always faked (a 10 GiB denoiser must cost nothing).
-    Buffers and lifted constants are faked only when the session's device
-    cannot hold a real tensor here -- and then their REAL values are captured
-    on the session, because the literal digest reads them.
+    Buffers and lifted constants stay REAL -- the drive device is a device
+    that exists, so there is never a reason to destroy a value here. The
+    stated device is applied afterwards, to the exported program
+    (:func:`restate_program`), which is the only thing that carries it.
     """
 
     import torch
 
-    device = session.device
-    real_ok = session.materializes_real_tensors
-    for prefix, submodule in module.named_modules():
+    device = session.drive_device
+    for _prefix, submodule in module.named_modules():
         for name, param in list(submodule._parameters.items()):
             if param is None:
                 continue
@@ -312,37 +375,123 @@ def virtualize_parameters(module: Any, session: HollowSession, *, dtype: Any = N
                     f"for the trace's literal digest. A module that moves its "
                     f"buffers to meta cannot be derived hollow."
                 )
-            submodule._buffers[name] = _rehome(
-                buffer, session, f"{prefix}.{name}" if prefix else name, real_ok
-            )
+            submodule._buffers[name] = _rehome(buffer, device)
         for name, value in _tensor_attributes(submodule):
-            setattr(
-                submodule,
-                name,
-                _rehome(value, session, f"{prefix}.{name}" if prefix else name, real_ok),
-            )
+            setattr(submodule, name, _rehome(value, device))
 
 
-def _rehome(value: Any, session: HollowSession, fqn: str, real_ok: bool) -> Any:
-    """Put one value-bearing tensor on the trace device, keeping its value.
+def _rehome(value: Any, device: str) -> Any:
+    """Put one value-bearing tensor on the drive device, keeping its value.
 
-    Real move when the device can hold one; otherwise a fake stand-in plus a
-    recorded real value, so ``restore_constants`` can put the truth back
-    before the program is serialized. A tensor already on the device is
-    untouched -- the cpu-trace path is bit-for-bit what it was.
+    A real move, always: the drive device can hold a real tensor by
+    construction. A tensor already there is untouched.
     """
 
-    if value.device.type == session.device_type:
+    if value.device.type == str(device).split(":", 1)[0]:
         return value
-    if real_ok:
-        return value.to(session.device)
-    import torch
+    return value.to(device)
 
-    session.real_constants[fqn] = value.detach().cpu()
-    with session.fake_mode:
-        return torch.empty(
-            tuple(int(d) for d in value.shape), dtype=value.dtype, device=session.device
-        )
+
+def restate_program(program: Any, device: Any) -> tuple[str, ...]:
+    """Restate an ``ExportedProgram``'s device, in place. Returns what stayed.
+
+    The whole device content of an exported program is METADATA: the fake
+    tensor in each node's ``meta['val']``, the ``device=`` a factory node
+    burnt in, and the placement of the state dict and the constant table.
+    None of it is computation, which is why this runs on a host that has no
+    such device at all -- and why the graph a GPU-less box derives is the same
+    graph, key for key, that a GPU box derives. Measured line-for-line against
+    a native fake-cuda export.
+
+    A weights-free program is FAKE all the way through, so the usual case
+    moves everything and returns ``()``. A tensor carrying a real VALUE (a
+    computed buffer, a lifted constant) can only be moved where a real tensor
+    can live: on a host without the device it stays where it is and its name
+    is returned. That is deliberate -- a value is the one thing a restate must
+    never destroy, the literal digest reads it (``.cpu()``, so the placement
+    does not change the key), and the mint re-homes it on a machine that has
+    the device (:func:`load_exported_program`).
+    """
+
+    import torch
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    # The restate runs INSIDE the session, so `OneTraceDevice` is live -- and
+    # `torch.device` construction goes through `__torch_function__`, so
+    # `torch.device("cuda", 0)` evaluated in here comes back `cpu:0`. The shim
+    # is doing its job (redirect every device ask to the drive device); it
+    # simply cannot tell the session's own repair from author code asking for
+    # a device it must not get. Measured, and it fails SILENTLY: every move
+    # became a no-op and the derive emitted cpu-stamped graphs while reporting
+    # a cuda trace. So the whole restate is the one thing in the session that
+    # opts out of the session's own redirection.
+    with torch._C.DisableTorchFunction():
+        return _restate(program, device, torch, FakeTensor)
+
+
+def _restate(program: Any, device: Any, torch: Any, FakeTensor: Any) -> tuple[str, ...]:
+    target = torch.device(device)
+    if target.type != "cpu" and target.index is None:
+        # torch normalizes a device-less `cuda` ask to `cuda:0` on the tensors
+        # it creates, so a restate that left it un-indexed would produce a
+        # `placement` of ('cuda',) where a native trace says ('cuda:0',).
+        target = torch.device(target.type, 0)
+    stranded: list[str] = []
+    # A non-strict export does not copy the module's parameters: the same
+    # FakeTensor object is the module's parameter, the program's state-dict
+    # entry AND a placeholder's `meta['val']`. So re-homing by assigning
+    # `fake_device` re-homes the LIVE MODULE, and the next observed call of the
+    # same target then exports cuda parameters against cpu synthesized inputs
+    # -- `FakeTensorDeviceMismatchError: cpu and cuda:0`, raised from a module
+    # nobody moved. Substituting a fresh fake tensor keeps the restate a
+    # property of the PROGRAM, which is what it is supposed to be. The memo
+    # preserves aliasing: one input object still maps to one output object, so
+    # a program that shared a tensor across nodes still shares it.
+    moved: dict[int, Any] = {}
+
+    def move(value: Any, fqn: str = "") -> Any:
+        if not isinstance(value, torch.Tensor) or value.device.type == target.type:
+            return value
+        if isinstance(value, FakeTensor):
+            known = moved.get(id(value))
+            if known is None:
+                with value.fake_mode:
+                    known = torch.empty_strided(
+                        value.shape, value.stride(), dtype=value.dtype, device=target
+                    )
+                known.requires_grad_(value.requires_grad)
+                if getattr(value, "_is_param", False):
+                    known._is_param = True
+                moved[id(value)] = known
+            return known
+        try:
+            return value.to(target)
+        except (RuntimeError, AssertionError, AttributeError):
+            stranded.append(fqn or f"<{value.device.type} node value>")
+            return value
+
+    for holder in ("_state_dict", "_constants"):
+        table = getattr(program, holder, None)
+        if not isinstance(table, dict):
+            continue
+        for name, value in list(table.items()):
+            table[name] = move(value, name)
+
+    for graph_module in program.graph_module.modules():
+        if not isinstance(graph_module, torch.fx.GraphModule):
+            continue
+        for node in graph_module.graph.nodes:
+            if "device" in node.kwargs:
+                node.kwargs = {**node.kwargs, "device": target}
+            if node.op == "call_function" and node.target is torch.ops.aten.to.device:
+                arguments = list(node.args)
+                arguments[1] = target
+                node.args = tuple(arguments)
+            for key in ("val", "example_value"):
+                if key in node.meta:
+                    node.meta[key] = torch.utils._pytree.tree_map(move, node.meta[key])
+
+    return tuple(sorted(set(stranded)))
 
 
 def _hollow_diffusers(session: HollowSession) -> Any:
@@ -655,11 +804,12 @@ def hollow_session(device: str = DEFAULT_TRACE_DEVICE) -> Iterator[HollowSession
     too -- the shims never touch non-fake tensors and ``torch.export``
     re-enters the session's own mode for hollow modules.
 
-    ``device`` is the trace DEVICE CLASS, and it is a real decision, not a
-    formality: it is stamped into every node's meta and therefore into the
-    graph's identity, and a mint for a different class refuses by name
-    (``RuntimeCompatibility.key``). It needs no silicon -- a fake-cuda trace
-    is measured working with ``torch.cuda.is_available() == False``.
+    ``device`` is the STATED trace device class, and it is a real decision,
+    not a formality: it is stamped into every node's meta and therefore into
+    the graph's identity, and a mint for a different class refuses by name
+    (``RuntimeCompatibility.key``). It needs no silicon (tcg#64): the drive
+    runs on ``session.drive_device`` -- a device that exists -- and each
+    exported program is restated onto the stated device before it is hashed.
     """
 
     from torch._subclasses.fake_tensor import FakeTensorMode
@@ -669,8 +819,8 @@ def hollow_session(device: str = DEFAULT_TRACE_DEVICE) -> Iterator[HollowSession
     )
     with (
         _loader_interception(session),
-        _hollow_module_moves(session.device),
-        observation_shims(session.device),
+        _hollow_module_moves(session.drive_device),
+        observation_shims(session.drive_device),
     ):
         yield session
 
@@ -684,5 +834,7 @@ __all__ = [
     "exported_program_devices",
     "load_exported_program",
     "observation_shims",
+    "program_graph_device",
+    "restate_program",
     "virtualize_parameters",
 ]

--- a/src/gen_worker/cli/endpoint_lock.py
+++ b/src/gen_worker/cli/endpoint_lock.py
@@ -87,9 +87,11 @@ class DeriveBlock:
     document_digest: str
     #: The derive document, verbatim ASCII JSON.
     document: str
-    #: ``cuda`` or ``cpu`` — the device CLASS traced, `derive._trace_device`'s
-    #: answer. A cpu-traced graph is a DIFFERENT graph specialization, not a degraded
-    #: cuda one, so it is stated rather than assumed by every reader.
+    #: The device CLASS traced, `derive._trace_device`'s answer (``cuda``
+    #: since tcg#64, on any host). A trace on another class is a DIFFERENT
+    #: graph specialization, not a degraded one, so it is stated rather than
+    #: assumed by every reader — which is also what retires a lock committed
+    #: before the class stopped depending on the deriving box.
     trace_device: str
     #: The endpoint identity the derive stamped (``module:Class``).
     endpoint: str

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -378,11 +378,7 @@ def _trace(
         _say(f"error: failed to import {config.main!r}: {exc}")
         return None
 
-    _say(
-        f"lock: trace device is {device}-class"
-        + ("" if device == "cuda" else " — CPU-class graphs are NOT servable on "
-                                       "a GPU; a cuda mint refuses by name")
-    )
+    _say(f"lock: trace device is {device}-class")
     from ..env_identity import lockfile_beside
 
     started = time.monotonic()

--- a/src/gen_worker/cli/workspace.py
+++ b/src/gen_worker/cli/workspace.py
@@ -65,18 +65,15 @@ def graph_cas_root() -> Path:
 
 
 def trace_device() -> str:
-    """The device CLASS this host traces on. ``derive._trace_device`` IS the law.
+    """The device CLASS a trace states. ``derive._trace_device`` IS the law.
 
-    Imported rather than reimplemented: the CLI deciding "cuda" while the derive
-    decides "cpu" would write a lock whose ``trace_device`` disagrees with the
-    document inside it, and the skip check would then hit forever or miss
+    Imported rather than reimplemented: the CLI answering this differently
+    from the derive would write a lock whose ``trace_device`` disagrees with
+    the document inside it, and the skip check would then hit forever or miss
     forever. There is one answer to this question and it lives in the derive.
 
-    Note for this box specifically: the answer comes from
-    ``torch.cuda.is_available()``, which uses the CUDA driver API. NVML is
-    broken here (userspace 595.84 against a 570.211.01 kernel module), so
-    ``nvidia-smi`` and ``pynvml`` both report no GPU while the device works
-    perfectly. Never health-check the GPU through NVML in this codebase.
+    Since tcg#64 the answer does not depend on the host at all -- `lock` is an
+    author-time command and a trace needs no GPU.
     """
     from ..release.derive import _trace_device
 

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -59,7 +59,6 @@ from __future__ import annotations
 import enum
 import hashlib
 import inspect
-import logging
 import itertools
 import json
 import types
@@ -86,8 +85,6 @@ from .trace_context import (
     TraceLoadContext,
     TraceRequestContext,
 )
-
-_LOG = logging.getLogger("gen_worker.release.derive")
 
 #: A hollow derive's REAL tensors are config-computed buffers and lifted
 #: constants -- KB to MB. Anything past this is a checkpoint weight that
@@ -220,42 +217,29 @@ def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
 
 
 def _trace_device() -> str:
-    """The DEVICE CLASS this derive traces on -- and it is a real choice.
+    """The DEVICE CLASS this derive traces on. Always ``cuda``, GPU or not.
 
-    pgw#1458: a graph's device is established at TRACE time and cannot be
-    re-homed downstream, so a cpu-traced graph cannot be cuda-minted. torchcg
-    records the class in the declaration and refuses the mismatch by name
-    (`RuntimeCompatibility.key`), which is the whole point -- but the refusal
-    is only useful if the derive states the class DELIBERATELY rather than
-    inheriting a default that happens to be wrong for the host.
+    pgw#1458 stands: a graph's device is established at TRACE time and cannot
+    be re-homed downstream, so a cpu-traced graph cannot be cuda-minted, and
+    torchcg refuses the mismatch by name (`RuntimeCompatibility.key`). What
+    is gone (Paul, 2026-08-19 "A NORMAL TRACE MUST JUST WORK"; tcg#64) is the
+    HOST answering the question. It never should have: the fleet compiles
+    cuda graphs, so a derive that emits cpu-class ones because the box it ran
+    on had no GPU produces a document nothing can serve, and hands the author
+    a device taxonomy to reason about for a device the trace never uses.
 
-    A fake-cuda trace needs no silicon in principle, and torchcg proves that
-    for plain modules. It does NOT yet hold for a full diffusers pipeline on a
-    GPU-less box: `encode_prompt` moves real token ids to the execution device
-    and the fake-tensor path runs a real cuda kernel for them
-    (`No CUDA GPUs are available`). Until that is closed, this states the
-    truth about the host instead of failing at the first pipeline call.
+    A trace needs no silicon. torchcg's session drives the author's code on a
+    device that EXISTS -- real sigmas, real token ids, real `encode_prompt` --
+    and restates each exported program onto the stated device before it is
+    hashed. Measured: a CPU-only sd1.5 derive reproduces the graph keys of the
+    GPU-traced one, key for key.
 
-    So: cuda when there IS a device, cpu otherwise, and the fallback SAYS what
-    it costs. A cpu-derived document is not a degraded cuda one -- it is a
-    different graph specialization, and a cuda mint of it refuses by name rather than
-    serving something wrong.
+    This is what makes `gen-worker lock` an AUTHOR-time command (2026-08-19
+    "the full artifact axis and who runs what"): endpoint.lock is committed to
+    git, produced once per version on whatever machine the author has.
     """
 
-    try:
-        import torch
-    except ImportError:  # pragma: no cover - torch is the derive's premise
-        return "cpu"
-    if torch.cuda.is_available():
-        return "cuda"
-    _LOG.warning(
-        "derive: no CUDA device is visible, so this derive traces on CPU and "
-        "produces CPU-CLASS graphs. They are a different graph specialization from the "
-        "cuda graphs a GPU pod serves — a cuda mint of this document refuses "
-        "by name (pgw#1458), it does not silently serve. Derive on a "
-        "CUDA-bearing host to publish servable graphs."
-    )
-    return "cpu"
+    return "cuda"
 
 
 def _assert_weights_free(torch: Any, program: Any) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=3d958bf9628f54f400ca6d1e570a6f8d4b066f4e" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=3d958bf9628f54f400ca6d1e570a6f8d4b066f4e#3d958bf9628f54f400ca6d1e570a6f8d4b066f4e" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6#0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
**DRAFT — blocked on #1055 (pgw#1489), and the reason is mechanical, not a review question.**

Consumer half of torchcg **tcg#64** (cozy-creator/torchcg#60, merged `00748eb`), which made a GPU-less cuda trace actually work. This PR needs `_vendor/torchcg` moved to `00748eb` for that to take effect — and `00748eb` sits on top of `3d958bf` (torchcg's pgw#1489 half), which deletes `closure_hash` / `installed_closure` and renames the document's `closure` to `stack`. pgw's `serving/{hub_store,host,serve_adoption,__main__}.py` still import the deleted names, and migrating them **is** #1055. So: #1055 lands, then this rebases and adds one `task vendor -- torchcg 00748eb` commit, then merges. Landing this without the re-vendor would state `cuda` against a vendored session that still forces the stated device onto the drive — a loud failure on a GPU-less box instead of a useless cpu-class document.

## The change

`_trace_device()` asked the HOST what device class to trace. It never should have: the fleet compiles cuda graphs, so a derive on a box without a GPU emitted cpu-class documents nothing can serve — and handed the author a device taxonomy to reason about for a device the trace never uses. Deleted, with its warning and the CLI line that repeated it.

## Who this is for — bigger than it was filed as

Filed against th#2162's CPU-only builder. By the time it landed, the 2026-08-19 ruling "the full artifact axis and who runs what" had made `endpoint.lock` **author-time and committed to git**, produced "once per version, no GPU needed". So this is the enabling mechanism for the whole author story — any author, on any machine, runs `gen-worker lock`. th#2162's consequence dissolves as a side effect; the bake step itself is not built here.

## Red / green — executed, both `CUDA_VISIBLE_DEVICES=""`, same endpoints and checkpoints

| | at master | after |
|---|---|---|
| `lock: trace device is` | `cpu-class — CPU-class graphs are NOT servable on a GPU; a cuda mint refuses by name` | `cuda-class`, no warning |
| sd1.5 | 14 cpu-class specializations, 367.6 s | 14 cuda-class, 382.7 s |
| sd1.5 keys vs the GPU-traced `sd15.lock` | all 14 differ | **all 14 identical** |
| sdxl keys vs the GPU-traced `sdxl.lock` | — | **all 18 identical**, 1327.2 s |
| blobs | cpu-stamped | 32/32 cuda-stamped, 0 bytes of weight payload |

anima locks green too (cuda-class), but contributes no graph evidence: it declares `lanes=()` and derives eager-permanent, so it never drives.

## What stayed

`endpoint_lock.derive_is_reusable`'s device check — the internal assert the ruling asks to keep, and what retires a lock committed before the class stopped depending on the deriving box.