### PR TITLE
pgw#1450: re-vendor torchcg at tcg#65 — a modular pipeline's components now REACH the derive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,7 +696,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "b5509c0dc89f027245b9cd56e103227b7afadb4c" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -306,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6"
+rev = "b5509c0dc89f027245b9cd56e103227b7afadb4c"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -533,7 +533,7 @@ rewrites = [
 "document.py" = "797a3f17f46e971ce165c7c64503efece8219c04c80530036727d7c838f173f7"
 "engine.py" = "d8275ad146c73ae5516ea7d60acc1fd63cdddb3036f4833f7741913fe340a1a9"
 "graph_identity.py" = "88c731a681eb1e0b878f30bc33fcaa4efdbfc16bdc612fd6d406a088e299e567"
-"hollow.py" = "a46d1b33a8b9b9501edee654eaaa2dd71406cb6c102127fddffa92a9a5ce4116"
+"hollow.py" = "2e24782b350bf4634171d8c3eb90bf3a1131527c69a4dc14234d7380b4276b36"
 "host_isa.py" = "679aa81547be2d60ae6593b6e8f75dd29dcd56ab85d8e858e219b5af5d0eadc4"
 "identity.py" = "a460a24836cbd46cc9e65bd684b9f6258f6718e5c56102f26a7071f01574a99e"
 "ingress.py" = "fa9b814dbfcd43e2a7cfdd2ed48299a7fa5a570aa73d3e2269448c974074d558"

--- a/src/gen_worker/_vendor/torchcg/hollow.py
+++ b/src/gen_worker/_vendor/torchcg/hollow.py
@@ -12,6 +12,12 @@ supplies the session that makes that code run hollow:
   literal digest reads), then every parameter becomes a FAKE tensor in the
   session's one ``FakeTensorMode``. Tokenizers, schedulers and processors
   load real from the config-only tree; they never carry weights.
+* **Lazy pipeline completion** (tcg#65) -- ``diffusers.ModularPipeline.from_pretrained``
+  returns a pipeline whose ``from_pretrained`` components are all ``None``:
+  it builds SPECS and defers the build to whoever holds the object. At serve
+  that caller exists; a derive has none, so it marked an empty pipeline and
+  armed nothing. The wrapped loader finishes the build in-session, so every
+  component is born hollow through the loaders above.
 * **Two devices, named honestly** (tcg#64) -- the STATED trace device, which
   the graphs are stamped with, and the DRIVE device, where the run's real
   tensors actually live. They are the same device whenever this host can hold
@@ -520,6 +526,101 @@ def _hollow_diffusers(session: HollowSession) -> Any:
     return classmethod(from_pretrained)
 
 
+def attach_lazy_components(pipeline: Any, *, dtype: Any = None) -> tuple[str, ...]:
+    """Build the components a LAZY loader declared and did not construct.
+
+    A classic ``DiffusionPipeline.from_pretrained`` returns a pipeline
+    CARRYING every component, so intercepting the component loaders is
+    enough to make that load hollow. A lazy pipeline loader returns the same
+    registry with every ``from_pretrained`` component ``None`` and defers the
+    build to whoever holds the object -- at serve, the streaming engine that
+    passes the components in. A derive has no such caller: it gets exactly
+    what the loader returned and marks what the pipeline carries, which is
+    nothing (pgw#1450 -- eleven declared names, eleven ``None`` attributes,
+    "no DiT resolves on this pipeline").
+
+    Duck-typed on the object's own surface, never on its class: an object
+    that NAMES unbuilt components and EXPOSES the call that builds them gets
+    that call made, here, inside the session -- so each component goes
+    through the intercepted loaders and is born hollow. An object without
+    that surface is left alone; nothing here knows any pipeline by name.
+
+    Then the postcondition, because the lazy build swallows per-component
+    failures into a log line (tcg#59's doctrine: intercept-or-REFUSE, never
+    silently pass through). A component the pipeline says it can build and
+    then has not built is named and refused -- it is the difference between
+    a traced DiT and a derive that arms nothing.
+
+    Returns the names attached, ``()`` when there was nothing to do.
+    """
+
+    build = getattr(pipeline, "load_components", None)
+    if not callable(build):
+        return ()
+    unbuilt = _buildable_names(pipeline)
+    if not unbuilt:
+        return ()
+    if dtype is None:
+        build(names=list(unbuilt))
+    else:
+        build(names=list(unbuilt), torch_dtype=dtype)
+    still_missing = _buildable_names(pipeline)
+    if still_missing:
+        raise HollowError(
+            f"{type(pipeline).__name__} declares component(s) "
+            f"{list(still_missing)} it can build and did not build them; the "
+            f"pipeline carries None under those names, so a trace would mark "
+            f"nothing and the derive would arm no graphs. The build reports "
+            f"the per-component cause on the diffusers logger."
+        )
+    return unbuilt
+
+
+def _buildable_names(pipeline: Any) -> tuple[str, ...]:
+    """Declared components that are unset AND have somewhere to load from.
+
+    A declared-but-absent optional (no source in the index) is legitimately
+    ``None`` and is not a defect -- the same distinction the lazy build makes
+    when it skips a spec with no source.
+    """
+
+    specs = getattr(pipeline, "_component_specs", None)
+    if not isinstance(specs, Mapping):
+        return ()
+    names = []
+    for name, spec in specs.items():
+        if getattr(spec, "default_creation_method", None) != "from_pretrained":
+            continue
+        if not getattr(spec, "pretrained_model_name_or_path", None):
+            continue
+        if getattr(pipeline, name, None) is None:
+            names.append(name)
+    return tuple(names)
+
+
+def _hollow_lazy_pipeline(original: Any) -> Any:
+    """Wrap a pipeline loader that returns SPECS where a load returns objects.
+
+    ``torch_dtype`` is consumed here rather than forwarded: a lazy pipeline
+    constructor does not take it (it lands in ``**kwargs`` and is dropped
+    with a warning, or refused by a strict author subclass), while the
+    component build it defers is exactly where the dtype belongs. So the ask
+    reaches the components, which is what a classic load does with it.
+    """
+
+    def from_pretrained(cls: Any, /, *args: Any, **kwargs: Any) -> Any:
+        dtype = kwargs.pop("torch_dtype", None)
+        if dtype is None:
+            dtype = kwargs.pop("dtype", None)
+        else:
+            kwargs.pop("dtype", None)
+        pipeline = original.__func__(cls, *args, **kwargs)
+        attach_lazy_components(pipeline, dtype=dtype)
+        return pipeline
+
+    return classmethod(from_pretrained)
+
+
 def _hollow_transformers(session: HollowSession) -> Any:
     def from_pretrained(cls: Any, /, pretrained_model_name_or_path: Any, **kwargs: Any) -> Any:
         subfolder = kwargs.get("subfolder") or ""
@@ -548,10 +649,15 @@ def _hollow_transformers(session: HollowSession) -> Any:
 def _loader_interception(session: HollowSession) -> Iterator[None]:
     """Patch the model-bearing loaders of whichever libraries are present.
 
-    Library-level, never family-level: the patch knows ``ModelMixin`` and
-    ``PreTrainedModel``, not what any endpoint builds with them. A library
-    that is not installed is simply not patched -- pure-transformers authors
-    and pure-diffusers authors both resolve.
+    Library-level, never family-level: the patch knows ``ModelMixin``,
+    ``PreTrainedModel`` and ``ModularPipeline``, not what any endpoint builds
+    with them. A library that is not installed is simply not patched --
+    pure-transformers authors and pure-diffusers authors both resolve.
+
+    The first two are the WEIGHT-BEARING loaders and are REPLACED: they build
+    from config and virtualize. The third is a LAZY pipeline loader and is
+    WRAPPED: it does not read weights, it hands back a registry of unbuilt
+    components, and the wrap makes it finish the job (:func:`attach_lazy_components`).
     """
 
     patched: list[tuple[Any, Any]] = []
@@ -563,12 +669,23 @@ def _loader_interception(session: HollowSession) -> Iterator[None]:
         import transformers.modeling_utils as _tmu
     except ImportError:
         _tmu = None
+    try:
+        import diffusers.modular_pipelines.modular_pipeline as _dmp
+    except ImportError:
+        _dmp = None
     if _dmu is None and _tmu is None:
         raise HollowError(
             "hollow instantiation intercepts diffusers and/or transformers "
             "loaders, and neither library is importable in this env"
         )
     try:
+        if _dmp is not None:
+            patched.append(
+                (_dmp.ModularPipeline, _dmp.ModularPipeline.__dict__["from_pretrained"])
+            )
+            _dmp.ModularPipeline.from_pretrained = _hollow_lazy_pipeline(
+                _dmp.ModularPipeline.__dict__["from_pretrained"]
+            )
         if _dmu is not None:
             patched.append((_dmu.ModelMixin, _dmu.ModelMixin.__dict__["from_pretrained"]))
             _dmu.ModelMixin.from_pretrained = _hollow_diffusers(session)
@@ -828,6 +945,7 @@ def hollow_session(device: str = DEFAULT_TRACE_DEVICE) -> Iterator[HollowSession
 __all__ = [
     "DEFAULT_TRACE_DEVICE",
     "HollowError",
+    "attach_lazy_components",
     "HollowSession",
     "TraceDeviceUnavailable",
     "hollow_session",

--- a/tests/release_fixtures/modular_tiny_endpoint.py
+++ b/tests/release_fixtures/modular_tiny_endpoint.py
@@ -1,0 +1,77 @@
+"""A main_v2-shaped endpoint over a MODULAR pipeline (pgw#1450 fixture).
+
+Same surface as ``tiny_endpoint``: contract-object ``lanes=``, an imperative
+``ctx.compile`` mark inside ``load``, free ctx-first entrypoints whose payload
+schema is what the derive enumerates. The one difference is the pipeline
+class -- a ``ModularPipeline`` subclass that attaches the components it is
+constructed with, which is what every modular endpoint in the fleet ships.
+
+The entrypoint calls the marked denoiser directly rather than a full modular
+``__call__``: the subject is whether the pipeline CARRIES the module at all,
+and a fixture that also had to be a working modular workflow would put a lot
+of diffusers between the defect and the assertion.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+import msgspec
+import torch
+from modular_tiny_tree import TinyStreamingPipeline
+
+from gen_worker import (
+    LoadContext,
+    Model,
+    RequestContext,
+    entrypoint,
+)
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class Size(StrEnum):
+    SMALL = "small"
+    LARGE = "large"
+
+
+_BUCKETS: dict[Size, int] = {Size.SMALL: 4, Size.LARGE: 8}
+
+
+class GenerateInput(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    size: Size = Size.SMALL
+
+
+class LatentOutput(msgspec.Struct):
+    model_used: str
+
+
+class ModularModel(Model[SDXL], lanes=(TINY_DIFFUSERS_FP32,)):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(TinyStreamingPipeline)
+        # The author's line, unchanged from the classic endpoint's. It reads
+        # the component off the pipeline -- which is exactly the read that
+        # found `None` before the loader finished the build.
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+@entrypoint
+def generate(
+    ctx: RequestContext, payload: GenerateInput, model: ModularModel
+) -> LatentOutput:
+    ctx.raise_if_cancelled()
+    side = _BUCKETS[payload.size]
+    unet = model.pipe.unet
+    device = next(unet.parameters()).device
+    dtype = next(unet.parameters()).dtype
+    with torch.inference_mode():
+        model.pipe.unet(
+            torch.zeros(1, 4, side, side, device=device, dtype=dtype),
+            torch.zeros((), device=device, dtype=dtype),
+            encoder_hidden_states=torch.zeros(1, 77, 16, device=device, dtype=dtype),
+        )
+    return LatentOutput(model_used=ctx.checkpoint_ref)

--- a/tests/release_fixtures/modular_tiny_tree.py
+++ b/tests/release_fixtures/modular_tiny_tree.py
@@ -1,0 +1,141 @@
+"""The tiny tree re-indexed as a MODULAR checkpoint repo (pgw#1450).
+
+A modular repo declares its components in ``modular_model_index.json`` as
+three-element entries -- ``[library, class_name, {repo, subfolder, ...}]`` --
+and ``ModularPipeline.from_pretrained`` turns those into SPECS, not objects.
+Which is the whole subject: the classic tree's loader hands back a populated
+pipeline and this one hands back a registry of names.
+
+The blocks and pipeline classes are resolved by NAME off the ``diffusers``
+package, exactly as a real endpoint's are (they ship inside the repo the index
+names), so the fixture registers them there.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import diffusers
+from diffusers.modular_pipelines.modular_pipeline import (
+    ModularPipeline,
+    ModularPipelineBlocks,
+    SequentialPipelineBlocks,
+)
+from diffusers.modular_pipelines.modular_pipeline_utils import ComponentSpec
+
+import tiny_tree
+
+#: The tiny tree's components in the modular index's own spelling.
+COMPONENTS = {
+    "unet": ("diffusers", "UNet2DConditionModel"),
+    "vae": ("diffusers", "AutoencoderKL"),
+    "text_encoder": ("transformers", "CLIPTextModel"),
+    "tokenizer": ("transformers", "CLIPTokenizer"),
+    "scheduler": ("diffusers", "DDIMScheduler"),
+}
+
+
+class TinyModularStep(ModularPipelineBlocks):  # type: ignore[misc]
+    model_name = "tiny-modular"  # type: ignore[assignment]
+
+    @property
+    def description(self) -> str:
+        return "the block whose expected_components ARE the pipeline's"
+
+    @property
+    def expected_components(self) -> list[Any]:
+        from diffusers import AutoencoderKL, DDIMScheduler, UNet2DConditionModel
+        from transformers import CLIPTextModel, CLIPTokenizer
+
+        return [
+            ComponentSpec("unet", UNet2DConditionModel),
+            ComponentSpec("vae", AutoencoderKL),
+            ComponentSpec("text_encoder", CLIPTextModel),
+            ComponentSpec("tokenizer", CLIPTokenizer),
+            ComponentSpec("scheduler", DDIMScheduler),
+        ]
+
+    @property
+    def inputs(self) -> list[Any]:
+        return []
+
+    @property
+    def intermediate_outputs(self) -> list[Any]:
+        return []
+
+    def __call__(self, components: Any, state: Any) -> Any:
+        return components, state
+
+
+class TinyModularBlocks(SequentialPipelineBlocks):  # type: ignore[misc]
+    model_name = "tiny-modular"  # type: ignore[assignment]
+    block_classes = [TinyModularStep]
+    block_names = ["tiny"]
+
+
+class TinyStreamingPipeline(ModularPipeline):  # type: ignore[misc]
+    """The adapter every modular endpoint writes (minimax-h3's, verbatim).
+
+    ``ModularPipeline.__init__`` routes ``**kwargs`` to ``load_config`` and
+    registers every component as ``None``, so an author who wants a pipeline
+    that KEEPS the components ``ctx.load`` hands it attaches them afterwards.
+    """
+
+    default_blocks_name = "TinyModularBlocks"  # type: ignore[assignment]
+
+    _OWN = (
+        "blocks",
+        "pretrained_model_name_or_path",
+        "components_manager",
+        "collection",
+        "modular_config_dict",
+        "config_dict",
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        own = {name: kwargs.pop(name) for name in self._OWN if name in kwargs}
+        super().__init__(**own)
+        components = {
+            name: value
+            for name, value in kwargs.items()
+            if name in self._component_specs and value is not None
+        }
+        if components:
+            self.update_components(**components)
+        left = sorted(name for name in kwargs if name not in self._component_specs)
+        if left:
+            raise TypeError(
+                f"{type(self).__name__}: {left} are neither pipeline arguments "
+                f"nor components of this pipeline"
+            )
+
+
+for _cls in (TinyModularBlocks, TinyStreamingPipeline):
+    setattr(diffusers, _cls.__name__, _cls)
+
+
+def save_config_only(tree: Path) -> Path:
+    """The tiny config-only tree plus a modular index that points INTO it."""
+
+    root = tiny_tree.save_config_only(tree)
+    index: dict[str, Any] = {
+        "_class_name": TinyStreamingPipeline.__name__,
+        "_blocks_class_name": TinyModularBlocks.__name__,
+        "_diffusers_version": diffusers.__version__,
+    }
+    for name, (library, class_name) in COMPONENTS.items():
+        index[name] = [
+            library,
+            class_name,
+            {
+                "repo": str(root),
+                "subfolder": name,
+                "type_hint": [library, class_name],
+                "variant": None,
+                "revision": None,
+            },
+        ]
+    (root / "modular_model_index.json").write_text(json.dumps(index, indent=2))
+    return root

--- a/tests/test_release_derive_modular.py
+++ b/tests/test_release_derive_modular.py
@@ -1,0 +1,128 @@
+"""pgw#1450: a MODULAR pipeline's components must reach the derive.
+
+``gen-worker release derive`` over a modular-pipeline endpoint, through the
+actual CLI codepath. Before tcg#65 this refused --
+
+    minimax-h3 serve recipe: no DiT resolves on this pipeline -- arming nothing
+    derive error: lane 'minimax.h3-dit-diffusers@1': load() marked nothing via
+    ctx.compile()
+
+-- because ``ModularPipeline.from_pretrained`` builds component SPECS and
+leaves every attribute ``None``, deferring the build to whoever holds the
+object. At serve that holder is the streaming engine; a derive has none.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+LOCK = (
+    "version = 1\n"
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+
+@pytest.fixture(scope="module")
+def modular_config_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import modular_tiny_tree as modular_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return modular_tree.save_config_only(tmp_path_factory.mktemp("modular-config-only"))
+
+
+def _derive(tree: Path, out: Path) -> int:
+    from gen_worker.cli import main
+
+    lockfile = out.parent / "uv.lock"
+    lockfile.write_text(LOCK)
+    return main(
+        [
+            "release",
+            "derive",
+            "--dir",
+            str(FIXTURES),
+            "--module",
+            "modular_tiny_endpoint",
+            "--checkpoint",
+            str(tree),
+            "--lockfile",
+            str(lockfile),
+            "--out",
+            str(out),
+        ]
+    )
+
+
+def test_a_modular_endpoint_derives_its_marked_denoiser(
+    modular_config_tree: Path, tmp_path: Path
+) -> None:
+    """The whole issue in one assertion: the lane carries graphs.
+
+    ``load() marked nothing via ctx.compile()`` is a DeriveError, so a red run
+    does not reach the document at all -- the exit code is the first signal.
+    """
+
+    out = tmp_path / "release.json"
+    assert _derive(modular_config_tree, out) == 0
+
+    document = json.loads(out.read_bytes())
+    assert document["kind"] == "gen-worker.release-metadata@1"
+    assert document["endpoint"].endswith(":ModularModel")
+
+    (lane,) = document["graphs"]["lanes"]
+    assert lane["contract"] == "tiny.diffusers-fp32@1"
+    assert lane["unobserved_targets"] == []
+    # One specialization per enumerated payload arm: Size.SMALL/LARGE change
+    # the denoiser's latent side, which is what the enumerator is for.
+    assert len(lane["graphs"]) == 2
+    assert {record["target"] for record in lane["graphs"]} == {"unet"}
+    sides = sorted(record["ingress"]["inputs"][0]["shape"][-1] for record in lane["graphs"])
+    assert sides == [4, 8]
+
+
+def test_the_pipeline_the_author_marked_carries_every_declared_component(
+    modular_config_tree: Path,
+) -> None:
+    """The mechanism, at the seam, without the CLI in the way.
+
+    pgw#1450 measured the opposite on the real H3 tree: ``pipe.components``
+    naming eleven and every attribute ``None``.
+    """
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import modular_tiny_tree as modular_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+    import torch
+    from gen_worker._vendor.torchcg.hollow import hollow_session
+
+    with hollow_session("cuda"):
+        pipeline = modular_tree.TinyStreamingPipeline.from_pretrained(
+            str(modular_config_tree), torch_dtype=torch.float32
+        )
+
+    components = pipeline.components
+    assert sorted(components) == sorted(modular_tree.COMPONENTS)
+    assert [name for name, value in components.items() if value is None] == []
+    modules = sorted(
+        name for name, value in components.items() if isinstance(value, torch.nn.Module)
+    )
+    assert modules == ["text_encoder", "unet", "vae"]

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=b5509c0dc89f027245b9cd56e103227b7afadb4c" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6#0fbd2c36de23a6d01d04db0a1e69d4aaf934b1f6" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=b5509c0dc89f027245b9cd56e103227b7afadb4c#b5509c0dc89f027245b9cd56e103227b7afadb4c" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
Closes the last local blocker between a modular-pipeline endpoint (minimax-h3 first) and a stamped release.

## The refusal this closes

```
minimax-h3 serve recipe: no DiT resolves on this pipeline — arming nothing
derive error: lane 'minimax.h3-dit-diffusers@1': load() marked nothing via ctx.compile()
```

**The refusal is correct and stays.** What is wrong is upstream of it, and it is not H3's: `ModularPipeline.from_pretrained` builds the component **specs** and leaves every `from_pretrained` attribute `None`, deferring the build to whoever holds the object. At serve that holder exists — `skeleton.build` constructs the components and the author's `update_components` adapter attaches them. **A derive has none**, so `ctx.load` handed `ctx.compile` a pipeline naming eleven components and carrying zero. Every modular-pipeline endpoint, not just H3.

Fixed in torchcg — **tcg#65 / torchcg#62, merged at `b5509c0d`**: the hollow session **wraps** the lazy pipeline loader (the two weight-bearing loaders are still **replaced**) and finishes the build in-session, where every component is born hollow through the interception already in place. Loader-agnostic and duck-typed; no per-pipeline registry. `torch_dtype` is consumed by the wrapper rather than forwarded, because a lazy pipeline constructor does not take it while the deferred component build is exactly where it belongs — which also retires the pgw#1447 TypeError retry for this shape.

This PR is the consumer half: re-vendor plus the pgw-side proof.

## Red/green by execution

New `release derive` fixture: a minimax-h3-shaped modular endpoint (a `ModularPipeline` subclass that attaches what it is constructed with) over the tiny tree re-indexed as a modular repo.

| arm | result |
|---|---|
| red, vendored `0fbd2c3` | `derive error: … load() failed under the trace session: TypeError: ctx.compile() marks nn.Modules …; got NoneType` — plus the pgw#1447 TypeError on `torch_dtype` |
| green, vendored `b5509c0` | `lane tiny.diffusers-fp32@1: 2 graph specialization(es)`, target `unet`, `unobserved_targets == []` |

## No regression on the classic shape

Byte-identical, not merely green: the `tiny_endpoint` (stock `DiffusionPipeline`, the sd15/sdxl shape) release document is **sha256 `c5657d0675026d3c974e6ecac40de4a8f57e0b22562f24d527929d748eaf413f` at both vendored revs**, 4 specializations each.

`tests/test_release_derive.py` 17 passed · vendor/env-identity/weightless/import-resolution 42 passed · `mypy src/gen_worker tests` clean over 597 files · ruff clean · `lint_incident_test_names`, `lint_lock_pin_agreement`, `lint_repo_ref_pins`, `lint_tcg_vocabulary`, `lint_unreached_surface` green. Everything ran CPU-only with `CUDA_VISIBLE_DEVICES=""`.

## Not in scope

pgw#1449 (`list[Struct]` synthesis — two H3 entrypoints unenumerable) and H3's own endpoint pins, which its lane owns.