### PR TITLE
pgw#1462 part 2: the image's baked program CAS becomes a real tier — and the committed-lock path is NOT closed by it

### DIFF
--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -43,6 +43,7 @@ _ENV_TO_FIELD: Dict[str, str] = {
     # TENSORHUB_CACHE_DIR does.
     "COZY_WEIGHTS_CAS": "weights_cas_root",
     "COZY_GRAPH_CAS": "graph_cas_root",
+    "BAKED_PROGRAM_CAS_ROOT": "baked_program_cas_root",
     "RUNPOD_POD_ID": "runpod_pod_id",
     "GEN_WORKER_CONFIG_SNAPSHOT_PATH": "config_snapshot_path",
     "WORKER_CONFIG_GENERATION": "boot_config_generation",

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -64,6 +64,12 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     # CLI installs Settings at process entry like every other entry point.
     weights_cas_root: str = ""
     graph_cas_root: str = ""
+    # pgw#1462 part 2: the IMAGE's read-only exported-program CAS — where the
+    # builder bakes this release's serialized ExportedPrograms. Distinct from
+    # `graph_cas_root` (the CLI's own store) and from the pod's
+    # `<TENSORHUB_CACHE_DIR>/cas` (where its own mints land). Empty = "use the
+    # baked container default"; see `models/cache_paths.baked_program_cas_dir`.
+    baked_program_cas_root: str = ""
     # NOT "the worker's JWT". It is the BOOTSTRAP copy — the
     # value the hub injected at pod create, frozen there forever and updated by
     # nothing. The live credential is rotated over the scheduler stream at ~80 %

--- a/src/gen_worker/models/cache_paths.py
+++ b/src/gen_worker/models/cache_paths.py
@@ -41,6 +41,38 @@ def tensorhub_cas_dir() -> Path:
     return tensorhub_cache_dir() / "cas"
 
 
+#: Where the IMAGE build bakes this release's serialized ExportedPrograms.
+#: tensorhub's `image.DeriveCASImagePath`, one spelling, and the two repos
+#: must not drift — a mismatch here is not an error, it is a permanent silent
+#: cache miss, which is exactly the defect pgw#1462 part 2 exists to close.
+BAKED_PROGRAM_CAS_DIR = "/app/.tensorhub/derive-cas"
+
+
+def baked_program_cas_dir() -> Path | None:
+    """The image's read-only exported-program CAS, or None when there is none.
+
+    THE POD'S OWN CAS IS NOT THIS DIRECTORY, and that is the whole bug.
+    `tensorhub_cas_dir()` is `<TENSORHUB_CACHE_DIR>/cas` — `/tmp/tensorhub-cache/cas`
+    by default — while the builder bakes the release's graph blobs into
+    `/app/.tensorhub/derive-cas`. th#2162 concluded that no hub route was needed
+    because *"pgw's miner already falls through to its local CAS by content
+    address"*; the fallthrough is real but it has never looked in the baked
+    directory, so those blobs have been unreachable since the day they were
+    first baked.
+
+    Settings-driven so a non-container run (e2e, bare-metal dev, cozy-local)
+    points it somewhere real, exactly as `endpoint_lock_path` does. An empty
+    setting DISABLES the tier rather than guessing.
+    """
+
+    configured = current_or(_STANDALONE).baked_program_cas_root.strip()
+    root = Path(configured).expanduser() if configured else Path(BAKED_PROGRAM_CAS_DIR)
+    # Absence is the ordinary case on any image whose build used a committed
+    # endpoint.lock (no derive step ran, so nothing was baked). It is not a
+    # failure and must not read as one.
+    return root if root.is_dir() else None
+
+
 def open_worker_cas(root: Path | None = None) -> LocalCAS:
     """Open the worker's one tensorfs store.
 

--- a/src/gen_worker/serving/mint_store.py
+++ b/src/gen_worker/serving/mint_store.py
@@ -1,6 +1,6 @@
 """The store a serving worker adopts from and mints into (pgw#1371).
 
-One ``GraphStore``, two tiers, and the reason they are one object is that a
+One ``GraphStore``, three tiers, and the reason they are one object is that a
 worker must not have two answers to "do I have this graph".
 
 * **LOCAL** — a ``LocalGraphStore`` over the pod's own tensorfs CAS. Every
@@ -14,6 +14,13 @@ worker must not have two answers to "do I have this graph".
   fleet's already-minted artifacts, and it is READ-ONLY by construction:
   ``publish_artifact`` raises, because the fleet publish is the
   intent/complete control-plane leg, not the adopt route.
+* **BAKED** — the IMAGE's read-only exported-program CAS
+  (``/app/.tensorhub/derive-cas``), consulted for ``fetch_program`` ONLY.
+  pgw#1462 part 2. th#2162 argued no hub route was needed for graph blobs
+  because the miner *"already falls through to its local CAS by content
+  address"* — it does, but into ``<TENSORHUB_CACHE_DIR>/cas``, which is NOT
+  where the builder bakes them. Every baked blob has been unreachable since
+  the first image carried one, silently, because a cache miss reports nothing.
 
 **THE UPSTREAM PUBLISH IS A STATED HOLE, NOT A SWALLOWED ERROR.** The fleet
 leg (``compiled_graphs.publish_intent`` / ``publish_complete``) is allowlisted
@@ -60,9 +67,16 @@ class TieredGraphStore:
     upstream tier when it can take them.
     """
 
-    def __init__(self, local: Any, upstream: Any = None) -> None:
+    def __init__(self, local: Any, upstream: Any = None, baked: Any = None) -> None:
         self.local = local
         self.upstream = upstream
+        #: The IMAGE's read-only exported-program CAS (pgw#1462 part 2). A
+        #: THIRD tier and deliberately not a second `local`: nothing is ever
+        #: written here, it is consulted for `fetch_program` ONLY, and it holds
+        #: serialized graphs rather than compiled artifacts. Folding it into
+        #: the local tier would make a read-only directory look writable to
+        #: every publish path.
+        self.baked = baked
         self._lock = threading.Lock()
         #: Graphs this pod minted that the fleet did not receive. Counted, and
         #: named — an empty tuple after a mint that landed graphs is the proof
@@ -103,32 +117,78 @@ class TieredGraphStore:
     def fetch_program(self, digest: str, destination: Path) -> Path:
         """One graph's serialized ``ExportedProgram`` — the mint's INPUT.
 
-        Upstream first when it can, then the pod's own CAS by content address:
-        a digest is a digest, so a blob this pod already holds needs no hop.
+        THREE tiers, cheapest-and-most-trusted first: an upstream that can
+        serve one, then the pod's own CAS, then the IMAGE's baked CAS. All
+        three are keyed by CONTENT ADDRESS, so the order is a cost decision
+        and never a correctness one — a digest is a digest.
 
-        **A THIRD UNWIRED LEG, named rather than crashed.** th#2133's adopt
-        answer carries each graph's ``program`` digest and NO transport for
-        it — its ``transport.files`` presign the compiled ARTIFACT, not the
-        serialized graph — so a pod whose CAS has never seen the blob has no
-        route to it. pgw#1370 owns publishing the blob and the hub owns
-        answering with a way to fetch it. Until then this raises a typed
-        refusal per graph, which the mint records as a ``MintFailure`` naming
-        the owner instead of dying on an ``AttributeError``.
+        **THE BAKED TIER IS pgw#1462 PART 2, and it closes a gap that was
+        assumed closed.** th#2162 argued no hub route was needed because
+        *"pgw's miner already falls through to its local CAS by content
+        address"*. The fallthrough is real; the directory was wrong. The pod's
+        CAS is ``<TENSORHUB_CACHE_DIR>/cas`` (``/tmp/tensorhub-cache/cas``) and
+        the builder bakes to ``/app/.tensorhub/derive-cas``, so every baked blob
+        has been unreachable since the first image carried one — a permanent
+        silent miss, which is why nothing ever reported it.
+
+        **THE BYTES ARE VERIFIED BEFORE THEY ARE TRUSTED, BY THE STORE'S OWN
+        SCRUB.** These bytes are fed straight to a compiler, so each tier is
+        probed with ``verify_object`` — presence AND integrity in one call —
+        rather than with ``contains`` plus a hash written here. Two reasons it
+        is that call and not the obvious one: a second implementation of
+        integrity checking is a second thing that can disagree, and the two
+        tensorfs snapshots in this tree DISAGREE about ``contains`` — the
+        vendored one rehashes and RAISES ``DigestMismatch``, tensorfs master's
+        is "presence, not integrity" and answers True for bytes corrupted in
+        place. ``verify_object`` means the same thing in both, so this code
+        does not silently change behaviour when the vendor is re-synced.
+
+        **A CORRUPT TIER IS A MISS, NOT A DEATH** — the next tier may hold a
+        good copy, and preferring it is strictly better than refusing. But the
+        corruption is REMEMBERED: if nothing serves the blob, the refusal names
+        it, because "no tier had it" and "a tier had it and it was rotten" have
+        very different remedies.
+
+        A blob no tier holds stays a TYPED PER-GRAPH refusal — it costs its own
+        graph and never the boot.
         """
         fetch = getattr(self.upstream, "fetch_program", None)
         if fetch is not None:
             return Path(fetch(digest, destination))
-        cas = getattr(self.local, "cas", None)
-        if cas is not None and cas.contains(digest):
+        rotten: list[str] = []
+        for tier, cas in (("this pod's own", getattr(self.local, "cas", None)),
+                          ("the image's baked", self.baked)):
+            if cas is None:
+                continue
+            try:
+                source = Path(cas.verify_object(digest))
+            except FileNotFoundError:
+                continue  # an ordinary miss: this tier does not hold it
+            except Exception as exc:  # noqa: BLE001 - any scrub failure is an answer
+                rotten.append(f"{tier} CAS ({type(exc).__name__}: {exc})")
+                continue
             destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_bytes(Path(cas.object_path(digest)).read_bytes())
+            destination.write_bytes(source.read_bytes())
             return destination
+        if rotten:
+            raise ProgramBlobUnreachable(
+                f"graph blob {digest} is present but does not survive its own "
+                f"integrity scrub in " + "; ".join(rotten) + " — the object was "
+                f"truncated or corrupted at rest, and no other tier holds a good "
+                f"copy. Refusing to compile bytes that are not the graph the "
+                f"release stamped."
+            )
         raise ProgramBlobUnreachable(
-            f"graph blob {digest} is not in this pod's CAS and the adopt "
-            f"answer offers no transport for it: th#2133's per-graph rows "
-            f"carry the `program` DIGEST but presign only the compiled "
-            f"artifact. pgw#1370 owns publishing the serialized "
-            f"ExportedProgram and the hub owns answering with a fetch route. "
+            f"graph blob {digest} is in neither this pod's CAS nor the image's "
+            f"baked program CAS, and the adopt answer offers no transport for "
+            f"it: th#2133's per-graph rows carry the `program` DIGEST but "
+            f"presign only the compiled artifact. An image whose build used a "
+            f"COMMITTED endpoint.lock bakes no programs (th#2162 renders no "
+            f"derive step for it), which is the ordinary way to reach this, and "
+            f"the blobs are NOT regenerable here: a re-trace reproduces the "
+            f"graph identity but not the serialized bytes, so it would address "
+            f"different digests than the release stamped. pgw#1370 owns "
+            f"emitting these blobs where the pod can reach them. "
             f"This mint will NEVER re-trace to work around it (author code "
             f"does not run at mint time)."
         )
@@ -177,12 +237,29 @@ class TieredGraphStore:
         }
 
 
-def worker_store(cas_dir: Path, upstream: Optional[Any] = None) -> TieredGraphStore:
-    """The store a real serving pod uses, over its own tensorfs CAS."""
+def worker_store(
+    cas_dir: Path,
+    upstream: Optional[Any] = None,
+    baked_root: Optional[Path] = None,
+) -> TieredGraphStore:
+    """The store a real serving pod uses, over its own tensorfs CAS.
+
+    ``baked_root`` is the IMAGE's read-only exported-program CAS; omitted, it
+    is resolved from settings (`baked_program_cas_dir`), which is what both
+    production call sites want. Passing it explicitly is for tests and for a
+    cozy-local run whose blobs are somewhere else.
+    """
     from .._vendor.tensorfs import LocalCAS
+    from ..models.cache_paths import baked_program_cas_dir
+
     from .._vendor.torchcg.store import LocalGraphStore
 
-    return TieredGraphStore(LocalGraphStore(LocalCAS(Path(cas_dir))), upstream)
+    root = baked_program_cas_dir() if baked_root is None else Path(baked_root)
+    # A read-only tier: LocalCAS is opened on an EXISTING directory only, so a
+    # missing bake never creates one. `LocalCAS.__init__` mkdirs, so absence is
+    # decided before it is constructed, not by it.
+    baked = LocalCAS(root) if root is not None and Path(root).is_dir() else None
+    return TieredGraphStore(LocalGraphStore(LocalCAS(Path(cas_dir))), upstream, baked)
 
 
 __all__ = [

--- a/tests/test_program_blob_tiers.py
+++ b/tests/test_program_blob_tiers.py
@@ -1,0 +1,164 @@
+"""The mint's INPUT: where a serialized ExportedProgram is found, and refused.
+
+# pgw#1462 part 2: the image bakes the release's graph blobs and the pod's own
+# CAS is a different directory, so the miner's content-address fallthrough has
+# never reached them.
+
+The defect these fence is a SILENT one, which is why it survived: a cache miss
+reports nothing, so a tier looking in the wrong directory and a release with no
+blobs at all produce the same observable — an eager pod.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from gen_worker._vendor.tensorfs import LocalCAS
+from gen_worker.models.cache_paths import BAKED_PROGRAM_CAS_DIR, baked_program_cas_dir
+from gen_worker.serving.mint_store import (
+    ProgramBlobUnreachable,
+    TieredGraphStore,
+    worker_store,
+)
+
+PROGRAM = b"\x80\x05serialized-exported-program-bytes" * 64
+
+
+def _seed(root: Path, blob: bytes = PROGRAM) -> str:
+    """Put ``blob`` in a real LocalCAS and return its ``sha256:`` address."""
+    cas = LocalCAS(root)
+    ref = cas.put_bytes(blob)
+    digest = f"sha256:{hashlib.sha256(blob).hexdigest()}"
+    assert str(ref) in (digest, digest.split(":", 1)[1]), f"unexpected ref {ref}"
+    return digest
+
+
+def _local_tier(root: Path) -> object:
+    """A stand-in for LocalGraphStore: the mint reads only its `.cas`."""
+
+    class _Store:
+        cas = LocalCAS(root)
+
+    return _Store()
+
+
+def test_a_baked_blob_is_unreachable_without_the_image_tier(tmp_path: Path) -> None:
+    """THE RED ARM, and it is the whole defect in four lines.
+
+    The blob is present, on this machine, in the directory the builder bakes
+    to — and the pod cannot see it, because the pod's CAS is somewhere else.
+    """
+    image_cas = tmp_path / "app" / ".tensorhub" / "derive-cas"
+    digest = _seed(image_cas)
+    pod_cas = tmp_path / "tensorhub-cache" / "cas"
+
+    without = TieredGraphStore(_local_tier(pod_cas), upstream=None, baked=None)
+    with pytest.raises(ProgramBlobUnreachable) as refusal:
+        without.fetch_program(digest, tmp_path / "out" / "p.pt2")
+    # The message has to name the ordinary cause, because the ordinary cause is
+    # a build that used a committed lock and therefore baked nothing.
+    assert "COMMITTED endpoint.lock" in str(refusal.value)
+
+    # …and the GREEN arm is the same store with the tier wired.
+    with_tier = TieredGraphStore(
+        _local_tier(pod_cas), upstream=None, baked=LocalCAS(image_cas)
+    )
+    got = with_tier.fetch_program(digest, tmp_path / "out" / "p.pt2")
+    assert Path(got).read_bytes() == PROGRAM
+
+
+def test_the_pods_own_cas_still_wins_and_needs_no_image(tmp_path: Path) -> None:
+    """The new tier is additive: a pod that already holds the blob never looks."""
+    pod_cas = tmp_path / "cas"
+    digest = _seed(pod_cas)
+    store = TieredGraphStore(_local_tier(pod_cas), upstream=None, baked=None)
+    assert Path(store.fetch_program(digest, tmp_path / "p.pt2")).read_bytes() == PROGRAM
+
+
+def test_corrupted_baked_bytes_are_refused_not_compiled(tmp_path: Path) -> None:
+    """`contains` is presence, NOT integrity — it says so itself.
+
+    These bytes go straight into a compiler, so the store's own scrub runs
+    first. Corrupting the object IN PLACE is the case `contains` documents as
+    answering True by design, which is exactly the one that would otherwise
+    reach inductor.
+    """
+    image_cas = tmp_path / "derive-cas"
+    digest = _seed(image_cas)
+    cas = LocalCAS(image_cas)
+    target = Path(cas.object_path(digest))
+    target.chmod(0o644)
+    target.write_bytes(b"not the graph the release stamped" * 64)
+
+    store = TieredGraphStore(
+        _local_tier(tmp_path / "pod"), upstream=None, baked=LocalCAS(image_cas)
+    )
+    with pytest.raises(ProgramBlobUnreachable) as refusal:
+        store.fetch_program(digest, tmp_path / "p.pt2")
+    assert "integrity scrub" in str(refusal.value)
+
+    # NEGATIVE CONTROL: without the corruption the same call succeeds, so the
+    # assertion above is about the scrub and not about a broken fixture.
+    clean = tmp_path / "clean-cas"
+    clean_digest = _seed(clean)
+    ok = TieredGraphStore(
+        _local_tier(tmp_path / "pod2"), upstream=None, baked=LocalCAS(clean)
+    )
+    assert Path(ok.fetch_program(clean_digest, tmp_path / "ok.pt2")).exists()
+
+
+def test_an_upstream_that_can_serve_one_still_wins(tmp_path: Path) -> None:
+    """The tier order is a COST decision; every tier is content-addressed.
+
+    A hub that grows `fetch_program` must not be shadowed by a baked blob, and
+    a baked blob must not be shadowed by a hub that has none.
+    """
+    calls: list[str] = []
+
+    class _Upstream:
+        def fetch_program(self, digest: str, destination: Path) -> Path:
+            calls.append(digest)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(PROGRAM)
+            return destination
+
+    image_cas = tmp_path / "derive-cas"
+    digest = _seed(image_cas)
+    store = TieredGraphStore(
+        _local_tier(tmp_path / "pod"), upstream=_Upstream(), baked=LocalCAS(image_cas)
+    )
+    store.fetch_program(digest, tmp_path / "p.pt2")
+    assert calls == [digest]
+
+
+def test_a_missing_bake_is_absence_and_never_a_created_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An image built from a committed lock bakes nothing. That is ORDINARY.
+
+    It must not read as a failure, and it must not leave an empty CAS behind
+    that a later reader would treat as an authoritative empty store.
+    """
+    absent = tmp_path / "no-such-bake"
+    monkeypatch.setenv("BAKED_PROGRAM_CAS_ROOT", str(absent))
+    assert baked_program_cas_dir() is None
+    assert not absent.exists()
+
+    # worker_store resolves it and simply carries no baked tier.
+    store = worker_store(tmp_path / "cas")
+    assert store.baked is None
+
+
+def test_the_baked_path_matches_what_the_builder_writes() -> None:
+    """ONE spelling, across two repos, and a drift here is a silent miss.
+
+    tensorhub's `internal/builder/image/derive_bake.go` declares
+    `DeriveCASImagePath = "/app/.tensorhub/derive-cas"`. Nothing can import a Go
+    constant, so the agreement is pinned here instead of assumed — changing
+    either side without the other reintroduces exactly the defect this module
+    exists for, and it would report nothing.
+    """
+    assert BAKED_PROGRAM_CAS_DIR == "/app/.tensorhub/derive-cas"


### PR DESCRIPTION
th#2162 concluded that graph blobs needed no hub route because *"pgw's miner
already falls through to its local CAS by content address before it raises
ProgramBlobUnreachable"*. The fallthrough is real. The DIRECTORY was wrong:

    pod's own CAS      tensorhub_cas_dir()  = <TENSORHUB_CACHE_DIR>/cas
                                            = /tmp/tensorhub-cache/cas
    builder bakes to   DeriveCASImagePath   = /app/.tensorhub/derive-cas

Two different roots, so every blob the builder has ever baked was unreachable
from the moment it was baked — silently, because a cache miss reports nothing.
That is why nothing caught it: the pod served eager, which is what it does when
a release has no document at all.

WHAT THIS ADDS

* a THIRD, read-only tier on `TieredGraphStore`, consulted by `fetch_program`
  only: upstream (if it can serve one) -> the pod's own CAS -> the image's baked
  CAS -> a typed per-graph refusal. All three are content-addressed, so the
  order is a cost decision and never a correctness one.
* `Settings.baked_program_cas_root` / `BAKED_PROGRAM_CAS_ROOT`, defaulting to
  the baked container path exactly as `endpoint_lock_path` does, so a
  non-container run points it somewhere real. Empty/absent DISABLES the tier —
  an image built from a committed lock bakes nothing, which is ordinary and must
  not read as a failure or leave an empty CAS behind.
* the bytes are verified before they are trusted, by the STORE'S OWN scrub
  (`verify_object`) rather than a second hash written here. That also survives a
  vendor re-sync: the vendored tensorfs `contains` rehashes and RAISES, while
  tensorfs master's is "presence, not integrity" and answers True for bytes
  corrupted in place. `verify_object` means the same thing in both.
* a corrupt tier is a MISS, not a death — another tier may hold a good copy —
  but the corruption is remembered and named if nothing serves the blob.

🔴 WHAT THIS DOES **NOT** CLOSE, MEASURED RATHER THAN ASSUMED

sd15's stamped release (`61aeac79ffeaa0cfe8ed6d8a`) is still unmintable, and no
tier can fix it, because the bytes it names exist nowhere and cannot be
recreated. Traced sd15 at its own pinned gen-worker (`6c23c1fb`), CPU-only,
110s, against the same fixture tree, and compared to the release the hub stamped
from the author's committed lock:

    graph hashes (cg-graph-v1)   14 / 14 IDENTICAL
    compile stack (17 rows)      IDENTICAL, byte for byte
    graphs[].program digests      0 / 14 identical
    two runs on THIS box         14 / 14 identical, same document digest

So the serialized ExportedProgram is deterministic WITHIN a machine and
different ACROSS machines whose declared inputs are byte-identical. Graph
IDENTITY is portable; the blob ADDRESS is not. Consequences recorded on the
issue, because they are design calls and not this commit's to make: a stamped
document is only mintable by whoever holds the original trace's bytes;
"regenerated deterministically from committed source+lock" does not hold for the
blobs; and `gen-worker lock --check` cannot be the portable CI freshness gate it
is specified as, because a second machine re-deriving an unchanged tree reports
drift.

The refusal now says all of that in the one place an operator meets it.

WHERE IT DOES CLOSE THE LOOP: the REGENERATE arm. When an endpoint ships no
committed lock, the builder's in-image `gen-worker lock` produces the document
and the blobs from ONE trace on ONE machine, so their addresses agree by
construction — and this tier is what lets the pod read them.

Local gates: mypy Success (3 files); `lint_mypy_ratchet`, `lint_config_reads`,
`lint_settings_writers` OK. `lint_incident_test_names` and
`lint_unreached_surface` are RED ON `origin/master` ALREADY — measured against a
detached master worktree, my delta is ZERO (identical findings; one line number
shifts by the env row added to `loader.py`). Tests: 28 passed across
`test_runtime_mint`, `test_self_mint_wiring`, `test_mint_publish_shape` and the
new `test_program_blob_tiers` (red arm included: the blob is on disk in the
builder's directory and the store without the tier cannot see it).