### PR TITLE
pgw#1499: reactive OOM ladders — tiled VAE retry, sliced-attention retry, async-OOM flush

### DIFF
--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -146,13 +146,28 @@ from .rung import (
 def is_cuda_oom(exc: Optional[BaseException]) -> bool:
     """CUDA allocator exhaustion in any of its shapes: torch.cuda.OutOfMemoryError
     (class name match — no torch import needed) plus the allocator's RuntimeError
-    flavors ("CUDA error: out of memory", CUBLAS/CUDNN alloc failures)."""
+    flavors ("CUDA error: out of memory", CUBLAS/CUDNN alloc failures).
+
+    pgw#1499 adds ``torch.AcceleratorError`` — the ASYNCHRONOUS shape. A kernel
+    that runs out of memory device-side surfaces later, on whatever call next
+    synchronizes, as an AcceleratorError carrying cudaErrorMemoryAllocation
+    (code 2). Missing it made a real OOM read as an unclassified crash, so no
+    ladder ever ran. It also leaves the context's error state poisoned, which
+    is what :func:`discard_cuda_async_error` clears — every caller of this
+    predicate is about to retry something, so the clear belongs here rather
+    than in each of them.
+    """
     if exc is None:
         return False
     if type(exc).__name__ in ("OutOfMemoryError", "CUDAOutOfMemoryError"):
         return True
+    text = str(exc).lower()
+    if type(exc).__name__ == "AcceleratorError" and (
+        getattr(exc, "error_code", None) == 2 or "out of memory" in text
+    ):
+        discard_cuda_async_error()
+        return True
     if isinstance(exc, RuntimeError):
-        text = str(exc).lower()
         return (
             "out of memory" in text
             or "cuda oom" in text
@@ -160,6 +175,29 @@ def is_cuda_oom(exc: Optional[BaseException]) -> bool:
             or "cudnn_status_alloc_failed" in text
         )
     return False
+
+
+def discard_cuda_async_error() -> None:
+    """Flush a poisoned asynchronous CUDA error so the PROCESS survives it.
+
+    An async device-side failure sticks to the context: the next launch
+    re-reports it, and a worker that has already caught and handled the OOM
+    then dies on an error it has no live cause for. A trivial kernel plus a
+    synchronize forces the sticky error out where it can be swallowed once,
+    deliberately, right here — we already learned the fact from the synchronous
+    return. Always safe to call; no-op without CUDA.
+    """
+    try:
+        import torch
+
+        if not cuda_ready():
+            return
+        a = torch.tensor([1], dtype=torch.uint8, device="cuda")
+        b = torch.tensor([1], dtype=torch.uint8, device="cuda")
+        _ = a + b
+        torch.cuda.synchronize()
+    except Exception:  # noqa: BLE001 — dumping the error IS the point
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -1640,6 +1678,15 @@ def apply_low_vram_config(
     if mode not in _VALID_MODES:
         raise ValueError(f"invalid low-VRAM mode: {mode!r}; expected one of {_VALID_MODES}")
 
+    # pgw#1499: arm the reactive in-rung ladders on EVERY rung, including the
+    # resident ones. The rung answers "where do the weights live"; these answer
+    # "this one op did not fit" — and the rung that most needs the second
+    # answer is `off`, where nothing was pre-tiled because everything fitted.
+    # Imported here, not at module scope: `oom_ladder` reads this module.
+    from . import oom_ladder
+
+    oom_ladder.install(pipeline, logger=log)
+
     prior = getattr(pipeline, _COZY_MODE_ATTR, None)
     if prior is not None:
         return {"mode": prior, "already_applied": True}
@@ -1844,6 +1891,7 @@ __all__ = [
     "place_pipeline",
     "touches_host_ram",
     "is_cuda_oom",
+    "discard_cuda_async_error",
     "transition_line",
     "PLACEMENT_LADDER",
     "select_auto_mode",

--- a/src/gen_worker/models/oom_ladder.py
+++ b/src/gen_worker/models/oom_ladder.py
@@ -1,0 +1,467 @@
+"""Reactive OOM ladders (pgw#1499) — IN-RUNG retries for the catchable cases.
+
+The placement ladder (``rung.py``) answers *"where do the weights live"* and
+descends a rung when a LOAD OOMs. It has nothing to say about a request that
+loads fine and then exhausts the card inside one op — a full-frame VAE decode,
+or an attention matmul at an unusually long sequence. Those are eager, they are
+catchable, and the cheap answer is to retry the SAME op smaller, on the same
+rung, rather than to spill the whole pipeline to host RAM.
+
+Two wrappers, installed once per pipeline by ``memory.apply_low_vram_config``:
+
+* ``vae.decode`` — full frame first; on OOM, tile and retry, shrinking the tile
+  each further OOM. Tiling is applied REACTIVELY here, unlike
+  ``_apply_vae_and_attention``'s per-rung proactive tiling: a pipeline that
+  fits natively pays nothing until the day a request is too big for the card.
+* the denoiser's ``forward`` (``unet``/``transformer``) — on OOM, empty the
+  cache and retry ONE step with a finer attention slice, to a cap.
+
+Both are degradations and both confess through ``memory._confess_serve_degrade``
+— a tiled retry is a confession, not a silent save.
+
+SCOPE, stated so it is not widened by accident. This is the EAGER half only.
+A mid-graph OOM inside a compiled artifact is not catchable (pgw#1255 leg 2);
+``serving/context.py`` decides that case by admission before the weights land
+and ``aot_serve`` serves the request eager. Nothing here changes either.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+from .memory import (
+    _confess_serve_degrade,
+    flush_memory,
+    get_available_vram_gb,
+    is_cuda_oom,
+)
+from .rung import transition_line
+
+_LOG = logging.getLogger(__name__)
+
+#: Phase tokens for the two confessions. Countable hub-side in
+#: `worker_activity_events` beside `cpu_offload_engaged`.
+VAE_TILED_RETRY_PHASE = "vae_tiled_retry"
+ATTENTION_SLICED_RETRY_PHASE = "attention_sliced_retry"
+
+#: Marker attribute — install is idempotent per object, and
+#: `apply_low_vram_config` runs again on every rung of a placement descent.
+_INSTALLED = "_cozy_oom_ladder"
+
+#: Peak live decoder activations, counted in units of
+#: "one full-resolution buffer at the decoder's WIDEST channel count".
+#: Calibrated against ComfyUI's hand-measured per-VAE table: their sd15/SDXL
+#: coefficient is 2178*64 bytes per latent element, and
+#: 17 * 128ch * 8*8 spatial * 2 B/elem = 278528 vs their 278784 — 0.1%.
+#: Wan-2.1 lands within 1.5x of their number on the same formula. It is a
+#: FIRST GUESS only: every rung below it is chosen by a real OOM, not by this.
+ACTIVATION_BUFFERS = 17
+
+#: Fraction of free VRAM one tile may plan to occupy.
+BUDGET_FRACTION = 0.8
+
+#: diffusers' attention-slicing knob has exactly these two useful settings
+#: ("auto" halves the slice dim, "max" slices to 1) — that IS the chunk-count
+#: doubling for the sliced-attention implementation we run.
+ATTENTION_LADDER: Tuple[str, ...] = ("auto", "max")
+
+
+# ---------------------------------------------------------------------------
+# The tile solver — pure arithmetic, no torch, unit-testable on a cardless box
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TilePlan:
+    """One rung of the tiling ladder, in LATENT units.
+
+    ``frames`` is 0 for an image VAE (no temporal axis to tile).
+    """
+
+    edge: int
+    frames: int = 0
+
+    @property
+    def overlap(self) -> int:
+        return max(1, self.edge // 4)
+
+    def __str__(self) -> str:
+        t = f"x{self.frames}f" if self.frames else ""
+        return f"{self.edge}²{t}"
+
+
+def tile_bytes(plan: TilePlan, *, latent_h: int, latent_w: int,
+               latent_frames: int, bytes_per_latent: float) -> float:
+    """Peak bytes of ONE tile's decode. A tiled decode's peak is per-tile, so a
+    tile clamped below the real extent is what makes the estimate drop."""
+    h = min(plan.edge, latent_h)
+    w = min(plan.edge, latent_w)
+    t = min(plan.frames, latent_frames) if plan.frames else max(1, latent_frames)
+    return float(h * w * t) * float(bytes_per_latent)
+
+
+def solve_tile_ladder(
+    *,
+    latent_h: int,
+    latent_w: int,
+    latent_frames: int = 0,
+    bytes_per_latent: float,
+    budget_bytes: float,
+    base_edge: int = 32,
+    min_edge: int = 8,
+    min_frames: int = 1,
+    max_rungs: int = 5,
+) -> Tuple[TilePlan, ...]:
+    """The tile ladder for one decode, largest tile first.
+
+    Rung 0 is the ComfyUI solve: start at ``base_edge``, halve the TEMPORAL
+    tile until one tile fits the budget, then double the SPATIAL tile while it
+    still fits. Temporal first because a video decoder's activations are linear
+    in frames and quadratic in edge — shrinking time costs the least seam.
+
+    One addition ComfyUI does not need. Their base tile is smaller than any
+    latent they tile, so their rung 0 is always a real shrink; this ladder is
+    solved only ONCE THE FULL FRAME HAS ALREADY OOMED, and it can be handed a
+    latent no bigger than the base tile — or a budget that says the frame fits,
+    which the allocator has just falsified. A rung that reproduces the shape
+    that failed is not a rung, so the spatial axis halves while the budget says
+    it does not fit, and rung 0 is shrunk once more if it still covers the
+    whole latent.
+
+    Every rung after that halves again (time to ``min_frames``, then space to
+    ``min_edge``), because the budget is an ESTIMATE and the allocator is the
+    only authority: rung N+1 is only ever reached by rung N actually OOMing.
+    """
+    latent_h = max(1, int(latent_h))
+    latent_w = max(1, int(latent_w))
+    latent_frames = max(0, int(latent_frames))
+    span = max(latent_h, latent_w)
+
+    def fits(edge: int, frames: int) -> bool:
+        return tile_bytes(
+            TilePlan(edge, frames), latent_h=latent_h, latent_w=latent_w,
+            latent_frames=latent_frames, bytes_per_latent=bytes_per_latent,
+        ) <= budget_bytes
+
+    edge = max(min_edge, min(base_edge, span))
+    frames = latent_frames
+    if frames:
+        while frames > min_frames and not fits(edge, frames):
+            frames = -(-frames // 2)
+    while edge > min_edge and not fits(edge, frames):
+        edge = max(min_edge, edge // 2)
+    while edge * 2 <= span and fits(edge * 2, frames):
+        edge *= 2
+
+    covers_all = edge >= span and (not frames or frames >= latent_frames)
+    if covers_all:
+        if frames > min_frames:
+            frames = max(min_frames, frames // 2)
+        else:
+            edge = max(min_edge, min(edge, span) // 2)
+
+    ladder = [TilePlan(edge, frames)]
+    while len(ladder) < max_rungs:
+        last = ladder[-1]
+        if last.frames > min_frames:
+            nxt = TilePlan(last.edge, max(min_frames, last.frames // 2))
+        elif last.edge > min_edge:
+            nxt = TilePlan(max(min_edge, last.edge // 2), last.frames)
+        else:
+            break
+        ladder.append(nxt)
+    return tuple(ladder)
+
+
+def decode_bytes_per_latent(vae: Any, *, dtype_bytes: int = 2) -> float:
+    """Estimated peak decode bytes per LATENT element for this VAE.
+
+    ``ACTIVATION_BUFFERS`` buffers at FULL output resolution, which is where a
+    decoder's activations dominate: ``block_out_channels[0]`` is the width
+    there (the 512-channel blocks live at 1/8 the resolution and cost less
+    despite the wider tensor). A VAE that answers none of the config gets the
+    sd-family shape, which is the wrong answer for exactly the models whose
+    next rung is one OOM away anyway.
+    """
+    cfg = getattr(vae, "config", None)
+    channels = 128
+    blocks = getattr(cfg, "block_out_channels", None) if cfg is not None else None
+    if blocks:
+        channels = int(blocks[0])
+    spatial = int(getattr(vae, "spatial_compression_ratio", 0) or 0)
+    if spatial <= 0 and blocks:
+        spatial = 2 ** (len(blocks) - 1)
+    spatial = spatial or 8
+    temporal = int(getattr(vae, "temporal_compression_ratio", 0) or 0) or 1
+    return float(ACTIVATION_BUFFERS * channels * spatial * spatial * temporal
+                 * max(1, int(dtype_bytes)))
+
+
+# ---------------------------------------------------------------------------
+# Applying a plan to a diffusers VAE
+# ---------------------------------------------------------------------------
+
+
+def apply_tile_plan(vae: Any, plan: TilePlan) -> Dict[str, Any]:
+    """Turn a ``TilePlan`` into whatever tiling knobs THIS VAE exposes.
+
+    diffusers is not consistent here: ``AutoencoderKL.enable_tiling()`` takes
+    no arguments and reads ``tile_sample_min_size``/``tile_overlap_factor``
+    attributes, while every video VAE takes keyword tile sizes and each takes a
+    different subset of them. So the knobs are discovered by signature, and the
+    attribute route is the fallback rather than a second implementation.
+
+    Returns what was actually set — the confession quotes it, so an operator
+    reads the tile the decode RAN at, not the one we asked for.
+    """
+    enable = getattr(vae, "enable_tiling", None)
+    if not callable(enable):
+        return {}
+    spatial = int(getattr(vae, "spatial_compression_ratio", 0) or 0) or 8
+    temporal = int(getattr(vae, "temporal_compression_ratio", 0) or 0) or 1
+    sample_edge = plan.edge * spatial
+    sample_stride = max(spatial, (plan.edge - plan.overlap) * spatial)
+    sample_frames = plan.frames * temporal if plan.frames else 0
+
+    try:
+        params = set(inspect.signature(enable).parameters)
+    except (TypeError, ValueError):
+        params = set()
+    kwargs: Dict[str, Any] = {}
+    for name, value in (
+        ("tile_sample_min_height", sample_edge),
+        ("tile_sample_min_width", sample_edge),
+        ("tile_sample_stride_height", sample_stride),
+        ("tile_sample_stride_width", sample_stride),
+        ("tile_sample_min_num_frames", sample_frames),
+        ("tile_sample_stride_num_frames", max(1, sample_frames // 2)),
+    ):
+        if name in params and value:
+            kwargs[name] = value
+
+    applied: Dict[str, Any] = {}
+    if not kwargs:
+        # The attribute route (AutoencoderKL and friends).
+        attrs: Tuple[Tuple[str, Any], ...] = (
+            ("tile_sample_min_size", sample_edge),
+            ("tile_latent_min_size", plan.edge),
+            ("tile_overlap_factor", 0.25),
+        )
+        for attr, attr_value in attrs:
+            if hasattr(vae, attr):
+                setattr(vae, attr, attr_value)
+                applied[attr] = attr_value
+    enable(**kwargs)
+    applied.update(kwargs)
+    applied["plan"] = str(plan)
+    return applied
+
+
+# ---------------------------------------------------------------------------
+# The wrappers
+# ---------------------------------------------------------------------------
+
+
+def _latent_geometry(args: Sequence[Any], kwargs: Dict[str, Any]) -> Tuple[int, int, int, int]:
+    """``(h, w, frames, dtype_bytes)`` of the latent this decode was handed."""
+    tensor = None
+    for candidate in list(args) + list(kwargs.values()):
+        if hasattr(candidate, "shape") and hasattr(candidate, "ndim"):
+            tensor = candidate
+            break
+    if tensor is None or tensor.ndim < 4:
+        return (0, 0, 0, 2)
+    shape = tuple(int(d) for d in tensor.shape)
+    frames = shape[2] if len(shape) >= 5 else 0
+    dtype_bytes = int(getattr(getattr(tensor, "dtype", None), "itemsize", 2) or 2)
+    return (shape[-2], shape[-1], frames, dtype_bytes)
+
+
+def _wrap_vae_decode(vae: Any, log: logging.Logger) -> bool:
+    """Full-frame decode, tiled retry on OOM, smaller tile on every OOM after.
+
+    THE ORDER MATTERS AND IT IS NOT COSMETIC. Inside the ``except`` block the
+    traceback holds every frame of the failed decode, and those frames hold
+    every live activation — so a retry started there runs against a card that
+    is still full and OOMs again on a tile that would have fitted. The except
+    block therefore does the minimum: record that it happened, drop the
+    traceback, and let the retry run after the scope closes.
+    """
+    original = getattr(vae, "decode", None)
+    if not callable(original):
+        return False
+    state: Dict[str, Any] = {"rung": -1, "ladder": ()}
+
+    def decode(*args: Any, **kwargs: Any) -> Any:
+        while True:
+            failed = ""
+            try:
+                return original(*args, **kwargs)
+            except BaseException as exc:  # noqa: BLE001 — re-raised below unless OOM
+                if not is_cuda_oom(exc):
+                    raise
+                failed = f"{type(exc).__name__}: {exc}"
+                # Drop the frames (and with them the activations) NOW; keep the
+                # text, never the exception object, so nothing outlives this.
+                exc.__traceback__ = None
+
+            flush_memory()
+            ladder: Tuple[TilePlan, ...] = state["ladder"]
+            if not ladder:
+                h, w, frames, dtype_bytes = _latent_geometry(args, kwargs)
+                if not h:
+                    raise RuntimeError(
+                        f"VAE decode ran out of memory and the latent shape is "
+                        f"unreadable, so no tiling can be planned ({failed})")
+                ladder = solve_tile_ladder(
+                    latent_h=h, latent_w=w, latent_frames=frames,
+                    bytes_per_latent=decode_bytes_per_latent(
+                        vae, dtype_bytes=dtype_bytes),
+                    budget_bytes=get_available_vram_gb() * BUDGET_FRACTION * 2**30,
+                )
+                state["ladder"] = ladder
+            state["rung"] += 1
+            if state["rung"] >= len(ladder):
+                raise RuntimeError(
+                    f"VAE decode ran out of memory at every tile the ladder has "
+                    f"({', '.join(str(p) for p in ladder)}); last failure: {failed}")
+            plan = ladder[state["rung"]]
+            applied = apply_tile_plan(vae, plan)
+            if not applied:
+                raise RuntimeError(
+                    f"VAE decode ran out of memory and {type(vae).__name__} "
+                    f"exposes no tiling to retry with ({failed})")
+            _confess_serve_degrade(
+                phase=VAE_TILED_RETRY_PHASE,
+                line=transition_line(
+                    event="engaged", phase="decode",
+                    from_rung="full_frame" if state["rung"] == 0 else "tiled",
+                    to_rung=f"tiled:{plan}",
+                    free_gb=get_available_vram_gb(),
+                    detail=f"VAE decode OOM ({failed}); retrying TILED {applied}",
+                ),
+                detail=(
+                    f"vae={type(vae).__name__}: decode exhausted device memory "
+                    f"({failed}) and is retrying tiled at {plan} "
+                    f"(rung {state['rung'] + 1}/{len(ladder)}). The request still "
+                    f"serves; a tiled decode re-runs the decoder per tile and "
+                    f"blends overlaps, so this pod is serving DEGRADED."
+                ),
+                log=log,
+            )
+
+    setattr(vae, "decode", decode)
+    return True
+
+
+def _denoiser(pipeline: Any) -> Optional[Any]:
+    for name in ("transformer", "unet"):
+        module = getattr(pipeline, name, None)
+        if module is not None and callable(getattr(module, "forward", None)):
+            return module
+    return None
+
+
+def _wrap_denoiser_forward(pipeline: Any, module: Any, log: logging.Logger) -> bool:
+    """One denoise step, retried with a finer attention slice on OOM.
+
+    The step is the right granularity: it is a pure function of its inputs, so
+    a retry is free of side effects, and it is where a long-sequence attention
+    matmul actually allocates. Retrying the whole request instead would pay for
+    every step already taken.
+
+    ``nn.Module.__call__`` resolves ``self.forward`` as an INSTANCE attribute,
+    which is why this can be installed without touching the class — and it is
+    the same seam ``aot_serve`` swaps, so an armed artifact simply captures
+    this wrapper as its eager fallback.
+    """
+    slicer = getattr(pipeline, "enable_attention_slicing", None)
+    original = getattr(module, "forward", None)
+    if not callable(slicer) or not callable(original):
+        return False
+    state = {"rung": -1}
+
+    def forward(*args: Any, **kwargs: Any) -> Any:
+        while True:
+            failed = ""
+            try:
+                return original(*args, **kwargs)
+            except BaseException as exc:  # noqa: BLE001 — re-raised below unless OOM
+                if not is_cuda_oom(exc):
+                    raise
+                failed = f"{type(exc).__name__}: {exc}"
+                exc.__traceback__ = None
+
+            flush_memory()
+            state["rung"] += 1
+            if state["rung"] >= len(ATTENTION_LADDER):
+                raise RuntimeError(
+                    f"denoise step ran out of memory at every attention slice "
+                    f"the ladder has ({', '.join(ATTENTION_LADDER)}); last "
+                    f"failure: {failed}")
+            slice_size = ATTENTION_LADDER[state["rung"]]
+            slicer(slice_size)
+            _confess_serve_degrade(
+                phase=ATTENTION_SLICED_RETRY_PHASE,
+                line=transition_line(
+                    event="engaged", phase="denoise",
+                    from_rung="fused" if state["rung"] == 0 else "sliced",
+                    to_rung=f"sliced:{slice_size}",
+                    free_gb=get_available_vram_gb(),
+                    detail=f"denoise step OOM ({failed}); retrying with "
+                           f"attention_slicing={slice_size}",
+                ),
+                detail=(
+                    f"module={type(module).__name__}: a denoise step exhausted "
+                    f"device memory ({failed}) and is retrying with "
+                    f"attention_slicing={slice_size} (rung {state['rung'] + 1}/"
+                    f"{len(ATTENTION_LADDER)}). The request still serves; sliced "
+                    f"attention replaces the fused kernel with a chunked loop, "
+                    f"so this pod is serving DEGRADED."
+                ),
+                log=log,
+            )
+
+    setattr(module, "forward", forward)
+    return True
+
+
+def install(pipeline: Any, *, logger: Optional[logging.Logger] = None) -> Dict[str, bool]:
+    """Arm both ladders on ``pipeline``. Idempotent, cheap, never raises.
+
+    Nothing here costs anything until an OOM: both wrappers are one Python
+    frame around a call that was going to happen anyway.
+    """
+    if pipeline is None or getattr(pipeline, _INSTALLED, None) is not None:
+        return {}
+    log = logger or _LOG
+    armed: Dict[str, bool] = {}
+    try:
+        vae = getattr(pipeline, "vae", None)
+        if vae is not None:
+            armed["vae_tiled_retry"] = _wrap_vae_decode(vae, log)
+        module = _denoiser(pipeline)
+        if module is not None:
+            armed["attention_sliced_retry"] = _wrap_denoiser_forward(
+                pipeline, module, log)
+        setattr(pipeline, _INSTALLED, armed)
+    except Exception:  # noqa: BLE001 — an unarmed ladder must never fail a load
+        log.debug("oom_ladder: install failed on %s",
+                  type(pipeline).__name__, exc_info=True)
+    return armed
+
+
+__all__ = [
+    "ATTENTION_LADDER",
+    "ATTENTION_SLICED_RETRY_PHASE",
+    "TilePlan",
+    "VAE_TILED_RETRY_PHASE",
+    "apply_tile_plan",
+    "decode_bytes_per_latent",
+    "install",
+    "solve_tile_ladder",
+    "tile_bytes",
+]

--- a/src/gen_worker/models/oom_ladder.py
+++ b/src/gen_worker/models/oom_ladder.py
@@ -265,6 +265,31 @@ def apply_tile_plan(vae: Any, plan: TilePlan) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _grad_warning() -> str:
+    """Empty unless autograd is on — in which case say so, because it is the
+    one condition under which tiling CANNOT help.
+
+    Measured on a real card (sd1.5 VAE, 320² latent, RTX 4070): with grad
+    enabled every tile's activations are retained for backward, so the tiled
+    retry accumulates instead of bounding, and the ladder walks all four rungs
+    down to an 8² tile and still fails. Under ``no_grad`` — which is what
+    diffusers' pipelines decode under — the SAME decode succeeds on the first
+    tiled rung at 2.7 GiB peak. Serving never wants the graph, so this is a
+    caller defect; the confession names it rather than leaving an operator to
+    infer it from four identical OOMs.
+    """
+    try:
+        import torch
+
+        if torch.is_grad_enabled():
+            return (" AUTOGRAD IS ENABLED for this decode, so every tile's "
+                    "activations are retained for backward and tiling cannot "
+                    "bound the peak — decode under `torch.no_grad()`.")
+    except Exception:  # noqa: BLE001 — a diagnostic may never be the failure
+        pass
+    return ""
+
+
 def _latent_geometry(args: Sequence[Any], kwargs: Dict[str, Any]) -> Tuple[int, int, int, int]:
     """``(h, w, frames, dtype_bytes)`` of the latent this decode was handed."""
     tensor = None
@@ -327,7 +352,8 @@ def _wrap_vae_decode(vae: Any, log: logging.Logger) -> bool:
             if state["rung"] >= len(ladder):
                 raise RuntimeError(
                     f"VAE decode ran out of memory at every tile the ladder has "
-                    f"({', '.join(str(p) for p in ladder)}); last failure: {failed}")
+                    f"({', '.join(str(p) for p in ladder)}); last failure: "
+                    f"{failed}.{_grad_warning()}")
             plan = ladder[state["rung"]]
             applied = apply_tile_plan(vae, plan)
             if not applied:
@@ -349,6 +375,7 @@ def _wrap_vae_decode(vae: Any, log: logging.Logger) -> bool:
                     f"(rung {state['rung'] + 1}/{len(ladder)}). The request still "
                     f"serves; a tiled decode re-runs the decoder per tile and "
                     f"blends overlaps, so this pod is serving DEGRADED."
+                    + _grad_warning()
                 ),
                 log=log,
             )

--- a/tests/test_oom_ladder_pgw1499.py
+++ b/tests/test_oom_ladder_pgw1499.py
@@ -236,8 +236,28 @@ def test_a_vae_that_can_never_fit_says_so_instead_of_looping() -> None:
     pipe = _Pipeline(vae)
     with _Events():
         memory.apply_low_vram_config(pipe, mode="off")
-        with pytest.raises(RuntimeError, match="every tile the ladder has"):
-            pipe.vae.decode(torch.randn(1, 4, 24, 24))
+        with torch.no_grad():
+            with pytest.raises(RuntimeError, match="every tile the ladder has") as caught:
+                pipe.vae.decode(torch.randn(1, 4, 24, 24))
+    assert "AUTOGRAD" not in str(caught.value)
+
+
+def test_the_one_condition_under_which_tiling_cannot_help_is_named() -> None:
+    """MEASURED on a real card (sd1.5 VAE, 320² latent, RTX 4070): with grad
+    enabled every tile's activations are retained for backward, the retry
+    accumulates instead of bounding, and all four rungs fail. Under `no_grad`
+    the SAME decode succeeds on the first tiled rung. An operator reading four
+    identical OOMs must not have to infer that."""
+    vae = _tiny_vae()
+    vae.decoder = _CardTooSmall(vae.decoder, limit=0)
+    pipe = _Pipeline(vae)
+    with _Events():
+        memory.apply_low_vram_config(pipe, mode="off")
+        with torch.enable_grad():
+            with pytest.raises(RuntimeError) as caught:
+                pipe.vae.decode(torch.randn(1, 4, 24, 24))
+    assert "AUTOGRAD IS ENABLED" in str(caught.value)
+    assert "torch.no_grad()" in str(caught.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_oom_ladder_pgw1499.py
+++ b/tests/test_oom_ladder_pgw1499.py
@@ -1,0 +1,347 @@
+"""pgw#1499: reactive OOM ladders — the retry is REAL, and it confesses.
+
+Three mechanisms, all of them the CATCHABLE eager cases:
+
+* a VAE decode that exhausts the card is retried TILED, shrinking a rung per
+  further OOM;
+* a denoise step that exhausts the card is retried with a finer attention
+  slice, to a cap;
+* an ASYNCHRONOUS out-of-memory (``AcceleratorError`` code 2) is recognised as
+  an OOM at all, and the poisoned context is flushed before the retry.
+
+Seam. The VAE half runs a REAL ``diffusers.AutoencoderKL`` — real
+``decode``/``_decode``/``tiled_decode``, real blending — armed through the REAL
+``memory.apply_low_vram_config`` install seam, with the OOM injected where a
+real one lands: inside the decoder, on a tensor that is too big. Nothing about
+the ladder is stubbed; only the card is. The events are drained through the
+real activity sink, so the assertions read the ActivityUpdates a hub banks.
+
+Every fixed arm below has a RED arm that flips a CONDITION (the ladder is not
+armed, the cap is exhausted) rather than cutting lines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+import torch
+from diffusers import AutoencoderKL
+
+from gen_worker import activity as activity_mod
+from gen_worker.models import memory, oom_ladder
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+
+class _Events:
+    """The REAL activity sink the worker transport installs."""
+
+    def __init__(self) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        self.loop = asyncio.new_event_loop()
+
+    def __enter__(self) -> "_Events":
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        activity_mod.bind_sink(_send, self.loop)
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.loop.run_until_complete(asyncio.sleep(0.02))
+        activity_mod.reset_for_tests()
+        self.loop.close()
+
+    def degrades(self, phase: str) -> List[pb.ActivityUpdate]:
+        return [
+            m.activity_update for m in self.sent
+            if m.WhichOneof("msg") == "activity_update"
+            and m.activity_update.kind == activity_mod.KIND_SERVE_DEGRADE
+            and m.activity_update.phase == phase
+        ]
+
+
+# ---------------------------------------------------------------------------
+# 1. The tile solver — pure arithmetic, no card
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_halves_first_then_spatial_doubles() -> None:
+    """The ComfyUI solve: shrink time until one tile fits, then grow space."""
+    # 16 latent frames, 128x128 latent, 1 byte per latent element.
+    # A 32-edge tile costs 1024 per frame; the budget takes 4 frames of it.
+    ladder = oom_ladder.solve_tile_ladder(
+        latent_h=128, latent_w=128, latent_frames=16,
+        bytes_per_latent=1.0, budget_bytes=32 * 32 * 4,
+    )
+    assert ladder[0] == oom_ladder.TilePlan(edge=32, frames=4)
+
+    # Quadruple the budget and the SPATIAL tile doubles instead — the temporal
+    # halving stops as soon as one tile fits, and the leftover goes to space.
+    wide = oom_ladder.solve_tile_ladder(
+        latent_h=128, latent_w=128, latent_frames=16,
+        bytes_per_latent=1.0, budget_bytes=64 * 64 * 16,
+    )
+    assert wide[0] == oom_ladder.TilePlan(edge=64, frames=16)
+
+
+def test_a_tile_the_size_of_the_frame_is_not_a_retry() -> None:
+    """A latent no bigger than the base tile still gets a SMALLER rung 0 —
+    retrying the exact shape that just OOMed is not a retry."""
+    ladder = oom_ladder.solve_tile_ladder(
+        latent_h=24, latent_w=24, latent_frames=0,
+        bytes_per_latent=1.0, budget_bytes=0.0,
+    )
+    assert ladder[0].edge < 24
+    assert ladder[0].edge == 8  # min_edge
+
+    # And when the BUDGET says the whole frame fits, the allocator has just
+    # said otherwise — the estimate loses.
+    generous = oom_ladder.solve_tile_ladder(
+        latent_h=24, latent_w=24, latent_frames=0,
+        bytes_per_latent=1.0, budget_bytes=1e12,
+    )
+    assert generous[0].edge < 24
+
+
+def test_the_ladder_descends_and_terminates() -> None:
+    ladder = oom_ladder.solve_tile_ladder(
+        latent_h=256, latent_w=256, latent_frames=8,
+        bytes_per_latent=1.0, budget_bytes=32 * 32 * 8, max_rungs=8,
+    )
+    assert len(ladder) <= 8
+    # Time first, then space, and never sideways.
+    for prev, nxt in zip(ladder, ladder[1:]):
+        assert (nxt.frames, nxt.edge) <= (prev.frames, prev.edge)
+        assert (nxt.frames, nxt.edge) != (prev.frames, prev.edge)
+    assert ladder[-1].frames == 1
+    assert ladder[-1].edge >= 8
+
+
+def test_bytes_per_latent_matches_the_measured_sd_family_coefficient() -> None:
+    """ComfyUI's hand-measured sd15/SDXL decode coefficient is
+    ``2178 * 64 * dtype_size`` bytes per latent element. The formula must land
+    on it, or the first rung is guesswork dressed as arithmetic."""
+
+    class _Cfg:
+        block_out_channels = (128, 256, 512, 512)
+
+    class _Vae:
+        config = _Cfg()
+
+    got = oom_ladder.decode_bytes_per_latent(_Vae(), dtype_bytes=2)
+    assert 0.9 <= got / (2178 * 64 * 2) <= 1.1
+
+
+# ---------------------------------------------------------------------------
+# 2. The VAE ladder against a REAL diffusers AutoencoderKL
+# ---------------------------------------------------------------------------
+
+
+def _tiny_vae() -> Any:
+    """A real AutoencoderKL with an 8x spatial compression and 8 channels."""
+    vae: Any = AutoencoderKL(
+        in_channels=3,
+        out_channels=3,
+        down_block_types=("DownEncoderBlock2D",) * 4,
+        up_block_types=("UpDecoderBlock2D",) * 4,
+        block_out_channels=(8, 8, 8, 8),
+        layers_per_block=1,
+        latent_channels=4,
+        norm_num_groups=8,
+        sample_size=64,
+    )
+    vae.eval()
+    return vae
+
+
+class _CardTooSmall(torch.nn.Module):
+    """The card. Any decoder call over ``limit`` latent elements raises the
+    allocator's real exception — which is exactly what a full-frame decode on a
+    card that cannot hold it does. Everything below that limit really decodes."""
+
+    def __init__(self, decoder: torch.nn.Module, limit: int) -> None:
+        super().__init__()
+        self.inner = decoder
+        self.limit = limit
+        self.calls: List[int] = []
+
+    def forward(self, z: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
+        elems = int(z.shape[-1]) * int(z.shape[-2])
+        self.calls.append(elems)
+        if elems > self.limit:
+            raise torch.cuda.OutOfMemoryError(
+                f"CUDA out of memory. Tried to allocate {elems} MiB")
+        return self.inner(z, *args, **kwargs)
+
+
+class _Pipeline:
+    """A diffusers pipeline reduced to the surface the ladder installs on."""
+
+    def __init__(self, vae: Any) -> None:
+        self.vae = vae
+        self.components: Dict[str, Any] = {"vae": vae}
+
+    def to(self, device: str) -> "_Pipeline":
+        return self
+
+
+def test_a_vae_oom_retries_tiled_and_confesses() -> None:
+    vae = _tiny_vae()
+    vae.decoder = _CardTooSmall(vae.decoder, limit=12 * 12)
+    pipe = _Pipeline(vae)
+    latent = torch.randn(1, 4, 24, 24)
+
+    with _Events() as events:
+        # THE REAL SEAM: placement arms the ladder. `off` is the rung that
+        # pre-applies nothing, so tiling here can only be reactive.
+        memory.apply_low_vram_config(pipe, mode="off")
+        out = pipe.vae.decode(latent).sample
+
+    assert out.shape == (1, 3, 192, 192)
+    # The full frame was tried first and failed; the tiles that followed fit.
+    assert vae.decoder.calls[0] == 24 * 24
+    assert max(vae.decoder.calls[1:]) <= 12 * 12
+    assert vae.use_tiling is True
+
+    banked = events.degrades(oom_ladder.VAE_TILED_RETRY_PHASE)
+    assert len(banked) == 1
+    assert "retrying tiled" in banked[0].detail
+    assert "OutOfMemoryError" in banked[0].detail
+
+
+def test_red_arm_without_the_ladder_the_same_decode_raises() -> None:
+    """The condition that is flipped is the INSTALL, nothing else."""
+    vae = _tiny_vae()
+    vae.decoder = _CardTooSmall(vae.decoder, limit=12 * 12)
+    latent = torch.randn(1, 4, 24, 24)
+    with pytest.raises(torch.cuda.OutOfMemoryError):
+        vae.decode(latent)
+
+
+def test_the_ladder_is_armed_once_per_pipeline() -> None:
+    """`apply_low_vram_config` runs again on every rung of a placement descent;
+    a second wrapper around the first would double every retry."""
+    pipe = _Pipeline(_tiny_vae())
+    memory.apply_low_vram_config(pipe, mode="off")
+    first = pipe.vae.decode
+    memory.apply_low_vram_config(pipe, mode="off")
+    assert pipe.vae.decode is first
+
+
+def test_a_vae_that_can_never_fit_says_so_instead_of_looping() -> None:
+    vae = _tiny_vae()
+    vae.decoder = _CardTooSmall(vae.decoder, limit=0)
+    pipe = _Pipeline(vae)
+    with _Events():
+        memory.apply_low_vram_config(pipe, mode="off")
+        with pytest.raises(RuntimeError, match="every tile the ladder has"):
+            pipe.vae.decode(torch.randn(1, 4, 24, 24))
+
+
+# ---------------------------------------------------------------------------
+# 3. The attention ladder on the denoise step
+# ---------------------------------------------------------------------------
+
+
+class _Denoiser(torch.nn.Module):
+    """A real nn.Module — the point of the seam is that `module(...)` resolves
+    `self.forward` as an INSTANCE attribute, so the wrapper is reached."""
+
+    def __init__(self, ooms: int) -> None:
+        super().__init__()
+        self.left = ooms
+        self.calls = 0
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D102
+        self.calls += 1
+        if self.left > 0:
+            self.left -= 1
+            raise torch.cuda.OutOfMemoryError("CUDA out of memory")
+        return x * 2
+
+
+class _SlicingPipeline(_Pipeline):
+    def __init__(self, vae: Any, unet: Any) -> None:
+        super().__init__(vae)
+        self.unet = unet
+        self.slices: List[Any] = []
+
+    def enable_attention_slicing(self, slice_size: Any = "auto") -> None:
+        self.slices.append(slice_size)
+
+
+def test_a_denoise_oom_slices_attention_and_retries() -> None:
+    unet = _Denoiser(ooms=1)
+    pipe = _SlicingPipeline(_tiny_vae(), unet)
+    x = torch.ones(2, 2)
+
+    with _Events() as events:
+        memory.apply_low_vram_config(pipe, mode="off")
+        out = pipe.unet(x)
+
+    assert torch.equal(out, x * 2)
+    assert unet.calls == 2
+    assert pipe.slices == ["auto"]
+    banked = events.degrades(oom_ladder.ATTENTION_SLICED_RETRY_PHASE)
+    assert len(banked) == 1
+    assert "attention_slicing=auto" in banked[0].detail
+
+
+def test_the_attention_ladder_stops_at_its_cap() -> None:
+    unet = _Denoiser(ooms=99)
+    pipe = _SlicingPipeline(_tiny_vae(), unet)
+    with _Events():
+        memory.apply_low_vram_config(pipe, mode="off")
+        with pytest.raises(RuntimeError, match="every attention slice"):
+            pipe.unet(torch.ones(2, 2))
+    assert pipe.slices == list(oom_ladder.ATTENTION_LADDER)
+
+
+def test_red_arm_without_the_ladder_the_step_raises() -> None:
+    unet = _Denoiser(ooms=1)
+    with pytest.raises(torch.cuda.OutOfMemoryError):
+        unet(torch.ones(2, 2))
+
+
+# ---------------------------------------------------------------------------
+# 4. The asynchronous OOM shape
+# ---------------------------------------------------------------------------
+
+
+def test_an_async_accelerator_oom_is_an_oom() -> None:
+    """Before this issue an AcceleratorError read as an unclassified crash, so
+    no ladder ran on the ASYNCHRONOUS shape of the same exhaustion."""
+    by_code = torch.AcceleratorError("CUDA error: unspecified launch failure")
+    by_code.error_code = 2  # type: ignore[attr-defined]
+    assert memory.is_cuda_oom(by_code) is True
+
+    by_text = torch.AcceleratorError("CUDA error: out of memory")
+    assert memory.is_cuda_oom(by_text) is True
+
+    other = torch.AcceleratorError("CUDA error: an illegal memory access")
+    other.error_code = 700  # type: ignore[attr-defined]
+    assert memory.is_cuda_oom(other) is False
+
+
+def test_discarding_the_async_error_is_safe_without_a_card() -> None:
+    """It runs on every OOM classification, so it may never raise — including
+    on the cardless box where most of this code is exercised."""
+    memory.discard_cuda_async_error()
+
+
+def test_the_ladder_ignores_a_non_oom_failure() -> None:
+    """A ValueError inside the decode is a defect, not a card size: it must
+    reach the caller untouched, with its traceback."""
+    class _Broken(torch.nn.Module):
+        def forward(self, *_a: Any, **_k: Any) -> Any:
+            raise ValueError("bad latent")
+
+    vae = _tiny_vae()
+    vae.decoder = _Broken()
+    pipe = _Pipeline(vae)
+    memory.apply_low_vram_config(pipe, mode="off")
+    with pytest.raises(ValueError, match="bad latent"):
+        pipe.vae.decode(torch.randn(1, 4, 24, 24))
+    assert vae.use_tiling is False


### PR DESCRIPTION
Tracker: pgw#1499 (small-card program axis 3). Ported from ComfyUI's measured
mechanisms; scope is the CATCHABLE eager cases only.

## What lands

| mechanism | seam | ladder |
|---|---|---|
| VAE OOM -> tiled retry | `vae.decode` (instance attr, so the pipeline reaches it) | solved tile, then one rung smaller per further OOM |
| denoise OOM -> sliced attention | the denoiser's `forward` (`nn.Module.__call__` resolves the instance attr) | `attention_slicing` auto -> max, to a cap |
| async OOM | `memory.is_cuda_oom` | `AcceleratorError` code 2 / "out of memory" text, + `discard_cuda_async_error` |

Armed by `apply_low_vram_config` on EVERY rung, including the resident ones —
the rung that most needs a reactive tile is `off`, where nothing was pre-tiled
because everything fitted. `_apply_vae_and_attention`'s per-rung proactive
tiling is unchanged. Both retries confess through the existing
`_confess_serve_degrade` under new phases `vae_tiled_retry` /
`attention_sliced_retry`.

## GPU proof — real card, real weights, matched red/green

RTX 4070 (8 GiB, ~5.2 GiB free), real sd1.5 VAE from the local HF cache, decode
of a 320² latent (2560 px out), armed through the REAL `memory.place_pipeline`:

| arm | result | events | peak |
|---|---|---|---|
| no ladder (master's behaviour) | `OutOfMemoryError` "Tried to allocate 3.12 GiB" | 0 | 6.71 GiB |
| armed | full frame OOMs, ONE tiled retry at 64² latent tiles, `(1,3,2560,2560)` in 14.9 s | 1 x `serve_degrade(vae_tiled_retry)` | **2.68 GiB** |

Transparency: 25 warmed steps @512², **122 ms/step unarmed vs 128 ms/step
armed** — within run-to-run noise on a box at load ~15 (the wrapper is one
Python frame per denoise step).

**Two things that run MEASURED, not assumed:**
1. `exc.__traceback__ = None` inside the `except` frees the failed decode's
   activations **immediately**: allocated 6.92 -> 0.17 GiB at that statement.
   ComfyUI's deferred-flag dance gets the same memory back one scope later;
   this is the same mechanism made explicit and cheaper.
2. **The one condition under which tiling cannot help**: with autograd enabled
   every tile's activations are retained for backward, the retry accumulates
   instead of bounding, and all four rungs fail. Under `no_grad` (what
   diffusers pipelines decode under, so production is safe) the same decode
   succeeds on the first tiled rung. Not papered over by silently disabling
   grad — the confession and the exhausted-ladder error NAME it.

## CPU evidence

`nice -n 19 pytest tests/test_oom_ladder_pgw1499.py` -> **15 passed**, no card
required. The VAE arm runs a REAL `diffusers.AutoencoderKL` through its real
`decode`/`_decode`/`tiled_decode`, armed through the REAL
`apply_low_vram_config` seam, with the OOM injected where a real one lands.
Every fixed arm has a red arm that flips a CONDITION. Events drained through
the real activity sink. Neighbours green (28 with
`test_offload_always_allowed_pgw1312` + `test_vram_fit`). `ruff` clean;
`MYPYPATH=$PWD/src mypy` clean.

## Out of scope, deliberately

The admission-first / mid-graph-OOM-is-fatal stance
(`serving/context.py:427-431`) and compiled-graph OOM handling
(`aot_serve.py:1411-1431`) are untouched. ComfyUI's optional 3-offset seam
averaging is NOT ported: it needs us to own the tiling, and we reuse each
diffusers VAE's own per-class tiled decode instead.

Known pre-existing red, reproduced identically on `origin/master`:
`test_bridge_placement::test_the_bridge_places_the_pipeline_where_the_worker_said`
— environmental: a peer session's VRAM makes the ladder correctly pick
`group_offload` while the test asserts full residency.