### PR TITLE
pgw#1449 + tcg#66 re-vendor: the lock enumerates PER ENTRYPOINT, so one unreachable signature costs the module nothing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,7 +696,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "b5509c0dc89f027245b9cd56e103227b7afadb4c" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "20e54d41c7f853e809fc985e795e1cdd539b3215" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -306,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "b5509c0dc89f027245b9cd56e103227b7afadb4c"
+rev = "20e54d41c7f853e809fc985e795e1cdd539b3215"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -533,7 +533,7 @@ rewrites = [
 "document.py" = "797a3f17f46e971ce165c7c64503efece8219c04c80530036727d7c838f173f7"
 "engine.py" = "d8275ad146c73ae5516ea7d60acc1fd63cdddb3036f4833f7741913fe340a1a9"
 "graph_identity.py" = "88c731a681eb1e0b878f30bc33fcaa4efdbfc16bdc612fd6d406a088e299e567"
-"hollow.py" = "2e24782b350bf4634171d8c3eb90bf3a1131527c69a4dc14234d7380b4276b36"
+"hollow.py" = "d0654b626ce367535e9a0f0782fb952e52128c395316932f4c5ad973b260429b"
 "host_isa.py" = "679aa81547be2d60ae6593b6e8f75dd29dcd56ab85d8e858e219b5af5d0eadc4"
 "identity.py" = "a460a24836cbd46cc9e65bd684b9f6258f6718e5c56102f26a7071f01574a99e"
 "ingress.py" = "fa9b814dbfcd43e2a7cfdd2ed48299a7fa5a570aa73d3e2269448c974074d558"

--- a/src/gen_worker/_vendor/torchcg/hollow.py
+++ b/src/gen_worker/_vendor/torchcg/hollow.py
@@ -350,26 +350,46 @@ def virtualize_parameters(module: Any, session: HollowSession, *, dtype: Any = N
     that exists, so there is never a reason to destroy a value here. The
     stated device is applied afterwards, to the exported program
     (:func:`restate_program`), which is the only thing that carries it.
+
+    **With one exception, and it is a difference in KIND rather than a
+    carve-out (tcg#66).** A lifted constant that is itself on ``meta`` is not
+    value-bearing at all: it was DERIVED FROM THE PARAMETERS during
+    ``__init__``, and this session put those on meta a moment earlier. The
+    canonical producer is ``torch.nn.utils.weight_norm``, which every
+    DAC/BigVGAN-derived audio VAE applies to every conv: it deletes the
+    ``weight`` Parameter and installs a plain tensor ATTRIBUTE
+    ``weight = _weight_norm(weight_v, weight_g, dim)``. Fed meta parents, that
+    attribute is meta -- and a meta tensor cannot be copied, only
+    re-allocated. So it is virtualized exactly like the parameters it came
+    from, and the module's own pre-forward hook recomputes it from them on
+    the first call anyway.
+
+    A meta BUFFER still refuses, and the asymmetry is the point: a buffer's
+    value is a function of CONFIG and feeds the trace's literal digest, so a
+    meta one is a real loss of information. A meta attribute is downstream of
+    tensors this session deliberately emptied, so there is no information to
+    lose.
     """
 
     import torch
 
     device = session.drive_device
+
+    def hollow_like(value: Any) -> Any:
+        target = (
+            dtype if dtype is not None and value.dtype.is_floating_point else value.dtype
+        )
+        with session.fake_mode:
+            return torch.empty(
+                tuple(int(d) for d in value.shape), dtype=target, device=device
+            )
+
     for _prefix, submodule in module.named_modules():
         for name, param in list(submodule._parameters.items()):
             if param is None:
                 continue
-            target = (
-                dtype
-                if dtype is not None and param.dtype.is_floating_point
-                else param.dtype
-            )
-            with session.fake_mode:
-                hollow = torch.empty(
-                    tuple(int(d) for d in param.shape), dtype=target, device=device
-                )
             submodule._parameters[name] = torch.nn.Parameter(
-                hollow, requires_grad=False
+                hollow_like(param), requires_grad=False
             )
         for name, buffer in list(submodule._buffers.items()):
             if buffer is None:
@@ -383,7 +403,11 @@ def virtualize_parameters(module: Any, session: HollowSession, *, dtype: Any = N
                 )
             submodule._buffers[name] = _rehome(buffer, device)
         for name, value in _tensor_attributes(submodule):
-            setattr(submodule, name, _rehome(value, device))
+            replacement = (
+                hollow_like(value) if value.device.type == "meta"
+                else _rehome(value, device)
+            )
+            setattr(submodule, name, replacement)
 
 
 def _rehome(value: Any, device: str) -> Any:
@@ -391,8 +415,22 @@ def _rehome(value: Any, device: str) -> Any:
 
     A real move, always: the drive device can hold a real tensor by
     construction. A tensor already there is untouched.
+
+    A meta tensor has no value to keep, so it is not this function's job and
+    it REFUSES by name rather than letting torch raise ``Cannot copy out of
+    meta tensor`` from three frames down (tcg#66). Deciding what a storageless
+    tensor should become needs the session; every caller that has one routes
+    it to :func:`virtualize_parameters`'s fake path instead. Never wrapped in
+    a broad ``try/except`` -- that is how a loud, correct, by-name refusal
+    becomes a silently dropped component.
     """
 
+    if value.device.type == "meta":
+        raise HollowError(
+            "_rehome moves a REAL tensor onto the drive device and was handed "
+            "a meta one, which has no storage to move. A storageless tensor is "
+            "virtualized, not copied."
+        )
     if value.device.type == str(device).split(":", 1)[0]:
         return value
     return value.to(device)

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -278,6 +278,12 @@ def run_lock(args: argparse.Namespace) -> int:
     graphs = sum(len(h) for h in result.lane_graphs.values())
     programs = el.program_digests(json.loads(result.document))
     _say_posture(result)
+    # pgw#1449: an entrypoint the enumerator could not reach no longer kills
+    # the lock — it is written with everything that COULD be enumerated and
+    # the rest is stated. Said here as well as in the document because the
+    # operator running this verb is the one who can reshape the signature.
+    for name, reason in result.unenumerable_entrypoints:
+        _say(f"lock: entrypoint {name} NOT enumerated -- {reason}")
     _say(
         f"lock: traced {graphs} specialization(s), {len(programs)} exported "
         f"program(s) in the CAS at {graph_cas_root} ({elapsed:.1f}s)"
@@ -292,6 +298,9 @@ def run_lock(args: argparse.Namespace) -> int:
         "trace_device": device,
         "specializations": graphs,
         "programs": len(programs),
+        "unenumerable_entrypoints": [
+            name for name, _reason in result.unenumerable_entrypoints
+        ],
         "seconds": round(elapsed, 1),
     }))
     return 0

--- a/src/gen_worker/cli/release.py
+++ b/src/gen_worker/cli/release.py
@@ -115,6 +115,11 @@ def _run_derive(args: argparse.Namespace) -> int:
 
     for warning in result.warnings:
         print(f"warning: {warning}", file=sys.stderr)
+    # pgw#1449: named, and named SEPARATELY from the warnings — an entrypoint
+    # with no traced coverage is a property of the document a reader has to
+    # be able to see without parsing prose.
+    for name, reason in result.unenumerable_entrypoints:
+        print(f"entrypoint {name}: NOT enumerated -- {reason}", file=sys.stderr)
     if result.eager_permanent:
         # pgw#1392: two different reasons reach "no lanes" and the log must
         # not conflate them — a model held eagerly (`lanes=()`), or NO MODEL

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -109,6 +109,43 @@ class DeriveError(RuntimeError):
     """The release derive cannot state this endpoint's graph set."""
 
 
+class PayloadEnumerationRefused(DeriveError):
+    """THIS ENTRYPOINT's payload cannot be auto-enumerated (pgw#1449).
+
+    A property of one signature, never of the module -- so it is caught per
+    entrypoint, stated in the document, and the entrypoints that CAN be
+    enumerated are derived anyway. Deliberately a NARROW subclass with
+    exactly one raise site: catching ``DeriveError`` instead would swallow
+    slot-order violations, empty enums and non-msgspec payloads, which are
+    author defects that must still take the module down.
+
+    The distinction is the one the derive already draws for a combination
+    the author refuses with ``ValidationError``: an enumeration the derive
+    cannot reach is counted and named, not treated as a broken endpoint.
+    """
+
+    def __init__(self, owner: str, field: str, annotation: Any) -> None:
+        self.owner = owner
+        self.field = field
+        self.annotation = _render_annotation(annotation)
+        super().__init__(
+            f"{owner}: required payload field {field!r} of type "
+            f"{annotation!r} cannot be auto-synthesized for the trace. Give "
+            f"it a default, or reshape it so the schema states its axes "
+            f"(enum fields enumerate)."
+        )
+
+
+def _render_annotation(annotation: Any) -> str:
+    """A stable spelling of a type for the document (never ``repr`` noise)."""
+
+    name = getattr(annotation, "__name__", None)
+    if name and not typing.get_args(annotation):
+        module = getattr(annotation, "__module__", "")
+        return f"{module}.{name}" if module and module != "builtins" else str(name)
+    return str(annotation).replace("typing.", "")
+
+
 def model_model_type(cls: type) -> Optional[type]:
     """The class-header model type, or None for an undeclared base."""
     try:
@@ -146,6 +183,10 @@ class ReleaseDeriveResult:
     #: Lanes that TRACED and found nothing marked via ``ctx.compile``. Zero
     #: graphs because the author marked zero modules — measured, not assumed.
     unmarked_lanes: tuple[str, ...] = ()
+    #: pgw#1449: entrypoints the enumerator could not build a trace payload
+    #: for, name -> the typed reason. They are STATED, not silently dropped,
+    #: and they no longer take the module's other entrypoints down with them.
+    unenumerable_entrypoints: tuple[tuple[str, str], ...] = ()
 
     @property
     def eager_permanent(self) -> bool:
@@ -554,11 +595,7 @@ def _synthesize_field(owner: str, name: str, annotation: Any) -> Any:
         return False
     if _optional_none(annotation):
         return None
-    raise DeriveError(
-        f"{owner}: required payload field {name!r} of type {annotation!r} "
-        f"cannot be auto-synthesized for the trace. Give it a default, or "
-        f"reshape it so the schema states its axes (enum fields enumerate)."
-    )
+    raise PayloadEnumerationRefused(owner, name, annotation)
 
 
 def _literal_axis(annotation: Any) -> Optional[list[Any]]:
@@ -1335,8 +1372,10 @@ def derive_release(
     entrypoints: dict[str, Any] = {}
     warnings: list[str] = []
     plans: list[tuple[_Entrypoint, tuple[Any, ...]]] = []
+    unenumerable: list[tuple[str, str]] = []
     for plan in _entrypoints(module, cls):
         owner = f"@entrypoint {plan.name}"
+        refusal: Optional[PayloadEnumerationRefused] = None
         if cls is None:
             # pgw#1392: a WEIGHTLESS entrypoint has no lane, so there is no
             # trace subject and no pass is ever run. `traced_passes` says 0
@@ -1345,7 +1384,19 @@ def derive_release(
             # auto-generated API docs are the point of this block.
             payloads: tuple[Any, ...] = ()
         else:
-            payloads, capped = _auto_payloads(owner, plan.payload_type)
+            try:
+                payloads, capped = _auto_payloads(owner, plan.payload_type)
+            except PayloadEnumerationRefused as exc:
+                # pgw#1449: ONE unenumerable signature used to cost the whole
+                # module — `gen-worker lock` died here and wrote NO lock, so
+                # the entrypoints the enumerator CAN reach never got written
+                # either. The derive is a pre-warming completeness aid, never
+                # a correctness gate: an endpoint that derives 2 of 3
+                # entrypoints is strictly more useful than one that derives
+                # none, and the third is STATED rather than dropped.
+                refusal = exc
+                payloads = ()
+                capped = False
             if capped:
                 warnings.append(
                     f"{owner}: enum cross-product exceeds the cap "
@@ -1353,7 +1404,8 @@ def derive_release(
                     f"rest is first-encounter discovery (eager + background "
                     f"mint)"
                 )
-        plans.append((plan, payloads))
+        if refusal is None:
+            plans.append((plan, payloads))
         entrypoints[plan.name] = {
             "envelope_schema": _envelope_schema(plan),
             # Renders EMPTY for a weightless entrypoint — an honest {}, never
@@ -1364,6 +1416,25 @@ def derive_release(
             },
             "traced_passes": len(payloads),
         }
+        if refusal is not None:
+            # A TYPED row, not a warning string: the hub and the miner read
+            # this document, and "this entrypoint has no traced coverage, for
+            # this reason" is a fact about the release, not a log line. The
+            # key is absent on every enumerable entrypoint, so a document that
+            # has no refusals is byte-identical to one derived before this.
+            entrypoints[plan.name]["unenumerable"] = {
+                "field": refusal.field,
+                "type": refusal.annotation,
+                "reason": "payload_field_not_synthesizable",
+            }
+            unenumerable.append((plan.name, str(refusal)))
+            warnings.append(
+                f"{owner}: NOT enumerated — {refusal.field!r} "
+                f"({refusal.annotation}) cannot be synthesized. This "
+                f"entrypoint has no traced coverage; it serves eager and "
+                f"mints on first encounter. Every other entrypoint is "
+                f"unaffected."
+            )
 
     if cls is not None:
         requires = model_requires(cls)
@@ -1450,6 +1521,7 @@ def derive_release(
         eager_only=eager_only,
         derived_lanes=tuple(derived_lanes),
         unmarked_lanes=tuple(unmarked_lanes),
+        unenumerable_entrypoints=tuple(unenumerable),
     )
 
 
@@ -1457,6 +1529,7 @@ __all__ = [
     "DOCUMENT_KIND",
     "ENUM_CAP",
     "DeriveError",
+    "PayloadEnumerationRefused",
     "ReleaseDeriveResult",
     "derive_release",
 ]

--- a/tests/release_fixtures/mixed_enumerability_endpoint.py
+++ b/tests/release_fixtures/mixed_enumerability_endpoint.py
@@ -1,0 +1,106 @@
+"""Three entrypoints; two carry a payload field the enumerator cannot reach.
+
+minimax-h3's exact shape (pgw#1449): `generate` enumerates, while
+`generate_long.slots: list[LongVideoSlot]` and
+`reference_to_video.references: list[ReferenceInput]` are required
+list-of-struct fields with no default and no axes. Under fail-the-module,
+ONE of those cost the whole derive — and this endpoint has two, so the
+"drop the other decorator" workaround was iterative.
+
+The enumerable entrypoint carries a real enum axis so the document has
+specializations to show, and every entrypoint drives the SAME marked module:
+the point is that a refused signature costs the module nothing, not that the
+survivors are trivial.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class Size(StrEnum):
+    SMALL = "small"
+    LARGE = "large"
+
+
+_BUCKETS: dict[Size, int] = {Size.SMALL: 32, Size.LARGE: 64}
+
+
+class Slot(msgspec.Struct):
+    """A struct the enumerator has no way to invent a value for."""
+
+    prompt: str
+    seconds: float
+
+
+class GenerateInput(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    size: Size = Size.SMALL
+
+
+class LongInput(msgspec.Struct, forbid_unknown_fields=True):
+    #: REQUIRED, no default, no axes — h3's `generate_long.slots`.
+    slots: list[Slot]
+    size: Size = Size.SMALL
+
+
+class ReferenceInput(msgspec.Struct, forbid_unknown_fields=True):
+    #: The second one, so the fixture proves the fix is not "skip the first".
+    references: list[Slot]
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class MixedModel(Model[SDXL], lanes=(TINY_DIFFUSERS_FP32,)):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+def _run(model: MixedModel, ctx: Any, side: int, prompt: str) -> None:
+    with torch.inference_mode():
+        model.pipe(
+            prompt=prompt,
+            num_inference_steps=2,
+            guidance_scale=0.0,
+            width=side,
+            height=side,
+            callback_on_step_end=ctx.step_callback(2),
+            output_type="latent",
+        )
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: GenerateInput, model: MixedModel) -> Out:
+    ctx.raise_if_cancelled()
+    _run(model, ctx, _BUCKETS[payload.size], payload.prompt)
+    return Out(model_used=ctx.checkpoint_ref)
+
+
+@entrypoint
+def generate_long(ctx: RequestContext, payload: LongInput, model: MixedModel) -> Out:
+    ctx.raise_if_cancelled()
+    _run(model, ctx, _BUCKETS[payload.size], payload.slots[0].prompt)
+    return Out(model_used=ctx.checkpoint_ref)
+
+
+@entrypoint
+def reference_to_video(
+    ctx: RequestContext, payload: ReferenceInput, model: MixedModel
+) -> Out:
+    ctx.raise_if_cancelled()
+    _run(model, ctx, 32, payload.references[0].prompt)
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_release_derive_partial_enumeration.py
+++ b/tests/test_release_derive_partial_enumeration.py
@@ -1,0 +1,203 @@
+"""pgw#1449: one unenumerable entrypoint must not cost the whole module.
+
+Verbatim, on minimax-h3, at master before this:
+
+    derive error: @entrypoint generate_long: required payload field 'slots' of
+    type list[minimax_h3.long_video.LongVideoSlot] cannot be auto-synthesized
+    for the trace.
+
+`generate_long` is one of three, and its unsynthesizable field stopped
+`generate` and `reference_to_video` from being derived at all -- so
+`gen-worker lock` died there and wrote NO lock, and even the enumerable
+entrypoint's specializations never reached the document.
+
+The derive is a pre-warming completeness aid, never a correctness gate (its
+own words), so an entrypoint it cannot enumerate is SKIPPED-AND-STATED --
+exactly as an enumerated combination the author refuses with
+``ValidationError`` already is.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import sys
+from pathlib import Path
+
+import msgspec
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+LOCK = (
+    "version = 1\n"
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+#: The two h3-shaped signatures the enumerator cannot reach.
+REFUSED = ("generate_long", "reference_to_video")
+
+
+class Empty(enum.Enum):
+    """An author defect, not an enumerability limit."""
+
+
+class EmptyAxis(msgspec.Struct):
+    mode: Empty
+
+
+class NotAStruct:
+    pass
+
+
+class Unsynthesizable(msgspec.Struct):
+    slots: list[int]
+
+
+@pytest.fixture(scope="module")
+def config_only_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return tiny_tree.save_config_only(tmp_path_factory.mktemp("mixed-config-only"))
+
+
+def _derive(tree: Path, out: Path) -> int:
+    from gen_worker.cli import main
+
+    lockfile = out.parent / "uv.lock"
+    lockfile.write_text(LOCK)
+    return main(
+        [
+            "release",
+            "derive",
+            "--dir",
+            str(FIXTURES),
+            "--module",
+            "mixed_enumerability_endpoint",
+            "--checkpoint",
+            str(tree),
+            "--lockfile",
+            str(lockfile),
+            "--out",
+            str(out),
+        ]
+    )
+
+
+def test_the_enumerable_entrypoint_derives_while_two_others_cannot(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    """2 of 3 is strictly more useful than none -- and the module SUCCEEDS."""
+
+    out = tmp_path / "release.json"
+    assert _derive(config_only_tree, out) == 0
+
+    document = json.loads(out.read_bytes())
+    entrypoints = document["entrypoints"]
+    assert sorted(entrypoints) == ["generate", "generate_long", "reference_to_video"]
+
+    # The one that CAN be enumerated is fully derived: 2 Size values, and the
+    # lane carries their graph specializations.
+    assert entrypoints["generate"]["traced_passes"] == 2
+    assert "unenumerable" not in entrypoints["generate"]
+    (lane,) = document["graphs"]["lanes"]
+    assert lane["contract"] == "tiny.diffusers-fp32@1"
+    assert len(lane["graphs"]) == 2
+    assert lane["unobserved_targets"] == []
+
+
+def test_each_refused_entrypoint_is_STATED_in_the_document_not_dropped(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    """Typed, per entrypoint, naming the field and its type.
+
+    A silent drop would leave the hub publishing an envelope schema for an
+    entrypoint with no traced coverage and no way to know that.
+    """
+
+    out = tmp_path / "release.json"
+    assert _derive(config_only_tree, out) == 0
+    entrypoints = json.loads(out.read_bytes())["entrypoints"]
+
+    for name in REFUSED:
+        row = entrypoints[name]
+        assert row["traced_passes"] == 0
+        assert row["unenumerable"]["reason"] == "payload_field_not_synthesizable"
+        assert row["unenumerable"]["type"].startswith("list[")
+        # Still published as API surface: the envelope schema and model slots
+        # come from the SIGNATURE and never needed the enumeration.
+        assert row["envelope_schema"]
+        assert row["model_slots"] == {"model": "MixedModel"}
+
+    assert entrypoints["generate_long"]["unenumerable"]["field"] == "slots"
+    assert entrypoints["reference_to_video"]["unenumerable"]["field"] == "references"
+
+
+def test_the_result_names_both_refusals_so_a_caller_need_not_parse_prose(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    """`gen-worker lock` prints these and puts the names in its JSON."""
+
+    from gen_worker.release.derive import derive_release
+
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(LOCK)
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import importlib
+
+        module = importlib.import_module("mixed_enumerability_endpoint")
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+    result = derive_release(
+        module, checkpoint_dir=config_only_tree, lockfile=lockfile
+    )
+
+    assert [name for name, _reason in result.unenumerable_entrypoints] == list(REFUSED)
+    for _name, reason in result.unenumerable_entrypoints:
+        assert "cannot be auto-synthesized" in reason
+    # The prose warning survives too -- it carries the author's remedy.
+    assert any("NOT enumerated" in warning for warning in result.warnings)
+
+
+def test_the_refusal_stays_NARROW_and_a_real_defect_still_fails_the_module() -> None:
+    """The isolation must not become a blanket swallow.
+
+    ``PayloadEnumerationRefused`` has exactly one raise site. An empty enum,
+    a non-msgspec payload and an out-of-order signature are author defects
+    and still take the module down -- catching ``DeriveError`` instead of the
+    narrow subclass would have quietly turned all of them into "eager".
+    """
+
+    from gen_worker.release.derive import (
+        DeriveError,
+        PayloadEnumerationRefused,
+        _auto_payloads,
+    )
+
+    assert issubclass(PayloadEnumerationRefused, DeriveError)
+
+    with pytest.raises(DeriveError) as defect:
+        _auto_payloads("@entrypoint x", EmptyAxis)
+    assert not isinstance(defect.value, PayloadEnumerationRefused)
+
+    with pytest.raises(DeriveError) as second:
+        _auto_payloads("@entrypoint x", NotAStruct)  # type: ignore[arg-type]
+    assert not isinstance(second.value, PayloadEnumerationRefused)
+
+    # And the narrow one still fires where it should.
+    with pytest.raises(PayloadEnumerationRefused) as refusal:
+        _auto_payloads("@entrypoint x", Unsynthesizable)
+    assert refusal.value.field == "slots"

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=b5509c0dc89f027245b9cd56e103227b7afadb4c" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=20e54d41c7f853e809fc985e795e1cdd539b3215" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=b5509c0dc89f027245b9cd56e103227b7afadb4c#b5509c0dc89f027245b9cd56e103227b7afadb4c" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=20e54d41c7f853e809fc985e795e1cdd539b3215#20e54d41c7f853e809fc985e795e1cdd539b3215" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
Two halves, both on the derive, both proven through the real CLI verbs.

## pgw#1449 — the lock died at the first unenumerable entrypoint and wrote nothing

On minimax-h3, `generate_long.slots: list[LongVideoSlot]` and `reference_to_video.references: list[ReferenceInput]` are required list-of-struct fields the enumerator cannot synthesize. Under fail-the-module either one cost the **whole** derive, so `gen-worker lock` exited 1 with **no `endpoint.lock`** — and `generate`, which enumerates perfectly, never got written either.

The derive is *a pre-warming completeness aid, never a correctness gate* — its own words. So an entrypoint the enumerator cannot reach is now **skipped-and-stated**, exactly as an enumerated combination the author refuses with `ValidationError` already is.

- **`PayloadEnumerationRefused`**, a **narrow** `DeriveError` subclass with exactly one raise site. Catching `DeriveError` instead would have swallowed slot-order violations, empty enums and non-msgspec payloads — author defects that must still take the module down. A test fails if that narrowness is ever widened.
- **A typed row in the document**, not a log line: `entrypoints.<name>.unenumerable = {field, type, reason}` with `traced_passes: 0`. The hub and the miner read this document, and "no traced coverage, for this reason" is a fact about the release. The envelope schema and model slots are still published — they come from the **signature** and never needed the enumeration.
- The key is **absent** on every enumerable entrypoint, so a document with no refusals is byte-identical to one derived before this.
- Named by both verbs: `release derive` and `lock` print each refusal, and lock's JSON summary carries `unenumerable_entrypoints`.

### Proven end to end through `gen-worker lock` itself

Fixture endpoint with h3's exact three-entrypoint shape (one enumerable, two list-of-struct):

| arm | result |
|---|---|
| red (master) | `error: derive: @entrypoint generate_long: … cannot be auto-synthesized` → **no `endpoint.lock` on disk** |
| green | `lock: wrote endpoint.lock`, `specializations: 2`, `programs: 2`, `"unenumerable_entrypoints": ["generate_long", "reference_to_video"]`, both named on stderr |

Reading the written lock's derive block back: `generate traced_passes=2`, the other two `traced_passes=0` carrying `{field, type, reason}`.

Implementing `list[Struct]` synthesis is deliberately **not** here: per-entrypoint isolation is the unblocking half and helps every endpoint, where synthesis is a second, larger question about what an invented struct would mean for coverage.

## tcg#66 re-vendor at `20e54d41`

The wall the H3 lane hit the moment tcg#65 let components attach: `_rehome` called `.to(device)` on a **meta** tensor and `audio_vae` died `Cannot copy out of meta tensor`. Root cause is `torch.nn.utils.weight_norm`, which replaces the `weight` Parameter with a plain tensor **attribute** derived from meta parents. A meta lifted constant is now virtualized like the parameters it came from, and `_rehome` refuses meta by name. Full story on torchcg#63.

## No regression

The classic `tiny_endpoint` document is sha256 `c5657d0675026d3c974e6ecac40de4a8f57e0b22562f24d527929d748eaf413f` — **the same bytes as before both changes**.

45 passed across the derive suites (classic, modular, partial-enumeration, weightless, vendor snapshot) · `mypy src/gen_worker tests` clean over 605 files · `ruff check src/gen_worker` clean. CPU-only throughout with `CUDA_VISIBLE_DEVICES=""`.