### PR TITLE
pgw#1497: per-module budgeted partial residency + streamed weight cast, and the measured partial_stream rung

### DIFF
--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -492,157 +492,17 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
     return applied
 
 
-class _BlockOffloadWindow:
-    """Degraded-mode rung 2: one transformer block's weights REST in
-    host RAM (pinned when possible) and stream to the execution device only
-    for that block's forward. The pre-hook is PREPENDED so the H2D copy runs
-    before any fp8 upcast window on the same block — composed order:
-    host fp8 bytes -> device fp8 -> device compute dtype. The post-hook
-    rebinds ``.data`` to the pristine host copy (weights are read-only at
-    inference; no copy-back), so whatever dtype games other hooks played in
-    between are discarded. ``always_call`` keeps the rebind on exceptions —
-    a mid-block CUDA OOM must not leave the window resident."""
-
-    def __init__(self, params: List[Any], hosts: List[Any], device: Any) -> None:
-        self._params = params
-        self._hosts = hosts
-        self._device = device
-
-    def install(self, block: Any) -> None:
-        block.register_forward_pre_hook(self._pre, prepend=True)
-        block.register_forward_hook(self._post, always_call=True)
-
-    def _pre(self, module: Any, args: Any) -> None:
-        for p, h in zip(self._params, self._hosts):
-            p.data = h.to(self._device, non_blocking=True)
-
-    def _post(self, module: Any, args: Any, output: Any = None) -> None:
-        for p, h in zip(self._params, self._hosts):
-            p.data = h
-
-
-def apply_block_window_offload(
-    obj: Any,
-    *,
-    components: tuple[str, ...] | None = None,
-    device: Any = None,
-) -> bool:
-    """Park a module's per-block weights in pinned host RAM and stream each
-    block to ``device`` for its forward only — the block windows in reverse
-    (degraded-mode rung 2). Quality-preserving but slow (whole-model PCIe
-    traffic per forward); a guaranteed-completion last resort for
-    VRAM-constrained cards, never a production serving mode.
-
-    ``obj`` is a pipeline (named ``components`` are offloaded) or a bare
-    module. Parameters outside the discovered block windows — embeddings,
-    final norms, projections — are moved TO ``device`` (they must be
-    resident; the outside-a-block dtype hazard applies to device placement
-    too). Composes with fp8 storage windows: fp8 bytes stream over PCIe (half
-    the traffic), upcast happens on-device.
-
-    Returns True when any module was armed. Idempotent per module."""
-    # Default resolved at call time, not in the signature: a def-time default
-    # would freeze the vocabulary before declare_components() ever runs.
-    if components is None:
-        components = denoiser_components()
-    try:
-        import torch
-    except ImportError:
-        logger.warning("block-window offload ignored: torch not installed")
-        return False
-    if device is None:
-        if not cuda_ready():
-            logger.warning("block-window offload ignored: no CUDA device")
-            return False
-        device = "cuda"
-
-    targets: List[tuple[str, Any]] = []
-    for name in components:
-        mod = getattr(obj, name, None)
-        if mod is not None and hasattr(mod, "parameters"):
-            targets.append((name, mod))
-    if not targets and hasattr(obj, "parameters"):
-        targets.append((type(obj).__name__, obj))
-
-    applied = False
-    for name, mod in targets:
-        if getattr(mod, "_cozy_block_offload_applied", False):
-            applied = True
-            continue
-        windows = _fp8_block_windows(mod) or _fp8_block_windows_whole(mod)
-        if not windows:
-            logger.warning("block-window offload: no weight windows in %s", name)
-            continue
-        pin = True
-        parked_ids: set[int] = set()
-        parked_bytes = 0
-        for _bname, block, params in windows:
-            hosts: List[Any] = []
-            for p in params:
-                host = None
-                if pin:
-                    try:
-                        host = torch.empty_like(p.data, device="cpu", pin_memory=True)
-                    except RuntimeError as exc:
-                        pin = False
-                        logger.warning(
-                            "block-window offload: pinned host alloc failed (%s); "
-                            "falling back to pageable staging (slower)", exc,
-                        )
-                if host is None:
-                    host = torch.empty_like(p.data, device="cpu")
-                host.copy_(p.data)
-                p.data = host
-                hosts.append(host)
-                parked_ids.add(id(p))
-                parked_bytes += host.numel() * host.element_size()
-            _BlockOffloadWindow(params, hosts, device).install(block)
-        # Everything OUTSIDE the windows must be resident on the device.
-        for p in mod.parameters():
-            if id(p) not in parked_ids and p.device != torch.device(device):
-                p.data = p.data.to(device)
-        for b in mod.buffers():
-            # `parked_ids` guards buffers too: the storage lanes hold their
-            # weights as BUFFERS (w8a8's scaled weights, the fp8 storage
-            # leaves), so without this the just-parked block weights are
-            # pulled straight back onto the device and the rung saves nothing.
-            if id(b) not in parked_ids and b.device != torch.device(device):
-                b.data = b.data.to(device)
-        mod._cozy_block_offload_applied = True
-        applied = True
-        logger.warning(
-            "DEGRADED_MODE=engaged model=%s phase=load rung=resident->block_offload: "
-            "%d blocks / %.1f GiB parked in %s host RAM, streaming per forward",
-            name, len(windows), parked_bytes / float(1 << 30),
-            "pinned" if pin else "pageable",
-        )
-        # Structurally reported, not just logged: every forward on this
-        # component now streams its weights over PCIe from host RAM, the
-        # biggest per-request latency change the loader can make. `pinned` vs
-        # `pageable` rides the detail — they differ by roughly 2x on a
-        # transfer that now sits in the critical path.
-        activity_mod.emit_event(
-            activity_mod.KIND_SERVE_DEGRADE,
-            f"component={name} obj={type(obj).__name__}: block-window offload "
-            f"ENGAGED — {len(windows)} block(s) / "
-            f"{parked_bytes / float(1 << 30):.1f} GiB rest in "
-            f"{'pinned' if pin else 'pageable'} host RAM and stream to the "
-            f"device per forward; every request on this component pays that "
-            f"transfer",
-            phase="block_offload_engaged",
-        )
-    return applied
-
-
-def block_offload_active(obj: Any) -> bool:
-    """True when :func:`apply_block_window_offload` armed ``obj`` or any of
-    its standard components."""
-    if getattr(obj, "_cozy_block_offload_applied", False):
-        return True
-    return any(
-        getattr(getattr(obj, name, None), "_cozy_block_offload_applied", False)
-        for name in denoiser_components()
-    )
+# pgw#1497 DELETED the block-window offload rung that stood here
+# (`_BlockOffloadWindow` / `apply_block_window_offload` / `block_offload_active`).
+# It was exported and NEVER CALLED, and every property it had, the
+# `stream_residency` rung has strictly better: it windowed whole transformer
+# BLOCKS where that one windows leaf modules, moved all of them or none of them
+# where that one fills a budget, and streamed on the ambient stream with no
+# reused cast buffer, no in-flight reservation and no partial-unload primitive.
+# Keeping both would have left three overlapping offload implementations in one
+# tree, which is exactly the disease the ComfyUI study named (report A,
+# do-not-copy list). `_fp8_block_windows` survives — the fp8 storage rung is its
+# real caller.
 
 
 def require_decodable(contract: str, path: Any, *, component: str = "") -> None:
@@ -2532,8 +2392,6 @@ __all__ = [
     "MixedComputeDtypeError",
     "composition_compute_dtype",
     "QUANT_EXECUTION_LANE_COMPUTE_DEFAULT",
-    "apply_block_window_offload",
-    "block_offload_active",
     "pipeline_weight_lane",
     "runtime_fp8_storage_supported",
     "component_load_dtypes",

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -53,8 +53,8 @@ _GIB = 1024 ** 3
 Mode = str  # "auto" | "off" | "vae_only" | "model_offload" | "group_offload" | "sequential" | "cpu"
 
 _VALID_MODES: tuple[str, ...] = (
-    "auto", "off", "vae_only", "model_offload", "group_offload", "sequential",
-    "cpu",
+    "auto", "off", "vae_only", "partial_stream", "model_offload",
+    "group_offload", "sequential", "cpu",
 )
 
 _DEFAULT_MODEL_OFFLOAD_THRESHOLD_GB = 8.0
@@ -1145,6 +1145,183 @@ def _pin_unhookable_components(
         )
 
 
+#: The typed phase a `partial_stream` arming FAILURE confesses under. A rung
+#: that could not arm and fell through to a coarser one is a placement the
+#: operator asked for and did not get — pgw#1497 measured that exact silence on
+#: the card (a component-vocabulary AttributeError, a warning, a pipeline that
+#: served on `model_offload`, and nothing off the pod said so).
+PARTIAL_STREAM_UNARMED_PHASE = "partial_stream_unarmed"
+
+#: Set on a pipeline the `partial_stream` rung armed: its
+#: :class:`~gen_worker.models.stream_residency.StreamedResidency`, so the tail
+#: can be trimmed or promoted later without rediscovering the tree.
+STREAM_RESIDENCY_ATTR = "_cozy_stream_residency"
+
+
+def stream_residency_of(pipeline: Any) -> Any:
+    """The `partial_stream` handle armed on ``pipeline``, or None."""
+    return getattr(pipeline, STREAM_RESIDENCY_ATTR, None)
+
+
+def _apply_partial_stream(
+    pipeline: Any,
+    applied: Dict[str, Any],
+    *,
+    budget_bytes: Any,
+    log: logging.Logger,
+    device: str = "cuda",
+) -> bool:
+    """Arm pgw#1497's per-leaf budgeted residency. False = could not.
+
+    ``budget_bytes`` is the DEVICE bytes this pipeline's weights may occupy,
+    and it is the caller's — the residency lease's — number. Nothing here
+    estimates it, and the whole rung refuses rather than invent one.
+
+    The dtype-fragile and content-shared union is excluded exactly as every
+    other rung excludes it: those components are handed to the ring by nobody
+    and stay wherever they are.
+    """
+    def _unarmed(reason: str) -> bool:
+        """The rung did not arm. Say so on BOTH channels and fall through.
+
+        A warning alone was the defect: the pipeline still served, on a
+        coarser rung than the budget asked for, and nothing off the pod
+        recorded it. Placement the operator did not get is a degradation.
+        """
+        _confess_serve_degrade(
+            phase=PARTIAL_STREAM_UNARMED_PHASE,
+            line=transition_line(
+                event="refused", phase="load", from_rung="partial_stream",
+                to_rung="model_offload", detail=reason,
+            ),
+            detail=(
+                f"pipeline={type(pipeline).__name__}: the partial_stream rung "
+                f"could NOT arm under its {budget_bytes} byte budget "
+                f"({reason}); this pipeline falls through to a COARSER rung "
+                f"and the per-leaf budget it was admitted for is not being "
+                f"honoured."
+            ),
+            log=log,
+        )
+        return False
+
+    try:
+        from .stream_residency import MemoryBudget, StreamedResidency
+    except Exception as exc:  # noqa: BLE001 — torch-less host
+        return _unarmed(f"{type(exc).__name__}: {exc}")
+
+    excluded = set(unhookable_components(pipeline))
+    # `_named_components` answers the pipeline's whole COMPONENT vocabulary,
+    # and a real sd1.5 pipeline puts a CLIPTokenizer, a scheduler and a feature
+    # extractor in it. Measured on the card: without this filter the rung
+    # raised `CLIPTokenizer has no attribute named_modules` and fell through to
+    # `model_offload` — silently, because the fall-through is a warning and the
+    # pipeline still served.
+    roots = [
+        (name, module)
+        for name, module in _named_components(pipeline)
+        if name not in excluded and hasattr(module, "named_modules")
+    ]
+    if not roots:
+        # A bare module (a lane ModuleDict, a test tree) is its own root.
+        roots = [(type(pipeline).__name__, pipeline)] if hasattr(
+            pipeline, "named_modules"
+        ) else []
+    if not roots:
+        return _unarmed("no hookable nn.Module tree on this pipeline")
+
+    # The excluded components are kept OUT of the ring, and that makes placing
+    # them this rung's job — exactly as `_apply_group_offload` keeps its own
+    # `exclude_modules` resident. MEASURED on the 4070: sd1.5's VAE is
+    # `force_upcast`, so it is dtype-fragile and excluded, and with nobody
+    # moving it the first decode died with `Input type (torch.cuda.HalfTensor)
+    # and weight type (torch.HalfTensor) should be the same`. An exclusion is a
+    # statement about HOOKS, never about residency.
+    components = getattr(pipeline, "components", None)
+    for name in sorted(excluded):
+        module = components.get(name) if isinstance(components, dict) else None
+        if module is None or not hasattr(module, "to"):
+            continue
+        try:
+            module.to(device)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "low_vram: partial_stream could not keep excluded component %r "
+                "on %s (%s: %s); it will not serve",
+                name, device, type(exc).__name__, exc,
+            )
+
+    try:
+        residency = StreamedResidency(
+            roots, device=device, budget_bytes=MemoryBudget.of(budget_bytes)
+        )
+        plan = residency.engage()
+    except Exception as exc:  # noqa: BLE001
+        return _unarmed(f"{type(exc).__name__}: {exc}")
+
+    try:
+        # Before the handle is visible, not after: the device repair below
+        # READS it, and diffusers' `__setattr__` treats attribute names as
+        # component registrations, so a failed set must not go unnoticed.
+        setattr(pipeline, STREAM_RESIDENCY_ATTR, residency)
+    except Exception:  # noqa: BLE001
+        log.warning(
+            "low_vram: could not stamp the partial_stream handle on %s; "
+            "`pipeline.device` will keep answering with the host while the "
+            "tail is parked there",
+            type(pipeline).__name__,
+        )
+    # The rung parks leaves on the host, so `pipeline.device` stops answering
+    # with the execution device. Install the repair HERE too, not only on the
+    # `apply_low_vram_config` path, so a direct caller gets a coherent
+    # pipeline rather than an embedding that dies on a host-side index.
+    install_execution_device_fallback()
+    applied["partial_stream"] = True
+    applied["stream_budget_bytes"] = int(plan.budget_bytes)
+    # The RAM half of the assigned pair, REPORTED — enforcement is the named
+    # pgw#1497 follow-up. `host_bytes` is what the pinned tail costs the host.
+    applied["stream_ram_budget_bytes"] = int(plan.ram_budget_bytes)
+    applied["stream_host_bytes"] = int(plan.host_bytes)
+    applied["stream_host_fits"] = bool(plan.host_fits)
+    applied["stream_resident_bytes"] = int(plan.resident_bytes)
+    applied["stream_streamed_bytes"] = int(plan.streamed_bytes)
+    applied["stream_window_bytes"] = int(plan.window_bytes)
+    applied["stream_resident_leaves"] = len(plan.all_resident)
+    applied["stream_streamed_leaves"] = len(plan.streamed)
+
+    if not plan.streamed:
+        # The budget held the whole tree. That is not a degradation and must
+        # not be reported as one — the rung armed and then had nothing to do.
+        log.info(
+            "low_vram: partial_stream armed on %s and streams nothing — the "
+            "%.2f GiB budget holds all %d leaves; serving fully resident",
+            type(pipeline).__name__, budget_bytes / _GIB, len(plan.all_resident),
+        )
+        return True
+
+    if not plan.fits:
+        # The confession the `fits` property exists for: even the streaming
+        # window is over the lease. It serves, and it says so.
+        log.warning(
+            "low_vram: partial_stream is OVER ITS LEASE on %s — %.2f GiB of "
+            "in-flight cast window against a %.2f GiB budget. It serves; the "
+            "budget arithmetic upstream is what needs looking at.",
+            type(pipeline).__name__, plan.window_bytes / _GIB,
+            budget_bytes / _GIB,
+        )
+    log.warning(
+        "DEGRADED_MODE=engaged model=%s phase=load rung=resident->"
+        "partial_stream: %d of %d leaves (%.2f GiB) rest in pinned host RAM "
+        "and cast per forward; %.2f GiB stays resident under a %.2f GiB "
+        "budget, %.2f GiB reserved for the in-flight cast window",
+        type(pipeline).__name__, len(plan.streamed),
+        len(plan.streamed) + len(plan.all_resident),
+        plan.streamed_bytes / _GIB, plan.resident_bytes / _GIB,
+        budget_bytes / _GIB, plan.window_bytes / _GIB,
+    )
+    return True
+
+
 def _apply_group_offload(
     pipeline: Any,
     applied: Dict[str, bool],
@@ -1596,6 +1773,19 @@ def install_execution_device_fallback() -> bool:
 
     def device(self: Any) -> Any:
         got = original_getter(self)
+        # pgw#1497. The SAME repair, for the rung one line below `meta` in
+        # severity. `partial_stream` parks leaves on the host, so the original
+        # getter — which answers with the first parameter it finds — reports
+        # `cpu` for a pipeline that executes on the card. The pipeline then
+        # builds `input_ids` on the host and the first embedding dies with
+        # `index is on cpu, different from other tensors on cuda:0`. MEASURED
+        # on the 4070: sd1.5 at a 5% budget and SDXL armed from the host, both
+        # of them at exactly the budgets the rung exists for. This is the rung
+        # breaking a public answer, so this is where it is repaired.
+        armed = getattr(self, STREAM_RESIDENCY_ATTR, None)
+        armed_device = getattr(armed, "device", None) if armed is not None else None
+        if armed_device is not None and getattr(armed, "plan", None) is not None:
+            return armed_device
         if getattr(got, "type", None) != "meta":
             return got
         if getattr(reentry, "active", False):
@@ -1630,15 +1820,37 @@ def apply_low_vram_config(
     model_size_gb: Optional[float] = None,
     peak_vram_gb: Optional[float] = None,
     offload_to_disk_path: Optional[str] = None,
+    stream_budget_bytes: int = 0,
+    stream_ram_budget_bytes: int = 0,
 ) -> Dict[str, Any]:
     """Apply a low-VRAM configuration to a diffusers pipeline.
 
     ``mode="auto"`` runs :func:`select_auto_mode` against free VRAM. Returns a
     dict describing what was applied. Idempotent per pipeline object.
+
+    ``stream_budget_bytes`` / ``stream_ram_budget_bytes`` are pgw#1497's
+    ADMISSION PAIR — the {VRAM, RAM} profile this model was assigned (Paul,
+    2026-08-19). The RAM half is REPORTED, not yet enforced (see
+    :class:`~gen_worker.models.stream_residency.MemoryBudget`); the signature
+    carries the pair now so enforcement is a change of behaviour, not shape.
+    ``stream_budget_bytes`` is the VRAM half and is the ADMISSION number: the device bytes
+    this pipeline's weights were leased. Passing it upgrades any offload rung
+    ``auto`` would otherwise have chosen to ``partial_stream``, which moves
+    only the bytes that did not fit instead of a whole component. Omitting it
+    is not a smaller version of that — the rung REFUSES without it, because a
+    budget nobody handed down is exactly the activation estimate this port
+    exists to avoid.
     """
     log = logger or _LOG
     if mode not in _VALID_MODES:
         raise ValueError(f"invalid low-VRAM mode: {mode!r}; expected one of {_VALID_MODES}")
+    if mode == "partial_stream" and int(stream_budget_bytes) <= 0:
+        raise ValueError(
+            "partial_stream needs an explicit stream_budget_bytes: its resident "
+            "set is sized by the RESIDENCY LEASE, never by an activation "
+            "estimate (pgw#1497). A caller with no lease in hand wants "
+            "model_offload."
+        )
 
     prior = getattr(pipeline, _COZY_MODE_ATTR, None)
     if prior is not None:
@@ -1661,12 +1873,43 @@ def apply_low_vram_config(
         effective_mode = "model_offload"
     if mode == "auto":
         effective_mode = _gguf_resident_override(pipeline, effective_mode, log)
+    # pgw#1497. `select_auto_mode` cannot pick this rung — it is a proactive
+    # decider and has no lease to read — so the UPGRADE happens here, where the
+    # caller's lease number is in scope. Any offload rung the free-VRAM walk
+    # chose becomes the fine-grained one, because the coarse rung's whole
+    # disadvantage is that it moves a component when it needed to move a few
+    # leaves. The budget is the SMALLER of the lease and what the card actually
+    # has free: both are facts, and admitting more than the card holds would
+    # OOM under a lease that was written when the card was emptier.
+    if effective_mode in ("model_offload", "group_offload", "sequential") and int(
+        stream_budget_bytes
+    ) > 0:
+        headroom = int(
+            max(0.0, get_available_vram_gb() - _DEFAULT_SAFETY_MARGIN_GB) * _GIB
+        )
+        budget = min(int(stream_budget_bytes), headroom) if headroom else 0
+        if budget > 0:
+            log.info(
+                "low_vram: upgrading %s -> partial_stream under a %.2f GiB "
+                "budget (lease %.2f GiB, free-VRAM headroom %.2f GiB)",
+                effective_mode, budget / _GIB,
+                int(stream_budget_bytes) / _GIB, headroom / _GIB,
+            )
+            effective_mode = "partial_stream"
+            stream_budget_bytes = budget
+        else:
+            log.info(
+                "low_vram: keeping %s — the card has no free headroom to hold "
+                "a partial_stream resident set (lease %.2f GiB)",
+                effective_mode, int(stream_budget_bytes) / _GIB,
+            )
 
     applied: Dict[str, Any] = {
         "mode": effective_mode,
         "vae_slicing": False,
         "vae_tiling": False,
         "attention_slicing": False,
+        "partial_stream": False,
         "model_offload": False,
         "group_offload": False,
         "sequential_offload": False,
@@ -1735,6 +1978,31 @@ def apply_low_vram_config(
                 "low_vram: CPU RAM tight (%.1f GB free); enabling disk offload at %s",
                 get_available_ram_gb(), offload_to_disk_path,
             )
+
+    if effective_mode == "partial_stream":
+        from .stream_residency import MemoryBudget as _MemoryBudget
+
+        if _apply_partial_stream(
+            pipeline,
+            applied,
+            budget_bytes=_MemoryBudget(
+                vram_bytes=int(stream_budget_bytes),
+                ram_bytes=max(0, int(stream_ram_budget_bytes)),
+            ),
+            log=log,
+        ):
+            setattr(pipeline, _COZY_MODE_ATTR, "partial_stream")
+            if applied.get("stream_streamed_leaves"):
+                _report_offload_engaged(pipeline, "partial_stream", applied, log)
+            return applied
+        # It could not arm (no torch, no hookable tree, a meta/aliased leaf).
+        # The next rung down is the honest answer, not a resident placement.
+        log.warning(
+            "low_vram: partial_stream did not arm; descending to model_offload"
+        )
+        applied["partial_stream"] = False
+        effective_mode = "model_offload"
+        applied["mode"] = effective_mode
 
     if effective_mode == "model_offload":
         _pin_unhookable_components(pipeline, applied, log)

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -223,13 +223,13 @@ def _obj_manages_own_device(obj: Any) -> bool:
 
 def _obj_offload_hooked(obj: Any) -> bool:
     """Any offload arming that parks weights in host RAM: the diffusers
-    CPU-offload modes plus the block-window rung."""
+    CPU-offload modes plus the pgw#1497 streamed-tail rung."""
     if _obj_manages_own_device(obj):
         return True
     try:
-        from .loading import block_offload_active
+        from .stream_residency import stream_residency_active
 
-        return bool(block_offload_active(obj))
+        return bool(stream_residency_active(obj))
     except Exception:
         return False
 

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -48,6 +48,13 @@ class Rung:
     run_mode: str
     latency: float
     touches_host_ram: bool
+    #: pgw#1497. True for a rung only the ADMISSION path can select, because
+    #: its budget comes from a residency lease. Neither ``select_auto_mode``
+    #: (a proactive decider, no lease) nor the reactive OOM descent (no lease
+    #: at the moment it fires) may produce one, and a run-mode-only
+    #: :func:`price` does not describe one — a caller standing on such a rung
+    #: passes its NAME.
+    admission_only: bool = False
 
 
 # Wire run modes (Go-mirrored: tensorhub profiling.RunMode). Values are the
@@ -60,6 +67,61 @@ RUN_CPU = "cpu"
 NATIVE = Rung("native", "", "", RUN_NATIVE, 1.0, False)
 FP8_STORAGE = Rung("fp8_storage", "", "fp8", RUN_FP8_STORAGE, 1.05, False)
 MODEL_OFFLOAD = Rung("model_offload", "model_offload", "", RUN_OFFLOAD, 2.5, True)
+# pgw#1497 — per-LEAF-MODULE budgeted residency, the tail cast per forward from
+# pinned host RAM (`models.stream_residency`). The only rung with a BUDGET: the
+# others move a whole component (model_offload), every leaf unconditionally
+# (sequential) or a fixed group (group_offload), and none of them can be asked
+# for a number.
+#
+# ITS POSITION IS MEASURED, AND IT IS NOT WHERE THE ISSUE PREDICTED.
+# pgw#1497 specified it "between fp8_storage and model_offload". On the card
+# that is false. sd1.5, 512^2, 25 steps, CFG, fp16, eager, one config, RTX
+# 4070, best of 2 timed runs after a warmup:
+#
+#   rung                        ms/step   x native   peak VRAM
+#   resident                      119.6      1.00      2.81 GB
+#   model_offload                 187.2      1.57      1.88 GB
+#   partial_stream @50% budget    228.9      1.91      1.89 GB
+#   partial_stream @25% budget    377.7      3.16      1.35 GB
+#   partial_stream @5%  budget    426.4      3.56      1.04 GB
+#   group_offload                 550.2      4.60      0.82 GB
+#   sequential                    903.6      7.55      0.65 GB
+#
+# At EQUAL peak VRAM (1.89 vs 1.88 GB) model_offload is faster — 1.57x against
+# 1.91x — because its offload tax is per-CALL (measured: 1.69 s per generation,
+# fixed) while streaming is per-STEP. So this rung does not belong above it.
+# What it does that model_offload cannot is go LOWER: model_offload is
+# whole-component granular and bottoms out near 1.9 GB here, and this rung
+# keeps serving down to 1.04 GB at 3.56x — still 1.3x faster than
+# group_offload and 2.1x faster than sequential, the only other rungs that
+# reach that floor. Hence: below model_offload, above group_offload.
+#
+# The PRICE is that interval read off the measurements. At the 25% budget —
+# the regime it is actually selected in, a budget model_offload cannot meet —
+# it sits 52% of the way from model_offload to group_offload on the measured
+# scale ((3.16-1.57)/(4.60-1.57)), which maps onto the declared [2.5, 3.0]
+# interval as 2.76. Filed as 2.8.
+#
+# CAVEAT, recorded because it is the honest reading of the same run: the
+# ladder's OTHER declared prices are stale against this card (model_offload
+# 2.5 declared / 1.57 measured, group_offload 3.0 / 4.60, sequential 4.0 /
+# 7.55). The ORDER is right and the magnitudes are not. Re-deriving them is a
+# separate issue; interpolating into the declared interval keeps this rung
+# consistent with its neighbours rather than correct against a scale nothing
+# else uses.
+#
+# ADMISSION-FIRST, its defining constraint: the budget is the residency
+# lease's, never an activation estimate. `select_auto_mode` NEVER returns it —
+# a proactive decider has no lease to read — and `apply_low_vram_config`
+# REFUSES it without an explicit `stream_budget_bytes`. The mechanism ported
+# here is the one ComfyUI drives from hand-fitted per-architecture activation
+# lambdas; taking the mechanism without the estimator is the whole point. The
+# reactive descent does not enter it either (`_walk` sends any resident token
+# to `model_offload`): a load-time OOM has no lease in hand when it fires.
+PARTIAL_STREAM = Rung(
+    "partial_stream", "partial_stream", "", RUN_OFFLOAD, 2.8, True,
+    admission_only=True,
+)
 GROUP_OFFLOAD = Rung("group_offload", "group_offload", "", RUN_OFFLOAD, 3.0, True)
 SEQUENTIAL = Rung("sequential", "sequential", "", RUN_OFFLOAD, 4.0, True)
 # touches_host_ram: a CPU-placed pipeline keeps its WHOLE tree in host RAM —
@@ -70,7 +132,8 @@ CPU = Rung("cpu", "cpu", "", RUN_CPU, 40.0, True)
 
 #: The ONE ordering, best first. ``descend`` walks it; nothing else may.
 LADDER: tuple[Rung, ...] = (
-    NATIVE, FP8_STORAGE, MODEL_OFFLOAD, GROUP_OFFLOAD, SEQUENTIAL, CPU,
+    NATIVE, FP8_STORAGE, MODEL_OFFLOAD, PARTIAL_STREAM, GROUP_OFFLOAD, SEQUENTIAL,
+    CPU,
 )
 
 #: The reactive placement tail, shallowest first (gw#463): a load-time CUDA
@@ -165,12 +228,26 @@ def run_mode_of(name: Optional[str]) -> str:
     return r.run_mode if r is not None else ""
 
 
-def price(run_mode: str) -> float:
-    """Honest latency multiplier vs a native run, by wire run mode. Coarse
-    order-of-magnitude guidance (the hub's measured fit-matrix latency is
-    authoritative when available); monotonic down the ladder."""
+def price(mode_or_rung: str) -> float:
+    """Honest latency multiplier vs a native run.
+
+    Takes either a RUNG NAME — the exact price of the rung the caller is
+    standing on — or a wire run mode, which is coarse order-of-magnitude
+    guidance (the hub's measured fit-matrix latency is authoritative when
+    available); monotonic down the ladder.
+
+    The run-mode scan skips ``admission_only`` rungs. Three rungs now project
+    onto ``RUN_OFFLOAD`` and they span the ladder, so the run-mode answer has
+    to name which one it describes: it describes the shallowest rung a
+    PROACTIVE walk can land on, because that is the only kind of walk a caller
+    holding nothing but a run mode has taken. A caller who knows it is on
+    ``partial_stream`` passes that name and gets that rung's own number.
+    """
+    exact = _BY_NAME.get(str(mode_or_rung or ""))
+    if exact is not None:
+        return exact.latency
     for r in LADDER:
-        if r.run_mode == run_mode:
+        if r.run_mode == mode_or_rung and not r.admission_only:
             return r.latency
     return 1.0
 

--- a/src/gen_worker/models/stream_residency.py
+++ b/src/gen_worker/models/stream_residency.py
@@ -1,0 +1,858 @@
+"""Per-module budgeted partial residency with cast-per-forward streaming.
+
+The finest rung on the degrade ladder (pgw#1497), ported from ComfyUI's
+lowvram mechanism (`comfy/model_patcher.py:982-1111`, `comfy/ops.py:337-459`,
+`comfy/model_management.py:1340-1494`) — THE reason a 20 GB model is usable on
+a 6 GB card over there.
+
+Three parts:
+
+* **The budget split** (:func:`plan_residency`) — walk the leaf modules sorted
+  by offload cost, fill a VRAM budget largest-first, and reserve the
+  ``streams``-deep IN-FLIGHT WINDOW so the streaming tail can never overshoot
+  the budget it was fitted to. Pure arithmetic, no torch, deterministic.
+* **The streaming tail** (:class:`StreamedResidency`) — every leaf that did
+  not fit rests in PINNED host RAM and is cast onto the device inside its own
+  forward, on round-robin offload streams writing into persistent reused cast
+  buffers, so leaf N+1's H2D overlaps leaf N's compute. Both fences matter:
+  the stream waits on compute before its buffer is refilled, and compute waits
+  on the stream before it reads.
+* **Partial unload/load** (:meth:`StreamedResidency.rebudget`) — the eviction
+  and demotion primitive. Freeing N bytes trims a model's cold tail instead of
+  dropping the model, which is what lets several warm endpoints share one card
+  and IS the implementation of the host tier's ``demote_to_host`` /
+  ``promote_to_device``.
+
+**The budget is handed down, never estimated.** ComfyUI derives it from
+hand-fitted per-architecture activation lambdas, and their own code is fleeing
+that (report A, weaknesses 1-3). Ours comes from the residency lease:
+admission already reserved ``weights + headroom`` before a byte moved, and the
+number this module is given is what that admission decided the resident
+weights may occupy. Nothing here measures, guesses or samples VRAM.
+
+**One walk, not two.** ComfyUI has a load walk and a separate inverse
+``partially_unload`` walk which can disagree about the same model. Here there
+is exactly one planner: unload is a re-plan at a smaller budget, load a re-plan
+at a larger one, and the transition is the set difference. Demotion to the host
+tier is the same call with a budget of zero.
+
+**Hooks, not op subclasses.** ComfyUI owns its layer classes; we serve
+arbitrary diffusers trees, so the mechanism is a forward pre/post hook pair
+over true leaf modules (no children, own tensors). A module that owns
+parameters AND children stays resident: its post-hook would fire after its
+children's forwards, holding a cast-buffer view alive across their casts.
+
+**LoRA.** Ours is attach-based (:mod:`gen_worker.utils.lora` →
+``load_lora_weights``/``set_adapters``), so an adapter is a pair of tiny
+``lora_A``/``lora_B`` leaves NEXT TO the base layer, never a patch fused into
+the base weight. That makes ComfyUI's LowVramPatch machinery unnecessary: peft
+computes ``base_layer(x) + lora_B(lora_A(x)) * scale``, the base layer streams
+through its own hook exactly as an unpatched one does, and the adapter leaves
+are forced resident (they are megabytes, and their cost is dwarfed by the
+launch overhead of streaming them). A MERGED adapter is just a different
+weight and streams like any other.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from . import staging
+
+logger = logging.getLogger(__name__)
+
+#: Round-robin offload streams. Two is ComfyUI's NVIDIA/AMD default and the
+#: point where a second in-flight cast stops buying overlap on one copy engine.
+DEFAULT_STREAMS = 2
+
+#: Leaves smaller than this are always resident. Streaming a 4 KiB norm weight
+#: costs two hook calls, a carve and a fence to save four kilobytes — the
+#: launch overhead dominates the transfer. (ComfyUI force-loads ≤16 KiB modules
+#: on its AIMDO path for the same reason; ours is coarser on purpose.)
+DEFAULT_MIN_STREAM_BYTES = 1 << 20
+
+#: Cast-buffer carve alignment. A uint8 slice must be re-viewable as the
+#: weight's dtype, so every sub-buffer starts on a 512-byte boundary.
+_ALIGN = 512
+
+#: Set on a module whose leaves this rung has hooked.
+ENGAGED_ATTR = "_cozy_stream_residency"
+
+#: Substrings marking adapter leaves that are never streamed (see the module
+#: docstring's LoRA note).
+_ADAPTER_MARKERS = ("lora_a", "lora_b", "lora_embedding", "lora_magnitude")
+
+
+def _aligned(n: int) -> int:
+    return (int(n) + _ALIGN - 1) // _ALIGN * _ALIGN
+
+
+# ---------------------------------------------------------------------------
+# The budget split — pure arithmetic, no torch
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LeafCost:
+    """One leaf module's two prices.
+
+    ``resident_bytes`` is what keeping it on the card costs. ``cast_bytes`` is
+    what streaming it costs *while it is in flight* — the cast-buffer space it
+    occupies. They differ only where storage and compute dtype differ (an fp8
+    leaf casting to bf16 needs twice its stored size in the buffer); ComfyUI
+    also folds an on-the-fly LoRA cost in here, which we do not need because
+    attached adapters are separate resident leaves.
+    """
+
+    name: str
+    resident_bytes: int
+    cast_bytes: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.cast_bytes:
+            object.__setattr__(self, "cast_bytes", int(self.resident_bytes))
+
+
+@dataclass(frozen=True)
+class ResidencyPlan:
+    """Which leaves stay on the card, which stream, and what it reserves."""
+
+    budget_bytes: int
+    streams: int
+    #: Forced resident (below ``min_stream_bytes``, or excluded by the caller).
+    forced: Tuple[str, ...]
+    #: Chose to stay resident, in fill order (largest first).
+    resident: Tuple[str, ...]
+    #: Streams from pinned host RAM, in the same walk order.
+    streamed: Tuple[str, ...]
+    resident_bytes: int
+    streamed_bytes: int
+    #: The in-flight cast window this split reserved out of the budget. The
+    #: subtle half of the port: without it a plan fits at rest and overshoots
+    #: the instant two casts are in flight.
+    window_bytes: int
+
+    @property
+    def device_bytes(self) -> int:
+        """What the card actually holds under this plan, at peak."""
+        return self.resident_bytes + self.window_bytes
+
+    @property
+    def fits(self) -> bool:
+        """False when even the forced set plus one window is over budget — the
+        split ran out of room to give back, and the caller is about to serve
+        over its lease. A confession, never a silent clamp."""
+        return self.device_bytes <= self.budget_bytes
+
+    @property
+    def all_resident(self) -> Tuple[str, ...]:
+        return self.forced + self.resident
+
+
+def plan_residency(
+    costs: Sequence[LeafCost],
+    *,
+    budget_bytes: int,
+    streams: int = DEFAULT_STREAMS,
+    min_stream_bytes: int = DEFAULT_MIN_STREAM_BYTES,
+    exclude: Iterable[str] = (),
+) -> ResidencyPlan:
+    """Split ``costs`` into a resident set and a streaming tail under a budget.
+
+    ``budget_bytes`` is the lease's, not an estimate (see the module
+    docstring). The walk is ComfyUI's ``ModelPatcher.load`` (`:1000-1001`):
+    sorted by offload cost descending, a leaf is admitted only when what is
+    already resident, plus the leaf, plus the in-flight cast window still
+    fits.
+
+    The window arithmetic is TIGHTER than theirs, and deliberately. They
+    reserve ``this leaf + the next NUM_STREAMS leaves`` — a lookahead over
+    leaves that may well end up RESIDENT, so the reservation is counted twice
+    and a budget that can genuinely stream the model reports that it cannot
+    (measured on a 6-leaf pyramid: 15 MB reserved where 12 MB is the real
+    peak, and the whole model then streams with a resident set of zero). What
+    the ring actually holds is ``streams`` buffers, each grown to the largest
+    leaf that ever rode it, so the honest reservation is ``streams x largest
+    STREAMED cast`` — and it matches :attr:`_CastRing.buffer_peak_bytes` at
+    run time.
+
+    That reservation depends on the split, and the split depends on the
+    reservation, so the walk is run to a FIXED POINT: start at a zero window
+    (fill by weight alone), compute what the tail that did not fit really
+    needs, refill under that reservation, repeat. The window only ever grows,
+    so it converges in at most one pass per leaf, and it terminates at zero
+    when nothing streams — which is what makes a budget equal to the model's
+    own size mean full residency instead of an empty resident set holding a
+    window for a tail that isn't there.
+
+    Deterministic: ties break on name, so the same tree and the same budget
+    always produce the same split. That is a hard requirement, not a
+    nicety — a mint's traced graph class and a residency reservation both
+    depend on the answer.
+    """
+    streams = max(1, int(streams))
+    budget = max(0, int(budget_bytes))
+    skip = {str(n) for n in exclude}
+
+    forced: List[LeafCost] = []
+    candidates: List[LeafCost] = []
+    for cost in costs:
+        if cost.name in skip or cost.cast_bytes < int(min_stream_bytes):
+            forced.append(cost)
+        else:
+            candidates.append(cost)
+
+    order = sorted(candidates, key=lambda c: (-c.cast_bytes, -c.resident_bytes, c.name))
+    floor = sum(c.resident_bytes for c in forced)
+
+    window = 0
+    mem = floor
+    resident: List[LeafCost] = []
+    streamed: List[LeafCost] = []
+    for _ in range(len(order) + 1):
+        mem = floor
+        resident = []
+        streamed = []
+        for cost in order:
+            if mem + cost.resident_bytes + window <= budget:
+                resident.append(cost)
+                mem += cost.resident_bytes
+            else:
+                streamed.append(cost)
+        needed = streams * max((c.cast_bytes for c in streamed), default=0)
+        if needed <= window:
+            break
+        window = needed
+
+    return ResidencyPlan(
+        budget_bytes=budget,
+        streams=streams,
+        forced=tuple(c.name for c in forced),
+        resident=tuple(c.name for c in resident),
+        streamed=tuple(c.name for c in streamed),
+        resident_bytes=mem,
+        streamed_bytes=sum(c.resident_bytes for c in streamed),
+        window_bytes=window,
+    )
+
+
+@dataclass(frozen=True)
+class PlanTransition:
+    """The moves from one plan to another. Empty tuples = nothing to do."""
+
+    demote: Tuple[str, ...]
+    promote: Tuple[str, ...]
+    freed_bytes: int
+    claimed_bytes: int
+
+
+def plan_transition(
+    old: ResidencyPlan,
+    new: ResidencyPlan,
+    costs: Sequence[LeafCost],
+    *,
+    allow_promote: bool = True,
+) -> PlanTransition:
+    """What moving from ``old`` to ``new`` costs and frees.
+
+    ``allow_promote=False`` is what makes a partial UNLOAD an unload: the
+    greedy fill is not perfectly monotone in the budget (dropping a large leaf
+    frees room a smaller one can take), and a call asked to free bytes must
+    never answer by moving bytes onto the card.
+    """
+    by_name = {c.name: c for c in costs}
+    was = set(old.all_resident)
+    now = set(new.all_resident)
+    demote = tuple(n for n in old.all_resident if n not in now)
+    promote = tuple(n for n in new.all_resident if n not in was) if allow_promote else ()
+    return PlanTransition(
+        demote=demote,
+        promote=promote,
+        freed_bytes=sum(by_name[n].resident_bytes for n in demote if n in by_name),
+        claimed_bytes=sum(by_name[n].resident_bytes for n in promote if n in by_name),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The streaming tail — cast per forward on round-robin offload streams
+# ---------------------------------------------------------------------------
+
+
+class _CastRing:
+    """``streams`` offload streams, each owning one persistent cast buffer.
+
+    The buffer is reused for every leaf that rides that stream, which is the
+    whole memory argument: the tail costs ``streams`` × the largest streamed
+    leaf, not the tail's size. Off CUDA the ring degrades to synchronous
+    copies into ordinary host buffers — the SAME driver loop, so every
+    ordering decision below is exercised by the CPU-side tests and only the
+    overlap is left for the card to prove.
+    """
+
+    def __init__(self, torch: Any, device: Any, streams: int) -> None:
+        self._torch = torch
+        self.device = device
+        self.cuda = getattr(device, "type", str(device)) == "cuda"
+        self._n = max(1, int(streams))
+        self._streams: List[Any] = (
+            [torch.cuda.Stream(device=device) for _ in range(self._n)]
+            if self.cuda
+            else [None] * self._n
+        )
+        self._buffers: List[Optional[Any]] = [None] * self._n
+        self._index = 0
+        #: Peak bytes any one buffer grew to — telemetry, and the number the
+        #: plan's ``window_bytes`` reservation is checked against.
+        self.buffer_peak_bytes = 0
+
+    def acquire(self, nbytes: int) -> Tuple[Any, Any]:
+        """The next (stream, buffer), fenced so the buffer is free to refill.
+
+        The fence LAGS by one acquisition, exactly as ``get_offload_stream``
+        does. Fencing the stream we are about to hand out against the compute
+        stream *now* would make its H2D wait for the forward that was just
+        enqueued — which is the serialization this rung exists to avoid.
+        """
+        torch = self._torch
+        if self.cuda:
+            current = torch.cuda.current_stream(self.device)
+            self._streams[self._index].wait_stream(current)
+        self._index = (self._index + 1) % self._n
+        stream = self._streams[self._index]
+        buffer = self._buffers[self._index]
+        if buffer is None or int(buffer.numel()) < int(nbytes):
+            if stream is not None:
+                stream.synchronize()
+            buffer = torch.empty(int(nbytes), dtype=torch.uint8, device=self.device)
+            self._buffers[self._index] = buffer
+            self.buffer_peak_bytes = max(self.buffer_peak_bytes, int(nbytes))
+        return stream, buffer
+
+    def release(self) -> None:
+        for stream in self._streams:
+            if stream is not None:
+                try:
+                    stream.synchronize()
+                except Exception:  # noqa: BLE001
+                    pass
+        self._buffers = [None] * self._n
+
+
+@dataclass
+class _TensorSlot:
+    """One streamed tensor: where it rests and how to put it back."""
+
+    attr: str
+    is_param: bool
+    host: Any
+    nbytes: int
+    offset: int
+
+
+class _StreamedLeaf:
+    """The forward pre/post hook pair over one leaf module.
+
+    Runs under the residency manager's single-flight guarantee (one request
+    per model instance), so the in-flight stream handle needs no lock.
+    """
+
+    __slots__ = ("name", "module", "slots", "total", "ring", "_torch", "_stream", "_handles")
+
+    def __init__(
+        self,
+        name: str,
+        module: Any,
+        slots: List[_TensorSlot],
+        total: int,
+        ring: _CastRing,
+        torch: Any,
+    ) -> None:
+        self.name = name
+        self.module = module
+        self.slots = slots
+        self.total = total
+        self.ring = ring
+        self._torch = torch
+        self._stream: Any = None
+        self._handles: List[Any] = []
+
+    def install(self) -> None:
+        # PREPENDED, so the H2D lands before any other pre-hook on this leaf
+        # (an fp8 upcast window, say) reads the weight. `always_call` on the
+        # post-hook keeps the restore on an exception: a mid-forward CUDA OOM
+        # must not leave a cast-buffer view bound as the module's weight,
+        # because the next acquisition of that stream overwrites it.
+        self._handles.append(
+            self.module.register_forward_pre_hook(self._pre, prepend=True)
+        )
+        self._handles.append(
+            self.module.register_forward_hook(self._post, always_call=True)
+        )
+
+    def remove(self) -> None:
+        for handle in self._handles:
+            try:
+                handle.remove()
+            except Exception:  # noqa: BLE001
+                pass
+        self._handles.clear()
+
+    def _pre(self, module: Any, args: Any) -> None:
+        torch = self._torch
+        stream, buffer = self.ring.acquire(self.total)
+        context = (
+            torch.cuda.stream(stream) if stream is not None else _nullcontext()
+        )
+        with context:
+            for slot in self.slots:
+                host = slot.host
+                view = (
+                    buffer[slot.offset : slot.offset + slot.nbytes]
+                    .view(host.dtype)
+                    .view(host.shape)
+                )
+                view.copy_(host, non_blocking=stream is not None)
+                _assign(module, slot.attr, view, slot.is_param)
+        if stream is not None:
+            torch.cuda.current_stream(self.ring.device).wait_stream(stream)
+        self._stream = stream
+
+    def _post(self, module: Any, args: Any, output: Any = None) -> None:
+        for slot in self.slots:
+            _assign(module, slot.attr, slot.host, slot.is_param)
+        stream, self._stream = self._stream, None
+        if stream is not None:
+            # The other half of the fence (ComfyUI's ``uncast_bias_weight``):
+            # the buffer must not be refilled while compute is still reading
+            # the views this forward bound.
+            stream.wait_stream(self._torch.cuda.current_stream(self.ring.device))
+
+
+class _nullcontext:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+
+def _assign(module: Any, attr: str, value: Any, is_param: bool) -> None:
+    if is_param:
+        module._parameters[attr].data = value
+    else:
+        module._buffers[attr] = value
+
+
+# ---------------------------------------------------------------------------
+# The rung
+# ---------------------------------------------------------------------------
+
+
+def _own_tensors(module: Any) -> List[Tuple[str, bool, Any]]:
+    """(attr, is_param, tensor) for the module's OWN parameters and buffers."""
+    out: List[Tuple[str, bool, Any]] = []
+    for name, param in getattr(module, "_parameters", {}).items():
+        if param is not None:
+            out.append((name, True, param))
+    for name, buf in getattr(module, "_buffers", {}).items():
+        if buf is not None:
+            out.append((name, False, buf))
+    return out
+
+
+def _tensor_bytes(t: Any) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def _is_adapter(name: str) -> bool:
+    lowered = name.lower()
+    return any(marker in lowered for marker in _ADAPTER_MARKERS)
+
+
+def _streamable(module: Any) -> bool:
+    """True leaves only: no children, and tensors of its own.
+
+    A module that owns parameters AND children cannot be hooked safely — its
+    post-hook fires after its children's forwards, so the cast-buffer views it
+    bound would still be live while the ring hands the same buffer to a child.
+    """
+    for _ in module.children():
+        return False
+    return bool(_own_tensors(module))
+
+
+class StreamedResidency:
+    """A budgeted resident set plus a streaming tail over one module tree.
+
+    Construct over an author model, a pipeline or a bare ``nn.Module``
+    (:meth:`over` finds the roots), :meth:`engage` to split at the lease's
+    budget, :meth:`rebudget` to trim or extend it, :meth:`release` to put the
+    tree back the way it was found.
+    """
+
+    def __init__(
+        self,
+        roots: Sequence[Tuple[str, Any]],
+        *,
+        device: Any = None,
+        budget_bytes: int = 0,
+        streams: int = DEFAULT_STREAMS,
+        min_stream_bytes: int = DEFAULT_MIN_STREAM_BYTES,
+        exclude: Iterable[str] = (),
+    ) -> None:
+        import torch
+
+        self._torch = torch
+        # `device=None` DERIVES the execution device from where this tree's
+        # weights already are. A global probe would answer "cuda" for a
+        # pipeline the CPU rung deliberately put on the host, and the first
+        # promote would then move it somewhere nobody asked for.
+        self.device = torch.device(
+            device if device is not None else tree_device(roots) or "cpu"
+        )
+        self.budget_bytes = max(0, int(budget_bytes))
+        self.streams = max(1, int(streams))
+        self.min_stream_bytes = int(min_stream_bytes)
+        self._exclude = {str(n) for n in exclude}
+        self._roots = list(roots)
+        self._leaves: Dict[str, Any] = {}
+        self._costs: List[LeafCost] = []
+        self._streamed: Dict[str, _StreamedLeaf] = {}
+        self._ring: Optional[_CastRing] = None
+        self._lock = threading.Lock()
+        self.plan: Optional[ResidencyPlan] = None
+        self._discover()
+
+    # -- construction -------------------------------------------------------
+
+    @classmethod
+    def over(
+        cls,
+        obj: Any,
+        *,
+        device: Any = None,
+        budget_bytes: int = 0,
+        **kwargs: Any,
+    ) -> "StreamedResidency":
+        """Build over whatever the caller has: a module, a diffusers pipeline
+        (its ``components``), or an author model object holding either."""
+        return cls(module_roots(obj), device=device, budget_bytes=budget_bytes, **kwargs)
+
+    def _discover(self) -> None:
+        for root_name, root in self._roots:
+            for name, module in root.named_modules():
+                if not _streamable(module):
+                    continue
+                qualified = f"{root_name}.{name}" if name else root_name
+                if _is_adapter(qualified):
+                    self._exclude.add(qualified)
+                own = _own_tensors(module)
+                total = sum(_tensor_bytes(t) for _, _, t in own)
+                if total <= 0:
+                    continue
+                self._leaves[qualified] = module
+                # `cast_bytes` is the ALIGNED carve, so the plan's window
+                # reservation is the number the ring really allocates rather
+                # than one that ignores the 512-byte sub-buffer boundaries.
+                self._costs.append(
+                    LeafCost(
+                        qualified,
+                        total,
+                        sum(_aligned(_tensor_bytes(t)) for _, _, t in own),
+                    )
+                )
+
+    # -- read side ----------------------------------------------------------
+
+    @property
+    def costs(self) -> Tuple[LeafCost, ...]:
+        return tuple(self._costs)
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(c.resident_bytes for c in self._costs)
+
+    @property
+    def buffer_peak_bytes(self) -> int:
+        return self._ring.buffer_peak_bytes if self._ring is not None else 0
+
+    # -- the one operation --------------------------------------------------
+
+    def engage(self) -> ResidencyPlan:
+        """Split at the construction budget and put the tree where it says."""
+        return self._apply(
+            plan_residency(
+                self._costs,
+                budget_bytes=self.budget_bytes,
+                streams=self.streams,
+                min_stream_bytes=self.min_stream_bytes,
+                exclude=self._exclude,
+            ),
+            allow_promote=True,
+        )
+
+    def rebudget(self, budget_bytes: int) -> ResidencyPlan:
+        """Re-split at a new budget — partial unload down, partial load up.
+
+        Downward is the eviction primitive: the cold tail is trimmed and
+        nothing is promoted. ``rebudget(0)`` is a full demotion to the host
+        tier; ``rebudget(self.total_bytes)`` promotes everything back.
+        """
+        new_budget = max(0, int(budget_bytes))
+        allow_promote = self.plan is None or new_budget >= self.plan.budget_bytes
+        self.budget_bytes = new_budget
+        return self._apply(
+            plan_residency(
+                self._costs,
+                budget_bytes=new_budget,
+                streams=self.streams,
+                min_stream_bytes=self.min_stream_bytes,
+                exclude=self._exclude,
+            ),
+            allow_promote=allow_promote,
+        )
+
+    def partial_unload(self, need_bytes: int) -> int:
+        """Free at least ``need_bytes`` of device weights; returns bytes freed.
+
+        Trims this model's cold tail rather than dropping the model — the
+        primitive that lets several warm endpoints degrade smoothly on one
+        card instead of evicting each other whole.
+        """
+        before = self.plan.resident_bytes if self.plan is not None else self.total_bytes
+        self.rebudget(max(0, before - int(need_bytes)))
+        after = self.plan.resident_bytes if self.plan is not None else 0
+        return max(0, before - after)
+
+    def partial_load(self, extra_bytes: int) -> int:
+        """Promote up to ``extra_bytes`` more of the tail; bytes claimed."""
+        before = self.plan.resident_bytes if self.plan is not None else 0
+        self.rebudget(before + max(0, int(extra_bytes)))
+        after = self.plan.resident_bytes if self.plan is not None else 0
+        return max(0, after - before)
+
+    def demote_to_host(self) -> int:
+        """Every weight to pinned host RAM. The residency HOST tier."""
+        return self.partial_unload(self.total_bytes)
+
+    def promote_to_device(self) -> int:
+        """Every weight back onto the card. An H2D, never a disk walk."""
+        return self.partial_load(self.total_bytes)
+
+    # -- execution ----------------------------------------------------------
+
+    def _apply(self, plan: ResidencyPlan, *, allow_promote: bool) -> ResidencyPlan:
+        with self._lock:
+            torch = self._torch
+            old = self.plan
+            if old is None:
+                demote = tuple(plan.streamed)
+                promote = tuple(plan.all_resident)
+            else:
+                transition = plan_transition(
+                    old, plan, self._costs, allow_promote=allow_promote
+                )
+                demote = transition.demote
+                promote = transition.promote
+                if not allow_promote:
+                    # An unload keeps everything the trim did not name where it
+                    # already is, so the plan we RECORD must say that rather
+                    # than the one the planner would have drawn.
+                    plan = self._recorded(plan, old, demote)
+
+            with torch.no_grad():
+                for name in demote:
+                    self._to_host(name)
+                for name in promote:
+                    self._to_device(name)
+            self.plan = plan
+            for _, root in self._roots:
+                try:
+                    setattr(root, ENGAGED_ATTR, bool(plan.streamed))
+                except Exception:  # noqa: BLE001
+                    pass
+            return plan
+
+    def _recorded(
+        self, planned: ResidencyPlan, old: ResidencyPlan, demote: Tuple[str, ...]
+    ) -> ResidencyPlan:
+        """The plan an unload actually produced: ``old`` minus the trim."""
+        dropped = set(demote)
+        by_name = {c.name: c for c in self._costs}
+        resident = tuple(n for n in old.resident if n not in dropped)
+        forced = tuple(n for n in old.forced if n not in dropped)
+        streamed = tuple(old.streamed) + tuple(
+            n for n in old.all_resident if n in dropped
+        )
+        return ResidencyPlan(
+            budget_bytes=planned.budget_bytes,
+            streams=planned.streams,
+            forced=forced,
+            resident=resident,
+            streamed=streamed,
+            resident_bytes=sum(
+                by_name[n].resident_bytes for n in forced + resident if n in by_name
+            ),
+            streamed_bytes=sum(
+                by_name[n].resident_bytes for n in streamed if n in by_name
+            ),
+            window_bytes=planned.window_bytes,
+        )
+
+    def _ring_for(self) -> _CastRing:
+        if self._ring is None:
+            self._ring = _CastRing(self._torch, self.device, self.streams)
+        return self._ring
+
+    def _to_host(self, name: str) -> None:
+        """Park a leaf in pinned host RAM and hook its forward."""
+        module = self._leaves.get(name)
+        if module is None or name in self._streamed:
+            return
+        torch = self._torch
+        slots: List[_TensorSlot] = []
+        offset = 0
+        for attr, is_param, tensor in _own_tensors(module):
+            if tensor.is_meta or tensor.storage_offset() != 0:
+                # Meta or an alias into a larger storage: this mover cannot
+                # represent it, so the leaf stays where it is rather than
+                # being half-moved. Loud, because it silently costs budget.
+                logger.warning(
+                    "stream residency: %s.%s is meta or a partial-view alias; "
+                    "the leaf stays resident and its bytes are over budget",
+                    name, attr,
+                )
+                return
+            host = staging.alloc_pinned_like(torch, tensor)
+            if host is None:
+                host = torch.empty_like(tensor, device="cpu")
+            host.copy_(tensor)
+            nbytes = _tensor_bytes(host)
+            slots.append(
+                _TensorSlot(
+                    attr=attr, is_param=is_param, host=host, nbytes=nbytes, offset=offset
+                )
+            )
+            offset += _aligned(nbytes)
+            _assign(module, attr, host, is_param)
+        leaf = _StreamedLeaf(name, module, slots, offset, self._ring_for(), torch)
+        leaf.install()
+        self._streamed[name] = leaf
+
+    def _to_device(self, name: str) -> None:
+        """Put a leaf back on the card and drop its hooks."""
+        module = self._leaves.get(name)
+        if module is None:
+            return
+        leaf = self._streamed.pop(name, None)
+        if leaf is not None:
+            leaf.remove()
+            for slot in leaf.slots:
+                try:
+                    pinned = bool(slot.host.is_pinned())
+                except Exception:  # noqa: BLE001
+                    pinned = False
+                _assign(
+                    module,
+                    slot.attr,
+                    slot.host.to(self.device, non_blocking=pinned),
+                    slot.is_param,
+                )
+            return
+        for attr, is_param, tensor in _own_tensors(module):
+            if tensor.is_meta or tensor.device == self.device:
+                continue
+            _assign(module, attr, tensor.to(self.device), is_param)
+
+    def release(self) -> None:
+        """Un-hook everything and leave every weight on the device."""
+        with self._lock:
+            with self._torch.no_grad():
+                for name in list(self._streamed):
+                    self._to_device(name)
+            if self._ring is not None:
+                self._ring.release()
+                self._ring = None
+            for _, root in self._roots:
+                try:
+                    setattr(root, ENGAGED_ATTR, False)
+                except Exception:  # noqa: BLE001
+                    pass
+            self.plan = None
+
+
+# ---------------------------------------------------------------------------
+# Finding the tree
+# ---------------------------------------------------------------------------
+
+
+def module_roots(obj: Any) -> List[Tuple[str, Any]]:
+    """(name, module) for every ``nn.Module`` tree under ``obj``.
+
+    A bare module is itself; a diffusers pipeline is its ``components``; an
+    author model object is whichever of its attributes are either. One walk
+    for all three, because the serve path holds all three shapes.
+    """
+    try:
+        import torch.nn as nn
+    except Exception:  # noqa: BLE001
+        return []
+    if isinstance(obj, nn.Module):
+        return [(type(obj).__name__, obj)]
+    components = getattr(obj, "components", None)
+    if isinstance(components, dict) and components:
+        return [(n, m) for n, m in components.items() if isinstance(m, nn.Module)]
+    out: List[Tuple[str, Any]] = []
+    for name, value in vars(obj).items():
+        if name.startswith("_"):
+            continue
+        if isinstance(value, nn.Module):
+            out.append((name, value))
+            continue
+        nested = getattr(value, "components", None)
+        if isinstance(nested, dict) and nested:
+            out.extend(
+                (f"{name}.{n}", m) for n, m in nested.items() if isinstance(m, nn.Module)
+            )
+    return out
+
+
+def tree_device(roots: Sequence[Tuple[str, Any]]) -> Optional[Any]:
+    """Where this tree's weights ARE — the device of its first real tensor.
+
+    Measured, never assumed: the execution device of an already-loaded object
+    is a property of the object, and a probe of the machine answers a
+    different question.
+    """
+    for _, root in roots:
+        for module in root.modules():
+            for _attr, _is_param, tensor in _own_tensors(module):
+                if not tensor.is_meta:
+                    return tensor.device
+    return None
+
+
+def stream_residency_active(obj: Any) -> bool:
+    """True when this rung has a streaming tail armed anywhere under ``obj``."""
+    if getattr(obj, ENGAGED_ATTR, False):
+        return True
+    return any(getattr(root, ENGAGED_ATTR, False) for _, root in module_roots(obj))
+
+
+__all__ = [
+    "DEFAULT_MIN_STREAM_BYTES",
+    "DEFAULT_STREAMS",
+    "ENGAGED_ATTR",
+    "LeafCost",
+    "PlanTransition",
+    "ResidencyPlan",
+    "StreamedResidency",
+    "module_roots",
+    "plan_residency",
+    "plan_transition",
+    "stream_residency_active",
+    "tree_device",
+]

--- a/src/gen_worker/models/stream_residency.py
+++ b/src/gen_worker/models/stream_residency.py
@@ -96,6 +96,37 @@ def _aligned(n: int) -> int:
 
 
 @dataclass(frozen=True)
+class MemoryBudget:
+    """The {VRAM, RAM} PAIR a model is assigned (Paul, 2026-08-19).
+
+    A memory profile is assigned top-down — worker, then execution group, then
+    model — and BOTH halves determine what this rung may do: the resident set
+    spends the VRAM half, and the streaming tail and every demotion to the host
+    tier spend the RAM half. Pinned staging is a slice of the same RAM budget,
+    not free space beside it.
+
+    ``ram_bytes == 0`` means UNSTATED, not unlimited. The plan then reports its
+    host cost (:attr:`ResidencyPlan.host_bytes`) without a verdict on it.
+
+    **ENFORCEMENT IS A NAMED DEFERRAL** (pgw#1497 follow-up): partial unload
+    must REFUSE, or degrade further down the ladder, when the RAM half cannot
+    absorb what VRAM evicts. Today it plans against the VRAM half and reports
+    the RAM cost. The signature is the pair now so that landing enforcement is
+    a change of behaviour and not a change of shape.
+    """
+
+    vram_bytes: int
+    ram_bytes: int = 0
+
+    @classmethod
+    def of(cls, value: "int | MemoryBudget") -> "MemoryBudget":
+        """Accept either half of the migration: a bare VRAM int, or the pair."""
+        if isinstance(value, MemoryBudget):
+            return value
+        return cls(vram_bytes=max(0, int(value)))
+
+
+@dataclass(frozen=True)
 class LeafCost:
     """One leaf module's two prices.
 
@@ -134,6 +165,21 @@ class ResidencyPlan:
     #: subtle half of the port: without it a plan fits at rest and overshoots
     #: the instant two casts are in flight.
     window_bytes: int
+    #: The RAM half of the assigned pair, 0 when unstated. Reported, not yet
+    #: enforced — see :class:`MemoryBudget`.
+    ram_budget_bytes: int = 0
+
+    @property
+    def host_bytes(self) -> int:
+        """What this plan costs in HOST RAM: the pinned streaming tail."""
+        return self.streamed_bytes
+
+    @property
+    def host_fits(self) -> bool:
+        """False when the tail is over the stated RAM half. Always True while
+        the RAM half is unstated — an unstated budget is not a passed one, and
+        callers that need the distinction read ``ram_budget_bytes``."""
+        return not self.ram_budget_bytes or self.host_bytes <= self.ram_budget_bytes
 
     @property
     def device_bytes(self) -> int:
@@ -155,7 +201,7 @@ class ResidencyPlan:
 def plan_residency(
     costs: Sequence[LeafCost],
     *,
-    budget_bytes: int,
+    budget_bytes: "int | MemoryBudget",
     streams: int = DEFAULT_STREAMS,
     min_stream_bytes: int = DEFAULT_MIN_STREAM_BYTES,
     exclude: Iterable[str] = (),
@@ -194,7 +240,8 @@ def plan_residency(
     depend on the answer.
     """
     streams = max(1, int(streams))
-    budget = max(0, int(budget_bytes))
+    pair = MemoryBudget.of(budget_bytes)
+    budget = max(0, int(pair.vram_bytes))
     skip = {str(n) for n in exclude}
 
     forced: List[LeafCost] = []
@@ -236,6 +283,7 @@ def plan_residency(
         resident_bytes=mem,
         streamed_bytes=sum(c.resident_bytes for c in streamed),
         window_bytes=window,
+        ram_budget_bytes=max(0, int(pair.ram_bytes)),
     )
 
 
@@ -498,7 +546,7 @@ class StreamedResidency:
         roots: Sequence[Tuple[str, Any]],
         *,
         device: Any = None,
-        budget_bytes: int = 0,
+        budget_bytes: "int | MemoryBudget" = 0,
         streams: int = DEFAULT_STREAMS,
         min_stream_bytes: int = DEFAULT_MIN_STREAM_BYTES,
         exclude: Iterable[str] = (),
@@ -513,7 +561,7 @@ class StreamedResidency:
         self.device = torch.device(
             device if device is not None else tree_device(roots) or "cpu"
         )
-        self.budget_bytes = max(0, int(budget_bytes))
+        self.budget = MemoryBudget.of(budget_bytes)
         self.streams = max(1, int(streams))
         self.min_stream_bytes = int(min_stream_bytes)
         self._exclude = {str(n) for n in exclude}
@@ -534,7 +582,7 @@ class StreamedResidency:
         obj: Any,
         *,
         device: Any = None,
-        budget_bytes: int = 0,
+        budget_bytes: "int | MemoryBudget" = 0,
         **kwargs: Any,
     ) -> "StreamedResidency":
         """Build over whatever the caller has: a module, a diffusers pipeline
@@ -586,7 +634,7 @@ class StreamedResidency:
         return self._apply(
             plan_residency(
                 self._costs,
-                budget_bytes=self.budget_bytes,
+                budget_bytes=self.budget,
                 streams=self.streams,
                 min_stream_bytes=self.min_stream_bytes,
                 exclude=self._exclude,
@@ -594,20 +642,26 @@ class StreamedResidency:
             allow_promote=True,
         )
 
-    def rebudget(self, budget_bytes: int) -> ResidencyPlan:
+    def rebudget(self, budget_bytes: "int | MemoryBudget") -> ResidencyPlan:
         """Re-split at a new budget — partial unload down, partial load up.
 
         Downward is the eviction primitive: the cold tail is trimmed and
         nothing is promoted. ``rebudget(0)`` is a full demotion to the host
         tier; ``rebudget(self.total_bytes)`` promotes everything back.
         """
-        new_budget = max(0, int(budget_bytes))
-        allow_promote = self.plan is None or new_budget >= self.plan.budget_bytes
-        self.budget_bytes = new_budget
+        pair = MemoryBudget.of(budget_bytes)
+        # The RAM half survives a re-plan that only names a VRAM number: a
+        # demotion does not revoke the profile the model was assigned.
+        if not pair.ram_bytes and self.budget.ram_bytes:
+            pair = MemoryBudget(pair.vram_bytes, self.budget.ram_bytes)
+        allow_promote = (
+            self.plan is None or pair.vram_bytes >= self.plan.budget_bytes
+        )
+        self.budget = pair
         return self._apply(
             plan_residency(
                 self._costs,
-                budget_bytes=new_budget,
+                budget_bytes=pair,
                 streams=self.streams,
                 min_stream_bytes=self.min_stream_bytes,
                 exclude=self._exclude,
@@ -668,6 +722,7 @@ class StreamedResidency:
                     self._to_host(name)
                 for name in promote:
                     self._to_device(name)
+                self._place_residue()
             self.plan = plan
             for _, root in self._roots:
                 try:
@@ -700,7 +755,29 @@ class StreamedResidency:
                 by_name[n].resident_bytes for n in streamed if n in by_name
             ),
             window_bytes=planned.window_bytes,
+            ram_budget_bytes=planned.ram_budget_bytes,
         )
+
+    def _place_residue(self) -> None:
+        """Everything OUTSIDE the streaming tail must be ON the device.
+
+        Not an optimization — a correctness clause, and dropping it is a defect
+        MEASURED on the card: a tensor owned by a module that has children
+        (CLIP's ``position_ids``, an embedding table's siblings, a final norm
+        hanging off a container) is never a leaf, so nothing else here ever
+        touches it. Left on the host it takes down the first kernel that reads
+        it with ``index is on cpu, different from other tensors on cuda:0`` —
+        which is exactly how sd1.5 died at a 5% budget.
+        """
+        for root_name, root in self._roots:
+            for name, module in root.named_modules():
+                qualified = f"{root_name}.{name}" if name else root_name
+                if qualified in self._streamed:
+                    continue  # its tensors rest on the host BY DESIGN
+                for attr, is_param, tensor in _own_tensors(module):
+                    if tensor.is_meta or tensor.device == self.device:
+                        continue
+                    _assign(module, attr, tensor.to(self.device), is_param)
 
     def _ring_for(self) -> _CastRing:
         if self._ring is None:
@@ -847,6 +924,7 @@ __all__ = [
     "DEFAULT_STREAMS",
     "ENGAGED_ATTR",
     "LeafCost",
+    "MemoryBudget",
     "PlanTransition",
     "ResidencyPlan",
     "StreamedResidency",

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -241,6 +241,7 @@ class LoadContext(Generic[MT_co]):
         engine: Optional[LoaderEngine] = None,
         compile_sink: Optional[Callable[[Any], Any]] = None,
         device: str = "",
+        weight_budget_bytes: int = 0,
     ) -> None:
         self._binding = binding
         self._model_type = model_type
@@ -256,6 +257,12 @@ class LoadContext(Generic[MT_co]):
         #: ladder was never consulted" (pgw#1486). Read by `compile()`, which
         #: may not arm a compiled graph over hook-managed weights.
         self._engaged_rung = ""
+        #: pgw#1497: the DEVICE bytes this instance's weights were ADMITTED
+        #: for — the residency lease's own number, handed down so the
+        #: `partial_stream` rung can size its resident set from it. 0 means no
+        #: lease was in scope (a local run, a fixture), and that rung then
+        #: refuses rather than invent a budget.
+        self._weight_budget_bytes = max(0, int(weight_budget_bytes))
 
     @property
     def checkpoint_dir(self) -> Path:
@@ -441,7 +448,11 @@ class LoadContext(Generic[MT_co]):
         try:
             from ..models.memory import apply_low_vram_config
 
-            applied = apply_low_vram_config(pipeline, mode="auto")
+            applied = apply_low_vram_config(
+                pipeline,
+                mode="auto",
+                stream_budget_bytes=self._weight_budget_bytes,
+            )
         except HostRamMoveRefusedError:
             # The guard did its job: this host cannot hold what the rung wanted
             # to move. Re-raising is right — the alternative is placing the

--- a/src/gen_worker/serving/residency.py
+++ b/src/gen_worker/serving/residency.py
@@ -345,6 +345,27 @@ class ResidencyManager:
             slot = self._slots.get((str(checkpoint_ref), str(lane)))
             return slot.tier if slot is not None else Tier.ABSENT
 
+    def weight_budget_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        """The DEVICE bytes this instance's weights are admitted for.
+
+        pgw#1497's admission-first seam, and the reason it is a method here
+        rather than a number the loader works out: this is the same figure
+        ``lease`` reserves against the budget before anything is allocated, so
+        the rung that sizes a resident set from it can never disagree with the
+        reservation that let the instance in. It is available BEFORE the
+        factory runs, which is when the load context that carries it is built.
+        """
+        try:
+            return int(self._sizer.resident_bytes(str(checkpoint_ref), str(lane)))
+        except Exception:  # noqa: BLE001 — a sizer that cannot answer means
+            # "no lease number", and the rung refuses on 0 rather than
+            # inventing one. Never a failed load.
+            logger.debug(
+                "weight_budget_bytes(%r, %r) unreadable", checkpoint_ref, lane,
+                exc_info=True,
+            )
+            return 0
+
     def reserved_bytes(self) -> Tuple[int, int]:
         """(vram reservations, host reservations) — the worker's own view."""
         with self._state:

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -194,7 +194,17 @@ class _InstanceBackend:
                 f"{self.model_cls.__name__}: a tier move was ordered on an "
                 f"instance that holds no model object"
             )
+        # A rung armed during the author's own load already owns this tree.
+        # Building a second handle over the same modules would give two
+        # planners two disagreeing views of one resident set.
+        from ..models.memory import stream_residency_of
         from ..models.stream_residency import StreamedResidency
+
+        for component in (getattr(self.model, "pipe", None), self.model):
+            armed = stream_residency_of(component) if component is not None else None
+            if armed is not None:
+                self._stream_residency = armed
+                return armed
 
         # No `device=`: the execution device is DERIVED from where this
         # instance's weights already are. Probing the machine instead would
@@ -233,7 +243,9 @@ class _InstanceBackend:
     @staticmethod
     def _engage_at(residency: Any, budget_bytes: int) -> int:
         """First tier move on an un-engaged instance: engage at ``budget``."""
-        residency.budget_bytes = int(budget_bytes)
+        from ..models.stream_residency import MemoryBudget
+
+        residency.budget = MemoryBudget.of(int(budget_bytes))
         plan = residency.engage()
         return int(plan.streamed_bytes)
 
@@ -302,6 +314,13 @@ class ServeLoop:
                     lane=lane,
                     engine=self._engine,
                     compile_sink=sink,
+                    # pgw#1497: ADMISSION-FIRST. The `partial_stream` rung
+                    # sizes its resident set from the bytes residency admitted
+                    # this instance for, not from an activation estimate, so
+                    # that number travels with the load moment.
+                    weight_budget_bytes=self.residency.weight_budget_bytes(
+                        binding.checkpoint_ref, key[2]
+                    ),
                 ),
                 lane,
                 self._on_loaded,

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -54,7 +54,7 @@ from .reserved_repos import (
     materialize_reserved_inputs,
     reserved_context_kwargs,
 )
-from .residency import InstanceSizer, ResidencyManager
+from .residency import InstanceSizer, ResidencyError, ResidencyManager
 
 logger = logging.getLogger(__name__)
 
@@ -97,11 +97,15 @@ class _InstanceBackend:
 
     ``load`` runs the author's ``Model()`` + ``load(ctx)`` (inside the
     manager's serialized load gate); ``drop`` runs the author's ``unload``
-    — best-effort tidiness, never correctness. The host tiers
-    (``demote_to_host``/``promote_to_device``) belong to the pgw#1380
-    native-loader wave: until it lands the loop runs the manager with a
-    zero host budget, so eviction is always a drop, and these arms refuse
-    loudly rather than pretend."""
+    — best-effort tidiness, never correctness.
+
+    The host tiers ride pgw#1497's
+    :class:`~gen_worker.models.stream_residency.StreamedResidency`: a demote
+    is a re-plan at a budget of zero (every leaf to pinned host RAM), a
+    promote a re-plan at the instance's full weight size. The SAME object and
+    the SAME arithmetic serve the partial case, so the warm tier is not a
+    second implementation of the offload rung — it is that rung at its two
+    end stops."""
 
     def __init__(
         self,
@@ -120,6 +124,9 @@ class _InstanceBackend:
         #: load. pgw#1371's background mint triggers here; anything earlier
         #: reads an empty work-list and mints nothing.
         self._on_loaded = on_loaded
+        #: pgw#1497's partial-residency handle for this instance, built on the
+        #: first tier move (or handed over by a rung engaged during load).
+        self._stream_residency: Optional[Any] = None
         #: Unmet machine floors, measured once at residency-admit. Non-empty
         #: means this instance is serving DEGRADED, and every request it
         #: serves says so (`invoke` warns the caller with these).
@@ -150,6 +157,18 @@ class _InstanceBackend:
                     "serves", self.model_cls.__name__)
 
     def drop(self) -> None:
+        residency, self._stream_residency = self._stream_residency, None
+        if residency is not None:
+            try:
+                # Un-hook before the author's unload: a live forward hook
+                # holding a cast-buffer view outlives the tree it was
+                # installed on and keeps the pinned host copies alive.
+                residency.release()
+            except Exception:
+                logger.exception(
+                    "releasing the streamed residency of %s raised; the drop "
+                    "proceeds", self.model_cls.__name__,
+                )
         model, self.model = self.model, None
         if model is None:
             return
@@ -161,17 +180,62 @@ class _InstanceBackend:
                 "correctness)", self.model_cls.__name__,
             )
 
+    def _residency(self) -> Any:
+        """This instance's :class:`StreamedResidency`, built on first use.
+
+        Built lazily and over the LIVE object, because the tree only exists
+        once the author's ``load`` has run, and a rung engaged during that
+        load may already own it.
+        """
+        if self._stream_residency is not None:
+            return self._stream_residency
+        if self.model is None:
+            raise ResidencyError(
+                f"{self.model_cls.__name__}: a tier move was ordered on an "
+                f"instance that holds no model object"
+            )
+        from ..models.stream_residency import StreamedResidency
+
+        # No `device=`: the execution device is DERIVED from where this
+        # instance's weights already are. Probing the machine instead would
+        # answer "cuda" for a pipeline the CPU rung deliberately put on the
+        # host, and the first promote would move it somewhere nobody asked.
+        residency = StreamedResidency.over(self.model, budget_bytes=0)
+        if not residency.costs:
+            raise ResidencyError(
+                f"{self.model_cls.__name__}: no nn.Module tree found under the "
+                f"author's model object, so its weights cannot be tiered — "
+                f"run this instance with host_budget_bytes=0 so eviction drops "
+                f"it instead"
+            )
+        self._stream_residency = residency
+        return residency
+
     def demote_to_host(self) -> None:
-        raise NotImplementedError(
-            "host-tier staging rides the pgw#1380 native loader; run the "
-            "ResidencyManager with host_budget_bytes=0 until it lands"
+        residency = self._residency()
+        moved = (
+            residency.demote_to_host()
+            if residency.plan is not None
+            else self._engage_at(residency, 0)
+        )
+        logger.info(
+            "residency: %s demoted to host (%d bytes to pinned host RAM)",
+            self.model_cls.__name__, moved,
         )
 
     def promote_to_device(self) -> None:
-        raise NotImplementedError(
-            "host-tier staging rides the pgw#1380 native loader; run the "
-            "ResidencyManager with host_budget_bytes=0 until it lands"
-        )
+        residency = self._residency()
+        if residency.plan is None:
+            self._engage_at(residency, residency.total_bytes)
+            return
+        residency.promote_to_device()
+
+    @staticmethod
+    def _engage_at(residency: Any, budget_bytes: int) -> int:
+        """First tier move on an un-engaged instance: engage at ``budget``."""
+        residency.budget_bytes = int(budget_bytes)
+        plan = residency.engage()
+        return int(plan.streamed_bytes)
 
 
 class ServeLoop:

--- a/tests/test_component_vocab_sweep_pgw740.py
+++ b/tests/test_component_vocab_sweep_pgw740.py
@@ -104,13 +104,19 @@ def test_both_moe_experts_are_lora_branch_targets() -> None:
     assert set(branch_targets(_WanMoE())) == {"transformer", "transformer_2"}
 
 
-def test_block_window_offload_defaults_to_every_denoiser() -> None:
-    """``apply_block_window_offload``'s default was a literal
-    ``("transformer","unet")`` in the signature — a default argument, so even
-    repointing it would have frozen the vocabulary at def time."""
+def test_stream_residency_reads_no_component_vocabulary_at_def_time() -> None:
+    """The rung that replaced the block-window offload (pgw#1497) takes no
+    component vocabulary at all — it discovers leaves from the tree it is
+    handed — so the def-time-frozen-default hazard this test was written for
+    cannot recur here. Assert the shape, not the deleted signature."""
     import inspect
 
-    from gen_worker.models.loading import apply_block_window_offload
+    from gen_worker.models.stream_residency import StreamedResidency
 
-    default = inspect.signature(apply_block_window_offload).parameters["components"].default
-    assert default is None, "a non-None default re-freezes the vocabulary at def time"
+    params = inspect.signature(StreamedResidency.__init__).parameters
+    assert "components" not in params
+    for name, param in params.items():
+        assert not isinstance(param.default, (tuple, list)) or not param.default, (
+            f"{name}: a non-empty sequence default re-freezes a vocabulary at "
+            "def time"
+        )

--- a/tests/test_partial_stream_rung_pgw1497.py
+++ b/tests/test_partial_stream_rung_pgw1497.py
@@ -1,0 +1,515 @@
+"""pgw#1497 — the `partial_stream` RUNG: its place on the ladder, and the
+admission-first budget that is the only thing allowed to size it.
+
+The mechanism has its own file (`test_stream_residency_pgw1497.py`). This one
+is about the rung: where it sits, who may select it, what it refuses, and
+whether the number the ladder prices it at was ever measured.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+
+import pytest
+
+from gen_worker.models import rung as rung_mod
+
+torch = pytest.importorskip("torch")
+nn = torch.nn
+
+
+# ---------------------------------------------------------------------------
+# 1. The ladder
+# ---------------------------------------------------------------------------
+
+
+def test_the_rung_sits_where_the_CARD_put_it_not_where_the_issue_predicted() -> None:
+    """pgw#1497 specified "between fp8_storage and model_offload". MEASURED on
+    an RTX 4070 that is false: at equal peak VRAM (1.89 vs 1.88 GB)
+    model_offload is FASTER, 1.57x against 1.91x, because its offload tax is
+    per-CALL and streaming's is per-STEP. What this rung does that
+    model_offload cannot is go LOWER — down to 1.04 GB at 3.56x, still ahead of
+    group_offload (4.60x) and sequential (7.55x), the only other rungs that
+    reach that floor. So it sits below model_offload and above group_offload,
+    and this test pins the measurement, not the hypothesis."""
+    names = [r.name for r in rung_mod.LADDER]
+    assert names.index("model_offload") < names.index("partial_stream")
+    assert names.index("partial_stream") < names.index("group_offload")
+    assert rung_mod.PARTIAL_STREAM.touches_host_ram
+    assert rung_mod.run_mode_of("partial_stream") == rung_mod.RUN_OFFLOAD
+
+
+def test_the_rungs_price_was_measured() -> None:
+    """THE instrument that cannot be forgotten.
+
+    `latency` is the honest multiplier vs a native run and the ladder is
+    monotonic down. A rung inserted with a placeholder would report a price
+    nobody measured. This one was measured (see `rung.PARTIAL_STREAM`'s own
+    table) and priced at 2.8 by reading its 25%-budget figure off the
+    model_offload -> group_offload interval. If the number ever goes back to a
+    placeholder, this is red.
+    """
+    assert rung_mod.PARTIAL_STREAM.latency > 0.0, (
+        "partial_stream still carries the unmeasured placeholder price"
+    )
+    assert rung_mod.MODEL_OFFLOAD.latency < rung_mod.PARTIAL_STREAM.latency
+    assert rung_mod.PARTIAL_STREAM.latency < rung_mod.GROUP_OFFLOAD.latency
+    prices = [r.latency for r in rung_mod.LADDER]
+    assert prices == sorted(prices), "the ladder must stay monotonic down"
+
+
+def test_adding_the_rung_did_not_move_the_wire_price_of_offload() -> None:
+    """Three rungs now project onto `offload`, and a run-mode-only price
+    describes the shallowest PROACTIVELY reachable one. `partial_stream` is
+    admission-only, so the caller-facing number is unchanged."""
+    assert rung_mod.price(rung_mod.RUN_OFFLOAD) == rung_mod.MODEL_OFFLOAD.latency
+    assert rung_mod.price(rung_mod.RUN_CPU) == rung_mod.CPU.latency
+    # A caller that KNOWS which rung it is on gets that rung's own number.
+    assert rung_mod.price("sequential") == rung_mod.SEQUENTIAL.latency
+    assert rung_mod.price("partial_stream") == rung_mod.PARTIAL_STREAM.latency
+
+
+def test_descending_from_the_rung_continues_down_the_measured_order() -> None:
+    assert rung_mod.descend("partial_stream") is rung_mod.GROUP_OFFLOAD
+
+
+def test_the_reactive_descent_never_enters_an_admission_only_rung() -> None:
+    """A load-time OOM has no lease in hand at the moment it fires, so a rung
+    whose budget would have to be invented there must not be on its path."""
+    assert rung_mod.descend(None) is rung_mod.MODEL_OFFLOAD
+    assert rung_mod.descend("off") is rung_mod.MODEL_OFFLOAD
+    assert rung_mod.descend("vae_only") is rung_mod.MODEL_OFFLOAD
+    assert rung_mod.floor_of("partial_stream", "model_offload") == "partial_stream"
+    assert rung_mod.floor_of("partial_stream", "") == "partial_stream"
+
+
+def test_select_auto_mode_can_never_return_it() -> None:
+    """A proactive decider has no lease to read. Sweep the whole input space
+    it branches on — free VRAM, model size, declared peak, capacity."""
+    from gen_worker.models.memory import select_auto_mode
+
+    class Empty:
+        components: dict = {}
+
+    seen = set()
+    for avail in (0.0, 0.5, 4.0, 6.0, 8.0, 12.0, 24.0, 80.0):
+        for size in (None, 0.0, 1.0, 7.0, 20.0, 60.0):
+            for peak in (None, 0.0, 3.0, 40.0):
+                for total in (None, 8.0, 24.0, 80.0):
+                    seen.add(
+                        select_auto_mode(
+                            pipeline=Empty(),
+                            available_vram_gb=avail,
+                            model_size_gb=size,
+                            peak_vram_gb=peak,
+                            total_vram_gb=total,
+                        )
+                    )
+    assert "partial_stream" not in seen
+    assert seen, "the sweep must actually exercise the decider"
+
+
+# ---------------------------------------------------------------------------
+# 2. The admission-first refusal
+# ---------------------------------------------------------------------------
+
+
+def test_the_rung_refuses_without_a_lease_budget() -> None:
+    """Not a smaller version of the rung — a refusal. A budget nobody handed
+    down is exactly the activation estimate this port exists to avoid."""
+    from gen_worker.models.memory import apply_low_vram_config
+
+    class Empty:
+        components: dict = {}
+
+    with pytest.raises(ValueError, match="RESIDENCY LEASE"):
+        apply_low_vram_config(Empty(), mode="partial_stream")
+    with pytest.raises(ValueError, match="RESIDENCY LEASE"):
+        apply_low_vram_config(Empty(), mode="partial_stream", stream_budget_bytes=0)
+
+
+def test_partial_stream_is_a_valid_mode_and_an_unknown_one_still_is_not() -> None:
+    from gen_worker.models.memory import apply_low_vram_config
+
+    class Empty:
+        components: dict = {}
+
+    with pytest.raises(ValueError, match="invalid low-VRAM mode"):
+        apply_low_vram_config(Empty(), mode="stream")
+
+
+# ---------------------------------------------------------------------------
+# 3. Arming it, over a real tree
+# ---------------------------------------------------------------------------
+
+
+class Pipe:
+    """A diffusers-shaped pipeline: `components` is the vocabulary every rung
+    in this module reads.
+
+    The leaves are deliberately over `DEFAULT_MIN_STREAM_BYTES` — under that
+    floor every leaf is forced resident and the rung correctly has nothing to
+    do, which would make this file's assertions vacuous."""
+
+    def __init__(self) -> None:
+        torch.manual_seed(1497)
+        # Eight same-sized leaves, so a budget splits them instead of the
+        # in-flight window (2 x the largest leaf) swallowing the whole tree.
+        self.unet = nn.Sequential(
+            *[m for _ in range(8) for m in (nn.Linear(1024, 1024), nn.ReLU())]
+        ).eval()
+        self.vae = nn.Linear(1024, 1024).eval()
+
+    @property
+    def components(self) -> dict:
+        return {"unet": self.unet, "vae": self.vae}
+
+
+def test_arming_the_rung_splits_a_real_pipeline_at_the_budget() -> None:
+    from gen_worker.models.memory import _apply_partial_stream, stream_residency_of
+
+    pipe = Pipe()
+    x = torch.randn(2, 1024)
+    with torch.no_grad():
+        want = pipe.unet(x).clone()
+
+    applied: dict = {}
+    total = sum(
+        p.numel() * p.element_size()
+        for m in pipe.components.values()
+        for p in m.parameters()
+    )
+    ok = _apply_partial_stream(
+        pipe,
+        applied,
+        budget_bytes=total // 2,
+        log=logging.getLogger(__name__),
+        device="cpu",
+    )
+    assert ok
+    assert applied["partial_stream"] is True
+    assert applied["stream_streamed_leaves"] >= 1
+    assert applied["stream_window_bytes"] > 0
+    assert applied["stream_resident_bytes"] + applied["stream_window_bytes"] <= (
+        applied["stream_budget_bytes"]
+    ), "the armed plan must fit the budget it was given, window included"
+
+    residency = stream_residency_of(pipe)
+    assert residency is not None and residency.plan is not None
+    with torch.no_grad():
+        assert torch.equal(pipe.unet(x), want), "the armed rung changed the answer"
+
+
+def test_a_budget_that_holds_everything_arms_but_reports_no_degradation() -> None:
+    """The rung armed and had nothing to do. Reporting that as a degradation
+    would put a DEGRADED_MODE confession on a fully-resident pipeline."""
+    from gen_worker.models.memory import _apply_partial_stream
+
+    pipe = Pipe()
+    applied: dict = {}
+    assert _apply_partial_stream(
+        pipe,
+        applied,
+        budget_bytes=1 << 30,
+        log=logging.getLogger(__name__),
+        device="cpu",
+    )
+    assert applied["stream_streamed_leaves"] == 0
+    assert applied["stream_streamed_bytes"] == 0
+    assert applied["stream_window_bytes"] == 0
+
+
+def test_the_unhookable_union_is_never_handed_to_the_ring() -> None:
+    """The same union every other rung excludes: a dtype-fragile VAE and a
+    content-shared module. Either alone is sufficient."""
+    from gen_worker.models.memory import (
+        SHARED_COMPONENT_ATTR,
+        _apply_partial_stream,
+        stream_residency_of,
+        unhookable_components,
+    )
+
+    pipe = Pipe()
+    setattr(pipe.vae, SHARED_COMPONENT_ATTR, True)
+    assert "vae" in unhookable_components(pipe)
+
+    applied: dict = {}
+    assert _apply_partial_stream(
+        pipe, applied, budget_bytes=0, log=logging.getLogger(__name__), device="cpu"
+    )
+    residency = stream_residency_of(pipe)
+    assert residency is not None
+    assert not any(name.startswith("vae") for name in residency.plan.streamed)
+    assert any(name.startswith("unet") for name in residency.plan.streamed)
+
+
+# ---------------------------------------------------------------------------
+# 4. The budget travels from the lease to the load moment
+# ---------------------------------------------------------------------------
+
+
+def test_the_manager_answers_the_budget_from_the_same_sizer_admission_uses() -> None:
+    from gen_worker.serving.residency import ResidencyManager
+
+    class Sizer:
+        def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
+            return 7 * (1 << 20) if checkpoint_ref == "known" else 0
+
+        def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+            return 1 << 20
+
+    manager = ResidencyManager(1 << 30, Sizer())
+    assert manager.weight_budget_bytes("known", "lane") == 7 * (1 << 20)
+    # An unreadable size is "no lease number", and the rung refuses on 0
+    # rather than inventing one. Never a failed load.
+    assert manager.weight_budget_bytes("unknown", "lane") == 0
+
+
+def test_the_load_context_carries_the_budget_down_to_the_ladder() -> None:
+    from gen_worker.serving.context import DeployBinding, LoadContext
+
+    binding = DeployBinding(checkpoint_ref="ref", checkpoint_dir="/tmp")
+    assert LoadContext(binding=binding)._weight_budget_bytes == 0
+    assert (
+        LoadContext(binding=binding, weight_budget_bytes=1234)._weight_budget_bytes
+        == 1234
+    )
+    # A negative figure is not a smaller budget; it is no budget.
+    assert (
+        LoadContext(binding=binding, weight_budget_bytes=-1)._weight_budget_bytes == 0
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. The two defects the CARD found (pgw#1497 GPU window, RTX 4070)
+# ---------------------------------------------------------------------------
+
+CUDA = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="cross-device placement needs a card"
+)
+
+
+class VocabPipe(Pipe):
+    """A pipeline whose component vocabulary holds NON-MODULES, exactly as a
+    real one does: sd1.5 answers `['vae','text_encoder','tokenizer','unet',
+    'scheduler','safety_checker','feature_extractor','image_encoder']`."""
+
+    class _Tokenizer:  # no `named_modules`, like CLIPTokenizer
+        pass
+
+    @property
+    def components(self) -> dict:
+        return {
+            "unet": self.unet,
+            "vae": self.vae,
+            "tokenizer": self._Tokenizer(),
+            "scheduler": object(),
+        }
+
+
+def test_a_non_module_in_the_component_vocabulary_does_not_unarm_the_rung() -> None:
+    """MEASURED on the card: without the filter this raised `CLIPTokenizer has
+    no attribute named_modules`, the rung reported False, and the pipeline
+    served on `model_offload` — a placement nobody asked for, announced only in
+    a log line."""
+    from gen_worker.models.memory import _apply_partial_stream, stream_residency_of
+
+    pipe = VocabPipe()
+    applied: dict = {}
+    assert _apply_partial_stream(
+        pipe, applied, budget_bytes=0, log=logging.getLogger(__name__), device="cpu"
+    ), "a tokenizer in the vocabulary unarmed the whole rung"
+    assert applied["stream_streamed_leaves"] >= 1
+    residency = stream_residency_of(pipe)
+    assert residency is not None
+    assert not any(
+        n.startswith(("tokenizer", "scheduler")) for n in residency.plan.streamed
+    )
+
+
+def test_an_unarmed_rung_confesses_on_the_typed_channel_not_just_the_log() -> None:
+    """A fall-through to a coarser rung is a placement the operator asked for
+    and did not get. The defect was that it was a warning and nothing else."""
+    from gen_worker import activity as activity_mod
+    from gen_worker.models.memory import (
+        PARTIAL_STREAM_UNARMED_PHASE,
+        _apply_partial_stream,
+    )
+
+    seen: list = []
+    original = activity_mod.emit_event
+    activity_mod.emit_event = lambda *a, **k: seen.append((a, k))  # type: ignore[assignment]
+    try:
+
+        class NoTree:
+            components: dict = {}
+
+        assert not _apply_partial_stream(
+            NoTree(), {}, budget_bytes=1 << 20,
+            log=logging.getLogger(__name__), device="cpu",
+        )
+    finally:
+        activity_mod.emit_event = original  # type: ignore[assignment]
+
+    phases = [k.get("phase") for _a, k in seen]
+    assert PARTIAL_STREAM_UNARMED_PHASE in phases, (
+        "the rung fell through silently — a log line is not a confession"
+    )
+    detail = " ".join(str(k.get("detail", "")) for _a, k in seen)
+    assert "COARSER" in detail
+
+
+@CUDA
+def test_tensors_owned_by_a_module_WITH_children_are_placed_on_the_device() -> None:
+    """MEASURED: CLIP's `position_ids` hangs off `CLIPTextEmbeddings`, which
+    has children, so it is never a leaf and nothing else in this rung touched
+    it. Left on the host it took sd1.5 down at a 5% budget with
+    `index is on cpu, different from other tensors on cuda:0`."""
+    from gen_worker.models.stream_residency import StreamedResidency, module_roots
+
+    class WithChildren(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_buffer("position_ids", torch.arange(77).unsqueeze(0))
+            self.child = nn.Linear(2048, 2048)
+
+    model = WithChildren().eval()  # starts on the HOST, as an offload rung finds it
+    assert model.position_ids.device.type == "cpu"
+    residency = StreamedResidency(
+        module_roots(model), device="cuda", budget_bytes=0, min_stream_bytes=1
+    )
+    plan = residency.engage()
+    assert any(n.endswith("child") for n in plan.streamed)
+    assert model.position_ids.device.type == "cuda", (
+        "a parent-owned tensor was left on the host"
+    )
+    residency.release()
+
+
+@CUDA
+def test_an_excluded_component_is_kept_ON_the_device_not_left_behind() -> None:
+    """An exclusion is a statement about HOOKS, never about residency.
+    MEASURED: sd1.5's VAE is `force_upcast`, so it is dtype-fragile and
+    excluded, and with nobody placing it the first decode died with
+    `Input type (torch.cuda.HalfTensor) and weight type (torch.HalfTensor)`."""
+    from gen_worker.models.memory import (
+        SHARED_COMPONENT_ATTR,
+        _apply_partial_stream,
+        unhookable_components,
+    )
+
+    pipe = Pipe()
+    setattr(pipe.vae, SHARED_COMPONENT_ATTR, True)
+    assert "vae" in unhookable_components(pipe)
+    assert next(pipe.vae.parameters()).device.type == "cpu"
+
+    assert _apply_partial_stream(
+        pipe, {}, budget_bytes=0, log=logging.getLogger(__name__), device="cuda"
+    )
+    assert next(pipe.vae.parameters()).device.type == "cuda", (
+        "the excluded component was kept out of the ring AND off the card"
+    )
+
+
+@CUDA
+def test_the_pipeline_still_answers_with_its_execution_device() -> None:
+    """`DiffusionPipeline.device` answers with the first parameter it finds, so
+    a parked tail makes it report the HOST — and the pipeline then builds its
+    input ids there, which is how sd1.5 died at a 5% budget with `index is on
+    cpu`. The rung that breaks a public answer repairs it.
+
+    Over a REAL `DiffusionPipeline`, because the repair is a patch of that
+    class's property and nothing else exercises it.
+    """
+    from diffusers import StableDiffusionPipeline
+
+    from gen_worker.models.memory import (
+        STREAM_RESIDENCY_ATTR,
+        install_execution_device_fallback,
+    )
+    from gen_worker.models.stream_residency import StreamedResidency
+
+    snapshots = sorted(
+        pathlib.Path.home().glob(
+            ".cache/huggingface/hub/models--hf-internal-testing--"
+            "tiny-stable-diffusion-pipe/snapshots/*"
+        )
+    )
+    if not snapshots:
+        pytest.skip("the tiny diffusers fixture is not cached on this host")
+    pipe = StableDiffusionPipeline.from_pretrained(
+        str(snapshots[-1]), safety_checker=None, requires_safety_checker=False,
+        local_files_only=True,
+    )
+    # The tail parks on the host, exactly as the rung leaves it.
+    roots = [
+        (n, m) for n, m in pipe.components.items() if hasattr(m, "named_modules")
+    ]
+    residency = StreamedResidency(
+        roots, device="cuda", budget_bytes=0, min_stream_bytes=1
+    )
+    residency.engage()
+    assert residency.plan is not None and residency.plan.streamed
+    assert pipe.device.type == "cpu", (
+        "with no repair installed the parked tail must still be visible as the "
+        "host — otherwise this test proves nothing"
+    )
+
+    setattr(pipe, STREAM_RESIDENCY_ATTR, residency)
+    install_execution_device_fallback()
+    assert pipe.device.type == "cuda", "pipeline.device still lies about the host"
+    assert pipe._execution_device.type == "cuda"
+    residency.release()
+
+
+# ---------------------------------------------------------------------------
+# 6. The {VRAM, RAM} pair
+# ---------------------------------------------------------------------------
+
+
+def test_the_budget_is_a_pair_and_the_ram_half_is_reported_not_enforced() -> None:
+    """Paul, 2026-08-19: the memory profile is a PAIR, assigned top-down. The
+    signature carries both halves NOW so that landing enforcement is a change
+    of behaviour and not a change of shape."""
+    from gen_worker.models.stream_residency import (
+        LeafCost,
+        MemoryBudget,
+        plan_residency,
+    )
+
+    costs = [LeafCost(f"m{i}", 4 << 20) for i in range(6)]
+    bare = plan_residency(costs, budget_bytes=8 << 20, min_stream_bytes=1)
+    assert bare.ram_budget_bytes == 0
+    assert bare.host_fits, "an UNSTATED ram half is not a failed one"
+
+    tight = plan_residency(
+        costs,
+        budget_bytes=MemoryBudget(vram_bytes=8 << 20, ram_bytes=1 << 20),
+        min_stream_bytes=1,
+    )
+    assert tight.resident == bare.resident, (
+        "the ram half must not silently change the VRAM split — enforcement is "
+        "deferred, and a half-done enforcement is worse than a named one"
+    )
+    assert tight.host_bytes == tight.streamed_bytes > (1 << 20)
+    assert not tight.host_fits, "an over-budget tail must be VISIBLE"
+
+
+def test_a_rebudget_does_not_revoke_the_assigned_ram_half() -> None:
+    from gen_worker.models.stream_residency import (
+        MemoryBudget,
+        StreamedResidency,
+        module_roots,
+    )
+
+    model = Pipe().unet
+    residency = StreamedResidency(
+        module_roots(model),
+        device="cpu",
+        budget_bytes=MemoryBudget(vram_bytes=1 << 30, ram_bytes=7 << 20),
+        min_stream_bytes=1,
+    )
+    residency.engage()
+    plan = residency.rebudget(0)  # a demotion names only a VRAM number
+    assert plan.ram_budget_bytes == 7 << 20

--- a/tests/test_stream_residency_pgw1497.py
+++ b/tests/test_stream_residency_pgw1497.py
@@ -1,0 +1,481 @@
+"""pgw#1497 — per-module budgeted partial residency + streamed weight cast.
+
+Every test here runs the REAL mechanism over a REAL ``nn.Module`` tree: the
+planner's arithmetic, the forward hooks, the cast ring and the partial
+unload/load transitions. Nothing is mocked, because the defects this rung can
+have (a weight left bound to a reused cast buffer, a plan that fits at rest
+and overshoots in flight, an unload that promotes) are all defects of the
+interaction, not of a unit.
+
+The CPU arm is not a simulation of the CUDA one: it is the same driver loop
+with a null stream and synchronous copies, so every ordering decision is
+exercised here and only the OVERLAP is left for the card to prove.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+nn = torch.nn
+
+from gen_worker.models.stream_residency import (  # noqa: E402
+    DEFAULT_STREAMS,
+    ENGAGED_ATTR,
+    LeafCost,
+    ResidencyPlan,
+    StreamedResidency,
+    module_roots,
+    plan_residency,
+    plan_transition,
+    stream_residency_active,
+)
+
+
+# ---------------------------------------------------------------------------
+# Trees
+# ---------------------------------------------------------------------------
+
+
+class Block(nn.Module):
+    def __init__(self, width: int) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(width, width * 2)
+        self.fc2 = nn.Linear(width * 2, width)
+        self.norm = nn.LayerNorm(width)
+
+    def forward(self, x):  # type: ignore[no-untyped-def]
+        return self.norm(x + self.fc2(torch.relu(self.fc1(x))))
+
+
+class Stack(nn.Module):
+    """Eight blocks of decreasing width — a tree where a budget genuinely
+    splits, instead of one that is all-or-nothing."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList([Block(256 - 16 * i) for i in range(8)])
+        self.proj = nn.Linear(256, 256)
+
+    def forward(self, x):  # type: ignore[no-untyped-def]
+        out = self.proj(x)
+        for block in self.blocks:
+            width = block.norm.normalized_shape[0]
+            out = torch.cat([block(out[..., :width]), out[..., width:]], dim=-1)
+        return out
+
+
+@pytest.fixture()
+def tree() -> nn.Module:
+    torch.manual_seed(1497)
+    model = Stack().eval()
+    return model
+
+
+def _pyramid(n: int = 6, unit: int = 1_000_000) -> list[LeafCost]:
+    return [LeafCost(f"m{i}", (i + 1) * unit) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# 1. The budget split
+# ---------------------------------------------------------------------------
+
+
+def test_budget_split_is_deterministic_and_largest_first() -> None:
+    costs = _pyramid()
+    first = plan_residency(costs, budget_bytes=14_000_000, min_stream_bytes=1)
+    # Same inputs in a different order must give the same answer: a mint's
+    # traced graph class and a residency reservation both depend on it.
+    shuffled = plan_residency(
+        list(reversed(costs)), budget_bytes=14_000_000, min_stream_bytes=1
+    )
+    assert first == shuffled
+    assert first.resident, "a 14 MB budget on a 21 MB model must hold something"
+    resident_sizes = [int(n[1:]) for n in first.resident]
+    assert resident_sizes == sorted(resident_sizes, reverse=True)
+
+
+def test_the_in_flight_window_is_reserved_out_of_the_budget() -> None:
+    """The subtle half of the port. A plan that ignores the window fits at
+    rest and overshoots the instant two casts are in flight."""
+    costs = _pyramid()
+    plan = plan_residency(
+        costs, budget_bytes=14_000_000, streams=2, min_stream_bytes=1
+    )
+    assert plan.streamed, "this budget must leave a tail"
+    largest_streamed = max(int(n[1:]) + 1 for n in plan.streamed) * 1_000_000
+    assert plan.window_bytes == 2 * largest_streamed
+    assert plan.device_bytes <= plan.budget_bytes
+    assert plan.fits
+
+    # RED ARM: had the window not been reserved, the same fill would have put
+    # this much on the card and the tail's casts would have had nowhere to go.
+    unreserved = sum(
+        c.resident_bytes
+        for c in sorted(costs, key=lambda c: -c.resident_bytes)
+        if _fits_ignoring_window(c, costs, 14_000_000)
+    )
+    assert unreserved + plan.window_bytes > plan.budget_bytes
+
+
+def _fits_ignoring_window(cost: LeafCost, costs: list[LeafCost], budget: int) -> bool:
+    mem = 0
+    for c in sorted(costs, key=lambda c: -c.resident_bytes):
+        if mem + c.resident_bytes <= budget:
+            mem += c.resident_bytes
+            if c is cost:
+                return True
+    return False
+
+
+def test_a_budget_at_the_model_size_means_full_residency() -> None:
+    """The window must terminate at zero when nothing streams. ComfyUI's
+    lookahead formula reserves for a tail that isn't there and reports an
+    empty resident set on a budget that fits the whole model."""
+    costs = _pyramid()
+    total = sum(c.resident_bytes for c in costs)
+    plan = plan_residency(costs, budget_bytes=total, min_stream_bytes=1)
+    assert not plan.streamed
+    assert plan.window_bytes == 0
+    assert plan.resident_bytes == total
+
+
+def test_a_budget_below_one_window_reports_that_it_does_not_fit() -> None:
+    plan = plan_residency(_pyramid(), budget_bytes=1_000_000, min_stream_bytes=1)
+    assert not plan.resident
+    assert not plan.fits, "an unservable budget must confess, not clamp"
+
+
+def test_leaves_below_the_floor_are_forced_resident() -> None:
+    costs = [LeafCost("big", 8_000_000), LeafCost("tiny", 4_096)]
+    plan = plan_residency(costs, budget_bytes=0, min_stream_bytes=1 << 20)
+    assert plan.forced == ("tiny",)
+    assert plan.streamed == ("big",)
+
+
+def test_excluded_leaves_are_never_streamed() -> None:
+    costs = _pyramid()
+    plan = plan_residency(
+        costs, budget_bytes=0, min_stream_bytes=1, exclude=("m5", "m0")
+    )
+    assert set(plan.forced) == {"m5", "m0"}
+    assert "m5" not in plan.streamed and "m0" not in plan.streamed
+
+
+def test_an_unload_never_promotes() -> None:
+    """The greedy fill is NOT monotone in the budget — dropping a large leaf
+    frees room a smaller one can take — so a re-plan at a lower budget can
+    genuinely want to move bytes ONTO the card. A call asked to free bytes
+    must never answer by claiming some.
+
+    These three sizes are a measured instance of that: at a 9 MB budget the
+    5 MB leaf is resident, and at 8 MB it is the 3 MB leaf instead."""
+    mib = 1_000_000
+    costs = [LeafCost("a", 5 * mib), LeafCost("b", 4 * mib), LeafCost("c", 3 * mib)]
+    wide = plan_residency(costs, budget_bytes=9 * mib, streams=1, min_stream_bytes=1)
+    narrow = plan_residency(costs, budget_bytes=8 * mib, streams=1, min_stream_bytes=1)
+    assert wide.resident == ("a",) and narrow.resident == ("c",)
+
+    # The instrument's own red arm: with promotion allowed this transition
+    # DOES promote, so a test that could not see it would be measuring nothing.
+    assert plan_transition(wide, narrow, costs, allow_promote=True).promote == ("c",)
+
+    move = plan_transition(wide, narrow, costs, allow_promote=False)
+    assert move.promote == ()
+    assert move.demote == ("a",)
+    assert move.freed_bytes == 5 * mib
+
+
+# ---------------------------------------------------------------------------
+# 2. The streaming tail over a real tree
+# ---------------------------------------------------------------------------
+
+
+def test_every_residency_state_computes_the_same_answer(tree: nn.Module) -> None:
+    """Resident, fully streamed, and partially streamed must be numerically
+    indistinguishable. This is the test the whole rung rests on."""
+    x = torch.randn(2, 256)
+    with torch.no_grad():
+        want = tree(x).clone()
+
+    residency = StreamedResidency(
+        module_roots(tree), device="cpu", budget_bytes=0, min_stream_bytes=1
+    )
+    plan = residency.engage()
+    assert plan.streamed and not plan.resident
+    with torch.no_grad():
+        assert torch.equal(tree(x), want), "fully streamed diverged"
+
+    residency.rebudget(residency.total_bytes // 2)
+    assert residency.plan is not None
+    assert residency.plan.resident and residency.plan.streamed, "wanted a split"
+    with torch.no_grad():
+        assert torch.equal(tree(x), want), "partially streamed diverged"
+
+    residency.promote_to_device()
+    assert residency.plan is not None and not residency.plan.streamed
+    with torch.no_grad():
+        assert torch.equal(tree(x), want), "promoted diverged"
+
+    residency.release()
+    with torch.no_grad():
+        assert torch.equal(tree(x), want), "released diverged"
+
+
+def test_a_streamed_weight_is_unbound_from_the_cast_buffer_after_its_forward(
+    tree: nn.Module,
+) -> None:
+    """The single most dangerous defect this rung can have: a weight left
+    pointing into a buffer the ring is about to refill for another leaf. The
+    bytes would be silently wrong, load-order dependent, and only sometimes."""
+    residency = StreamedResidency(
+        module_roots(tree), device="cpu", budget_bytes=0, min_stream_bytes=1
+    )
+    residency.engage()
+    with torch.no_grad():
+        tree(torch.randn(2, 256))
+    for name, leaf in residency._streamed.items():
+        for slot in leaf.slots:
+            live = getattr(leaf.module, slot.attr)
+            assert live.data_ptr() == slot.host.data_ptr(), (
+                f"{name}.{slot.attr} is still bound to the cast buffer after "
+                f"its forward returned"
+            )
+
+
+def test_the_cast_buffer_costs_the_window_not_the_tail(tree: nn.Module) -> None:
+    """The memory argument, measured: the ring holds ``streams`` buffers sized
+    to the largest streamed leaf, never the tail's own size — and the planner's
+    reservation is exactly that number, not an estimate of it."""
+    residency = StreamedResidency(
+        module_roots(tree),
+        device="cpu",
+        budget_bytes=0,
+        streams=DEFAULT_STREAMS,
+        min_stream_bytes=1,
+    )
+    plan = residency.engage()
+    with torch.no_grad():
+        tree(torch.randn(2, 256))
+    largest = max(c.cast_bytes for c in residency.costs)
+    assert residency.buffer_peak_bytes == largest
+    assert plan.window_bytes == DEFAULT_STREAMS * largest
+    assert plan.window_bytes < residency.total_bytes
+
+
+def test_partial_unload_trims_the_cold_tail_instead_of_dropping_the_model(
+    tree: nn.Module,
+) -> None:
+    """The eviction primitive: freeing N bytes leaves the model SERVING."""
+    x = torch.randn(2, 256)
+    with torch.no_grad():
+        want = tree(x).clone()
+    residency = StreamedResidency(
+        module_roots(tree),
+        device="cpu",
+        budget_bytes=1 << 30,
+        min_stream_bytes=1,
+    )
+    plan = residency.engage()
+    assert not plan.streamed, "a huge budget must start fully resident"
+
+    freed = residency.partial_unload(residency.total_bytes // 3)
+    assert freed >= residency.total_bytes // 3
+    assert residency.plan is not None
+    assert residency.plan.resident, "an unload must not drop the whole model"
+    assert residency.plan.streamed
+    with torch.no_grad():
+        assert torch.equal(tree(x), want)
+
+    # Smallest-first is the point: the tail that leaves is the CHEAP end, so
+    # the expensive leaves keep their residency.
+    by_name = {c.name: c for c in residency.costs}
+    smallest_resident = min(
+        by_name[n].resident_bytes for n in residency.plan.all_resident
+    )
+    largest_streamed = max(by_name[n].resident_bytes for n in residency.plan.streamed)
+    assert largest_streamed >= smallest_resident
+
+
+def test_partial_unload_and_partial_load_round_trip(tree: nn.Module) -> None:
+    residency = StreamedResidency(
+        module_roots(tree), device="cpu", budget_bytes=1 << 30, min_stream_bytes=1
+    )
+    residency.engage()
+    before = residency.plan.resident_bytes if residency.plan else 0
+    freed = residency.partial_unload(residency.total_bytes // 2)
+    claimed = residency.partial_load(freed)
+    assert residency.plan is not None
+    assert residency.plan.resident_bytes == before
+    assert claimed == freed
+
+
+def test_the_host_tier_is_this_rung_at_its_end_stops(tree: nn.Module) -> None:
+    x = torch.randn(2, 256)
+    with torch.no_grad():
+        want = tree(x).clone()
+    residency = StreamedResidency(
+        module_roots(tree), device="cpu", budget_bytes=1 << 30, min_stream_bytes=1
+    )
+    residency.engage()
+    residency.demote_to_host()
+    assert residency.plan is not None and not residency.plan.resident
+    assert stream_residency_active(tree)
+    residency.promote_to_device()
+    assert residency.plan is not None and not residency.plan.streamed
+    assert not getattr(tree, ENGAGED_ATTR, False)
+    with torch.no_grad():
+        assert torch.equal(tree(x), want)
+
+
+def test_release_removes_every_hook(tree: nn.Module) -> None:
+    residency = StreamedResidency(
+        module_roots(tree), device="cpu", budget_bytes=0, min_stream_bytes=1
+    )
+    residency.engage()
+    assert any(m._forward_pre_hooks for m in tree.modules())
+    residency.release()
+    for module in tree.modules():
+        assert not module._forward_pre_hooks
+        assert not module._forward_hooks
+
+
+def test_a_module_owning_both_children_and_weights_is_never_hooked() -> None:
+    """Its post-hook would fire AFTER its children's forwards, holding a
+    cast-buffer view alive while the ring hands the same buffer to a child."""
+
+    class Mixed(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.scale = nn.Parameter(torch.ones(1024, 256))
+            self.child = nn.Linear(256, 256)
+
+        def forward(self, x):  # type: ignore[no-untyped-def]
+            return self.child(x) * self.scale.mean()
+
+    model = Mixed().eval()
+    residency = StreamedResidency(
+        module_roots(model), device="cpu", budget_bytes=0, min_stream_bytes=1
+    )
+    names = {c.name for c in residency.costs}
+    assert any(n.endswith("child") for n in names)
+    assert not any(n == "Mixed" for n in names), (
+        "a module with children AND its own weights was offered to the ring"
+    )
+
+
+def test_attached_lora_leaves_are_forced_resident() -> None:
+    """Our LoRA is attach-based, so an adapter is a pair of tiny leaves next
+    to the base layer, never a patch fused into the base weight. They stay
+    resident and the base layer streams unchanged — which is why no
+    LowVramPatch equivalent is needed (see the module docstring)."""
+
+    class Attached(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.base_layer = nn.Linear(512, 512)
+            self.lora_A = nn.Linear(512, 8, bias=False)
+            self.lora_B = nn.Linear(8, 512, bias=False)
+
+        def forward(self, x):  # type: ignore[no-untyped-def]
+            return self.base_layer(x) + self.lora_B(self.lora_A(x))
+
+    model = Attached().eval()
+    x = torch.randn(2, 512)
+    with torch.no_grad():
+        want = model(x).clone()
+    residency = StreamedResidency(
+        module_roots(model), device="cpu", budget_bytes=0, min_stream_bytes=1
+    )
+    plan = residency.engage()
+    assert any(n.endswith("lora_A") for n in plan.forced)
+    assert any(n.endswith("lora_B") for n in plan.forced)
+    assert any(n.endswith("base_layer") for n in plan.streamed)
+    with torch.no_grad():
+        assert torch.equal(model(x), want)
+
+
+# ---------------------------------------------------------------------------
+# 3. The serve-loop host tier
+# ---------------------------------------------------------------------------
+
+
+def test_the_serve_loop_backend_tiers_a_real_author_model() -> None:
+    """``demote_to_host``/``promote_to_device`` raised NotImplementedError
+    until this issue; the manager was run with a zero host budget so eviction
+    was always a drop. Drive the REAL backend arms over a real tree."""
+    from gen_worker.serving.serve_loop import _InstanceBackend
+
+    class AuthorModel:
+        def __init__(self) -> None:
+            torch.manual_seed(7)
+            self.pipe = Stack().eval()
+
+    backend = _InstanceBackend.__new__(_InstanceBackend)
+    backend.model_cls = AuthorModel
+    backend.model = AuthorModel()
+    backend._stream_residency = None
+
+    x = torch.randn(2, 256)
+    with torch.no_grad():
+        want = backend.model.pipe(x).clone()
+
+    backend.demote_to_host()
+    assert backend._stream_residency is not None
+    assert not backend._stream_residency.plan.resident
+    with torch.no_grad():
+        assert torch.equal(backend.model.pipe(x), want), (
+            "a host-tier instance must still compute the same answer"
+        )
+
+    backend.promote_to_device()
+    assert not backend._stream_residency.plan.streamed
+    with torch.no_grad():
+        assert torch.equal(backend.model.pipe(x), want)
+
+
+def test_a_tier_move_on_a_weightless_instance_refuses_loudly() -> None:
+    """Silence is the one answer a placement report must never give: an
+    instance with no module tree cannot be tiered, and must say so rather than
+    report a successful demote that moved nothing."""
+    from gen_worker.serving.residency import ResidencyError
+    from gen_worker.serving.serve_loop import _InstanceBackend
+
+    class Weightless:
+        pass
+
+    backend = _InstanceBackend.__new__(_InstanceBackend)
+    backend.model_cls = Weightless
+    backend.model = Weightless()
+    backend._stream_residency = None
+    with pytest.raises(ResidencyError, match="no nn.Module tree"):
+        backend.demote_to_host()
+
+
+def test_module_roots_finds_the_three_shapes_the_serve_path_holds() -> None:
+    bare = nn.Linear(4, 4)
+    assert module_roots(bare) == [("Linear", bare)]
+
+    class Pipeline:
+        def __init__(self) -> None:
+            self.components = {"unet": nn.Linear(4, 4), "cfg": "not a module"}
+
+    pipeline = Pipeline()
+    assert [n for n, _ in module_roots(pipeline)] == ["unet"]
+
+    class Author:
+        def __init__(self) -> None:
+            self.pipe = pipeline
+            self.extra = nn.Linear(4, 4)
+            self._private = nn.Linear(4, 4)
+
+    names = [n for n, _ in module_roots(Author())]
+    assert "pipe.unet" in names and "extra" in names
+    assert not any(n.startswith("_") for n in names)
+
+
+def test_plans_are_frozen_records() -> None:
+    plan = plan_residency(_pyramid(), budget_bytes=0, min_stream_bytes=1)
+    assert isinstance(plan, ResidencyPlan)
+    with pytest.raises(Exception):
+        plan.resident = ()  # type: ignore[misc]


### PR DESCRIPTION
Ports the ComfyUI lowvram mechanism (`model_patcher.py:982-1111`, `ops.py:337-459`, `model_management.py:1340-1494`) as our own primitive, and uses it to fill in the two `NotImplementedError` host-tier arms in `serve_loop`.

### `models/stream_residency.py`

| part | what |
|---|---|
| `plan_residency` | the budget split — leaves sorted by offload cost, filled largest-first, **in-flight cast window reserved out of the budget**. Pure arithmetic, deterministic to the tie-break. |
| `StreamedResidency` | the tail — leaves that did not fit rest in pinned host RAM and cast onto the device inside their own forward, on round-robin offload streams into persistent reused cast buffers, fenced both ways. |
| `rebudget` | partial unload / partial load — and therefore `demote_to_host` / `promote_to_device`, which are that call at its two end stops. |

### Two deliberate departures from the source

**The window arithmetic is tighter.** They reserve `this leaf + the next NUM_STREAMS leaves` — a lookahead over leaves that often end up *resident*, so it is counted twice. Measured on a 6-leaf pyramid: 15 MB reserved where 12 MB is the real peak, and the whole model then streams with a resident set of **zero**. What the ring actually holds is `streams` buffers each grown to the largest streamed leaf, so that is what is reserved. The reservation depends on the split and the split on the reservation, so the walk runs to a fixed point — terminating at a zero window when nothing streams, which is what makes a budget equal to the model's own size mean full residency.

**One walk, not two.** They have a load walk and a separate inverse `partially_unload` walk that can disagree about the same model. Here unload is a re-plan at a smaller budget. The greedy fill is *not* monotone in the budget (measured: at 9 MB the 5 MB leaf is resident, at 8 MB the 3 MB leaf is), so an unload explicitly refuses to promote.

### Constraints held

- **Budget handed down, never estimated** — from the residency lease. None of ComfyUI's fudge-factor activation lambdas are imported; nothing here measures, guesses or samples VRAM.
- **Hooks over arbitrary `nn.Module` trees**, since we do not own the model classes. True leaves only: a module owning parameters *and* children stays resident (its post-hook fires after its children's forwards and would hold a cast-buffer view alive while the ring hands the same buffer to a child).
- **LoRA**: ours is attach-based, so an adapter is a pair of tiny `lora_A`/`lora_B` leaves *next to* the base layer, never fused into the base weight. peft computes `base_layer(x) + lora_B(lora_A(x))`, the base layer streams unchanged, adapter leaves are forced resident. No `LowVramPatch` equivalent needed.

### Deleted

`apply_block_window_offload` / `_BlockOffloadWindow` / `block_offload_active` — 153 lines, exported and **never called**, strictly worse on every axis (whole blocks not leaves, all-or-nothing not budgeted, ambient stream, no reused buffer, no reservation, no partial unload). Keeping it would have left three overlapping offload implementations in one tree. `_fp8_block_windows` survives; the fp8 storage rung is its real caller.

### Red/green — $0, no GPU

`tests/test_stream_residency_pgw1497.py`, **20 tests over real `nn.Module` trees** (an 8-block stack, a peft-shaped attached adapter, a mixed parent). Resident, fully streamed and partially streamed are bit-identical.

Five red arms forced, each flipping ONE condition:

| red arm | result |
|---|---|
| window reservation removed | **3 fail** |
| post-hook host rebind removed | still-bound-to-the-cast-buffer test **fails** |
| unload allowed to promote | **fails** |
| modules with children made streamable | **fails** |
| adapter leaves streamed | **fails** |

The unload test's first instrument was **false** — the pyramid never triggers a non-monotone fill and it stayed green under its own red arm. It now carries the measured non-monotone case and its red arm inline.

Neighbours green: `test_component_vocab_sweep_pgw740`, `test_limits_census_wave3_pgw973`. `ruff` clean, `mypy` clean over the four touched sources.

### Not in this PR

**The rung itself.** `models/rung.py`'s `LADDER` takes a MEASURED latency price and until the card has run it that field would be a guess. The rung, its `apply_low_vram_config` arm and the measured price land in the follow-up.

---

## Second commit: the rung itself, measured onto the ladder

### The issue's hypothesis was falsified by the card

pgw#1497 specified the rung "between `fp8_storage` and `model_offload`". Measured on an RTX 4070 — sd1.5, 512², 25 steps, CFG, fp16, **eager**, one config, best of 2 timed runs after a warmup:

| rung | ms/step | × native | peak VRAM |
|---|---|---|---|
| resident | 119.6 | 1.00 | 2.81 GB |
| model_offload | 187.2 | 1.57 | 1.88 GB |
| **partial_stream @50% budget** | 228.9 | **1.91** | 1.89 GB |
| **partial_stream @25%** | 377.7 | **3.16** | 1.35 GB |
| **partial_stream @5%** | 426.4 | **3.56** | 1.04 GB |
| group_offload | 550.2 | 4.60 | 0.82 GB |
| sequential | 903.6 | 7.55 | 0.65 GB |

At **equal peak VRAM** (1.89 vs 1.88 GB) `model_offload` is *faster* — 1.57× against 1.91× — because its offload tax is per-**call** (measured: 1.69 s/generation, fixed) while streaming's is per-**step**. What this rung does that `model_offload` cannot is go **lower**: `model_offload` is whole-component granular and bottoms out near 1.9 GB here, and this rung keeps serving to 1.04 GB at 3.56× — 1.3× faster than `group_offload` and 2.1× faster than `sequential`, the only other rungs that reach that floor.

**Landed between `MODEL_OFFLOAD` and `GROUP_OFFLOAD`, priced 2.8.** Ladder monotonicity holds. Filed separately as **pgw#1505**: the ladder's other declared prices are stale against this card (order right, magnitudes wrong).

### In-flight window reservation: confirmed to the byte

At the 5% budget the observed cast-buffer peak was **75,890,688 B** — the largest leaf exactly — and the plan reserved **151,781,376 = 2 ×** that. Same ratio at 50%. `window_bytes == streams × observed buffer peak` on every arm.

### Admission-first, enforced not documented

`select_auto_mode` cannot return it (swept over its whole branch space), the reactive descent cannot enter it (`admission_only`), and `apply_low_vram_config` **refuses** it without an explicit `stream_budget_bytes`. The number travels `ResidencyManager.weight_budget_bytes` → `LoadContext` → `_placed` → the ladder. `price(RUN_OFFLOAD)` is unchanged at 2.5 — the run-mode scan skips admission-only rungs, so no caller-facing number moved.

### Two defects the card found, both invisible CPU-side

1. **The component vocabulary is not all modules.** `CLIPTokenizer has no attribute named_modules` → the rung reported failure and the pipeline **served on `model_offload`**, announced in a log line and nowhere else. Filtered; the fall-through is now a typed `partial_stream_unarmed` confession on both channels.
2. **Two placement holes at low budgets.** A tensor owned by a module with *children* (CLIP's `position_ids`) is never a leaf, so nothing touched it — `_place_residue` restores the clause the deleted block-window rung had and this port dropped. And the dtype-fragile VAE, correctly *excluded from the ring*, was then nobody's job to place — an exclusion is a statement about hooks, never about residency. Plus `pipeline.device` reported the host once the tail was parked. sd1.5 at a 5% budget died on all three in sequence and serves correctly now.

### The {VRAM, RAM} pair

`MemoryBudget(vram_bytes, ram_bytes)` accepted everywhere a budget is; `ResidencyPlan` reports `host_bytes` / `host_fits` / `ram_budget_bytes`; a re-plan naming only VRAM does not revoke the assigned RAM half. **Enforcement is a named deferral** — today it plans against VRAM and *reports* the RAM cost.

### Red/green (both commits)

**40 tests, all green. Ten forced red arms**, each flipping one condition — window reservation, post-hook restore, unload-promotes, non-leaf streamability, adapter leaves, component-vocabulary filter, the unarmed confession, `_place_residue`, excluded-component placement, the `pipeline.device` repair. Two instruments were caught **false** and rewritten (the unload test's pyramid; the device test asserting on the residency object rather than the patched property). Four tests are CUDA-gated — all four *ran* on the 4070, none skipped.

`ruff` clean; `mypy` clean over 337 source files. Neighbours green. (`test_quantization_lanes::test_w8a8_contract_artifact…` fails identically on untouched master — pre-existing.)

### Named deferrals

- **RAM-half enforcement** (partial unload refusing / degrading when the RAM budget cannot absorb what VRAM evicts).
- **SDXL `partial_stream` arm** — needs its own GPU window.
