### PR TITLE
pgw#1498: GGUF as torch weights — dequant-per-forward, LoRA attached, blocks straight from the CAS

### DIFF
--- a/src/gen_worker/models/adapter_fidelity.py
+++ b/src/gen_worker/models/adapter_fidelity.py
@@ -253,6 +253,12 @@ def _has_weight_scale(mod: Any) -> bool:
     return scale is not None and hasattr(scale, "numel")
 
 
+def _is_gguf_leaf(mod: Any) -> bool:
+    from .gguf_torch import LEAF_MARKER
+
+    return bool(getattr(type(mod), LEAF_MARKER, False))
+
+
 def grid_of_module(mod: Any, *, path: str) -> TargetGrid:
     """The REAL grid this module's arithmetic lands on — read off the module,
     never supplied by the caller. A detector that diffs in the SOURCE dtype
@@ -265,6 +271,18 @@ def grid_of_module(mod: Any, *, path: str) -> TargetGrid:
     weight = getattr(mod, "weight", None)
     if weight is None:
         raise ValueError(f"module {type(mod).__name__} carries no weight to fuse into")
+    if _is_gguf_leaf(mod):
+        # pgw#1498. A GGML leaf's `weight` is BLOCK BYTES (uint8), not the
+        # weight — `_dtype_name` would answer "uint8" and hand back a grid that
+        # means nothing, which is the worst outcome available here: a fuse
+        # gated against a fiction. There is no fuse path for this lane at all.
+        # Adapters attach to the leaf and are applied to the dequantized copy
+        # inside forward (`gguf_torch.attach_lora`), which never writes to the
+        # grid and is therefore not what this refusal is about.
+        raise ValueError(
+            f"module {type(mod).__name__} holds GGML block bytes: there is no "
+            "fuse into a quantized grid to gate — attach the adapter instead "
+            "(gguf_torch.attach_lora), which applies it post-dequant")
     if weight.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         gran = _GRID_ROW if _has_weight_scale(mod) else _GRID_NONE
         return TargetGrid(PATH_FUSE, _dtype_name(weight.dtype), gran)
@@ -638,6 +656,16 @@ def gate_fuse(
     this is the enforcement, and it is per-adapter evidence rather
     than a blanket dtype ban, so a genuinely fuse-safe adapter (rel |D|/|W|
     well above the grid's half-ulp) is not refused for its neighbours' sake.
+
+    The ruling's premise is that a MERGE damages the quantization: the grid's
+    scales were fit to the base weights, so a delta written into them is
+    silently rounded, and on a small quant rounded away. That premise has no
+    referent where there is no merge. The GGML lane (pgw#1498) never writes to
+    the grid — the block bytes are read-only and byte-identical before and
+    after, and the adapter is added to a dense copy that lives for one op — so
+    it is not gated here and this refusal must not be extended to cover it.
+    ``grid_of_module`` refuses such a module outright rather than inventing a
+    "uint8 grid" to gate against.
     """
     return gate(evaluate_fuse(mapped, modules, ref=ref, grid=grid),
                 request_id=request_id)

--- a/src/gen_worker/models/gguf_dequant.py
+++ b/src/gen_worker/models/gguf_dequant.py
@@ -1,0 +1,407 @@
+"""GGML block-format dequantization as vectorized torch ops.
+
+A GGML quantized tensor is a flat byte array cut into fixed-size BLOCKS. Each
+block packs a scale (and for some types a min, or a second level of 6-bit
+sub-scales) next to the packed weight nibbles/crumbs. Dequantizing is pure bit
+arithmetic: split the block into its fields, shift, mask, scale. No kernel, no
+vendor extension — every function here is a handful of batched torch ops that
+run identically on CUDA, ROCm, MPS and CPU.
+
+This is the half of the GGUF lane that lets quantized weights STAY quantized in
+memory: :mod:`gen_worker.models.gguf_torch` holds the block bytes on the device
+and calls in here once per forward, per layer, to materialize the weight for
+one matmul and then drop it. Weight residency is the quantized size (2-4x under
+bf16); the dequant is memory-bound and costs ~10-20% of step time.
+
+Ported from city96's ComfyUI-GGUF ``dequant.py`` (Apache-2.0), whose numerics
+are the de-facto reference for the diffusion GGUF ecosystem. The 13 types below
+are the ones with a vectorized form; IQ1/IQ2/IQ3 (importance-matrix 2-3 bit)
+have no batched decode and are deliberately NOT supported — a per-block numpy
+fallback would be slower than not serving the rung at all, so an unsupported
+qtype raises instead of silently degrading.
+
+Correctness is pinned to the ``gguf`` package's own numpy implementation:
+``tests/test_gguf_dequant_pgw1498.py`` asserts BIT-EXACT equality against
+``gguf.quants.dequantize`` over random block bytes for every type here.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, Dict, Tuple
+
+#: K-quant super-block: 256 weights, 8 or 16 sub-blocks with their own scales.
+QK_K = 256
+
+#: Bytes holding a K-quant super-block's packed 6-bit scale/min pairs.
+K_SCALE_SIZE = 12
+
+#: IQ4 codebook. The 4-bit index selects one of these 16 int8 levels, which are
+#: spaced non-linearly to match a normal-ish weight distribution.
+_IQ4_KVALUES: Tuple[int, ...] = (
+    -127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113,
+)
+
+#: Types torch holds natively — no block decode, just a dtype view.
+_PASSTHROUGH_NAMES: Tuple[str, ...] = ("F32", "F16")
+
+
+def _shifts(values: Tuple[int, ...], shape: Tuple[int, ...], device: Any) -> Any:
+    import torch
+
+    return torch.tensor(values, device=device, dtype=torch.uint8).reshape(shape)
+
+
+def _split(blocks: Any, *widths: int) -> Tuple[Any, ...]:
+    """Cut each block row into ``widths`` byte fields plus the remainder."""
+    import torch
+
+    dims = list(widths) + [blocks.shape[1] - sum(widths)]
+    return tuple(torch.split(blocks, dims, dim=1))
+
+
+def _to_uint32(x: Any) -> Any:
+    """Little-endian u32 from 4 uint8 columns (torch has no uint32)."""
+    import torch
+
+    x = x.view(torch.uint8).to(torch.int32)
+    return (x[:, 0] | x[:, 1] << 8 | x[:, 2] << 16 | x[:, 3] << 24).unsqueeze(1)
+
+
+def _to_uint16(x: Any) -> Any:
+    import torch
+
+    x = x.view(torch.uint8).to(torch.int32)
+    return (x[:, 0] | x[:, 1] << 8).unsqueeze(1)
+
+
+# --- full-precision -------------------------------------------------------
+
+def _blocks_bf16(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    return (blocks.view(torch.int16).to(torch.int32) << 16).view(torch.float32)
+
+
+# --- legacy quants (32-weight blocks) -------------------------------------
+
+def _blocks_q8_0(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    d, x = _split(blocks, 2)
+    return d.view(torch.float16).to(dtype) * x.view(torch.int8)
+
+
+def _blocks_q5_1(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    d, m, qh, qs = _split(blocks, 2, 2, 4)
+    d = d.view(torch.float16).to(dtype)
+    m = m.view(torch.float16).to(dtype)
+
+    qh = _to_uint32(qh).reshape((n, 1)) >> torch.arange(
+        32, device=d.device, dtype=torch.int32).reshape(1, 32)
+    ql = qs.reshape((n, -1, 1, block_size // 2)) >> _shifts((0, 4), (1, 1, 2, 1), d.device)
+    qh = (qh & 1).to(torch.uint8)
+    ql = (ql & 0x0F).reshape((n, -1))
+    return d * (ql | (qh << 4)) + m
+
+
+def _blocks_q5_0(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    d, qh, qs = _split(blocks, 2, 4)
+    d = d.view(torch.float16).to(dtype)
+
+    qh = _to_uint32(qh).reshape(n, 1) >> torch.arange(
+        32, device=d.device, dtype=torch.int32).reshape(1, 32)
+    ql = qs.reshape(n, -1, 1, block_size // 2) >> _shifts((0, 4), (1, 1, 2, 1), d.device)
+    qh = (qh & 1).to(torch.uint8)
+    ql = (ql & 0x0F).reshape(n, -1)
+    return d * ((ql | (qh << 4)).to(torch.int8) - 16)
+
+
+def _blocks_q4_1(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    d, m, qs = _split(blocks, 2, 2)
+    d = d.view(torch.float16).to(dtype)
+    m = m.view(torch.float16).to(dtype)
+
+    qs = qs.reshape((n, -1, 1, block_size // 2)) >> _shifts((0, 4), (1, 1, 2, 1), d.device)
+    return d * (qs & 0x0F).reshape(n, -1) + m
+
+
+def _blocks_q4_0(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    d, qs = _split(blocks, 2)
+    d = d.view(torch.float16).to(dtype)
+
+    qs = qs.reshape((n, -1, 1, block_size // 2)) >> _shifts((0, 4), (1, 1, 2, 1), d.device)
+    return d * ((qs & 0x0F).reshape((n, -1)).to(torch.int8) - 8)
+
+
+# --- K quants (256-weight super-blocks) -----------------------------------
+
+def _scale_min(scales: Any) -> Tuple[Any, Any]:
+    """Unpack a K-quant's 12 scale bytes into 8 six-bit scales and 8 mins."""
+    import torch
+
+    n = scales.shape[0]
+    scales = scales.view(torch.uint8).reshape((n, 3, 4))
+    d, m, m_d = torch.split(scales, 1, dim=-2)
+    sc = torch.cat([d & 0x3F, (m_d & 0x0F) | ((d >> 2) & 0x30)], dim=-1)
+    mn = torch.cat([m & 0x3F, (m_d >> 4) | ((m >> 2) & 0x30)], dim=-1)
+    return sc.reshape((n, 8)), mn.reshape((n, 8))
+
+
+def _blocks_q6_k(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    ql, qh, scales, d = _split(blocks, QK_K // 2, QK_K // 4, QK_K // 16)
+
+    scales = scales.view(torch.int8).to(dtype)
+    d = d.view(torch.float16).to(dtype)
+    d = (d * scales).reshape((n, QK_K // 16, 1))
+
+    ql = ql.reshape((n, -1, 1, 64)) >> _shifts((0, 4), (1, 1, 2, 1), d.device)
+    ql = (ql & 0x0F).reshape((n, -1, 32))
+    qh = qh.reshape((n, -1, 1, 32)) >> _shifts((0, 2, 4, 6), (1, 1, 4, 1), d.device)
+    qh = (qh & 0x03).reshape((n, -1, 32))
+    q = ((ql | (qh << 4)).to(torch.int8) - 32).reshape((n, QK_K // 16, -1))
+    return (d * q).reshape((n, QK_K))
+
+
+def _blocks_q5_k(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    d, dmin, scales, qh, qs = _split(blocks, 2, 2, K_SCALE_SIZE, QK_K // 8)
+    d = d.view(torch.float16).to(dtype)
+    dmin = dmin.view(torch.float16).to(dtype)
+
+    sc, mn = _scale_min(scales)
+    d = (d * sc).reshape((n, -1, 1))
+    dm = (dmin * mn).reshape((n, -1, 1))
+
+    ql = qs.reshape((n, -1, 1, 32)) >> _shifts((0, 4), (1, 1, 2, 1), d.device)
+    qh = qh.reshape((n, -1, 1, 32)) >> _shifts(tuple(range(8)), (1, 1, 8, 1), d.device)
+    ql = (ql & 0x0F).reshape((n, -1, 32))
+    qh = (qh & 0x01).reshape((n, -1, 32))
+    return (d * (ql | (qh << 4)) - dm).reshape((n, QK_K))
+
+
+def _blocks_q4_k(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    d, dmin, scales, qs = _split(blocks, 2, 2, K_SCALE_SIZE)
+    d = d.view(torch.float16).to(dtype)
+    dmin = dmin.view(torch.float16).to(dtype)
+
+    sc, mn = _scale_min(scales)
+    d = (d * sc).reshape((n, -1, 1))
+    dm = (dmin * mn).reshape((n, -1, 1))
+
+    qs = qs.reshape((n, -1, 1, 32)) >> _shifts((0, 4), (1, 1, 2, 1), d.device)
+    qs = (qs & 0x0F).reshape((n, -1, 32))
+    return (d * qs - dm).reshape((n, QK_K))
+
+
+def _blocks_q3_k(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    hmask, qs, scales, d = _split(blocks, QK_K // 8, QK_K // 4, 12)
+    d = d.view(torch.float16).to(dtype)
+
+    lscales, hscales = scales[:, :8], scales[:, 8:]
+    lscales = (lscales.reshape((n, 1, 8))
+               >> _shifts((0, 4), (1, 2, 1), d.device)).reshape((n, 16))
+    hscales = (hscales.reshape((n, 1, 4))
+               >> _shifts((0, 2, 4, 6), (1, 4, 1), d.device)).reshape((n, 16))
+    scales = (lscales & 0x0F) | ((hscales & 0x03) << 4)
+    dl = (d * (scales.to(torch.int8) - 32)).reshape((n, 16, 1))
+
+    ql = qs.reshape((n, -1, 1, 32)) >> _shifts((0, 2, 4, 6), (1, 1, 4, 1), d.device)
+    qh = hmask.reshape((n, -1, 1, 32)) >> _shifts(tuple(range(8)), (1, 1, 8, 1), d.device)
+    ql = ql.reshape((n, 16, QK_K // 16)) & 3
+    qh = (qh.reshape((n, 16, QK_K // 16)) & 1) ^ 1
+    q = ql.to(torch.int8) - (qh << 2).to(torch.int8)
+    return (dl * q).reshape((n, QK_K))
+
+
+def _blocks_q2_k(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    n = blocks.shape[0]
+    scales, qs, d, dmin = _split(blocks, QK_K // 16, QK_K // 4, 2)
+    import torch
+
+    d = d.view(torch.float16).to(dtype)
+    dmin = dmin.view(torch.float16).to(dtype)
+
+    dl = (d * (scales & 0x0F)).reshape((n, QK_K // 16, 1))
+    ml = (dmin * (scales >> 4)).reshape((n, QK_K // 16, 1))
+
+    qs = (qs.reshape((n, -1, 1, 32))
+          >> _shifts((0, 2, 4, 6), (1, 1, 4, 1), d.device)) & 3
+    qs = qs.reshape((n, QK_K // 16, 16))
+    return (dl * qs - ml).reshape((n, -1))
+
+
+# --- IQ4 (codebook) -------------------------------------------------------
+
+def _kvalues(like: Any) -> Any:
+    import torch
+
+    return torch.tensor(_IQ4_KVALUES, device=like.device, dtype=torch.int8)
+
+
+def _blocks_iq4_nl(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    d, qs = _split(blocks, 2)
+    d = d.view(torch.float16).to(dtype)
+
+    qs = qs.reshape((n, -1, 1, block_size // 2)) >> _shifts((0, 4), (1, 1, 2, 1), d.device)
+    qs = (qs & 0x0F).reshape((n, -1, 1)).to(torch.int64)
+    table = _kvalues(qs).expand(*qs.shape[:-1], 16)
+    qs = torch.gather(table, dim=-1, index=qs).reshape((n, -1))
+    return d * qs
+
+
+def _blocks_iq4_xs(blocks: Any, block_size: int, type_size: int, dtype: Any) -> Any:
+    import torch
+
+    n = blocks.shape[0]
+    d, scales_h, scales_l, qs = _split(blocks, 2, 2, QK_K // 64)
+    d = d.view(torch.float16).to(dtype)
+    scales_h = _to_uint16(scales_h)
+
+    shift_a = _shifts((0, 4), (1, 1, 2), d.device)
+    shift_b = _shifts(tuple(2 * i for i in range(QK_K // 32)), (1, -1, 1), d.device)
+
+    scales_l = (scales_l.reshape((n, -1, 1)) >> shift_a).reshape((n, -1)) & 0x0F
+    scales_h = (scales_h.reshape((n, -1, 1)) >> shift_b).reshape(
+        (n, -1)).to(torch.uint8) & 0x03
+    scales = (scales_l | (scales_h << 4)).to(torch.int8) - 32
+    dl = (d * scales.to(dtype)).reshape((n, -1, 1))
+
+    qs = qs.reshape((n, -1, 1, 16)) >> shift_a.reshape((1, 1, 2, 1))
+    qs = qs.reshape((n, -1, 32, 1)) & 0x0F
+    table = _kvalues(qs).expand(*qs.shape[:-1], 16)
+    qs = torch.gather(table, dim=-1, index=qs.to(torch.int64)).reshape((n, -1, 32))
+    return (dl * qs).reshape((n, -1))
+
+
+_Kernel = Callable[[Any, int, int, Any], Any]
+
+#: qtype NAME -> block decoder. Keyed by name so the table needs no ``gguf``
+#: import to exist; :func:`_kernels` resolves the names to the wire ids once.
+_BY_NAME: Dict[str, _Kernel] = {
+    "BF16": _blocks_bf16,
+    "Q8_0": _blocks_q8_0,
+    "Q5_1": _blocks_q5_1,
+    "Q5_0": _blocks_q5_0,
+    "Q4_1": _blocks_q4_1,
+    "Q4_0": _blocks_q4_0,
+    "Q6_K": _blocks_q6_k,
+    "Q5_K": _blocks_q5_k,
+    "Q4_K": _blocks_q4_k,
+    "Q3_K": _blocks_q3_k,
+    "Q2_K": _blocks_q2_k,
+    "IQ4_NL": _blocks_iq4_nl,
+    "IQ4_XS": _blocks_iq4_xs,
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _kernels() -> Dict[int, _Kernel]:
+    import gguf
+
+    out: Dict[int, _Kernel] = {}
+    for name, fn in _BY_NAME.items():
+        qtype = getattr(gguf.GGMLQuantizationType, name, None)
+        if qtype is not None:
+            out[int(qtype)] = fn
+    return out
+
+
+@functools.lru_cache(maxsize=1)
+def passthrough_qtypes() -> frozenset[int]:
+    """Types a torch tensor already holds natively (F32, F16)."""
+    import gguf
+
+    return frozenset(
+        int(getattr(gguf.GGMLQuantizationType, n)) for n in _PASSTHROUGH_NAMES)
+
+
+def supported_qtypes() -> frozenset[int]:
+    """Every GGML type this lane can serve, block-decoded or native."""
+    return frozenset(_kernels()) | passthrough_qtypes()
+
+
+def is_supported(qtype: int) -> bool:
+    return int(qtype) in supported_qtypes()
+
+
+def qtype_name(qtype: int) -> str:
+    import gguf
+
+    try:
+        return str(gguf.GGMLQuantizationType(int(qtype)).name)
+    except ValueError:
+        return f"<ggml type {int(qtype)}>"
+
+
+def block_geometry(qtype: int) -> Tuple[int, int]:
+    """``(weights per block, bytes per block)`` for one GGML type."""
+    import gguf
+
+    block_size, type_size = gguf.GGML_QUANT_SIZES[gguf.GGMLQuantizationType(int(qtype))]
+    return int(block_size), int(type_size)
+
+
+def dequantize(data: Any, qtype: int, shape: Any, *, dtype: Any = None) -> Any:
+    """Decode packed GGML ``data`` into a dense tensor of logical ``shape``.
+
+    ``data`` is the raw block bytes exactly as they sit in the store — any
+    dtype whose bytes are the block stream; it is reinterpreted as uint8. The
+    whole tensor decodes in ONE batched pass over ``(n_blocks, type_size)``:
+    there is no python loop over blocks anywhere in this module.
+    """
+    import torch
+
+    qtype = int(qtype)
+    if qtype in passthrough_qtypes():
+        return data.reshape(shape).to(dtype) if dtype is not None else data.reshape(shape)
+
+    kernel = _kernels().get(qtype)
+    if kernel is None:
+        raise NotImplementedError(
+            f"gguf-torch: no vectorized dequant for {qtype_name(qtype)}. "
+            "IQ1/IQ2/IQ3 have no batched decode and are not served — "
+            "pick a supported quant (Q2_K..Q8_0, IQ4_NL, IQ4_XS, BF16).")
+
+    block_size, type_size = block_geometry(qtype)
+    rows = data.reshape((-1, data.shape[-1])).view(torch.uint8)
+    blocks = rows.reshape((rows.numel() // type_size, type_size))
+    return kernel(blocks, block_size, type_size, dtype).reshape(shape)
+
+
+__all__ = [
+    "K_SCALE_SIZE",
+    "QK_K",
+    "block_geometry",
+    "dequantize",
+    "is_supported",
+    "passthrough_qtypes",
+    "qtype_name",
+    "supported_qtypes",
+]

--- a/src/gen_worker/models/gguf_torch.py
+++ b/src/gen_worker/models/gguf_torch.py
@@ -7,12 +7,21 @@ tiling, no compiled graphs. This module makes GGML a weight STORAGE format
 inside the same torch serving path as bf16, so a 4-bit flux/wan/sdxl runs on a
 small card with everything else intact.
 
-**The weights stay quantized.** Nothing here converts a checkpoint to bf16 up
-front — that would forfeit the whole point (4x the residency). Each leaf holds
-its own block bytes on the device and, once per forward, decodes them
+**The weights stay quantized — as far as the lease says they must.** Each leaf
+holds its own block bytes on the device and, once per forward, decodes them
 (:mod:`gen_worker.models.gguf_dequant`), matmuls at compute precision, and drops
 the dense copy. Residency is the quantized size; peak transient is ONE leaf's
 dense weight; the decode is memory-bound and costs ~10-20% of step time.
+
+That is one end of a DIAL, not the only setting (Paul, 2026-08-19). A worker
+handed surplus memory should use it: :func:`dequant_ahead` decodes as many
+weights ONCE at load as the surplus pays for, largest first, because paying a
+per-forward decode every step for the life of the endpoint is worse than paying
+it once. ``surplus_bytes=0`` is the constrained tier, ``math.inf`` the surplus
+tier, anything between graduates per layer. Nothing is ever RE-quantized — the
+dial only moves a weight from "decoded every step" to "decoded once", and the
+ladder still SELECTS artifacts rather than manufacturing them (``rung.py``).
+LoRA semantics are identical on both sides of the dial.
 
 Three deliberate divergences from the reference (city96's ComfyUI-GGUF, which
 these kernels and the attach-never-merge LoRA are ported from):
@@ -75,6 +84,12 @@ SPEC_ATTR = "gguf_specs"
 
 #: Per-leaf attribute: ``{"weight": (LoraPatch, ...)}`` applied post-dequant.
 ADAPTER_ATTR = "gguf_adapters"
+
+#: Per-leaf attribute: the specs of tensors :func:`dequant_ahead` already
+#: decoded. They are dense now, but the lane still owns them — an adapter may
+#: still attach, and residency reporting must not lose track of where the bytes
+#: came from.
+MATERIALIZED_ATTR = "gguf_materialized"
 
 #: (plain class, kind) -> punned class. One class object per pair: the module
 #: TYPE enters the compiled graph's composition digest and must be stable for
@@ -141,9 +156,11 @@ class LoraPatch:
 def _materialize(leaf: Any, name: str, dtype: Any) -> Any:
     """One tensor of ``leaf``, dense and at ``dtype``, for THIS forward.
 
-    Dense already (norms, biases the packer left in F32) -> a cast. Block bytes
-    -> decode, then every attached adapter on top. The dense copy is a local:
-    it dies when the caller's op returns.
+    Three cases, one expression. Block bytes -> decode. Already dense, because
+    the packer left it alone (norms, biases) or because :func:`dequant_ahead`
+    decoded it at load -> a cast, which is free when the dtype already matches.
+    Then every attached adapter, in BOTH cases: LoRA semantics must not depend
+    on which side of the budget dial a leaf landed on.
     """
     tensor = getattr(leaf, name, None)
     if tensor is None:
@@ -151,12 +168,17 @@ def _materialize(leaf: Any, name: str, dtype: Any) -> Any:
 
     spec = getattr(leaf, SPEC_ATTR, {}).get(name)
     if spec is None:
-        return tensor.to(dtype)
+        weight = tensor.to(dtype)
+    else:
+        weight = gguf_dequant.dequantize(
+            tensor, spec.qtype, spec.shape,
+            dtype=getattr(leaf, "dequant_dtype", None) or dtype)
 
-    weight = gguf_dequant.dequantize(
-        tensor, spec.qtype, spec.shape, dtype=getattr(leaf, "dequant_dtype", None) or dtype)
-    for patch in getattr(leaf, ADAPTER_ATTR, {}).get(name, ()):
-        weight = weight + patch.delta(weight)
+    patches = getattr(leaf, ADAPTER_ATTR, {}).get(name, ())
+    if patches:
+        weight = weight.to(dtype)
+        for patch in patches:
+            weight = weight + patch.delta(weight)
     return weight.to(dtype)
 
 
@@ -321,6 +343,7 @@ def install_quantized_weights(
                 leaf.__class__ = punned_class(type(leaf), kind)
                 setattr(leaf, SPEC_ATTR, {})
                 setattr(leaf, ADAPTER_ATTR, {})
+                setattr(leaf, MATERIALIZED_ATTR, {})
                 punned.append(path)
             getattr(leaf, SPEC_ATTR)[attr] = value.spec
             _install_buffer(leaf, attr, _detached(value.blocks, device))
@@ -383,6 +406,95 @@ def _install_buffer(leaf: Any, name: str, tensor: Any) -> None:
     leaf.register_buffer(name, tensor, persistent=True)
 
 
+# ---------------------------------------------------------------------------
+# the budget dial
+# ---------------------------------------------------------------------------
+
+def dequant_ahead(model: Any, *, surplus_bytes: float, dtype: Any) -> List[str]:
+    """Decode as many weights ONCE at load as ``surplus_bytes`` pays for.
+
+    Paul, 2026-08-19: quantized-resident and fully-dequantized are the two
+    ENDPOINTS OF ONE DIAL, set from the residency lease at load time. A worker
+    handed surplus memory should use it — a single dequant pass beats paying a
+    per-forward decode on every step for the life of the endpoint — and a
+    constrained worker pays per forward. Nothing is ever re-quantized: this only
+    ever moves a weight from "decoded every step" to "decoded once".
+
+    ``surplus_bytes`` is the lease's headroom over the quantized-resident plan,
+    so ``0`` is the constrained tier, ``math.inf`` the surplus tier, and
+    anything between graduates per layer. The price of one weight is the DELTA
+    (dense minus its blocks), because its blocks are dropped.
+
+    LARGEST FIRST, and the order is not arbitrary. Per-step decode saved is
+    proportional to bytes either way, so that alone would not pick an order —
+    but the transient headroom the fit plan must reserve is set by the LARGEST
+    still-quantized weight, and largest-first is the only order that shrinks it.
+    Spending continues past a weight too big for what is left, so a small
+    remainder is not stranded.
+
+    Returns the materialized ``"<path>.<tensor>"`` keys, largest first.
+    """
+    import torch
+
+    itemsize = torch.empty((), dtype=dtype).element_size()
+    candidates: List[Tuple[int, int, str, Any, str]] = []
+    for path, leaf in gguf_leaves(model).items():
+        for name, spec in getattr(leaf, SPEC_ATTR, {}).items():
+            blocks = getattr(leaf, name)
+            dense = _elements(spec.shape) * itemsize
+            price = dense - blocks.numel() * blocks.element_size()
+            candidates.append((dense, price, path, leaf, name))
+    candidates.sort(key=lambda c: -c[0])
+
+    spent = 0
+    done: List[str] = []
+    for dense, price, path, leaf, name in candidates:
+        if spent + price > surplus_bytes:
+            continue
+        materialize(leaf, name, dtype=dtype)
+        spent += price
+        done.append(f"{path}.{name}")
+
+    logger.info("gguf-torch: dequant-ahead materialized %d/%d weights for "
+                "%d bytes of a %s surplus", len(done), len(candidates), spent,
+                surplus_bytes)
+    return done
+
+
+def materialize(leaf: Any, name: str, *, dtype: Any) -> None:
+    """Decode one weight once and drop its blocks. The leaf STAYS punned, so
+    adapters keep applying exactly as they did on the quantized side."""
+    specs = getattr(leaf, SPEC_ATTR, {})
+    spec = specs.get(name)
+    if spec is None:
+        return
+    dense = gguf_dequant.dequantize(getattr(leaf, name), spec.qtype, spec.shape,
+                                    dtype=dtype)
+    del specs[name]
+    getattr(leaf, MATERIALIZED_ATTR)[name] = spec
+    _install_buffer(leaf, name, dense.contiguous())
+
+
+def peak_transient_bytes(model: Any, *, dtype: Any) -> int:
+    """The largest weight still decoded per forward — the headroom a fit plan
+    must reserve on top of the resident bytes. Falls as the dial turns up."""
+    import torch
+
+    itemsize = torch.empty((), dtype=dtype).element_size()
+    return max(
+        (_elements(spec.shape) * itemsize
+         for leaf in gguf_leaves(model).values()
+         for spec in getattr(leaf, SPEC_ATTR, {}).values()),
+        default=0)
+
+
+def _elements(shape: Any) -> int:
+    total = 1
+    for dim in shape:
+        total *= int(dim)
+    return total
+
+
 def quantized_bytes(model: Any) -> int:
     """Resident bytes of block storage — the number the small-card ladder cares
     about. Honest precisely because ``.shape`` was not made to lie."""
@@ -420,9 +532,10 @@ def attach_lora(leaf: Any, patches: Iterable[LoraPatch], *,
     """
     if not is_gguf_leaf(leaf):
         raise ValueError("gguf-torch: attach_lora expects a punned leaf")
-    if name not in getattr(leaf, SPEC_ATTR, {}):
+    if name not in getattr(leaf, SPEC_ATTR, {}) and \
+            name not in getattr(leaf, MATERIALIZED_ATTR, {}):
         raise ValueError(
-            f"gguf-torch: {name!r} on this leaf is dense, not block bytes — "
+            f"gguf-torch: {name!r} on this leaf never held block bytes — "
             "apply the adapter through the ordinary LoRA path")
     getattr(leaf, ADAPTER_ATTR)[name] = tuple(patches)
 
@@ -559,16 +672,20 @@ __all__ = [
     "ADAPTER_ATTR",
     "BASE_ATTR",
     "LEAF_MARKER",
+    "MATERIALIZED_ATTR",
     "SPEC_ATTR",
     "GgufRead",
     "LoraPatch",
     "QuantSpec",
     "QuantizedTensor",
     "attach_lora",
+    "dequant_ahead",
     "detach_lora",
     "gguf_leaves",
     "install_quantized_weights",
     "is_gguf_leaf",
+    "materialize",
+    "peak_transient_bytes",
     "punned_class",
     "quantized_bytes",
     "quantized_tensors_from_views",

--- a/src/gen_worker/models/gguf_torch.py
+++ b/src/gen_worker/models/gguf_torch.py
@@ -365,7 +365,7 @@ def install_quantized_weights(
             dense = _detached(value, device)
             if dense.is_floating_point():
                 dense = dense.to(compute_dtype)
-            _install_buffer(leaf, attr, dense)
+            _install_parameter(leaf, attr, dense)
 
         leaf.compute_dtype = compute_dtype
         leaf.dequant_dtype = dequant_dtype
@@ -395,15 +395,37 @@ def _detached(tensor: Any, device: Any) -> Any:
     return tensor.detach().to(device=device, copy=True)
 
 
+def _install_parameter(leaf: Any, name: str, tensor: Any) -> None:
+    """Install a DENSE tensor, keeping it a Parameter.
+
+    Load-bearing, and the opposite call from :func:`_install_buffer` on
+    purpose. diffusers resolves ``ModelMixin.dtype`` by walking for the first
+    floating-point PARAMETER, and a denoiser that casts to ``self.dtype``
+    inside forward breaks when that walk finds nothing. Installing a whole
+    checkpoint through here is exactly the case that would leave a model with
+    no floating-point parameters at all — every dense tensor demoted to a
+    buffer — so dense tensors stay parameters and only the block bytes become
+    buffers. The blocks need no such care: they are uint8 and the walk skips
+    them either way.
+    """
+    import torch
+
+    param = leaf._parameters.get(name)
+    if param is not None:
+        param.data = tensor
+        param.requires_grad_(False)
+        return
+    leaf._buffers.pop(name, None)
+    leaf.register_parameter(name, torch.nn.Parameter(tensor, requires_grad=False))
+
+
 def _install_buffer(leaf: Any, name: str, tensor: Any) -> None:
     """Replace ``leaf.<name>`` with ``tensor`` as a persistent BUFFER.
 
-    Buffer, not Parameter, for the reason the fp8-storage lane found the hard
-    way: diffusers resolves ``ModelMixin.dtype`` from the first floating-point
-    PARAMETER, and a denoiser that casts to ``self.dtype`` inside forward breaks
-    when that answer is a storage dtype. Block bytes are uint8, so they would
-    not even be seen by that walk — but a leaf's dense bias would be, and
-    keeping one rule for both is the point. state_dict keys are unchanged.
+    Buffer, not Parameter, because block bytes are storage rather than
+    weights — nothing trains them, nothing should cast them, and they must not
+    appear in a ``parameters()`` walk that expects weights. state_dict keys are
+    unchanged.
     """
     param = leaf._parameters.get(name)
     if param is not None and param.data.data_ptr() != tensor.data_ptr():
@@ -486,7 +508,9 @@ def materialize(leaf: Any, name: str, *, dtype: Any) -> None:
                                     dtype=dtype)
     del specs[name]
     getattr(leaf, MATERIALIZED_ATTR)[name] = spec
-    _install_buffer(leaf, name, dense.contiguous())
+    # A Parameter, not a buffer: past the dial this leaf IS an ordinary dense
+    # layer and should look like one to every walk in the worker.
+    _install_parameter(leaf, name, dense.contiguous())
 
 
 def peak_transient_bytes(model: Any, *, dtype: Any) -> int:

--- a/src/gen_worker/models/gguf_torch.py
+++ b/src/gen_worker/models/gguf_torch.py
@@ -1,0 +1,577 @@
+"""GGML-quantized weights served by the ORDINARY torch path.
+
+Today a GGUF checkpoint can only be served by a separate llama.cpp engine on a
+torch-free image (``serving/gguf_fit.py``) — llama-shaped LLMs only, and it gets
+none of the torch stack: no diffusers pipeline, no LoRA, no ladder, no VAE
+tiling, no compiled graphs. This module makes GGML a weight STORAGE format
+inside the same torch serving path as bf16, so a 4-bit flux/wan/sdxl runs on a
+small card with everything else intact.
+
+**The weights stay quantized.** Nothing here converts a checkpoint to bf16 up
+front — that would forfeit the whole point (4x the residency). Each leaf holds
+its own block bytes on the device and, once per forward, decodes them
+(:mod:`gen_worker.models.gguf_dequant`), matmuls at compute precision, and drops
+the dense copy. Residency is the quantized size; peak transient is ONE leaf's
+dense weight; the decode is memory-bound and costs ~10-20% of step time.
+
+Three deliberate divergences from the reference (city96's ComfyUI-GGUF, which
+these kernels and the attach-never-merge LoRA are ported from):
+
+1. **No lying tensor subclass.** The reference wraps every tensor in a
+   ``torch.Tensor`` subclass whose ``.shape`` reports the DEQUANTIZED shape, so
+   ComfyUI's shape-sniffing model detection keeps working on a quantized state
+   dict. We build models from a config-only snapshot, never by sniffing shapes,
+   so we pay none of that — and a lying ``.shape`` would corrupt exactly the
+   thing this lane exists for: every VRAM/residency walk in the worker reads
+   buffer shapes, and would over-report a 4-bit denoiser by ~4x. The qtype and
+   the logical shape live on the LEAF (:class:`QuantSpec`), where they are also
+   free of the subclass/``torch.compile`` interaction the reference has to
+   version-gate. Nothing traces a subclass because there is no subclass.
+2. **Blocks are uint8 buffers, not parameters.** ``nn.Module._apply`` only casts
+   FLOATING-POINT tensors, so ``model.to(dtype=bf16)`` silently skips them —
+   the fp8-storage lane's standing "never ``.to(dtype=...)`` a restructured
+   module" hazard simply does not exist here. Device moves work normally.
+3. **mmap release is a copy at install**, not the reference's
+   ``.to(load_device).to(offload_device)`` bounce. A ``.gguf`` read through
+   ``GGUFReader`` hands out numpy views of an mmap; leaving them installed means
+   every step faults through the page cache and the tensors can never be pinned.
+   One forced copy at install time is the same fix stated directly.
+
+The restructure itself is the repo's CLASS PUN (see
+:mod:`gen_worker.models.fp8_storage`): the leaf keeps its identity, FQNs and
+attributes, and only ``forward`` changes, so ``isinstance`` stays true for the
+offload rung, LoRA branch targeting and dtype introspection.
+
+**LoRA is attached, never merged.** Merging into a 4-bit grid would requantize
+and lose the adapter; attaching costs one rank-r product per forward and is
+LOSSLESS, with instant unpatch. See :func:`attach_lora` for why this does NOT
+trip the refuse-adapters-on-a-quantized-grid rule.
+
+Where the bytes come from is not this module's business. :func:`read_gguf` is
+the EDGE reader for a community ``.gguf`` file; the normalized path is per-tensor
+block bytes out of the CAS, which arrive at :func:`install_quantized_weights` as
+the same :class:`QuantizedTensor` values.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from . import gguf_dequant
+
+logger = logging.getLogger(__name__)
+
+#: Class attribute marking a punned leaf, and (on the class) the plain class it
+#: was punned from. Structural markers, never name checks.
+LEAF_MARKER = "_cozy_gguf_leaf"
+BASE_ATTR = "_cozy_gguf_base"
+
+#: Per-leaf attribute: ``{"weight": QuantSpec, ...}`` for the tensors that are
+#: block bytes. A tensor absent from this map is dense and used as-is.
+SPEC_ATTR = "gguf_specs"
+
+#: Per-leaf attribute: ``{"weight": (LoraPatch, ...)}`` applied post-dequant.
+ADAPTER_ATTR = "gguf_adapters"
+
+#: (plain class, kind) -> punned class. One class object per pair: the module
+#: TYPE enters the compiled graph's composition digest and must be stable for
+#: the life of the process.
+_PUNNED: Dict[Tuple[Any, str], type] = {}
+
+
+@dataclass(frozen=True)
+class QuantSpec:
+    """What a leaf needs to decode one tensor: the GGML type and the shape the
+    flat block stream expands to."""
+
+    qtype: int
+    shape: Any
+
+    def __post_init__(self) -> None:
+        if not gguf_dequant.is_supported(self.qtype):
+            raise NotImplementedError(
+                f"gguf-torch: {gguf_dequant.qtype_name(self.qtype)} has no "
+                "vectorized decode")
+
+
+@dataclass(frozen=True)
+class QuantizedTensor:
+    """Block bytes plus what they decode to — the unit that crosses into this
+    module, whether it came from a ``.gguf`` file or from the CAS."""
+
+    blocks: Any
+    spec: QuantSpec
+
+    @property
+    def qtype(self) -> int:
+        return self.spec.qtype
+
+    @property
+    def shape(self) -> Any:
+        return self.spec.shape
+
+
+@dataclass(frozen=True)
+class LoraPatch:
+    """One low-rank adapter branch, applied to the DEQUANTIZED weight.
+
+    ``down`` is ``[rank, in...]`` and ``up`` is ``[out, rank...]``; conv branches
+    carry the extra kernel dims, which flatten into the rank product. ``scale``
+    is the caller's strength already folded with ``alpha / rank``.
+    """
+
+    down: Any
+    up: Any
+    scale: float = 1.0
+
+    def delta(self, like: Any) -> Any:
+        up = self.up.to(device=like.device, dtype=like.dtype)
+        down = self.down.to(device=like.device, dtype=like.dtype)
+        product = up.flatten(1) @ down.flatten(1)
+        return product.reshape(like.shape) * self.scale
+
+
+# ---------------------------------------------------------------------------
+# decode
+# ---------------------------------------------------------------------------
+
+def _materialize(leaf: Any, name: str, dtype: Any) -> Any:
+    """One tensor of ``leaf``, dense and at ``dtype``, for THIS forward.
+
+    Dense already (norms, biases the packer left in F32) -> a cast. Block bytes
+    -> decode, then every attached adapter on top. The dense copy is a local:
+    it dies when the caller's op returns.
+    """
+    tensor = getattr(leaf, name, None)
+    if tensor is None:
+        return None
+
+    spec = getattr(leaf, SPEC_ATTR, {}).get(name)
+    if spec is None:
+        return tensor.to(dtype)
+
+    weight = gguf_dequant.dequantize(
+        tensor, spec.qtype, spec.shape, dtype=getattr(leaf, "dequant_dtype", None) or dtype)
+    for patch in getattr(leaf, ADAPTER_ATTR, {}).get(name, ()):
+        weight = weight + patch.delta(weight)
+    return weight.to(dtype)
+
+
+def _compute_dtype(leaf: Any, x: Any) -> Any:
+    return getattr(leaf, "compute_dtype", None) or x.dtype
+
+
+@functools.lru_cache(maxsize=1)
+def _forwards() -> Dict[str, Any]:
+    """One ``forward`` per layer KIND — the stock torch forward with the weight
+    decoded at the use site. Upstream's own weight-parameterized entry point is
+    used where one exists (``_conv_forward``), so padding modes and
+    output-padding math are never reimplemented."""
+    import torch.nn.functional as F
+
+    def linear_forward(self: Any, x: Any) -> Any:
+        dtype = _compute_dtype(self, x)
+        return F.linear(x, _materialize(self, "weight", dtype),
+                        _materialize(self, "bias", dtype))
+
+    def conv_forward(self: Any, x: Any) -> Any:
+        dtype = _compute_dtype(self, x)
+        return self._conv_forward(x, _materialize(self, "weight", dtype),
+                                  _materialize(self, "bias", dtype))
+
+    def conv_transpose_forward(self: Any, x: Any,
+                               output_size: Optional[Any] = None) -> Any:
+        if self.padding_mode != "zeros":
+            raise ValueError(
+                "gguf-torch: only `zeros` padding is supported for transposed "
+                f"convolution (got {self.padding_mode!r})")
+        dims = len(self.kernel_size)
+        output_padding = self._output_padding(
+            x, output_size, self.stride, self.padding, self.kernel_size, dims,
+            self.dilation)
+        fn = (F.conv_transpose1d, F.conv_transpose2d, F.conv_transpose3d)[dims - 1]
+        dtype = _compute_dtype(self, x)
+        return fn(x, _materialize(self, "weight", dtype),
+                  _materialize(self, "bias", dtype), self.stride, self.padding,
+                  output_padding, self.groups, self.dilation)
+
+    def embedding_forward(self: Any, x: Any) -> Any:
+        dtype = _compute_dtype(self, x)
+        return F.embedding(x, _materialize(self, "weight", dtype),
+                           self.padding_idx, self.max_norm, self.norm_type,
+                           self.scale_grad_by_freq, self.sparse)
+
+    return {
+        "linear": linear_forward,
+        "conv": conv_forward,
+        "conv_transpose": conv_transpose_forward,
+        "embedding": embedding_forward,
+    }
+
+
+def _kind(module: Any) -> str:
+    """The pun kind for one leaf, ``""`` when it has none. Order matters:
+    transposed convs are not ``nn.ConvNd`` subclasses."""
+    import torch.nn as nn
+
+    if isinstance(module, nn.Linear):
+        return "linear"
+    if isinstance(module, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
+        return "conv"
+    if isinstance(module, (nn.ConvTranspose1d, nn.ConvTranspose2d,
+                           nn.ConvTranspose3d)):
+        return "conv_transpose"
+    if isinstance(module, nn.Embedding):
+        return "embedding"
+    return ""
+
+
+def punned_class(base: Any, kind: str) -> type:
+    """The GGML-storage twin of ``base``: same class, same attributes, only
+    ``forward`` replaced by the decode-at-use-site form. Cached, so one class
+    object per (base, kind)."""
+    cached = _PUNNED.get((base, kind))
+    if cached is not None:
+        return cached
+    built = type(
+        f"Gguf{base.__name__}", (base,),
+        {
+            "forward": _forwards()[kind],
+            LEAF_MARKER: True,
+            BASE_ATTR: base,
+            "__doc__": (
+                f"{base.__name__} holding GGML block bytes, decoded to "
+                "``compute_dtype`` at the use site inside forward (pgw#1498)."
+            ),
+        },
+    )
+    return _PUNNED.setdefault((base, kind), built)
+
+
+def is_gguf_leaf(module: Any) -> bool:
+    return bool(getattr(type(module), LEAF_MARKER, False))
+
+
+def structural_base(module: Any) -> type:
+    """A punned leaf's structure-relevant class. Consumers that select modules
+    by EXACT type (LoRA branch targeting) must ask this instead of ``type()``."""
+    return getattr(type(module), BASE_ATTR, type(module))
+
+
+def gguf_leaves(model: Any) -> Dict[str, Any]:
+    """``path -> leaf`` for every punned leaf under ``model``."""
+    return {n: m for n, m in model.named_modules() if is_gguf_leaf(m)}
+
+
+# ---------------------------------------------------------------------------
+# install
+# ---------------------------------------------------------------------------
+
+def install_quantized_weights(
+    model: Any,
+    tensors: Mapping[str, Any],
+    *,
+    compute_dtype: Any,
+    device: Any = None,
+    dequant_dtype: Any = None,
+) -> List[str]:
+    """Install ``tensors`` into ``model``, punning every leaf that gets blocks.
+
+    ``tensors`` maps a state-dict key (``"...to_q.weight"``) to either a
+    :class:`QuantizedTensor` or a plain dense tensor. Dense tensors land
+    unchanged at ``compute_dtype``; quantized ones land as uint8 buffers on a
+    punned leaf. Returns the punned leaf paths, sorted.
+
+    Every tensor is COPIED onto ``device`` on the way in. That is not an
+    optimization: a ``.gguf`` read hands out numpy views of an mmap, and an
+    installed mmap view faults through the page cache on every step and can
+    never be pinned. One copy here is the reference's mmap-release bounce,
+    stated directly.
+    """
+    import torch
+
+    if device is not None:
+        device = torch.device(device)
+
+    punned: List[str] = []
+    missing: List[str] = []
+    for key in sorted(tensors):
+        value = tensors[key]
+        path, _, attr = key.rpartition(".")
+        try:
+            leaf = model.get_submodule(path) if path else model
+        except AttributeError:
+            missing.append(key)
+            continue
+
+        if isinstance(value, QuantizedTensor):
+            if not is_gguf_leaf(leaf):
+                kind = _kind(leaf)
+                if not kind:
+                    raise ValueError(
+                        f"gguf-torch: no decode-at-use-site forward for {path!r} "
+                        f"({type(leaf).__name__}); it cannot hold block bytes")
+                if "forward" in leaf.__dict__:
+                    raise ValueError(
+                        f"gguf-torch: {path!r} already carries an instance "
+                        "forward (hooks or a LoRA wrap must be applied AFTER)")
+                leaf.__class__ = punned_class(type(leaf), kind)
+                setattr(leaf, SPEC_ATTR, {})
+                setattr(leaf, ADAPTER_ATTR, {})
+                punned.append(path)
+            getattr(leaf, SPEC_ATTR)[attr] = value.spec
+            _install_buffer(leaf, attr, _detached(value.blocks, device))
+        else:
+            dense = _detached(value, device)
+            if dense.is_floating_point():
+                dense = dense.to(compute_dtype)
+            _install_buffer(leaf, attr, dense)
+
+        leaf.compute_dtype = compute_dtype
+        leaf.dequant_dtype = dequant_dtype
+
+    if missing:
+        raise KeyError(
+            f"gguf-torch: {len(missing)} tensor(s) name no module on the model "
+            f"(first: {missing[0]!r})")
+
+    logger.info("gguf-torch: %d leaves hold block bytes (compute %s)",
+                len(punned), compute_dtype)
+    return sorted(punned)
+
+
+def _detached(tensor: Any, device: Any) -> Any:
+    """``tensor`` on ``device``, guaranteed NOT to alias its source storage.
+
+    ``copy=True`` is the whole point and is never redundant: a ``.gguf`` read
+    hands out numpy views of an mmap, and ``.to(same_device)`` would keep the
+    view. Installed mmap views fault through the page cache on every step and
+    can never be pinned — the reference works around this after the fact by
+    bouncing each module ``.to(load_device).to(offload_device)``; forcing the
+    copy once, here, is the same fix said directly.
+    """
+    if device is None:
+        return tensor.detach().clone()
+    return tensor.detach().to(device=device, copy=True)
+
+
+def _install_buffer(leaf: Any, name: str, tensor: Any) -> None:
+    """Replace ``leaf.<name>`` with ``tensor`` as a persistent BUFFER.
+
+    Buffer, not Parameter, for the reason the fp8-storage lane found the hard
+    way: diffusers resolves ``ModelMixin.dtype`` from the first floating-point
+    PARAMETER, and a denoiser that casts to ``self.dtype`` inside forward breaks
+    when that answer is a storage dtype. Block bytes are uint8, so they would
+    not even be seen by that walk — but a leaf's dense bias would be, and
+    keeping one rule for both is the point. state_dict keys are unchanged.
+    """
+    param = leaf._parameters.get(name)
+    if param is not None and param.data.data_ptr() != tensor.data_ptr():
+        # Rebind the outgoing Parameter onto the new storage before dropping it,
+        # so anything still holding it (accelerate device hooks, an earlier
+        # `list(model.parameters())`) follows instead of pinning the original.
+        # `requires_grad` has to go first: torch refuses to point an autograd
+        # leaf at integer storage, and block bytes are uint8. Nothing here
+        # trains, so dropping it is the truth, not a workaround.
+        param.requires_grad_(False)
+        param.data = tensor
+    leaf._parameters.pop(name, None)
+    leaf._buffers.pop(name, None)
+    leaf.register_buffer(name, tensor, persistent=True)
+
+
+def quantized_bytes(model: Any) -> int:
+    """Resident bytes of block storage — the number the small-card ladder cares
+    about. Honest precisely because ``.shape`` was not made to lie."""
+    total = 0
+    for leaf in gguf_leaves(model).values():
+        for name in getattr(leaf, SPEC_ATTR, {}):
+            tensor = getattr(leaf, name, None)
+            if tensor is not None:
+                total += tensor.numel() * tensor.element_size()
+    return total
+
+
+# ---------------------------------------------------------------------------
+# adapters
+# ---------------------------------------------------------------------------
+
+def attach_lora(leaf: Any, patches: Iterable[LoraPatch], *,
+                name: str = "weight") -> None:
+    """Attach adapter branches to one leaf, applied AFTER the decode.
+
+    Never merged. Merging a LoRA into a 4-bit grid means dequantize, add,
+    requantize — which rounds the delta away on exactly the small quants this
+    lane exists to serve, and cannot be undone. Attaching costs one rank-r
+    product per forward, is numerically identical to applying the adapter to the
+    bf16 weight, and unpatching is :func:`detach_lora`.
+
+    RECONCILED with the refuse-adapters-on-a-quantized-grid rule
+    (``models/adapter_fidelity.py``): that rule refuses to WRITE an adapter INTO
+    a quantized grid, because the grid's scales were fit to the base weights and
+    a merged delta is silently rounded. Nothing here writes to the grid. The
+    block bytes are read-only and byte-identical before and after; the delta is
+    added to a dense fp copy that lives for one op. The refusal's premise —
+    "the merge damages the quantization" — has no referent when there is no
+    merge, so it does not apply and must not be extended here.
+    """
+    if not is_gguf_leaf(leaf):
+        raise ValueError("gguf-torch: attach_lora expects a punned leaf")
+    if name not in getattr(leaf, SPEC_ATTR, {}):
+        raise ValueError(
+            f"gguf-torch: {name!r} on this leaf is dense, not block bytes — "
+            "apply the adapter through the ordinary LoRA path")
+    getattr(leaf, ADAPTER_ATTR)[name] = tuple(patches)
+
+
+def detach_lora(model: Any) -> int:
+    """Drop every attached adapter. Instant, because nothing was ever merged."""
+    dropped = 0
+    for leaf in gguf_leaves(model).values():
+        adapters = getattr(leaf, ADAPTER_ATTR, None)
+        if adapters:
+            dropped += len(adapters)
+            adapters.clear()
+    return dropped
+
+
+# ---------------------------------------------------------------------------
+# the store: per-tensor block bytes, no container
+# ---------------------------------------------------------------------------
+
+def quantized_tensors_from_views(views: Mapping[str, Any], *,
+                                 pin_memory: bool = False) -> Dict[str, Any]:
+    """The SERVED path: :class:`tensorfs.tensors.TensorView` -> installable values.
+
+    No ``.gguf`` file is involved and none is composed. tensorfs' ``gguf-v1``
+    planner already cuts a container into one CAS region per tensor, and a
+    ``TensorView`` already carries the two facts a quantized parameter needs
+    that safetensors has no equivalent for: the GGML type (``dtype``, e.g.
+    ``"Q4_K"``) and the block geometry (``block``, e.g. ``(256, 144)``). The
+    block BYTES cross unchanged — dequantizing at ingest would forfeit the 4x
+    that is the entire reason this lane exists.
+
+    ``shape`` is translated: GGUF stores ``ne`` fastest-varying-first, torch is
+    row-major, so the dims reverse. That reversal is the only transformation
+    applied to anything here.
+    """
+    import gguf
+    import torch
+
+    out: Dict[str, Any] = {}
+    for key, view in views.items():
+        shape = torch.Size(tuple(int(d) for d in reversed(view.shape)))
+        blocks = torch.empty(int(view.nbytes), dtype=torch.uint8,
+                             pin_memory=pin_memory)
+        view.readinto(memoryview(blocks.numpy()))
+        qtype = int(gguf.GGMLQuantizationType[str(view.dtype)])
+        if qtype in gguf_dequant.passthrough_qtypes():
+            dense = blocks.view(torch.float32 if view.dtype == "F32" else torch.float16)
+            out[key] = dense.view(shape)
+        else:
+            out[key] = QuantizedTensor(blocks, QuantSpec(qtype, shape))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# the .gguf edge
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GgufRead:
+    """What one ``.gguf`` file yields: tensors keyed by their name in the file,
+    plus the container's own metadata."""
+
+    tensors: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    architecture: str = ""
+
+
+def read_gguf(path: Any, *, prefix: str = "") -> GgufRead:
+    """Read a ``.gguf`` container into :class:`QuantizedTensor` values.
+
+    This is an EDGE reader — community ingest and local development. The served
+    path takes block bytes per-tensor out of the CAS and never sees a container.
+
+    GGML stores a quantized tensor as flat bytes, so the logical shape is
+    metadata: the reversed ``tensor.shape`` dims, unless the packer recorded a
+    true original shape under ``comfy.gguf.orig_shape.<name>`` (5-D tensors get
+    split by every packer, and conv weights lose their trailing 1s).
+    """
+    import warnings
+
+    import gguf
+    import torch
+
+    reader = gguf.GGUFReader(str(path))
+    out = GgufRead(architecture=_field_str(reader, "general.architecture") or "")
+
+    for tensor in reader.tensors:
+        name = tensor.name
+        if prefix:
+            if not name.startswith(prefix):
+                continue
+            name = name[len(prefix):]
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="The given NumPy array is not writable")
+            blocks = torch.from_numpy(tensor.data)
+
+        shape = _orig_shape(reader, tensor.name) or torch.Size(
+            tuple(int(v) for v in reversed(tensor.shape)))
+        qtype = int(tensor.tensor_type)
+
+        if qtype in gguf_dequant.passthrough_qtypes():
+            out.tensors[name] = blocks.view(shape)
+        else:
+            out.tensors[name] = QuantizedTensor(blocks, QuantSpec(qtype, shape))
+
+    counts: Dict[str, int] = {}
+    for value in out.tensors.values():
+        key = (gguf_dequant.qtype_name(value.qtype)
+               if isinstance(value, QuantizedTensor) else "dense")
+        counts[key] = counts.get(key, 0) + 1
+    logger.info("gguf-torch: read %s — %s", path,
+                ", ".join(f"{k} ({v})" for k, v in sorted(counts.items())))
+    return out
+
+
+def _field_str(reader: Any, key: str) -> Optional[str]:
+    field_ = reader.get_field(key)
+    if field_ is None:
+        return None
+    return str(field_.parts[field_.data[-1]], encoding="utf-8")
+
+
+def _orig_shape(reader: Any, name: str) -> Any:
+    import torch
+
+    field_ = reader.get_field(f"comfy.gguf.orig_shape.{name}")
+    if field_ is None:
+        return None
+    return torch.Size(tuple(int(field_.parts[i][0]) for i in field_.data))
+
+
+__all__ = [
+    "ADAPTER_ATTR",
+    "BASE_ATTR",
+    "LEAF_MARKER",
+    "SPEC_ATTR",
+    "GgufRead",
+    "LoraPatch",
+    "QuantSpec",
+    "QuantizedTensor",
+    "attach_lora",
+    "detach_lora",
+    "gguf_leaves",
+    "install_quantized_weights",
+    "is_gguf_leaf",
+    "punned_class",
+    "quantized_bytes",
+    "quantized_tensors_from_views",
+    "read_gguf",
+    "structural_base",
+]

--- a/src/gen_worker/models/gguf_torch.py
+++ b/src/gen_worker/models/gguf_torch.py
@@ -183,7 +183,21 @@ def _materialize(leaf: Any, name: str, dtype: Any) -> Any:
 
 
 def _compute_dtype(leaf: Any, x: Any) -> Any:
-    return getattr(leaf, "compute_dtype", None) or x.dtype
+    """The dtype this op must run in.
+
+    THE ACTIVATION DECIDES, not the load-time declaration. A weight that does
+    not match its input is not a precision choice, it is a `RuntimeError` —
+    caught by running the stack at bf16 with fp32 activations, which is exactly
+    the mixed state a partially-cast pipeline is in. ``compute_dtype`` answers
+    only where the input carries no float dtype of its own: an Embedding is
+    indexed by int64, so its output precision cannot be read off its input.
+    ``dequant_dtype`` remains the separate knob for the DECODE's own precision.
+    """
+    import torch
+
+    if x is not None and x.is_floating_point():
+        return x.dtype
+    return getattr(leaf, "compute_dtype", None) or torch.get_default_dtype()
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/test_gguf_dequant_pgw1498.py
+++ b/tests/test_gguf_dequant_pgw1498.py
@@ -1,0 +1,146 @@
+"""The torch GGML dequant kernels are BIT-EXACT against the `gguf` package.
+
+The reference is ``gguf.quants.dequantize`` — the numpy implementation that
+defines the format. Two independent inputs, because each catches what the other
+cannot:
+
+1. RANDOM BLOCK BYTES. The kernels are pure functions of bytes, so random bytes
+   exercise scale/min/sub-scale fields real weights never reach (all-ones
+   exponents, saturated 6-bit scales, every codebook index). This is the only
+   input available for the K-quants and IQ4 at all: the `gguf` package can
+   DEQUANTIZE them but raises NotImplementedError on `quantize`.
+2. ROUND-TRIPPED REAL VALUES, for the six types `gguf` can quantize. Proves the
+   decode agrees on the byte distribution an actual checkpoint produces.
+
+No weights are downloaded and nothing runs on a GPU: the kernels are device
+agnostic torch ops and CPU is the honest place to pin numerics.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+gguf = pytest.importorskip("gguf")
+
+from gen_worker.models import gguf_dequant
+
+#: Every type the lane claims. Values are (name, logical columns) — K-quants
+#: need a multiple of 256, legacy quants a multiple of 32.
+QTYPES = [
+    ("BF16", 512),
+    ("Q8_0", 512),
+    ("Q5_1", 512),
+    ("Q5_0", 512),
+    ("Q4_1", 512),
+    ("Q4_0", 512),
+    ("Q6_K", 512),
+    ("Q5_K", 512),
+    ("Q4_K", 512),
+    ("Q3_K", 512),
+    ("Q2_K", 512),
+    ("IQ4_NL", 512),
+    ("IQ4_XS", 512),
+]
+
+#: The subset `gguf.quants.quantize` implements.
+QUANTIZABLE = {"BF16", "Q8_0", "Q5_1", "Q5_0", "Q4_1", "Q4_0"}
+
+ROWS = 6
+
+
+def _qtype(name: str) -> int:
+    return int(getattr(gguf.GGMLQuantizationType, name))
+
+
+def _row_bytes(name: str, cols: int) -> int:
+    block_size, type_size = gguf_dequant.block_geometry(_qtype(name))
+    assert cols % block_size == 0, f"{name}: {cols} not a multiple of {block_size}"
+    return cols // block_size * type_size
+
+
+def _ours(raw: np.ndarray, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    out = gguf_dequant.dequantize(
+        torch.from_numpy(raw), _qtype(name), torch.Size(shape),
+        dtype=torch.float32)
+    assert out.dtype is torch.float32
+    return out.numpy()
+
+
+def _assert_bit_exact(ours: np.ndarray, ref: np.ndarray, name: str) -> None:
+    ref = ref.astype(np.float32)
+    assert ours.shape == ref.shape, f"{name}: shape {ours.shape} != {ref.shape}"
+    # Bit patterns, not tolerances: NaN must land in the same places and every
+    # finite value must be the same float32.
+    ours_bits = ours.view(np.uint32)
+    ref_bits = ref.view(np.uint32)
+    finite = np.isfinite(ref)
+    mismatch = (ours_bits != ref_bits) & finite
+    if mismatch.any():
+        i = np.argmax(mismatch.ravel())
+        raise AssertionError(
+            f"{name}: {int(mismatch.sum())}/{mismatch.size} finite values differ; "
+            f"first at flat {i}: ours={ours.ravel()[i]!r} ref={ref.ravel()[i]!r}")
+    assert np.array_equal(np.isnan(ours), np.isnan(ref)), f"{name}: NaN mask differs"
+    assert np.array_equal(np.isinf(ours), np.isinf(ref)), f"{name}: Inf mask differs"
+
+
+@pytest.mark.parametrize("name,cols", QTYPES)
+def test_random_block_bytes_match_gguf_reference(name: str, cols: int) -> None:
+    rng = np.random.default_rng(abs(hash(name)) % (2**32))
+    raw = rng.integers(0, 256, size=(ROWS, _row_bytes(name, cols)), dtype=np.uint8)
+
+    ref = gguf.quants.dequantize(raw, gguf.GGMLQuantizationType[name])
+    _assert_bit_exact(_ours(raw, name, (ROWS, cols)), ref, name)
+
+
+@pytest.mark.parametrize("name,cols",
+                         [(n, c) for n, c in QTYPES if n in QUANTIZABLE])
+def test_round_tripped_weights_match_gguf_reference(name: str, cols: int) -> None:
+    rng = np.random.default_rng(1498)
+    values = (rng.standard_normal((ROWS, cols)) * 0.02).astype(np.float32)
+    raw = gguf.quants.quantize(values, gguf.GGMLQuantizationType[name])
+
+    ref = gguf.quants.dequantize(raw, gguf.GGMLQuantizationType[name])
+    _assert_bit_exact(_ours(raw, name, (ROWS, cols)), ref, name)
+    # …and the decode is a faithful approximation, not merely self-consistent.
+    assert np.abs(ref - values).max() < 0.02
+
+
+@pytest.mark.parametrize("name,cols", QTYPES)
+def test_multi_dim_logical_shape_is_restored(name: str, cols: int) -> None:
+    """Conv weights are 4-D; the block stream is flat. The logical shape is
+    metadata, so the decode must honour any shape with the right element count."""
+    rng = np.random.default_rng(7)
+    raw = rng.integers(0, 256, size=(4, _row_bytes(name, cols)), dtype=np.uint8)
+    flat = _ours(raw, name, (4 * cols,))
+    shaped = _ours(raw, name, (4, 2, cols // 2))
+    assert shaped.shape == (4, 2, cols // 2)
+    assert np.array_equal(shaped.reshape(-1).view(np.uint32),
+                          flat.view(np.uint32))
+
+
+def test_unsupported_qtype_refuses_loudly() -> None:
+    raw = np.zeros((2, 128), dtype=np.uint8)
+    with pytest.raises(NotImplementedError, match="IQ2_XXS"):
+        gguf_dequant.dequantize(
+            torch.from_numpy(raw), _qtype("IQ2_XXS"), torch.Size((2, 512)),
+            dtype=torch.float32)
+
+
+def test_supported_set_is_exactly_the_thirteen_plus_native() -> None:
+    names = {gguf_dequant.qtype_name(q) for q in gguf_dequant.supported_qtypes()}
+    assert names == {n for n, _ in QTYPES} | {"F32", "F16"}
+    for name in ("IQ1_S", "IQ2_XXS", "IQ3_S"):
+        assert not gguf_dequant.is_supported(_qtype(name))
+
+
+@pytest.mark.parametrize("name", ["F32", "F16"])
+def test_native_types_pass_through(name: str) -> None:
+    values = np.arange(64, dtype=np.float32).reshape(8, 8)
+    src = torch.from_numpy(values).to(
+        torch.float32 if name == "F32" else torch.float16)
+    out = gguf_dequant.dequantize(src, _qtype(name), torch.Size((8, 8)),
+                                  dtype=torch.float32)
+    assert torch.equal(out, torch.from_numpy(values))

--- a/tests/test_gguf_torch_pgw1498.py
+++ b/tests/test_gguf_torch_pgw1498.py
@@ -13,6 +13,8 @@ be true.
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pytest
 
@@ -232,10 +234,115 @@ def test_a_conv_lora_flattens_into_the_rank_product() -> None:
 
 def test_a_dense_tensor_refuses_the_attach_path() -> None:
     quantized, _, _ = _stack()
-    with pytest.raises(ValueError, match="dense, not block bytes"):
+    with pytest.raises(ValueError, match="never held block bytes"):
         attach_lora(quantized.fc1, [_patch(64, 32)], name="bias")
     with pytest.raises(ValueError, match="punned leaf"):
         attach_lora(quantized.norm, [_patch(32, 32)])
+
+
+# --- the budget dial -------------------------------------------------------
+
+
+def test_a_full_surplus_decodes_everything_once_and_answers_identically() -> None:
+    """The surplus tier: same outputs, no per-forward decode left."""
+    quantized, reference, _ = _stack()
+    ids, img = _inputs()
+    before = quantized(ids, img)
+
+    done = gguf_torch.dequant_ahead(quantized, surplus_bytes=math.inf,
+                                    dtype=torch.float32)
+    assert sorted(done) == ["conv.weight", "embed.weight", "fc1.weight",
+                            "fc2.weight"]
+    assert gguf_torch.quantized_bytes(quantized) == 0
+    assert gguf_torch.peak_transient_bytes(quantized, dtype=torch.float32) == 0
+    assert torch.equal(quantized(ids, img), before)
+    assert torch.equal(quantized(ids, img), reference(ids, img))
+    for leaf in gguf_leaves(quantized).values():
+        assert leaf.weight.dtype is torch.float32
+
+
+def test_a_zero_surplus_leaves_every_weight_quantized() -> None:
+    """The constrained tier is the same call with the dial at zero."""
+    quantized, _, _ = _stack()
+    resident = gguf_torch.quantized_bytes(quantized)
+    assert gguf_torch.dequant_ahead(quantized, surplus_bytes=0,
+                                    dtype=torch.float32) == []
+    assert gguf_torch.quantized_bytes(quantized) == resident
+
+
+def test_a_partial_surplus_graduates_largest_first_and_shrinks_the_transient() -> None:
+    """The dial between the endpoints. Largest first is the ordering that also
+    lowers the transient headroom a fit plan must reserve, which is the reason
+    it is the ordering."""
+    quantized, reference, _ = _stack()
+    ids, img = _inputs()
+    before = quantized(ids, img)
+    assert gguf_torch.peak_transient_bytes(quantized, dtype=torch.float32) == 64 * 32 * 4
+
+    # Buy the three 2048-element weights (embed, fc1, fc2) and not the 512-element
+    # conv, so what is left is strictly smaller than what was bought.
+    price = sum(64 * 32 * 4 - getattr(quantized, n).weight.numel()
+                for n in ("embed", "fc1", "fc2"))
+    done = gguf_torch.dequant_ahead(quantized, surplus_bytes=price,
+                                    dtype=torch.float32)
+
+    assert sorted(done) == ["embed.weight", "fc1.weight", "fc2.weight"]
+    assert gguf_torch.quantized_bytes(quantized) > 0  # conv still pays per forward
+    assert gguf_torch.peak_transient_bytes(quantized, dtype=torch.float32) == 16 * 8 * 2 * 2 * 4
+    assert torch.equal(quantized(ids, img), before)
+    assert torch.equal(quantized(ids, img), reference(ids, img))
+
+
+def test_lora_semantics_are_identical_on_both_sides_of_the_dial() -> None:
+    """A weight decoded at load takes the SAME attach path as one decoded per
+    forward — the tier must not be observable through the adapter."""
+    per_forward, reference, _ = _stack()
+    at_load, _, _ = _stack()
+    gguf_torch.dequant_ahead(at_load, surplus_bytes=math.inf, dtype=torch.float32)
+
+    patch = _patch(64, 32)
+    attach_lora(per_forward.fc1, [patch])
+    attach_lora(at_load.fc1, [patch])
+    with torch.no_grad():
+        reference.fc1.weight.add_(patch.delta(reference.fc1.weight))
+
+    ids, img = _inputs()
+    assert torch.equal(at_load(ids, img), per_forward(ids, img))
+    assert torch.equal(at_load(ids, img), reference(ids, img))
+
+    assert detach_lora(at_load) == 1
+    assert detach_lora(per_forward) == 1
+    assert torch.equal(at_load(ids, img), per_forward(ids, img))
+
+
+def test_the_dial_never_requantizes() -> None:
+    """Turning the dial up is one-way by construction: there is no path back to
+    block bytes, which is the rung.py rule (the ladder SELECTS artifacts)."""
+    quantized, _, _ = _stack()
+    gguf_torch.dequant_ahead(quantized, surplus_bytes=math.inf,
+                             dtype=torch.float32)
+    assert gguf_torch.dequant_ahead(quantized, surplus_bytes=math.inf,
+                                    dtype=torch.float32) == []
+    assert not hasattr(gguf_torch, "requantize")
+
+
+def test_the_fuse_gate_refuses_a_gguf_leaf_instead_of_inventing_a_grid() -> None:
+    """The other half of the reconciliation, at the site of the check.
+
+    ``adapter_fidelity.grid_of_module`` reads the grid off the module's
+    ``weight``. On a GGML leaf that is BLOCK BYTES, so the unguarded answer
+    would be a "uint8 grid" — a fuse gated against a fiction. It refuses.
+    """
+    from gen_worker.models import adapter_fidelity
+
+    quantized, _, _ = _stack()
+    with pytest.raises(ValueError, match="no fuse into a quantized grid"):
+        adapter_fidelity.grid_of_module(quantized.fc1,
+                                        path=adapter_fidelity.PATH_FUSE)
+    # …and an ordinary Linear is untouched by the new arm.
+    plain = nn.Linear(4, 4)
+    assert adapter_fidelity.grid_of_module(
+        plain, path=adapter_fidelity.PATH_FUSE).dtype == "float32"
 
 
 # --- install refusals ------------------------------------------------------

--- a/tests/test_gguf_torch_pgw1498.py
+++ b/tests/test_gguf_torch_pgw1498.py
@@ -173,6 +173,33 @@ def test_shape_does_not_lie() -> None:
     assert stored.numel() < 64 * 32 * 4
 
 
+def test_the_lane_runs_at_the_production_compute_dtype() -> None:
+    """Everything else here pins numerics in fp32. Production serves bf16.
+
+    RED before the fix: the punned forward cast the weight to the leaf's
+    declared ``compute_dtype`` while the activation kept its own, so a bf16
+    leaf fed an fp32 activation raised `RuntimeError: Input type (float) and
+    bias type (c10::BFloat16) should be the same`. The activation decides;
+    ``compute_dtype`` answers only for an Embedding, whose int64 indices carry
+    no float dtype to read.
+    """
+    quantized, reference, _ = _stack()
+    for leaf in gguf_leaves(quantized).values():
+        leaf.compute_dtype = torch.bfloat16
+    ids, img = _inputs()
+
+    # Mixed state on purpose: bf16 leaves, fp32 activations. The op runs in the
+    # activation's dtype and the embedding — whose input is int64 — in bf16.
+    got = quantized(ids, img)
+    assert torch.isclose(got.float(), reference(ids, img), rtol=5e-2, atol=5e-2)
+
+    # …and a fully bf16 stack, which is what production actually feeds.
+    all_bf16 = quantized(ids, img.to(torch.bfloat16))
+    assert all_bf16.dtype is torch.bfloat16
+    assert torch.isclose(all_bf16.float(), reference(ids, img),
+                         rtol=5e-2, atol=5e-2)
+
+
 # --- LoRA -----------------------------------------------------------------
 
 

--- a/tests/test_gguf_torch_pgw1498.py
+++ b/tests/test_gguf_torch_pgw1498.py
@@ -1,0 +1,355 @@
+"""A layer stack holding GGML block bytes computes what dequantized-eager does.
+
+The claim under test is the whole lane: weights RESIDE quantized, each forward
+decodes its own weight, and the answer is the one you would get from a model
+whose weights had been dequantized up front — with an attached LoRA on top, and
+with the block bytes still byte-identical afterwards.
+
+Everything is synthesized here (``gguf.quants.quantize`` over random values) and
+everything runs on CPU. No community checkpoint is downloaded: multi-GB weights
+must not transit this machine, and nothing about cast-per-forward needs a GPU to
+be true.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+gguf = pytest.importorskip("gguf")
+
+import torch.nn as nn
+
+from gen_worker.models import gguf_torch
+from gen_worker.models.gguf_torch import (
+    LoraPatch,
+    QuantSpec,
+    QuantizedTensor,
+    attach_lora,
+    detach_lora,
+    gguf_leaves,
+    install_quantized_weights,
+    is_gguf_leaf,
+    quantized_bytes,
+    read_gguf,
+    structural_base,
+)
+
+#: The types `gguf.quants.quantize` implements. The K-quants' DECODE is pinned
+#: bit-exactly in tests/test_gguf_dequant_pgw1498.py; the packing side is
+#: llama-quantize's, so the stack here is built from what we can pack locally.
+LINEAR_QTYPE = "Q4_0"
+CONV_QTYPE = "Q5_1"
+EMBED_QTYPE = "Q8_0"
+
+
+class Tiny(nn.Module):
+    """Every leaf kind the lane puns, in one graph."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(64, 32)
+        self.fc1 = nn.Linear(32, 64)
+        self.fc2 = nn.Linear(64, 32)
+        self.conv = nn.Conv2d(8, 16, kernel_size=2)
+        self.norm = nn.LayerNorm(32)
+
+    def forward(self, ids: torch.Tensor, img: torch.Tensor) -> torch.Tensor:
+        h = self.embed(ids)
+        h = self.fc2(torch.relu(self.fc1(h)))
+        h = self.norm(h)
+        return h.sum() + self.conv(img).sum()
+
+
+def _pack(weight: torch.Tensor, name: str) -> tuple[QuantizedTensor, torch.Tensor]:
+    """``(installable block bytes, what they decode to)`` for one weight.
+
+    A GGML row is the flattened per-output row — that is why the logical shape
+    has to travel as metadata rather than being read off the byte array.
+    """
+    qtype = gguf.GGMLQuantizationType[name]
+    rows = weight.detach().numpy().reshape(weight.shape[0], -1).astype(np.float32)
+    raw = gguf.quants.quantize(rows, qtype)
+    dense = torch.from_numpy(
+        gguf.quants.dequantize(raw, qtype).astype(np.float32)).reshape(weight.shape)
+    blocks = torch.from_numpy(raw.reshape(-1).copy())
+    return QuantizedTensor(blocks, QuantSpec(int(qtype), weight.shape)), dense
+
+
+def _stack() -> tuple[Tiny, Tiny, dict[str, object]]:
+    """A punned model and the dequantized-eager model it must agree with."""
+    torch.manual_seed(1498)
+    reference = Tiny().to(torch.float32)
+
+    plan = {
+        "embed.weight": EMBED_QTYPE,
+        "fc1.weight": LINEAR_QTYPE,
+        "fc2.weight": LINEAR_QTYPE,
+        "conv.weight": CONV_QTYPE,
+    }
+    tensors: dict[str, object] = {}
+    for key, qname in plan.items():
+        module = reference.get_submodule(key.rsplit(".", 1)[0])
+        packed, dense = _pack(module.weight, qname)
+        tensors[key] = packed
+        # The reference holds exactly what the blocks decode to, so any
+        # difference in the outputs is the LANE's, never the quantizer's.
+        with torch.no_grad():
+            module.weight.copy_(dense)
+    for key in ("fc1.bias", "fc2.bias", "conv.bias"):
+        tensors[key] = reference.get_parameter(key).detach().clone()
+
+    torch.manual_seed(1498)
+    quantized = Tiny().to(torch.float32)
+    install_quantized_weights(quantized, tensors, compute_dtype=torch.float32)
+    with torch.no_grad():
+        quantized.norm.weight.copy_(reference.norm.weight)
+        quantized.norm.bias.copy_(reference.norm.bias)
+    return quantized, reference, tensors
+
+
+def _inputs() -> tuple[torch.Tensor, torch.Tensor]:
+    torch.manual_seed(7)
+    return torch.randint(0, 64, (3, 5)), torch.randn(2, 8, 6, 6)
+
+
+# ---------------------------------------------------------------------------
+
+
+def test_cast_per_forward_matches_dequantized_eager() -> None:
+    quantized, reference, _ = _stack()
+    ids, img = _inputs()
+    assert torch.equal(quantized(ids, img), reference(ids, img))
+
+
+def test_every_quantized_leaf_kind_was_punned() -> None:
+    quantized, _, _ = _stack()
+    assert sorted(gguf_leaves(quantized)) == ["conv", "embed", "fc1", "fc2"]
+    # The pun keeps identity: isinstance still answers for the offload rung,
+    # LoRA branch targeting and dtype introspection.
+    assert isinstance(quantized.fc1, nn.Linear)
+    assert isinstance(quantized.conv, nn.Conv2d)
+    assert structural_base(quantized.fc1) is nn.Linear
+    assert not is_gguf_leaf(quantized.norm)
+
+
+def test_weights_stay_quantized_in_memory() -> None:
+    quantized, reference, _ = _stack()
+    dense = sum(p.numel() * p.element_size()
+                for n, p in reference.named_parameters()
+                if n.rsplit(".", 1)[-1] == "weight" and not n.startswith("norm"))
+    assert quantized_bytes(quantized) * 2 < dense, (
+        f"{quantized_bytes(quantized)} block bytes vs {dense} dense — the lane "
+        "must at least halve weight residency")
+    for leaf in gguf_leaves(quantized).values():
+        assert leaf.weight.dtype is torch.uint8
+
+
+def test_a_dtype_cast_cannot_touch_the_blocks() -> None:
+    """``model.to(dtype=...)`` is the fp8-storage lane's standing hazard. Here
+    it is structurally impossible: ``nn.Module._apply`` casts only
+    floating-point tensors, and block bytes are uint8."""
+    quantized, reference, _ = _stack()
+    before = {n: m.weight.clone() for n, m in gguf_leaves(quantized).items()}
+    quantized.to(torch.bfloat16)
+    for name, leaf in gguf_leaves(quantized).items():
+        assert leaf.weight.dtype is torch.uint8
+        assert torch.equal(leaf.weight, before[name])
+
+
+def test_shape_does_not_lie() -> None:
+    """The reference makes ``.shape`` report the DEQUANTIZED shape so ComfyUI's
+    shape-sniffing model detection keeps working. We report the storage shape,
+    because every residency walk in the worker reads buffer shapes and the lie
+    would over-report a quantized denoiser by the compression ratio."""
+    quantized, reference, _ = _stack()
+    stored = quantized.fc1.weight
+    logical = getattr(quantized.fc1, gguf_torch.SPEC_ATTR)["weight"].shape
+    assert tuple(logical) == (64, 32)
+    assert tuple(stored.shape) != (64, 32)
+    assert stored.numel() < 64 * 32 * 4
+
+
+# --- LoRA -----------------------------------------------------------------
+
+
+def _patch(out_features: int, in_features: int, rank: int = 4) -> LoraPatch:
+    torch.manual_seed(31)
+    return LoraPatch(down=torch.randn(rank, in_features) * 0.1,
+                     up=torch.randn(out_features, rank) * 0.1,
+                     scale=0.75)
+
+
+def test_attached_lora_equals_the_same_delta_merged_into_dense_weights() -> None:
+    quantized, reference, _ = _stack()
+    patch = _patch(64, 32)
+
+    attach_lora(quantized.fc1, [patch])
+    with torch.no_grad():
+        reference.fc1.weight.add_(patch.delta(reference.fc1.weight))
+
+    ids, img = _inputs()
+    assert torch.equal(quantized(ids, img), reference(ids, img))
+
+
+def test_attaching_a_lora_leaves_the_quantized_grid_byte_identical() -> None:
+    """The reconciliation with the refuse-adapters-on-a-quantized-grid rule,
+    asserted rather than argued: the blocks the refusal protects are not
+    written. Nothing here can round a delta into a 4-bit grid, because nothing
+    here writes to the grid."""
+    quantized, _, _ = _stack()
+    before = quantized.fc1.weight.clone()
+    attach_lora(quantized.fc1, [_patch(64, 32)])
+    ids, img = _inputs()
+    quantized(ids, img)
+    assert torch.equal(quantized.fc1.weight, before)
+
+
+def test_unpatching_is_instant_and_exact() -> None:
+    quantized, reference, _ = _stack()
+    ids, img = _inputs()
+    clean = quantized(ids, img)
+
+    attach_lora(quantized.fc1, [_patch(64, 32)])
+    assert not torch.equal(quantized(ids, img), clean)
+
+    assert detach_lora(quantized) == 1
+    assert torch.equal(quantized(ids, img), clean)
+
+
+def test_a_conv_lora_flattens_into_the_rank_product() -> None:
+    quantized, reference, _ = _stack()
+    torch.manual_seed(5)
+    patch = LoraPatch(down=torch.randn(2, 8, 2, 2) * 0.05,
+                      up=torch.randn(16, 2, 1, 1) * 0.05, scale=1.5)
+    attach_lora(quantized.conv, [patch])
+    with torch.no_grad():
+        reference.conv.weight.add_(patch.delta(reference.conv.weight))
+    ids, img = _inputs()
+    assert torch.equal(quantized(ids, img), reference(ids, img))
+
+
+def test_a_dense_tensor_refuses_the_attach_path() -> None:
+    quantized, _, _ = _stack()
+    with pytest.raises(ValueError, match="dense, not block bytes"):
+        attach_lora(quantized.fc1, [_patch(64, 32)], name="bias")
+    with pytest.raises(ValueError, match="punned leaf"):
+        attach_lora(quantized.norm, [_patch(32, 32)])
+
+
+# --- install refusals ------------------------------------------------------
+
+
+def test_a_leaf_with_no_decode_forward_refuses_block_bytes() -> None:
+    model = Tiny()
+    packed, _ = _pack(torch.randn(32, 32), LINEAR_QTYPE)
+    with pytest.raises(ValueError, match="no decode-at-use-site forward"):
+        install_quantized_weights(model, {"norm.weight": packed},
+                                  compute_dtype=torch.float32)
+
+
+def test_an_unknown_module_path_refuses() -> None:
+    model = Tiny()
+    packed, _ = _pack(torch.randn(32, 32), LINEAR_QTYPE)
+    with pytest.raises(KeyError, match="name no module"):
+        install_quantized_weights(model, {"nope.weight": packed},
+                                  compute_dtype=torch.float32)
+
+
+def test_an_unserveable_qtype_refuses_at_the_spec() -> None:
+    with pytest.raises(NotImplementedError, match="IQ2_XXS"):
+        QuantSpec(int(gguf.GGMLQuantizationType.IQ2_XXS), torch.Size((4, 256)))
+
+
+def test_installed_blocks_do_not_alias_the_source() -> None:
+    """The mmap-release property: an installed buffer must own its bytes."""
+    model = Tiny()
+    packed, _ = _pack(torch.randn(64, 32), LINEAR_QTYPE)
+    install_quantized_weights(model, {"fc1.weight": packed},
+                              compute_dtype=torch.float32)
+    assert model.fc1.weight.data_ptr() != packed.blocks.data_ptr()
+
+
+# --- the .gguf edge --------------------------------------------------------
+
+
+def _write_gguf(path, raw, qtype) -> None:
+    writer = gguf.GGUFWriter(str(path), arch="llama")
+    # `raw_shape` is the BYTE shape; the writer derives the logical shape from
+    # the block geometry and stores it in GGUF's reversed `ne` order.
+    writer.add_tensor("fc1.weight", raw, raw_shape=raw.shape, raw_dtype=qtype)
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
+def _packed_weight():
+    torch.manual_seed(11)
+    weight = torch.randn(64, 32)
+    qtype = gguf.GGMLQuantizationType[LINEAR_QTYPE]
+    raw = gguf.quants.quantize(weight.numpy().astype(np.float32), qtype)
+    dense = torch.from_numpy(gguf.quants.dequantize(raw, qtype).astype(np.float32))
+    return raw, qtype, dense
+
+
+def test_a_written_gguf_round_trips_through_the_edge_reader(tmp_path) -> None:
+    """A real container, written and read back — the community-ingest edge,
+    proved without downloading anything."""
+    raw, qtype, dense = _packed_weight()
+    path = tmp_path / "tiny.gguf"
+    _write_gguf(path, raw, qtype)
+
+    read = read_gguf(path)
+    assert read.architecture == "llama"
+    got = read.tensors["fc1.weight"]
+    assert isinstance(got, QuantizedTensor)
+    assert tuple(got.shape) == (64, 32)
+    assert got.qtype == int(qtype)
+
+    model = Tiny()
+    install_quantized_weights(model, {"fc1.weight": got},
+                              compute_dtype=torch.float32)
+    x = torch.randn(3, 32)
+    assert torch.equal(model.fc1(x),
+                       torch.nn.functional.linear(x, dense, model.fc1.bias))
+
+
+def test_the_served_path_reads_block_bytes_out_of_the_cas(tmp_path) -> None:
+    """The NORMALIZED path, Paul 2026-08-19: the store hands back per-tensor
+    block bytes and the serving side never sees a container.
+
+    tensorfs' ``gguf-v1`` planner already cuts the file into one region per
+    tensor, and a ``TensorView`` already carries the GGML type and the block
+    geometry. Nothing is dequantized on the way in — the bytes that land in the
+    buffer are the bytes that were ingested.
+    """
+    from gen_worker._vendor.tensorfs import LocalCAS
+    from gen_worker._vendor.tensorfs.tensors import open_tensors
+
+    raw, qtype, dense = _packed_weight()
+    staged = tmp_path / "staged"
+    staged.mkdir()
+    _write_gguf(staged / "model.gguf", raw, qtype)
+
+    cas = LocalCAS(tmp_path / "cas")
+    manifest = cas.ingest_repository(staged)
+    with open_tensors(cas, manifest) as reader:
+        view = reader["fc1.weight"]
+        assert view.format == "gguf-v1"
+        assert view.dtype == LINEAR_QTYPE
+        assert view.block.quantized
+        tensors = gguf_torch.quantized_tensors_from_views({"fc1.weight": view})
+
+    packed = tensors["fc1.weight"]
+    assert isinstance(packed, QuantizedTensor)
+    assert tuple(packed.shape) == (64, 32)
+    assert torch.equal(packed.blocks,
+                       torch.from_numpy(raw.reshape(-1).copy()))
+
+    model = Tiny()
+    install_quantized_weights(model, tensors, compute_dtype=torch.float32)
+    x = torch.randn(3, 32)
+    assert torch.equal(model.fc1(x),
+                       torch.nn.functional.linear(x, dense, model.fc1.bias))

--- a/tests/test_gguf_torch_pgw1498.py
+++ b/tests/test_gguf_torch_pgw1498.py
@@ -160,6 +160,22 @@ def test_a_dtype_cast_cannot_touch_the_blocks() -> None:
         assert torch.equal(leaf.weight, before[name])
 
 
+def test_installing_a_whole_stack_leaves_the_model_with_float_parameters() -> None:
+    """diffusers reads ``ModelMixin.dtype`` off the first floating-point
+    PARAMETER, and a denoiser that casts to ``self.dtype`` inside forward breaks
+    when that walk finds nothing. Installing a checkpoint is exactly the case
+    that would demote every dense tensor to a buffer."""
+    quantized, _, _ = _stack()
+    floats = [n for n, p in quantized.named_parameters() if p.is_floating_point()]
+    assert "fc1.bias" in floats and "norm.weight" in floats
+    # …and the block bytes are NOT parameters.
+    assert not any(p.dtype is torch.uint8 for p in quantized.parameters())
+
+    # Past the dial a leaf is an ordinary dense layer and looks like one.
+    gguf_torch.dequant_ahead(quantized, surplus_bytes=math.inf, dtype=torch.float32)
+    assert "fc1.weight" in dict(quantized.named_parameters())
+
+
 def test_shape_does_not_lie() -> None:
     """The reference makes ``.shape`` report the DEQUANTIZED shape so ComfyUI's
     shape-sniffing model detection keeps working. We report the storage shape,

--- a/tests/test_gguf_torch_pgw1498.py
+++ b/tests/test_gguf_torch_pgw1498.py
@@ -14,6 +14,8 @@ be true.
 from __future__ import annotations
 
 import math
+from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -57,14 +59,14 @@ class Tiny(nn.Module):
         self.conv = nn.Conv2d(8, 16, kernel_size=2)
         self.norm = nn.LayerNorm(32)
 
-    def forward(self, ids: torch.Tensor, img: torch.Tensor) -> torch.Tensor:
+    def forward(self, ids: Any, img: Any) -> Any:
         h = self.embed(ids)
         h = self.fc2(torch.relu(self.fc1(h)))
         h = self.norm(h)
         return h.sum() + self.conv(img).sum()
 
 
-def _pack(weight: torch.Tensor, name: str) -> tuple[QuantizedTensor, torch.Tensor]:
+def _pack(weight: Any, name: str) -> tuple[QuantizedTensor, Any]:
     """``(installable block bytes, what they decode to)`` for one weight.
 
     A GGML row is the flattened per-output row — that is why the logical shape
@@ -92,13 +94,13 @@ def _stack() -> tuple[Tiny, Tiny, dict[str, object]]:
     }
     tensors: dict[str, object] = {}
     for key, qname in plan.items():
-        module = reference.get_submodule(key.rsplit(".", 1)[0])
-        packed, dense = _pack(module.weight, qname)
+        param = reference.get_parameter(key)
+        packed, dense = _pack(param, qname)
         tensors[key] = packed
         # The reference holds exactly what the blocks decode to, so any
         # difference in the outputs is the LANE's, never the quantizer's.
         with torch.no_grad():
-            module.weight.copy_(dense)
+            param.copy_(dense)
     for key in ("fc1.bias", "fc2.bias", "conv.bias"):
         tensors[key] = reference.get_parameter(key).detach().clone()
 
@@ -111,7 +113,7 @@ def _stack() -> tuple[Tiny, Tiny, dict[str, object]]:
     return quantized, reference, tensors
 
 
-def _inputs() -> tuple[torch.Tensor, torch.Tensor]:
+def _inputs() -> tuple[Any, Any]:
     torch.manual_seed(7)
     return torch.randint(0, 64, (3, 5)), torch.randn(2, 8, 6, 6)
 
@@ -424,7 +426,7 @@ def test_installed_blocks_do_not_alias_the_source() -> None:
 # --- the .gguf edge --------------------------------------------------------
 
 
-def _write_gguf(path, raw, qtype) -> None:
+def _write_gguf(path: Path, raw: np.ndarray, qtype: Any) -> None:
     writer = gguf.GGUFWriter(str(path), arch="llama")
     # `raw_shape` is the BYTE shape; the writer derives the logical shape from
     # the block geometry and stores it in GGUF's reversed `ne` order.
@@ -435,7 +437,7 @@ def _write_gguf(path, raw, qtype) -> None:
     writer.close()
 
 
-def _packed_weight():
+def _packed_weight() -> tuple[np.ndarray, Any, Any]:
     torch.manual_seed(11)
     weight = torch.randn(64, 32)
     qtype = gguf.GGMLQuantizationType[LINEAR_QTYPE]
@@ -444,7 +446,7 @@ def _packed_weight():
     return raw, qtype, dense
 
 
-def test_a_written_gguf_round_trips_through_the_edge_reader(tmp_path) -> None:
+def test_a_written_gguf_round_trips_through_the_edge_reader(tmp_path: Path) -> None:
     """A real container, written and read back — the community-ingest edge,
     proved without downloading anything."""
     raw, qtype, dense = _packed_weight()
@@ -466,7 +468,7 @@ def test_a_written_gguf_round_trips_through_the_edge_reader(tmp_path) -> None:
                        torch.nn.functional.linear(x, dense, model.fc1.bias))
 
 
-def test_the_served_path_reads_block_bytes_out_of_the_cas(tmp_path) -> None:
+def test_the_served_path_reads_block_bytes_out_of_the_cas(tmp_path: Path) -> None:
     """The NORMALIZED path, Paul 2026-08-19: the store hands back per-tensor
     block bytes and the serving side never sees a container.
 


### PR DESCRIPTION
Axis 2 of the small-card program. GGML stops being a separate llama.cpp engine on a torch-free image and becomes a weight STORAGE format inside the ordinary torch serving path — so a 4-bit flux/wan/sdxl runs with the whole stack intact (diffusers pipeline, LoRA, ladder, VAE tiling, compiled graphs), not just llama-shaped LLMs. The llama.cpp lane is untouched and REMAINS for LLMs.

### What landed

- `models/gguf_dequant.py` — 13 GGML block formats (BF16, Q8_0, Q5_1/0, Q4_1/0, Q6_K..Q2_K, IQ4_NL/XS) as vectorized torch ops, one batched pass per tensor, no python loop over blocks, no vendor kernel. IQ1/IQ2/IQ3 have no batched decode and RAISE rather than fall back to a per-block numpy path slower than not serving the rung.
- `models/gguf_torch.py` — the class pun (`fp8_storage`'s idiom) for Linear / Conv / ConvTranspose / Embedding, the install path, the budget dial, attached-never-merged LoRA, and the two sources: `read_gguf()` (community-ingest edge) and `quantized_tensors_from_views()` (served path, straight out of the CAS).
- `models/adapter_fidelity.py` — `grid_of_module` refuses a GGML leaf on the fuse path instead of inventing a grid out of uint8 block bytes.

### Residency is a dial (Paul, 2026-08-19)

Quantized-resident and fully-dequantized are the two endpoints of ONE dial, set from the residency lease at load. `dequant_ahead(model, surplus_bytes=, dtype=)` decodes as many weights once as the surplus pays for and drops their blocks: `0` is the constrained tier, `math.inf` the surplus tier, anything between graduates per layer.

**Largest first**, and the order is argued rather than assumed: per-step decode saved is proportional to bytes either way, so that alone would not pick an order — but the transient headroom a fit plan must reserve is set by the largest STILL-quantized weight (`peak_transient_bytes`), and largest-first is the only order that shrinks it. Spending continues past a weight too big for the remainder, so a small tail is not stranded. The dial is one-way; nothing is ever re-quantized and the ladder still SELECTS artifacts (`rung.py`). LoRA semantics are identical on both sides.

### Deliberate divergences from the reference (city96's ComfyUI-GGUF)

1. **No lying tensor subclass.** The reference's `GGMLTensor.shape` reports the DEQUANTIZED shape so ComfyUI's shape-sniffing model detection works on a quantized state dict. We build from a config-only snapshot and never sniff — and the lie would over-report every residency walk in the worker by the compression ratio, i.e. corrupt the one number this lane exists to move. qtype and logical shape live on the leaf. Nothing traces a tensor subclass because there is no tensor subclass, so the torch<2.8 `torch.compiler.disable` version gate is moot too.
2. **Blocks are uint8 buffers.** `nn.Module._apply` casts only floating-point tensors, so the fp8-storage lane's standing "never `.to(dtype=...)` a restructured module" hazard is structurally impossible here. Asserted.
3. **mmap release is a forced copy at install**, not the reference's `.to(load_device).to(offload_device)` bounce after the fact.

### Storage shape (Paul, 2026-08-19) — serve half done

Normalize at INGEST; no `.gguf` container in the middle. tensorfs' `gguf-v1` planner already cuts a container into one CAS region per tensor, and `TensorView` already carries the GGML type and the block geometry (`BlockLayout`) — so LESS was missing than the issue assumed. `quantized_tensors_from_views()` consumes exactly that and the block BYTES cross into VRAM unchanged; a test ingests a `.gguf` into a `LocalCAS` and serves from the store without composing a file. Still owed: our own key layout, a QUANT layout-contract handle for the ggml block encodings (tensorhub-side registration first), and the ingest job.

### LoRA, and the quantized-grid rule

Attached, never merged: one rank-r product on the dequantized copy per forward. Lossless on a 4-bit grid where a merge would round the delta away; unpatching is a list clear. The reconciliation is recorded AT THE CHECK: `adapter_fidelity.grid_of_module` used to read `weight.dtype` to name the grid, which on a GGML leaf is uint8 block bytes — a fuse gated against a fiction. It now refuses. The ruling is about a MERGE rounding a delta into scales fit to the base weights; this lane never writes to the grid, and `test_attaching_a_lora_leaves_the_quantized_grid_byte_identical` asserts the blocks are byte-identical after serving with an adapter attached.

### Evidence

CPU only, no weights downloaded (weights-locality), nothing on the GPU. ruff + `mypy --strict` clean on both new modules and on the `adapter_fidelity` change.

- `tests/test_gguf_dequant_pgw1498.py` — **36 passed**. Every kernel BIT-EXACT (bit patterns, not tolerances, including NaN and Inf masks) vs `gguf.quants.dequantize` on random block bytes — the only input available for the K-quants and IQ4, which the `gguf` package can dequantize but not quantize, and which covers more of the byte domain than any real checkpoint — and on round-tripped real values for the six it can quantize.
- `tests/test_gguf_torch_pgw1498.py` — **24 passed**. Cast-per-forward BITWISE equal to dequantized-eager over a Linear/Conv/Embedding stack; attached LoRA equal to the same delta merged into dense weights (conv branch too); grid untouched; a dtype cast can't reach the blocks; both dial endpoints plus a partial graduation with the transient measured before and after; LoRA identical across tiers; a real container written and read back; the served path installing straight out of a `LocalCAS`; and the fuse-gate refusal with a plain Linear as the control.

### Two defects the widening found (both RED before their fix)

1. **The activation decides the op's dtype, not the load-time declaration.** Every other assertion pins numerics in fp32; production serves bf16. A bf16 leaf fed an fp32 activation was an outright `RuntimeError` — the punned forward cast the weight to `compute_dtype` while the activation kept its own. `compute_dtype` now answers only where the input carries no float dtype to read (an Embedding is indexed by int64). Found by RUNNING the stack at the production dtype, not by reading it.
2. **Dense tensors stay Parameters.** Copying fp8-storage's demote-to-buffer rule wholesale was wrong in the one case that matters: `install_quantized_weights` takes a WHOLE checkpoint, so demoting every dense tensor leaves a denoiser with no floating-point parameters — and a denoiser that casts to `self.dtype` inside forward then has nothing to read. Blocks are uint8, so the dtype walk skips them either way; only the dense half needed care, and it needed the opposite call.

### Explicitly deferred (honest, not hidden)

- **Not wired into the serving path.** `models/loading.py:713 load_gguf_pipeline` still delegates decode to diffusers' `GGUFQuantizationConfig`, and `w8a8_lora.branch_modules` does not admit the punned classes. The module is correct but not yet reachable — that is the next PR on this lane, together with the `models/ladder.py` precision class and the `execution_lanes` weights token.
- The ingest/normalization half of the storage ruling (our key layout + a registered QUANT contract handle).
- No torch.compile measurement of the lane.
- Tier 1 of the runtime strategy (variant auto-pick at download) is cozy-local/hub-side, not this lane.
