### PR TITLE
pgw#1506: the provenance walk is RECURSIVE — a pipeline inside an engine names its denoiser like any other

### DIFF
--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -907,36 +907,134 @@ def _defaults_variants(model_type: Optional[type]) -> list[Any]:
     return variants
 
 
+#: How far the provenance walk descends from the model instance (pgw#1506).
+#: `model.engine.pipeline.components[...]` is depth 2; the headroom is for a
+#: second wrapper, and the bound exists so a cyclic or pathological object
+#: graph refuses with a sentence instead of running forever.
+PROVENANCE_MAX_DEPTH = 4
+
+
+def _components_mapping(value: Any) -> Optional[Mapping[str, Any]]:
+    """``value.components`` when it is a Mapping -- the diffusers convention.
+
+    Read through ``try`` because ``components`` is a PROPERTY on every
+    diffusers pipeline and a half-built one can raise; a wrapper that cannot
+    answer is simply not a component holder.
+    """
+
+    try:
+        components = getattr(value, "components", None)
+    except Exception:
+        return None
+    return components if isinstance(components, Mapping) else None
+
+
+def _is_wrapper(value: Any) -> bool:
+    """A plain object that may HOLD a pipeline -- worth descending into.
+
+    Deliberately narrow. An ``nn.Module`` is never descended: its ``vars()``
+    is ``_parameters``/``_modules``/``_buffers``, so walking one would offer
+    provenance names for the marked module's own internals and turn a 10 GiB
+    denoiser into a traversal. Everything without an instance ``__dict__``
+    (msgspec Structs, primitives, containers) has no attributes to walk.
+    """
+
+    import torch
+
+    if isinstance(value, (torch.nn.Module, torch.Tensor)):
+        return False
+    if isinstance(value, (str, bytes, int, float, bool, Path)):
+        return False
+    return hasattr(value, "__dict__") and isinstance(getattr(value, "__dict__"), dict)
+
+
 def _named_marked_modules(instance: Any, marked: list[Any]) -> dict[str, Any]:
     """Deterministic provenance names for the author's ctx.compile marks.
 
     The author marks REAL objects; the document needs stable names. Names
     come from where the module actually lives on the model instance:
     component names of any ``.components``-bearing attribute (the diffusers
-    convention), then bare attribute names, then dotted
-    ``attribute.component`` as the disambiguated spelling. A marked module
-    that cannot be named on the instance is refused -- provenance is part of
-    the release row.
+    convention), then bare attribute names, then the dotted PATH as the
+    disambiguated spelling. A marked module that cannot be named on the
+    instance is refused -- provenance is part of the release row.
+
+    **The walk is RECURSIVE (pgw#1506).** It used to look exactly one level
+    deep -- ``vars(instance)`` plus ``.components`` on each value -- which
+    assumed the model holds its pipeline directly. That is sdxl's and sd15's
+    shape, not a rule: an endpoint with a runtime engine owns the engine and
+    the ENGINE owns the pipeline, so minimax-h3's DiT sits at
+    ``model.engine.pipeline.components['transformer']`` and the resolver
+    could not see it. The engine wrapper carries real state (an AdaLN cache,
+    conditioner buffers, the serve recipe), so it is a legitimate authoring
+    shape and the tracer is what had to learn to traverse it. Adding a
+    second reference to the pipeline on the model would have satisfied
+    depth 1 and left every other engine-wrapper endpoint broken.
+
+    Depth-1 endpoints are unaffected by construction: the candidate set at
+    depth 1 is offered exactly as before, and the recursion only ADDS names
+    that were previously unreachable.
     """
 
     candidates: dict[int, str] = {}
+    #: (owner path, component name, component) for every components mapping
+    #: found anywhere in the walk -- uniqueness is decided across ALL of them,
+    #: because "is this bare name unique?" is a question about the instance,
+    #: not about one attribute.
+    component_rows: list[tuple[str, str, Any]] = []
+    #: Paths not descended because the depth bound was reached. Named only if
+    #: a marked module turns out to be unnameable, where it is the likely why.
+    truncated: list[str] = []
 
     def offer(module: Any, name: str) -> None:
         identity = id(module)
         if identity not in candidates or len(name) < len(candidates[identity]):
             candidates[identity] = name
 
-    for attr, value in sorted(vars(instance).items()):
-        if value is None:
-            continue
-        offer(value, attr)
-        components = getattr(value, "components", None)
-        if isinstance(components, Mapping):
-            for name, component in sorted(components.items()):
-                if component is None or not isinstance(name, str):
-                    continue
-                unique = _unique_component(instance, name, component)
-                offer(component, name if unique else f"{attr}.{name}")
+    # Cycle safety by IDENTITY: an engine that back-references its model
+    # (`self.engine.model is self`) is an ordinary shape and must not loop.
+    visited: set[int] = {id(instance)}
+
+    def descend(node: Any, path: tuple[str, ...], depth: int) -> None:
+        try:
+            attributes = sorted(vars(node).items())
+        except TypeError:
+            return
+        for attr, value in attributes:
+            if value is None:
+                continue
+            here = (*path, attr)
+            name = ".".join(here)
+            offer(value, name)
+            components = _components_mapping(value)
+            if components is not None:
+                for component_name, component in sorted(components.items()):
+                    if component is None or not isinstance(component_name, str):
+                        continue
+                    component_rows.append((name, component_name, component))
+                # A pipeline's components ARE its provenance; there is nothing
+                # below them worth a name.
+                continue
+            if not _is_wrapper(value):
+                continue
+            if id(value) in visited:
+                continue
+            if depth + 1 > PROVENANCE_MAX_DEPTH:
+                truncated.append(name)
+                continue
+            visited.add(id(value))
+            descend(value, here, depth + 1)
+
+    descend(instance, (), 0)
+
+    by_name: dict[str, list[Any]] = {}
+    for _owner, component_name, component in component_rows:
+        by_name.setdefault(component_name, []).append(component)
+    for owner, component_name, component in component_rows:
+        # The bare name when it means ONE object across the whole instance,
+        # the full dotted path otherwise -- the same preference order as
+        # before, asked across every mapping the walk found instead of one.
+        unique = all(other is component for other in by_name[component_name])
+        offer(component, component_name if unique else f"{owner}.{component_name}")
 
     named: dict[str, Any] = {}
     for module in marked:
@@ -947,24 +1045,24 @@ def _named_marked_modules(instance: Any, marked: list[Any]) -> dict[str, Any]:
                 f"({type(module).__name__}) is not reachable as a model "
                 f"attribute or pipeline component; the release document "
                 f"cannot name its provenance"
+                + (
+                    f". The provenance walk stopped at depth "
+                    f"{PROVENANCE_MAX_DEPTH} on {sorted(set(truncated))!r}; if "
+                    f"the module lives below one of those, it is nested "
+                    f"deeper than the derive will look."
+                    if truncated
+                    else ""
+                )
             )
         if name in named and named[name] is not module:
             raise DeriveError(
-                f"two marked modules both resolve to provenance name {name!r}"
+                f"two marked modules both resolve to provenance name "
+                f"{name!r}; the release document names a graph's provenance "
+                f"and cannot pick between them. Give one of them a distinct "
+                f"attribute or component name."
             )
         named[name] = module
     return named
-
-
-def _unique_component(instance: Any, name: str, component: Any) -> bool:
-    seen = 0
-    for value in vars(instance).values():
-        components = getattr(value, "components", None)
-        if isinstance(components, Mapping) and components.get(name) is not None:
-            if components.get(name) is not component:
-                return False
-            seen += 1
-    return seen <= 1
 
 
 def _compile_stack_from_lockfile(lockfile: Path) -> tuple[tuple[str, str], ...]:

--- a/tests/release_fixtures/engine_wrapper_endpoint.py
+++ b/tests/release_fixtures/engine_wrapper_endpoint.py
@@ -1,0 +1,73 @@
+"""The model owns an ENGINE and the engine owns the pipeline (pgw#1506).
+
+minimax-h3's shape: `H3Model.engine` carries the AdaLN cache, the conditioner
+buffers and the serve recipe, and the pipeline lives on the engine. So the DiT
+is at `model.engine.pipeline.components['transformer']` -- depth 2 -- while
+sdxl and sd15 happen to hold their pipeline directly.
+
+The engine also back-references its model, which is how a runtime engine
+normally reaches request state. That makes the object graph CYCLIC and is why
+the walk has to be identity-visited rather than merely bounded.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class Engine:
+    """A runtime wrapper with state of its own -- not a pass-through."""
+
+    def __init__(self, model: Any, pipeline: Any) -> None:
+        self.model = model  # the back-reference: the cycle is deliberate
+        self.pipeline = pipeline
+        self.step_cache: dict[str, Any] = {}
+
+    def compile_dit(self, ctx: Any) -> None:
+        # h3's own line: mark through the engine, because WHICH partition a
+        # checkpoint carries is the checkpoint's business.
+        for name in ("unet", "unet_ref"):
+            module = getattr(self.pipeline, name, None)
+            if module is not None:
+                setattr(self.pipeline, name, ctx.compile(module))
+                return
+
+
+class EngineModel(Model[SDXL], lanes=(TINY_DIFFUSERS_FP32,)):
+    engine: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.engine = Engine(self, ctx.load(StableDiffusionPipeline))
+        self.engine.compile_dit(ctx)
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In, model: EngineModel) -> Out:
+    ctx.raise_if_cancelled()
+    with torch.inference_mode():
+        model.engine.pipeline(
+            prompt=payload.prompt,
+            num_inference_steps=2,
+            guidance_scale=0.0,
+            width=32,
+            height=32,
+            callback_on_step_end=ctx.step_callback(2),
+            output_type="latent",
+        )
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_release_derive_provenance.py
+++ b/tests/test_release_derive_provenance.py
@@ -1,0 +1,193 @@
+"""pgw#1506: the provenance walk must reach a pipeline inside an ENGINE.
+
+`_named_marked_modules` looked exactly one level deep -- `vars(instance)` plus
+`.components` on each value -- so an endpoint whose model owns an engine that
+owns the pipeline could not name its own compiled denoiser:
+
+    error: derive: a module marked via ctx.compile()
+    (MiniMaxH3Transformer3DModel) is not reachable as a model attribute or
+    pipeline component; the release document cannot name its provenance
+
+Measured on minimax-h3 by introspecting the live instance: the DiT is at
+`model.engine.pipeline.components['transformer']`, depth 2, and the pipeline
+is internally consistent (attribute and registry are one object) -- so this is
+reachability FROM THE MODEL, not an attachment failure.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+import torch  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+LOCK = (
+    "version = 1\n"
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+
+@pytest.fixture(scope="module")
+def config_only_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return tiny_tree.save_config_only(tmp_path_factory.mktemp("engine-config-only"))
+
+
+def test_a_pipeline_inside_an_engine_names_its_denoiser_like_any_other(
+    config_only_tree: Path, tmp_path: Path
+) -> None:
+    """End to end through the CLI: the depth-2 DiT is named `unet`.
+
+    The bare component name, exactly as a depth-1 endpoint gets -- the wrapper
+    changes where the module LIVES, never what the graph is called.
+    """
+
+    from gen_worker.cli import main
+
+    out = tmp_path / "release.json"
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(LOCK)
+    assert main([
+        "release", "derive",
+        "--dir", str(FIXTURES),
+        "--module", "engine_wrapper_endpoint",
+        "--checkpoint", str(config_only_tree),
+        "--lockfile", str(lockfile),
+        "--out", str(out),
+    ]) == 0
+
+    (lane,) = json.loads(out.read_bytes())["graphs"]["lanes"]
+    assert lane["unobserved_targets"] == []
+    assert {record["target"] for record in lane["graphs"]} == {"unet"}
+
+
+class _Pipe:
+    def __init__(self, **components: Any) -> None:
+        self._components = components
+        for name, value in components.items():
+            setattr(self, name, value)
+
+    @property
+    def components(self) -> dict[str, Any]:
+        return dict(self._components)
+
+
+class _Model:
+    pass
+
+
+def _named(instance: Any, marked: list[Any]) -> dict[str, Any]:
+    from gen_worker.release.derive import _named_marked_modules
+
+    return _named_marked_modules(instance, marked)
+
+
+def test_a_cyclic_object_graph_terminates() -> None:
+    """An engine that back-references its model is an ordinary shape."""
+
+    from gen_worker.release.derive import DeriveError  # noqa: F401
+
+    unet = torch.nn.Linear(2, 2)
+    model = _Model()
+    engine = _Model()
+    engine.model = model  # type: ignore[attr-defined]
+    engine.pipeline = _Pipe(unet=unet)  # type: ignore[attr-defined]
+    model.engine = engine  # type: ignore[attr-defined]
+
+    assert _named(model, [unet]) == {"unet": unet}
+
+
+def test_a_module_nested_BELOW_the_bound_refuses_and_says_where_it_stopped() -> None:
+    """Depth-bounded, and the bound is NAMED rather than read as absent."""
+
+    from gen_worker.release.derive import PROVENANCE_MAX_DEPTH, DeriveError
+
+    unet = torch.nn.Linear(2, 2)
+    node: Any = _Pipe(unet=unet)
+    for _ in range(PROVENANCE_MAX_DEPTH + 2):
+        wrapper = _Model()
+        wrapper.inner = node  # type: ignore[attr-defined]
+        node = wrapper
+    model = _Model()
+    model.engine = node  # type: ignore[attr-defined]
+
+    with pytest.raises(DeriveError) as refusal:
+        _named(model, [unet])
+    assert "stopped at depth" in str(refusal.value)
+    assert "nested deeper than the derive will look" in str(refusal.value)
+
+
+def test_the_same_bare_name_at_two_paths_takes_the_DOTTED_spelling() -> None:
+    """The existing preference order, asked across the whole instance.
+
+    Two different denoisers both called `unet` must not collapse onto one
+    name -- each keeps its full path, so both are nameable and neither is
+    picked over the other.
+    """
+
+    first = torch.nn.Linear(2, 2)
+    second = torch.nn.Linear(2, 2)
+    model = _Model()
+    model.a = _Pipe(unet=first)  # type: ignore[attr-defined]
+    engine = _Model()
+    engine.pipeline = _Pipe(unet=second)  # type: ignore[attr-defined]
+    model.b = engine  # type: ignore[attr-defined]
+
+    named = _named(model, [first, second])
+    assert named == {"a.unet": first, "b.pipeline.unet": second}
+
+
+def test_two_marks_that_collapse_onto_ONE_name_refuse_by_name() -> None:
+    """The ambiguity the walk cannot resolve is refused, never guessed.
+
+    A module reachable BOTH as a bare attribute and as the unique component
+    of a pipeline held under that same attribute name: the shortest-name
+    preference gives them one spelling, and two graphs cannot share one
+    provenance row.
+    """
+
+    from gen_worker.release.derive import DeriveError
+
+    first = torch.nn.Linear(2, 2)
+    second = torch.nn.Linear(2, 2)
+    model = _Model()
+    # Both marked modules are offered the SAME bare name: `second` as the
+    # unique `unet` component, `first` as the attribute literally called
+    # `unet`. Equal length, so neither displaces the other.
+    model.unet = first  # type: ignore[attr-defined]
+    model.pipe = _Pipe(unet=second)  # type: ignore[attr-defined]
+
+    with pytest.raises(DeriveError) as refusal:
+        _named(model, [first, second])
+    assert "both resolve to provenance name" in str(refusal.value)
+    assert "cannot pick between them" in str(refusal.value)
+
+
+def test_a_module_that_is_nowhere_on_the_instance_still_refuses() -> None:
+    """The original refusal survives -- the walk got wider, not permissive."""
+
+    from gen_worker.release.derive import DeriveError
+
+    model = _Model()
+    model.pipe = _Pipe(unet=torch.nn.Linear(2, 2))  # type: ignore[attr-defined]
+
+    with pytest.raises(DeriveError) as refusal:
+        _named(model, [torch.nn.Linear(2, 2)])
+    assert "cannot name its provenance" in str(refusal.value)


### PR DESCRIPTION
`_named_marked_modules` looked exactly one level deep: `vars(instance)` plus `.components` on each value. That assumed the model holds its pipeline **directly** — sdxl's and sd15's shape, not a rule. minimax-h3's model owns an engine and the **engine** owns the pipeline, so its DiT sits at `model.engine.pipeline.components['transformer']` (depth 2) and the derive refused:

```
a module marked via ctx.compile() (MiniMaxH3Transformer3DModel) is not reachable
as a model attribute or pipeline component; the release document cannot name its provenance
```

The engine wrapper carries real state (AdaLN cache, conditioner buffers, serve recipe) and marks through itself precisely because *which* partition a checkpoint carries is the checkpoint's business. It is a legitimate authoring shape and the tracer is what had to learn to traverse it. Exposing a second reference to the pipeline on the model would have satisfied depth 1 in one endpoint line and left every other engine-wrapper endpoint broken — declined as wrong-direction; this is the ruled fix.

## The walk

Descends through **wrapper** attributes, keeping the existing name-preference order, so H3 names its DiT `transformer` exactly as sdxl names `unet`. Guards, all three tested:

- **Cycle-safe by identity.** An engine that back-references its model (`self.engine.model is self`) is an ordinary runtime shape — the fixture has that cycle on purpose.
- **Depth-bounded at 4 with a named refusal.** A module nested below the bound says *where the walk stopped*, so "too deep" never reads as "absent".
- **Ambiguity refuses.** Uniqueness of a bare component name is now asked across *every* mapping the walk found rather than one attribute, so two different denoisers both called `unet` keep their full paths; two marks that still collapse onto one spelling refuse by name rather than one being picked.

An `nn.Module` is never descended into — its `vars()` is `_parameters`/`_modules`/`_buffers`, so walking one would offer provenance names for a marked module's own internals and turn a 10 GiB denoiser into a traversal.

## Red/green by execution

New engine-wrapper fixture (h3's shape, cycle and all):

| arm | result |
|---|---|
| master | **5 of 6 fail**, the pgw#1506 sentence verbatim — `a module marked via ctx.compile() (UNet2DConditionModel) is not reachable as a model attribute or pipeline component` |
| with the fix | **6 pass** — the derive names the depth-2 module `unet`, `unobserved_targets == []` |

## Depth-1 endpoints unaffected — byte-proven for the third time

The classic `tiny_endpoint` document is sha256 `c5657d0675026d3c974e6ecac40de4a8f57e0b22562f24d527929d748eaf413f` — the same bytes as before tcg#65, tcg#66, pgw#1449 and now this. The candidate set at depth 1 is offered exactly as before; the recursion only **adds** names that were previously unreachable.

36 passed across the derive suites · `ruff check src/gen_worker` clean · **zero delta** on the master-red gates: `lint_unreached_surface` is 109 on this branch and 109 at master tip, and all 23 mypy errors are pgw#1497's test files, untouched here. CPU-only throughout.