### PR TITLE
pgw#1508: a secondary model slot has its OWN checkpoint — the derive's world-model now matches the binding table's

### DIFF
--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -43,17 +43,29 @@ def add_subparser(sub: Any) -> None:
         help="endpoint project root — the directory holding pyproject.toml "
              "and endpoint.toml (default: cwd)",
     )
+    # pgw#1508: REPEATABLE, and each may name the SLOT it belongs to. An
+    # entrypoint with two model slots is two models with two checkpoints —
+    # h3's `generate` is video -> minimax-h3 plus rife -> rife-4.25 — and the
+    # serving binding table has been per-slot since 0.9.0. The BARE form is
+    # the primary/single-slot case and behaves exactly as it always has.
     parser.add_argument(
         "--checkpoint-ref",
-        default="",
+        action="append",
+        default=[],
+        metavar="[SLOT=]OWNER/NAME@REV",
         help="owner/name@revision to trace against. Required for an endpoint "
-             "that declares a model slot; a weightless endpoint needs none.",
+             "that declares a model slot; a weightless endpoint needs none. "
+             "Repeat with `slot=ref` to give a SECONDARY model slot its own "
+             "checkpoint; the bare form is the primary model's.",
     )
     parser.add_argument(
         "--checkpoint",
-        default="",
+        action="append",
+        default=[],
+        metavar="[SLOT=]PATH",
         help="a local checkpoint tree, INSTEAD of resolving --checkpoint-ref "
-             "through the weight CAS (for a tree the store does not hold)",
+             "through the weight CAS (for a tree the store does not hold). "
+             "Repeatable as `slot=path`, same rule as --checkpoint-ref.",
     )
     parser.add_argument(
         "--graph-cas",
@@ -90,19 +102,80 @@ def _say(message: str) -> None:
     print(message, file=sys.stderr, flush=True)
 
 
-def _checkpoint_tree(args: argparse.Namespace) -> tuple[Optional[Path], str]:
-    """(tree, ref-string). Both may be absent — a weightless endpoint has none."""
-    if args.checkpoint:
-        tree = Path(args.checkpoint).resolve()
+def _split_slot(value: str) -> tuple[str, str]:
+    """``slot=rest`` -> ("slot", "rest"); a bare value -> ("", value).
+
+    Split on the FIRST ``=`` and only when the left side is a plain
+    identifier, so a checkpoint ref or a path that happens to contain ``=``
+    is not mistaken for a slot spelling.
+    """
+
+    slot, sep, rest = value.partition("=")
+    if sep and slot.isidentifier():
+        return slot, rest
+    return "", value
+
+
+def _one_tree(checkpoint: str, ref_text: str) -> tuple[Optional[Path], str]:
+    if checkpoint:
+        tree = Path(checkpoint).resolve()
         if not tree.is_dir():
             raise ws.WorkspaceError(f"--checkpoint {tree} is not a directory")
         # A local tree still needs an identity for the skip key. Without one,
         # swapping the tree under a stable path would reuse a stale trace.
-        return tree, args.checkpoint_ref or f"local:{tree}"
-    if not args.checkpoint_ref:
+        return tree, ref_text or f"local:{tree}"
+    if not ref_text:
         return None, ""
-    ref = ws.parse_checkpoint_ref(args.checkpoint_ref)
+    ref = ws.parse_checkpoint_ref(ref_text)
     return ws.resolve_checkpoint(ref), str(ref)
+
+
+def _checkpoint_tree(
+    args: argparse.Namespace,
+) -> tuple[Optional[Path], str, dict[str, Path], tuple[str, ...]]:
+    """(primary tree, primary ref, per-slot trees, per-slot ref strings).
+
+    Everything may be absent — a weightless endpoint has no checkpoint at all.
+    The per-slot halves are EMPTY for every endpoint that names one model, so
+    the reuse key and the derive are bit-for-bit what they were (pgw#1508).
+    """
+
+    refs: dict[str, str] = {}
+    trees: dict[str, str] = {}
+    for raw in args.checkpoint_ref:
+        slot, value = _split_slot(raw)
+        if slot in refs:
+            raise ws.WorkspaceError(
+                "--checkpoint-ref given twice for "
+                + (f"slot {slot!r}" if slot else "the primary model")
+            )
+        refs[slot] = value
+    for raw in args.checkpoint:
+        slot, value = _split_slot(raw)
+        if slot in trees:
+            raise ws.WorkspaceError(
+                "--checkpoint given twice for "
+                + (f"slot {slot!r}" if slot else "the primary model")
+            )
+        trees[slot] = value
+
+    primary_tree, primary_ref = _one_tree(trees.get("", ""), refs.get("", ""))
+    slot_trees: dict[str, Path] = {}
+    slot_refs: list[str] = []
+    for slot in sorted(set(refs) | set(trees)):
+        if not slot:
+            continue
+        tree, ref_text = _one_tree(trees.get(slot, ""), refs.get(slot, ""))
+        if tree is None:
+            raise ws.WorkspaceError(
+                f"slot {slot!r} was named with no resolvable checkpoint"
+            )
+        slot_trees[slot] = tree
+        # Sorted and slot-qualified so the reuse key moves when an AUXILIARY
+        # checkpoint moves — otherwise swapping rife under a stable primary
+        # would silently reuse a trace of the old one.
+        slot_refs.append(f"{slot}={ref_text}")
+    return primary_tree, primary_ref, slot_trees, tuple(slot_refs)
 
 
 def run_lock(args: argparse.Namespace) -> int:
@@ -142,7 +215,7 @@ def run_lock(args: argparse.Namespace) -> int:
 
     # ------------------------------------------------------------------- trace
     try:
-        tree, ref_text = _checkpoint_tree(args)
+        tree, ref_text, slot_trees, slot_refs = _checkpoint_tree(args)
     except ws.WorkspaceError as exc:
         _say(f"error: {exc}")
         return 2
@@ -185,6 +258,9 @@ def run_lock(args: argparse.Namespace) -> int:
         checkpoint_ref=ref_text,
         trace_device=device,
         lockfile=lockfile,
+        # pgw#1508: an AUXILIARY checkpoint is an input too. Empty for every
+        # single-slot endpoint, so their reuse keys do not move.
+        extra=slot_refs,
     )
 
     existing: Optional[el.DeriveBlock]
@@ -218,6 +294,7 @@ def run_lock(args: argparse.Namespace) -> int:
              "document moved with them")
         return _check_by_rederive(
             config, root, out, existing, tree, graph_cas_root, device, lockfile,
+            slot_trees,
         )
 
     cas = ws.local_cas(graph_cas_root)
@@ -258,7 +335,9 @@ def run_lock(args: argparse.Namespace) -> int:
             "say so rather than emit an empty document."
         )
 
-    traced = _trace(config, root, tree, graph_cas_root, device, lockfile)
+    traced = _trace(
+        config, root, tree, graph_cas_root, device, lockfile, slot_trees,
+    )
     if traced is None:
         return 1
     result, elapsed = traced
@@ -368,6 +447,7 @@ def _trace(
     graph_cas_root: Path,
     device: str,
     lockfile: Optional[Path] = None,
+    slot_trees: Optional[dict[str, Path]] = None,
 ) -> Optional[tuple[Any, float]]:
     """Import the author's module and derive it. ``None`` = said why, failed.
 
@@ -397,6 +477,7 @@ def _trace(
             checkpoint_dir=tree if tree is not None else root,
             lockfile=lockfile if lockfile is not None else lockfile_beside(root),
             graph_cas=graph_cas_root,
+            slot_checkpoints=slot_trees or {},
         )
     except DeriveError as exc:
         _say(f"error: derive: {exc}")
@@ -416,6 +497,7 @@ def _check_by_rederive(
     graph_cas_root: Path,
     device: str,
     lockfile: Optional[Path] = None,
+    slot_trees: Optional[dict[str, Path]] = None,
 ) -> int:
     """``--check``'s expensive arm: does the committed DOCUMENT still hold?
 
@@ -425,7 +507,9 @@ def _check_by_rederive(
     and NOTHING IS WRITTEN either way: `--check` is a question.
     """
 
-    traced = _trace(config, root, tree, graph_cas_root, device, lockfile)
+    traced = _trace(
+        config, root, tree, graph_cas_root, device, lockfile, slot_trees,
+    )
     if traced is None:
         return 1
     result, elapsed = traced

--- a/src/gen_worker/cli/release.py
+++ b/src/gen_worker/cli/release.py
@@ -41,8 +41,13 @@ def add_subparser(sub: Any) -> None:
     derive.add_argument(
         "--checkpoint",
         required=True,
+        action="append",
+        default=[],
+        metavar="[SLOT=]PATH",
         help="CONFIG-ONLY checkpoint tree the author's load path resolves "
-        "(subset snapshot; weights never transit the derive)",
+        "(subset snapshot; weights never transit the derive). Repeat as "
+        "`slot=path` to give a SECONDARY model slot its own tree (pgw#1508); "
+        "the bare form is the primary model's.",
     )
     # pgw#1489: a derive STATES the compile stack it traced under, and reads it
     # from the endpoint's own `uv.lock` — the one file the derive, the mint and
@@ -81,10 +86,28 @@ def _run_derive(args: argparse.Namespace) -> int:
     if not root.is_dir():
         print(f"error: --dir {root} is not a directory", file=sys.stderr)
         return 2
-    checkpoint = Path(args.checkpoint).resolve()
-    if not checkpoint.is_dir():
-        print(f"error: --checkpoint {checkpoint} is not a directory", file=sys.stderr)
+    trees: dict[str, Path] = {}
+    for raw in args.checkpoint:
+        slot, _sep, rest = raw.partition("=")
+        if not (_sep and slot.isidentifier()):
+            slot, rest = "", raw
+        if slot in trees:
+            owner = f"slot {slot!r}" if slot else "the primary model"
+            print(f"error: --checkpoint given twice for {owner}", file=sys.stderr)
+            return 2
+        resolved = Path(rest).resolve()
+        if not resolved.is_dir():
+            print(f"error: --checkpoint {resolved} is not a directory", file=sys.stderr)
+            return 2
+        trees[slot] = resolved
+    if "" not in trees:
+        print(
+            "error: --checkpoint names only secondary slots; the primary "
+            "model's tree is the bare form",
+            file=sys.stderr,
+        )
         return 2
+    checkpoint = trees.pop("")
     prime_sys_path(root)
     try:
         module = importlib.import_module(args.module)
@@ -103,6 +126,7 @@ def _run_derive(args: argparse.Namespace) -> int:
             checkpoint_dir=checkpoint,
             lockfile=lockfile,
             graph_cas=Path(args.graph_cas).resolve() if args.graph_cas else None,
+            slot_checkpoints=trees,
         )
     except DeriveError as exc:
         print(f"derive error: {exc}", file=sys.stderr)

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -66,7 +66,7 @@ import typing
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from types import ModuleType
+from types import MappingProxyType, ModuleType
 from typing import Any, Optional
 
 from ..serving.entrypoints import ENTRYPOINT_ATTR
@@ -1247,6 +1247,7 @@ def _derive_lane(
     checkpoint_dir: Path,
     warnings: list[str],
     program_sink: Optional[Any] = None,
+    slot_checkpoints: Mapping[str, Path] = MappingProxyType({}),
 ) -> Optional[Any]:
     """One lane's instrumented runs, merged across defaults variants.
 
@@ -1327,26 +1328,51 @@ def _derive_lane(
             # slot, loaded under the SAME hollow session. Every slot named in
             # a signature must be fillable at trace or the release cannot
             # state its graph set.
+            #
+            # pgw#1508: EACH SLOT GETS ITS OWN TREE. This comment said "an
+            # auxiliary model with its own checkpoint" and then handed every
+            # aide the PRIMARY's `checkpoint_dir`, so h3's `generate`
+            # (video -> minimax-h3, rife -> rife-4.25) tried to build a RIFE
+            # interpolator out of the DiT's tree and refused on a missing
+            # `flownet`. The binding table has been per-slot since 0.9.0; the
+            # derive's world-model now matches it. A slot with no entry falls
+            # back to the primary tree, which is every single-slot endpoint
+            # and is why their documents do not move.
             aides: dict[str, Any] = {}
             for plan, _payloads in plans:
                 for slot_name, slot_cls in plan.model_slots:
                     if slot_cls is cls or slot_name in aides:
                         continue
+                    slot_tree = slot_checkpoints.get(slot_name, checkpoint_dir)
                     aide = slot_cls()
                     try:
                         aide.load(
                             TraceLoadContext(
                                 lane=resolved,
-                                checkpoint_dir=checkpoint_dir,
+                                checkpoint_dir=slot_tree,
                                 model_type=model_model_type(slot_cls),
                                 defaults_instance=None,
                             )
                         )
                     except Exception as exc:
+                        # Name the SLOT and the TREE IT WAS GIVEN. The failure
+                        # that produced pgw#1508 read as a broken aide class
+                        # when it was a wrong checkpoint, and one line saying
+                        # which tree was used is the difference between a
+                        # one-read diagnosis and an afternoon.
+                        shared = (
+                            " (the PRIMARY checkpoint — this slot has no "
+                            "--checkpoint-ref of its own; an auxiliary model "
+                            "with a separate checkpoint needs "
+                            f"`--checkpoint-ref {slot_name}=<ref>`)"
+                            if slot_name not in slot_checkpoints
+                            else ""
+                        )
                         raise DeriveError(
                             f"lane {handle!r}: entrypoint {plan.name!r} slot "
                             f"{slot_name!r} ({slot_cls.__name__}) failed to "
-                            f"load under the trace session: "
+                            f"load from {slot_tree}{shared} under the trace "
+                            f"session: "
                             f"{type(exc).__name__}: {exc}"
                         ) from exc
                     aides[slot_name] = aide
@@ -1445,8 +1471,17 @@ def derive_release(
     checkpoint_dir: Path,
     lockfile: Optional[Path] = None,
     graph_cas: Optional[Path] = None,
+    slot_checkpoints: Mapping[str, Path] = MappingProxyType({}),
 ) -> ReleaseDeriveResult:
-    """Derive the release metadata document for one endpoint module."""
+    """Derive the release metadata document for one endpoint module.
+
+    ``checkpoint_dir`` is the PRIMARY model's tree. ``slot_checkpoints`` maps a
+    secondary model slot to its OWN tree (pgw#1508) -- an auxiliary model is a
+    different model with a different checkpoint, which the serving binding
+    table has said since 0.9.0 and the derive used to contradict. A slot with
+    no entry falls back to the primary tree, so every single-slot endpoint
+    derives exactly the bytes it did before.
+    """
 
     torchcg = _torchcg()
     program_sink = _program_sink(graph_cas)
@@ -1540,6 +1575,7 @@ def derive_release(
             lane_graphs = _derive_lane(
                 torchcg, cls, lane, plans, checkpoint_dir, warnings,
                 program_sink=program_sink,
+                slot_checkpoints=slot_checkpoints,
             )
             if lane_graphs is None:
                 # Traced, nothing marked (pgw#1488). No lane row: an empty one

--- a/tests/release_fixtures/two_slot_endpoint.py
+++ b/tests/release_fixtures/two_slot_endpoint.py
@@ -1,0 +1,74 @@
+"""One entrypoint, TWO model slots, backed by TWO checkpoints (pgw#1508).
+
+h3's `generate` shape: `video` is the primary (a diffusers pipeline out of the
+DiT's tree) and `aide` is an auxiliary model with a checkpoint of its own --
+h3's is the RIFE interpolator at `rife-4.25`. The serving binding table has
+been per-slot since 0.9.0; the derive used to hand every slot the PRIMARY's
+tree, so the aide tried to build itself out of the wrong checkpoint.
+
+The aide here loads a bare `UNet2DConditionModel` from its own tree, which the
+primary tree does NOT contain at the top level -- so pointing it at the primary
+fails the way h3's RIFE did, and pointing it at its own succeeds.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline, UNet2DConditionModel
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class VideoModel(Model[SDXL], lanes=(TINY_DIFFUSERS_FP32,)):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+class AideModel(Model[SDXL], eager_only="an interpolator has no AOT story here"):
+    """Eager-permanent, and it STILL hydrates -- the drive calls it.
+
+    Skipping hydration for an eager_only slot was the tempting shortcut and is
+    wrong: the entrypoint body runs at trace and calls this model, so a `None`
+    here fails one layer later with a worse message.
+    """
+
+    net: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.net = ctx.load(UNet2DConditionModel)
+
+
+@entrypoint
+def generate(
+    ctx: RequestContext, payload: In, video: VideoModel, aide: AideModel
+) -> Out:
+    ctx.raise_if_cancelled()
+    with torch.inference_mode():
+        video.pipe(
+            prompt=payload.prompt,
+            num_inference_steps=2,
+            guidance_scale=0.0,
+            width=32,
+            height=32,
+            callback_on_step_end=ctx.step_callback(2),
+            output_type="latent",
+        )
+        # The aide is CALLED, which is why it has to be real at trace.
+        assert aide.net is not None
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_release_derive_slot_checkpoints.py
+++ b/tests/test_release_derive_slot_checkpoints.py
@@ -1,0 +1,191 @@
+"""pgw#1508: a secondary model slot has its OWN checkpoint.
+
+`_derive_lane` hydrated every aide with the PRIMARY's `checkpoint_dir` while
+its own comment said "an auxiliary model with its own checkpoint (e.g. h3's
+RIFE interpolator)". No per-slot plumbing existed anywhere -- `gen-worker
+lock` took ONE `--checkpoint-ref` -- so an entrypoint naming two slots backed
+by two checkpoints was unlockable by construction. h3's `generate` is exactly
+that: `video` -> minimax-h3, `rife` -> rife-4.25, and its binding rows have
+been per-slot since 0.9.0.
+
+The fix makes the derive's world-model match the binding table's.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+LOCK = (
+    "version = 1\n"
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+
+@pytest.fixture(scope="module")
+def primary_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return tiny_tree.save_config_only(tmp_path_factory.mktemp("primary-config-only"))
+
+
+@pytest.fixture(scope="module")
+def aide_tree(primary_tree: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """The auxiliary model's OWN tree: a bare UNet config, not a pipeline.
+
+    Deliberately a different SHAPE, so pointing the aide at the primary tree
+    fails the way h3's RIFE did rather than quietly succeeding.
+    """
+
+    tree = tmp_path_factory.mktemp("aide-config-only")
+    for name in ("config.json",):
+        (tree / name).write_text((primary_tree / "unet" / name).read_text())
+    return tree
+
+
+def _derive(
+    tmp_path: Path, *checkpoints: str
+) -> tuple[int, Path]:
+    from gen_worker.cli import main
+
+    out = tmp_path / "release.json"
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(LOCK)
+    argv = [
+        "release", "derive",
+        "--dir", str(FIXTURES),
+        "--module", "two_slot_endpoint",
+        "--lockfile", str(lockfile),
+        "--out", str(out),
+    ]
+    for checkpoint in checkpoints:
+        argv += ["--checkpoint", checkpoint]
+    return main(argv), out
+
+
+def test_two_slots_with_two_checkpoints_derive(
+    primary_tree: Path, aide_tree: Path, tmp_path: Path
+) -> None:
+    """The whole issue: each slot loads from ITS OWN tree."""
+
+    code, out = _derive(tmp_path, str(primary_tree), f"aide={aide_tree}")
+    assert code == 0
+
+    (lane,) = json.loads(out.read_bytes())["graphs"]["lanes"]
+    assert lane["unobserved_targets"] == []
+    assert {record["target"] for record in lane["graphs"]} == {"unet"}
+
+
+def test_the_aide_pointed_at_the_PRIMARY_tree_refuses_naming_slot_and_tree(
+    primary_tree: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The diagnosis has to be one read, which is what pgw#1508 cost.
+
+    The failure that produced this issue read as a broken aide class when it
+    was a wrong checkpoint. The refusal now names the SLOT, the TREE it was
+    given, and -- when the slot has no ref of its own -- says so and spells
+    the flag that fixes it.
+    """
+
+    code, _out = _derive(tmp_path, str(primary_tree))
+    assert code == 1
+
+    message = capsys.readouterr().err
+    assert "slot 'aide'" in message
+    assert str(primary_tree) in message
+    assert "the PRIMARY checkpoint" in message
+    assert "--checkpoint-ref aide=<ref>" in message
+
+
+def test_an_eager_only_slot_STILL_hydrates(
+    primary_tree: Path, aide_tree: Path, tmp_path: Path
+) -> None:
+    """Skipping eager_only slots was the tempting shortcut and is wrong.
+
+    The drive executes the entrypoint body, which CALLS the aide, so a `None`
+    there fails one layer later with a worse message. `AideModel` is
+    `eager_only=` and the fixture asserts it is real inside the handler --
+    this derive passing IS that assertion running at trace.
+    """
+
+    from gen_worker.models import __name__ as _models  # noqa: F401
+
+    code, out = _derive(tmp_path, str(primary_tree), f"aide={aide_tree}")
+    assert code == 0
+    document = json.loads(out.read_bytes())
+    # One lane, the primary's. The eager_only aide contributes no lane row.
+    assert len(document["graphs"]["lanes"]) == 1
+
+
+def test_a_slot_named_twice_refuses(
+    primary_tree: Path, aide_tree: Path, tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code, _out = _derive(
+        tmp_path, str(primary_tree), f"aide={aide_tree}", f"aide={primary_tree}"
+    )
+    assert code == 2
+    assert "given twice for slot 'aide'" in capsys.readouterr().err
+
+
+def test_only_secondary_slots_named_refuses(
+    aide_tree: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The bare form is the primary's; omitting it is not a default."""
+
+    code, _out = _derive(tmp_path, f"aide={aide_tree}")
+    assert code == 2
+    assert "the primary model's tree is the bare form" in capsys.readouterr().err
+
+
+def test_the_slot_spelling_never_eats_a_ref_or_a_path() -> None:
+    """`slot=` splits only on a plain identifier before the FIRST `=`."""
+
+    from gen_worker.cli.lock import _split_slot
+
+    assert _split_slot("owner/name@rev") == ("", "owner/name@rev")
+    assert _split_slot("/tmp/a=b") == ("", "/tmp/a=b")
+    assert _split_slot("rife=owner/name@rev") == ("rife", "owner/name@rev")
+    assert _split_slot("rife=/tmp/tree") == ("rife", "/tmp/tree")
+
+
+def test_an_auxiliary_checkpoint_moves_the_REUSE_KEY(tmp_path: Path) -> None:
+    """Otherwise swapping rife under a stable primary reuses a stale trace.
+
+    And the key must NOT move for a single-slot endpoint, or every existing
+    committed lock re-derives for nothing.
+    """
+
+    from gen_worker.cli import endpoint_lock as el
+
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(LOCK)
+    common = dict(
+        root=tmp_path,
+        module_name="two_slot_endpoint",
+        checkpoint_ref="owner/primary@1",
+        trace_device="cuda",
+        lockfile=lockfile,
+    )
+    bare = el.inputs_digest(**common)  # type: ignore[arg-type]
+    assert bare == el.inputs_digest(**common, extra=())  # type: ignore[arg-type]
+    first = el.inputs_digest(**common, extra=("aide=owner/rife@1",))  # type: ignore[arg-type]
+    second = el.inputs_digest(**common, extra=("aide=owner/rife@2",))  # type: ignore[arg-type]
+    assert bare != first
+    assert first != second


### PR DESCRIPTION
`_derive_lane` hydrated every aide with the **primary's** `checkpoint_dir` while its own comment said *"an auxiliary model with its own checkpoint (e.g. h3's RIFE interpolator)"*. And no per-slot plumbing existed anywhere to fix it with: `gen-worker lock` took **one** `--checkpoint-ref`, so an entrypoint naming two slots backed by two checkpoints was **unlockable by construction**. h3's `generate` is exactly that — `video` → minimax-h3, `rife` → rife-4.25 — and its serving binding rows have been per-slot since 0.9.0. The derive was the only thing that believed an endpoint has one checkpoint.

## Direction (1), per-slot checkpoints

- `--checkpoint-ref [slot=]ref` and `--checkpoint [slot=]path` are now **repeatable** on `lock`, and `--checkpoint [slot=]path` on `release derive`. The **bare form is the primary** and is exactly today's behaviour.
- `derive_release(..., slot_checkpoints=)` threads a per-slot map to `_derive_lane`; each `aide.load` gets its own tree. A slot with no entry falls back to the primary — every single-slot endpoint.
- The slot spelling splits on the **first** `=` and only when the left side is a plain identifier, so a ref or a path containing `=` is never eaten.
- An auxiliary checkpoint is an **input**: its ref joins the reuse key via `inputs_digest(extra=)`. Otherwise swapping rife under a stable primary would silently reuse a trace of the old one. Empty for single-slot endpoints, so no committed lock re-derives for nothing.

## Option (2) is not the fix, and the fixture proves it

Skipping hydration for `eager_only` slots fails one layer later: the drive **executes the entrypoint body**, which calls the aide. `AideModel` in the fixture is `eager_only=` and the handler asserts it is real — that assertion runs at trace, so the derive passing *is* the proof.

**(2)'s true half is folded in**, and it is the part that cost this issue an afternoon: a slot hydration failure now names the **slot** and **the tree it was given**, and when the slot has no ref of its own it says so and spells the flag that fixes it. The original failure read as a broken aide class when it was a wrong checkpoint.

## Red/green by execution

New two-slot fixture whose aide loads a shape the primary tree does not carry (h3's RIFE-vs-DiT relationship):

| arm | result |
|---|---|
| master | **6 of 7 fail** — `--checkpoint aide=<path>` is not even expressible, which *is* the "unlockable by construction" half |
| with the fix | **7 pass**, two slots deriving from two trees |

## Single-slot endpoints unaffected — byte-proven for the fourth time

`tiny_endpoint` is sha256 `c5657d0675026d3c974e6ecac40de4a8f57e0b22562f24d527929d748eaf413f` — the same bytes as before tcg#65, tcg#66, pgw#1449, pgw#1506 and now this.

43 passed across the derive suites · ruff clean (**it caught a real one** — the `--check` re-derive arm needed the map threaded too) · **zero delta** on master's reds: `lint_unreached_surface` 109 here and 109 at master tip; all 23 mypy errors are pgw#1497's two test files, untouched. CPU-only throughout.

## Owed follow-up (not in this PR)

Whether th#2162's plural `[derive] checkpoint_configs` **directory** was already intended as one-tree-per-slot — the builder has per-slot bind refs at regenerate time, so the hub-side plumbing may half-exist. Flagged for a matched note on th#2162 rather than guessed at here.