### PR TITLE
pgw#1497 fix-forward: master fast gates RED — 23 mypy errors in this lane's tests (gate checks src+tests, close-out ran src only)

### DIFF
--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -511,3 +511,39 @@ gen_worker.serving.engine_runtime.process_vram_bytes()
 #             caller and the ratchet will say so by going red on STALE.
 #     EXPIRY: none. A guard's undo living beside its do is the correct shape.
 gen_worker.serving.weightless_program.uninstall()
+
+# pgw#1498's GGUF-as-torch-weights lane (#1058, `d47b5c59` — `feef87cc` /
+# `52cd05ba` / `cf600a71`) landed `models/gguf_torch.py` with nine public
+# callables and no production caller. Measured at `f420bb5b^`: this guard
+# ALREADY exited 1 there, so master was red before pgw#1497 merged and pgw#1497
+# then stacked a `[stale-exemption]` on top of it. That second red is fixed in
+# its own lane; these rows are the first.
+#
+# Added by the pgw#1497 fix-forward lane rather than deleted, for the reason the
+# pgw#1421/pgw#1425 block above states and this lane learned the hard way in the
+# same hour: guessing another lane's intent about public surface is how a wire
+# gets silenced — or, in pgw#1497's case, how a PROD endpoint's import gets
+# deleted. They are OWED, not accepted.
+#
+#     OWNER:  pgw#1498. The dequant path is the whole point of that issue: a
+#             Linear that dequantizes its own GGML block bytes per forward.
+#             `read_gguf`/`quantized_tensors_from_views`/
+#             `install_quantized_weights`/`structural_base` are the ingest and
+#             install seam, `dequant_ahead`/`peak_transient_bytes`/
+#             `quantized_bytes` the residency arithmetic, and
+#             `attach_lora`/`detach_lora` the attach-never-merge half. Wire them
+#             into the serving path, or say which successor already does.
+#     EXPIRY: 2026-08-21, set by the program owner, not by this lane. The
+#             wiring lane is ACTIVE and its own PR should remove these rows
+#             sooner; the date is a backstop, not a deadline. If they outlive
+#             it, pgw#1498 shipped a quant engine nothing on the pod calls, and
+#             that is a finding rather than a lint row.
+gen_worker.models.gguf_torch.attach_lora()
+gen_worker.models.gguf_torch.dequant_ahead()
+gen_worker.models.gguf_torch.detach_lora()
+gen_worker.models.gguf_torch.install_quantized_weights()
+gen_worker.models.gguf_torch.peak_transient_bytes()
+gen_worker.models.gguf_torch.quantized_bytes()
+gen_worker.models.gguf_torch.quantized_tensors_from_views()
+gen_worker.models.gguf_torch.read_gguf()
+gen_worker.models.gguf_torch.structural_base()

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -511,39 +511,3 @@ gen_worker.serving.engine_runtime.process_vram_bytes()
 #             caller and the ratchet will say so by going red on STALE.
 #     EXPIRY: none. A guard's undo living beside its do is the correct shape.
 gen_worker.serving.weightless_program.uninstall()
-
-# pgw#1498's GGUF-as-torch-weights lane (#1058, `d47b5c59` — `feef87cc` /
-# `52cd05ba` / `cf600a71`) landed `models/gguf_torch.py` with nine public
-# callables and no production caller. Measured at `f420bb5b^`: this guard
-# ALREADY exited 1 there, so master was red before pgw#1497 merged and pgw#1497
-# then stacked a `[stale-exemption]` on top of it. That second red is fixed in
-# its own lane; these rows are the first.
-#
-# Added by the pgw#1497 fix-forward lane rather than deleted, for the reason the
-# pgw#1421/pgw#1425 block above states and this lane learned the hard way in the
-# same hour: guessing another lane's intent about public surface is how a wire
-# gets silenced — or, in pgw#1497's case, how a PROD endpoint's import gets
-# deleted. They are OWED, not accepted.
-#
-#     OWNER:  pgw#1498. The dequant path is the whole point of that issue: a
-#             Linear that dequantizes its own GGML block bytes per forward.
-#             `read_gguf`/`quantized_tensors_from_views`/
-#             `install_quantized_weights`/`structural_base` are the ingest and
-#             install seam, `dequant_ahead`/`peak_transient_bytes`/
-#             `quantized_bytes` the residency arithmetic, and
-#             `attach_lora`/`detach_lora` the attach-never-merge half. Wire them
-#             into the serving path, or say which successor already does.
-#     EXPIRY: 2026-08-21, set by the program owner, not by this lane. The
-#             wiring lane is ACTIVE and its own PR should remove these rows
-#             sooner; the date is a backstop, not a deadline. If they outlive
-#             it, pgw#1498 shipped a quant engine nothing on the pod calls, and
-#             that is a finding rather than a lint row.
-gen_worker.models.gguf_torch.attach_lora()
-gen_worker.models.gguf_torch.dequant_ahead()
-gen_worker.models.gguf_torch.detach_lora()
-gen_worker.models.gguf_torch.install_quantized_weights()
-gen_worker.models.gguf_torch.peak_transient_bytes()
-gen_worker.models.gguf_torch.quantized_bytes()
-gen_worker.models.gguf_torch.quantized_tensors_from_views()
-gen_worker.models.gguf_torch.read_gguf()
-gen_worker.models.gguf_torch.structural_base()

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -492,17 +492,105 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
     return applied
 
 
-# pgw#1497 DELETED the block-window offload rung that stood here
-# (`_BlockOffloadWindow` / `apply_block_window_offload` / `block_offload_active`).
-# It was exported and NEVER CALLED, and every property it had, the
-# `stream_residency` rung has strictly better: it windowed whole transformer
-# BLOCKS where that one windows leaf modules, moved all of them or none of them
-# where that one fills a budget, and streamed on the ambient stream with no
-# reused cast buffer, no in-flight reservation and no partial-unload primitive.
-# Keeping both would have left three overlapping offload implementations in one
-# tree, which is exactly the disease the ComfyUI study named (report A,
-# do-not-copy list). `_fp8_block_windows` survives — the fp8 storage rung is its
-# real caller.
+# pgw#1497 REPLACED the block-window offload rung's IMPLEMENTATION with the
+# budgeted per-leaf one (`models.stream_residency`) and kept its NAME, because
+# the name has a production consumer this lane originally missed.
+#
+# The first pass DELETED it outright on the evidence that nothing in `src/`
+# called it. That evidence was real and the conclusion was WRONG: `src/` is not
+# the tree. `scripts/author_surface_allowlist.txt:48` recorded the caller —
+# `serverless-endpoints/ltx-video-2.3/.../main.py:128`, marked PROD — and
+# pgw#849 guard 2 says so in as many words: *"'No call site in this repo' is NOT
+# 'no consumer'"*. Deleting it would have made the ltx-video-2.3 endpoint fail
+# at IMPORT on its next gen-worker bump, nowhere near the offload path. The
+# lesson is the guard's own: run `lint_unreached_surface.py --siblings` before
+# deleting public surface, because CI structurally cannot.
+#
+# What DID die is the second implementation. `_BlockOffloadWindow` (per-BLOCK
+# windows, all-or-nothing, ambient stream, no reused cast buffer, no in-flight
+# reservation, no partial unload) is gone; this is now a thin adapter onto the
+# one mechanism, at the budget that means what the old rung meant — zero, park
+# everything, stream per forward. Strictly finer, and one mechanism, not three.
+
+
+def apply_block_window_offload(
+    obj: Any,
+    *,
+    components: tuple[str, ...] | None = None,
+    device: Any = None,
+) -> bool:
+    """Park a pipeline's weights in pinned host RAM and stream them per forward
+    (degraded-mode rung 2). Returns True when any component was armed.
+
+    Quality-preserving and slow (whole-model PCIe traffic per forward); a
+    guaranteed-completion last resort for VRAM-constrained cards, never a
+    production serving mode.
+
+    ``components`` names which components to arm; everything else is left where
+    it is for the caller to place. Each armed component is stamped
+    ``_cozy_block_offload_applied``, which is how a caller tells an armed
+    component from one it still has to move onto the device itself.
+
+    Idempotent per component. The default is resolved at CALL time, never in
+    the signature: a def-time default would freeze the component vocabulary
+    before ``declare_components()`` ever runs.
+    """
+    if components is None:
+        components = denoiser_components()
+    try:
+        from .stream_residency import StreamedResidency
+    except Exception as exc:  # noqa: BLE001 — torch-less host
+        logger.warning("block-window offload ignored: %s", exc)
+        return False
+    if device is None:
+        if not cuda_ready():
+            logger.warning("block-window offload ignored: no CUDA device")
+            return False
+        device = "cuda"
+
+    targets: List[tuple[str, Any]] = []
+    for name in components:
+        mod = getattr(obj, name, None)
+        if mod is not None and hasattr(mod, "named_modules"):
+            targets.append((name, mod))
+    if not targets and hasattr(obj, "named_modules"):
+        targets.append((type(obj).__name__, obj))
+
+    applied = False
+    for name, mod in targets:
+        if getattr(mod, "_cozy_block_offload_applied", False):
+            applied = True
+            continue
+        # Budget zero: every leaf streams. That IS what this rung always meant,
+        # and `_place_residue` keeps everything outside the tail on the device,
+        # which is the clause the old implementation spelled as "parameters
+        # outside the discovered block windows must be resident".
+        residency = StreamedResidency([(name, mod)], device=device, budget_bytes=0)
+        plan = residency.engage()
+        if not plan.streamed:
+            logger.warning("block-window offload: no streamable leaves in %s", name)
+            continue
+        try:
+            mod._cozy_block_offload_applied = True
+        except Exception:  # noqa: BLE001
+            pass
+        applied = True
+        logger.warning(
+            "DEGRADED_MODE=engaged model=%s phase=load rung=resident->"
+            "block_offload: %d leaves / %.1f GiB parked in host RAM, streaming "
+            "per forward",
+            name, len(plan.streamed), plan.streamed_bytes / float(1 << 30),
+        )
+        activity_mod.emit_event(
+            activity_mod.KIND_SERVE_DEGRADE,
+            f"component={name} obj={type(obj).__name__}: block-window offload "
+            f"ENGAGED — {len(plan.streamed)} leaf module(s) / "
+            f"{plan.streamed_bytes / float(1 << 30):.1f} GiB rest in host RAM "
+            f"and stream to the device per forward; every request on this "
+            f"component pays that transfer",
+            phase="block_offload_engaged",
+        )
+    return applied
 
 
 def require_decodable(contract: str, path: Any, *, component: str = "") -> None:
@@ -2387,6 +2475,7 @@ __all__ = [
     "safetensors_file_valid",
     "read_on_disk_quant_config",
     "synthesize_quantization_config",
+    "apply_block_window_offload",
     "apply_fp8_storage",
     "assert_uniform_compute_dtype",
     "MixedComputeDtypeError",

--- a/tests/test_component_vocab_sweep_pgw740.py
+++ b/tests/test_component_vocab_sweep_pgw740.py
@@ -104,11 +104,29 @@ def test_both_moe_experts_are_lora_branch_targets() -> None:
     assert set(branch_targets(_WanMoE())) == {"transformer", "transformer_2"}
 
 
-def test_stream_residency_reads_no_component_vocabulary_at_def_time() -> None:
-    """The rung that replaced the block-window offload (pgw#1497) takes no
-    component vocabulary at all — it discovers leaves from the tree it is
-    handed — so the def-time-frozen-default hazard this test was written for
-    cannot recur here. Assert the shape, not the deleted signature."""
+def test_block_window_offload_defaults_to_every_denoiser() -> None:
+    """``apply_block_window_offload``'s default was a literal
+    ``("transformer","unet")`` in the signature — a default argument, so even
+    repointing it would have frozen the vocabulary at def time.
+
+    pgw#1497 briefly deleted this function and this test with it, on the
+    evidence that nothing in `src/` called it. A PROD endpoint did
+    (`scripts/author_surface_allowlist.txt:48`), so both are back — and the
+    def-time hazard is back with them, which is why the assertion is restored
+    rather than replaced.
+    """
+    import inspect
+
+    from gen_worker.models.loading import apply_block_window_offload
+
+    default = inspect.signature(apply_block_window_offload).parameters["components"].default
+    assert default is None, "a non-None default re-freezes the vocabulary at def time"
+
+
+def test_the_rung_behind_it_reads_no_component_vocabulary_either() -> None:
+    """The implementation is now `StreamedResidency`, which takes no component
+    vocabulary at all — it discovers leaves from the tree it is handed — so the
+    def-time-frozen-default hazard cannot recur one layer down."""
     import inspect
 
     from gen_worker.models.stream_residency import StreamedResidency

--- a/tests/test_partial_stream_rung_pgw1497.py
+++ b/tests/test_partial_stream_rung_pgw1497.py
@@ -16,7 +16,14 @@ import pytest
 from gen_worker.models import rung as rung_mod
 
 torch = pytest.importorskip("torch")
-nn = torch.nn
+
+# A real static import, not `nn = torch.nn`. The rebinding form leaves `nn` a
+# module-valued VARIABLE, so `class Block(nn.Module)` gives mypy no type to use
+# as a base and it reports `Name "nn.Module" is not defined` — 19 of the 23
+# errors that took master's `fast gates` red. The skip guard above still runs
+# first, so this import cannot fire on a torch-less host. Same idiom as
+# `test_engine_placement.py`.
+import torch.nn as nn  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -269,7 +276,7 @@ def test_the_manager_answers_the_budget_from_the_same_sizer_admission_uses() -> 
 def test_the_load_context_carries_the_budget_down_to_the_ladder() -> None:
     from gen_worker.serving.context import DeployBinding, LoadContext
 
-    binding = DeployBinding(checkpoint_ref="ref", checkpoint_dir="/tmp")
+    binding = DeployBinding(checkpoint_ref="ref", checkpoint_dir=pathlib.Path("/tmp"))
     assert LoadContext(binding=binding)._weight_budget_bytes == 0
     assert (
         LoadContext(binding=binding, weight_budget_bytes=1234)._weight_budget_bytes

--- a/tests/test_stream_residency_pgw1497.py
+++ b/tests/test_stream_residency_pgw1497.py
@@ -14,10 +14,19 @@ exercised here and only the OVERLAP is left for the card to prove.
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 torch = pytest.importorskip("torch")
-nn = torch.nn
+
+# A real static import, not `nn = torch.nn`. The rebinding form leaves `nn` a
+# module-valued VARIABLE, so `class Block(nn.Module)` gives mypy no type to use
+# as a base and it reports `Name "nn.Module" is not defined` — 19 of the 23
+# errors that took master's `fast gates` red. The skip guard above still runs
+# first, so this import cannot fire on a torch-less host. Same idiom as
+# `test_engine_placement.py`.
+import torch.nn as nn  # noqa: E402
 
 from gen_worker.models.stream_residency import (  # noqa: E402
     DEFAULT_STREAMS,
@@ -40,6 +49,11 @@ from gen_worker.models.stream_residency import (  # noqa: E402
 class Block(nn.Module):
     def __init__(self, width: int) -> None:
         super().__init__()
+        # A plain int, not read back off `norm.normalized_shape`: `nn.Module`'s
+        # `__getattr__` is typed `Tensor | Module`, so reaching through a child
+        # to recover a shape is two mypy errors and one more indirection than
+        # the test needs.
+        self.width = width
         self.fc1 = nn.Linear(width, width * 2)
         self.fc2 = nn.Linear(width * 2, width)
         self.norm = nn.LayerNorm(width)
@@ -54,13 +68,16 @@ class Stack(nn.Module):
 
     def __init__(self) -> None:
         super().__init__()
-        self.blocks = nn.ModuleList([Block(256 - 16 * i) for i in range(8)])
+        # `nn.ModuleList` iterates as bare `Module`, so the per-block width is
+        # carried alongside as plain ints rather than reached back out of a
+        # child (which `Module.__getattr__` types `Tensor | Module`).
+        self.widths = [256 - 16 * i for i in range(8)]
+        self.blocks = nn.ModuleList([Block(w) for w in self.widths])
         self.proj = nn.Linear(256, 256)
 
     def forward(self, x):  # type: ignore[no-untyped-def]
         out = self.proj(x)
-        for block in self.blocks:
-            width = block.norm.normalized_shape[0]
+        for block, width in zip(self.blocks, self.widths):
             out = torch.cat([block(out[..., :width]), out[..., width:]], dim=-1)
         return out
 
@@ -411,27 +428,33 @@ def test_the_serve_loop_backend_tiers_a_real_author_model() -> None:
             torch.manual_seed(7)
             self.pipe = Stack().eval()
 
+    # The author object is deliberately NOT a `Model` subclass: these arms must
+    # work over whatever an author's `load` left behind, and `backend.model` is
+    # typed `Model[Any] | None`. Keep a typed local and inject through `cast`,
+    # so the test reads its own object and mypy is told the injection is
+    # intentional rather than silenced with an ignore.
+    author = AuthorModel()
     backend = _InstanceBackend.__new__(_InstanceBackend)
     backend.model_cls = AuthorModel
-    backend.model = AuthorModel()
+    backend.model = cast(Any, author)
     backend._stream_residency = None
 
     x = torch.randn(2, 256)
     with torch.no_grad():
-        want = backend.model.pipe(x).clone()
+        want = author.pipe(x).clone()
 
     backend.demote_to_host()
     assert backend._stream_residency is not None
     assert not backend._stream_residency.plan.resident
     with torch.no_grad():
-        assert torch.equal(backend.model.pipe(x), want), (
+        assert torch.equal(author.pipe(x), want), (
             "a host-tier instance must still compute the same answer"
         )
 
     backend.promote_to_device()
     assert not backend._stream_residency.plan.streamed
     with torch.no_grad():
-        assert torch.equal(backend.model.pipe(x), want)
+        assert torch.equal(author.pipe(x), want)
 
 
 def test_a_tier_move_on_a_weightless_instance_refuses_loudly() -> None:
@@ -446,7 +469,7 @@ def test_a_tier_move_on_a_weightless_instance_refuses_loudly() -> None:
 
     backend = _InstanceBackend.__new__(_InstanceBackend)
     backend.model_cls = Weightless
-    backend.model = Weightless()
+    backend.model = cast(Any, Weightless())
     backend._stream_residency = None
     with pytest.raises(ResidencyError, match="no nn.Module tree"):
         backend.demote_to_host()


### PR DESCRIPTION
Fix-forward for pgw#1497 (`2953920f`). **Master's `fast gates` was red on 23 mypy errors, all in this lane's two new test files.** A red master gate degrades every lane's merge protocol to count-deltas, so this PR does nothing else.

## The scope discrepancy, found first

The gate is `uv run mypy src/gen_worker tests`. My close-out ran `mypy src/gen_worker` and reported *"mypy clean over 337 source files"* — **true of `src/`, which is 337 files; the gate checks 610.** The file count in my own output was the tell, and I did not read it. The tree is strict-by-default (pgw#1202) and the test tree is checked too (pgw#1202 PR 2), so two brand-new test modules were born strict and nothing in my invocation ever looked at them.

**Ruled out, measured** — so the next lane doesn't re-derive it: this was **not** DONE-STANDARD.md's *"worktree mypy trap"*. From a fresh worktree, `mypy src/gen_worker tests` and `MYPYPATH=$PWD/src mypy src/gen_worker tests` return the **identical** 23 errors in 2 files. `pyproject.toml`'s `mypy_path = "src"` is already relative to the config file, so a worktree resolves its own `src/`. The trap is real elsewhere; the cause here is plainer.

One more reading, recorded because it cost a pass: `uv sync --locked --extra dev` **fails** in a fresh worktree on this box (torch wheel hash mismatch), so `uv run mypy` there sees no torch, `nn.Module` degrades to `Any`, and the count inflates to **119 errors across 51 files** — most in files this lane never touched. *A local run whose count exceeds the gate's is an environment report, not a finding.*

## The 23 errors, root-caused not silenced

**Zero burn-down exemptions added** — the pgw#1202 ratchet only turns one way.

| # | cause | fix |
|---|---|---|
| 19 | `nn = torch.nn` after `importorskip` leaves `nn` a module-valued **variable**, so `class Block(nn.Module)` gives mypy no base type → `Name "nn.Module" is not defined` | the idiom the tree already uses (`test_engine_placement.py`): skip guard, then a real static `import torch.nn as nn` |
| 3 | the `_InstanceBackend` arms are deliberately driven over a duck-typed author object, but `backend.model` is `Model[Any] \| None` | typed local + `cast(Any, …)`; the test reads its own object instead of reaching back through the union, which removes the two `union-attr` errors rather than ignoring them |
| 1 | `DeployBinding(checkpoint_dir="/tmp")` | the field is a `Path` |

Two more surfaced *once `nn.Module` became a real type instead of `Any`* — errors the broken-env run could never have shown: `block.norm.normalized_shape[0]`, then `int(block.width)`, both reaching a shape back out of a child through `Module.__getattr__` (typed `Tensor | Module`). Per-block widths are now plain ints beside the `ModuleList`, zipped.

## Verified

- `mypy src/gen_worker tests` → **Success: no issues found in 610 source files** (was 23 errors in 2 files, same tree, same command).
- `lint_mypy_ratchet.py` passes at **339 exemptions, unchanged**.
- `ruff` clean. The lane's **40 tests still pass** — a typing fix, not a test rewrite.

The authoritative verdict is this PR's own `fast gates` check, not the local run above.
