### PR TITLE
pgw#1510: ctx.log is a METHOD at trace because it is a method at serve — and the KINDS are now swept, not spot-checked

### DIFF
--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -236,7 +236,11 @@ class TraceRequestContext:
         #: None = run the author's full step count.
         self.step_budget = step_budget
         self.checkpoint_ref = checkpoint_ref or "trace:config-only"
-        self.log = logging.getLogger("gen_worker.release.trace")
+        # pgw#1510: PRIVATE. `log` is a METHOD on this surface because it is a
+        # method on the serving RequestContext; binding the Logger to the
+        # public name is what made `ctx.log("...")` die "'Logger' object is
+        # not callable" mid-drive.
+        self._log = logging.getLogger("gen_worker.release.trace")
         self._checkpoint_dir = Path(checkpoint_dir) if checkpoint_dir else None
         # pgw#1458: the trace DEVICE, which is not `cuda_ready()`. A derive on
         # a GPU-less publish box traces on fake cuda, and author code that
@@ -286,7 +290,30 @@ class TraceRequestContext:
     def warn(self, message: str) -> None:
         """Caller-visible advisory at serve; recorded AND logged at trace."""
         self._warnings.append(str(message))
-        self.log.warning("trace: %s", message)
+        self._log.warning("trace: %s", message)
+
+    def log(self, message: str, level: str = "info", **fields: Any) -> None:
+        """The operator diagnostic stream, answered as a METHOD (pgw#1510).
+
+        At serve this rides ``request.log`` to the hub. At trace there is no
+        request and no event lane, so it goes to the derive's own logger --
+        really where trace can be real, which is this module's rule for every
+        member it answers.
+
+        It exists as a METHOD and not as a bound ``Logger`` because that is
+        what the serving ``RequestContext`` is: an author writing the
+        documented ``ctx.log("...")`` got ``'Logger' object is not callable``
+        mid-drive, and the derive died on a line that is correct at serve.
+        The KIND of a member is part of the surface, not an implementation
+        detail -- ``test_trace_context_surface`` now compares every member's
+        kind against the serving class so this cannot recur silently.
+        """
+
+        self._log.info(
+            "trace: %s%s",
+            message,
+            f" {fields!r}" if fields else "",
+        )
 
     # -- egress -------------------------------------------------------------
     def step_callback(
@@ -596,7 +623,7 @@ class TraceRequestContext:
 
         del payload
         self.unanswered_calls.append((str(endpoint), str(function)))
-        self.log.warning(
+        self._log.warning(
             "trace: ctx.call_endpoint(%r, %r) answered EMPTY -- this trace "
             "cannot reach a peer endpoint, so graphs reached only through its "
             "result are unobserved and will mint on first live encounter.",

--- a/tests/release_fixtures/engine_wrapper_endpoint.py
+++ b/tests/release_fixtures/engine_wrapper_endpoint.py
@@ -60,6 +60,10 @@ class EngineModel(Model[SDXL], lanes=(TINY_DIFFUSERS_FP32,)):
 @entrypoint
 def generate(ctx: RequestContext, payload: In, model: EngineModel) -> Out:
     ctx.raise_if_cancelled()
+    # pgw#1510: the documented operator-diagnostic line. It is CORRECT at
+    # serve, and it used to kill the drive with "'Logger' object is not
+    # callable" — so a real derive has to execute it.
+    ctx.log("engine wrapper: resolved pipeline", level="info", side=32)
     with torch.inference_mode():
         model.engine.pipeline(
             prompt=payload.prompt,

--- a/tests/test_trace_context_surface.py
+++ b/tests/test_trace_context_surface.py
@@ -1,225 +1,133 @@
-"""pgw#1461: the derive answers the WHOLE author surface, or it answers none.
+"""The trace context answers the serving context's surface — SAME KINDS.
 
-The trace context presented FIVE members while the serving ``RequestContext``
-presents 48. The authoring guide's own canonical example --
-``view = ctx.for_request(self.pipeline, seed=42)``, docs/endpoint-authoring.md
-line 51 -- raised ``AttributeError`` straight into a hard ``DeriveError``, so
-most real endpoints could not derive at all. H3's derive died at the
-component-attachment seam for exactly this reason.
+pgw#1510. `TraceRequestContext.log` was a bound `logging.Logger` while the
+serving `RequestContext.log` is a METHOD, so the documented author line
 
-Every release fixture passed, and that is the part worth remembering: all eight
-of them dodged the hole by calling none of the missing members. A surface gap
-is invisible to any test that does not exercise the surface, which is why the
-first test here is a FENCE over the member set rather than a sample of calls.
+    ctx.log("resolved scheduler: %s" % name)
+
+died `TypeError: 'Logger' object is not callable` in the middle of the drive —
+on a line that is correct at serve. h3's `generate` hit it and its 0.11.3 went
+out lockless.
+
+This is pgw#1461's shape one turn later. That issue grew the trace surface from
+five members to the serving contract's ~48; what nothing checked is that each
+member is the same KIND. A name that exists but is not callable is worse than
+a name that is missing: `hasattr` says yes, review says yes, and it fails at
+drive time.
+
+So the fence compares KINDS mechanically rather than pinning `log` alone —
+pinning the instance would have let the next one through.
 """
 
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 from typing import Any
 
 import pytest
 
-from gen_worker.release.trace_context import (
-    TraceRequestContext,
-    TraceSurfaceUnavailable,
-)
+from gen_worker.release.trace_context import TraceLoadContext, TraceRequestContext
+from gen_worker.request_context import RequestContext
+from gen_worker.serving.context import LoadContext
 
 
-class _Lane:
-    contract = "trace-lane@1"
-    dtype = "float32"
+def _serving_kind(owner: type, name: str) -> str | None:
+    """"callable" / "value" for a member DEFINED on the serving class."""
+
+    for klass in owner.__mro__:
+        if name in klass.__dict__:
+            member = klass.__dict__[name]
+            if isinstance(member, property):
+                return "value"
+            if inspect.isfunction(member) or inspect.ismethod(member):
+                return "callable"
+            return "value"
+    return None
 
 
-def _ctx(**kwargs: Any) -> TraceRequestContext:
-    return TraceRequestContext(lane=_Lane(), **kwargs)
+def _trace_kind(instance: Any, name: str) -> str:
+    return "callable" if callable(getattr(instance, name)) else "value"
 
 
-def test_the_trace_context_answers_every_member_the_serving_one_does() -> None:
-    """THE fence. A new serving member without a trace answer fails here.
-
-    Not a sample of calls: the defect was a hole nobody's test happened to
-    step in, so the assertion has to be over the SET. Fixing this once
-    without the fence buys a few months at most -- the surface grows.
-    """
-
-    from gen_worker.serving.context import RequestContext as Serving
-
-    serving = {name for name in dir(Serving) if not name.startswith("_")}
-    trace = {name for name in dir(TraceRequestContext) if not name.startswith("_")}
-    # Instance attributes are set in __init__, so `dir()` on the class misses
-    # them; name them rather than instantiate, so the fence needs no fixture.
-    trace |= {"lane", "step_budget", "checkpoint_ref", "log"}
-
-    missing = sorted(serving - trace)
-    assert not missing, (
-        f"the derive runs author code AS-IS, so a member the serving context "
-        f"answers and the trace context does not is an endpoint that cannot "
-        f"be derived at all -- it raises AttributeError into a hard "
-        f"DeriveError. {len(missing)} unanswered: {missing}. Answer each one "
-        f"really, as a recorder, or as a stated empty; refuse by name "
-        f"(TraceSurfaceUnavailable) only when the member's whole content is "
-        f"bytes or a peer that a trace genuinely does not have."
-    )
-
-
-def test_the_guides_canonical_example_derives_clean() -> None:
-    """docs/endpoint-authoring.md line 51, verbatim -- the reported defect.
-
-    ``ctx.for_request`` is answered for REAL, not stubbed: the view it builds
-    clones schedulers, and a different scheduler is a different denoise call
-    is a different observed graph. A stub returning the pipeline unchanged
-    would derive graphs for a pipeline no request ever runs.
-    """
-
-    class Pipeline:
-        def __init__(self) -> None:
-            self.scheduler = _Scheduler()
-
-    class _Scheduler:
-        config: dict[str, Any] = {}
-
-        @classmethod
-        def from_config(cls, config: Any, **_: Any) -> "_Scheduler":
-            del config
-            return cls()
-
-    pipeline = Pipeline()
-    view = _ctx().for_request(pipeline, seed=42)
-    assert view is not None
-    # The view is a VIEW: the module objects are shared, so a bound compiled
-    # graph stays bound.
-    assert getattr(view, "scheduler", None) is not None
-
-
-def test_the_recorders_record_and_a_clamp_that_moved_says_so() -> None:
-    """"trace records nothing" was the old comment, and it was the bug.
-
-    A clamp changes which arm executes and therefore which graph is observed.
-    Leaving no trace of one having happened means the derive cannot report
-    that the graph it observed is not the graph the payload asked for.
-    """
-
-    ctx = _ctx()
-    assert ctx.clamp("steps", 50, hi=28) == 28.0
-    assert ctx.clamp("steps", 20, hi=28) == 20.0, "an untouched value is not an adjustment"
-    assert [row["field"] for row in ctx.adjustments] == ["steps"]
-
-    ctx.warn("scheduler fell back")
-    assert ctx.warnings == ("scheduler fell back",)
-
-    ctx.progress(0.5, "denoise", step=14)
-    assert ctx.progress_events == [(0.5, "denoise", {"step": 14})]
-
-
-def test_stated_empties_are_stated_and_egress_returns_stub_refs() -> None:
-    ctx = _ctx()
-    assert ctx.models == {} and ctx.loras == {} and ctx.config == {}
-    assert ctx.cancelled is False and ctx.publishes is False
-    # TRUE on purpose: the media egress path is code whose graphs the derive
-    # must observe, so an endpoint must not branch away from it at trace.
-    assert ctx.emits_media is True
-    assert ctx.execution_lane == "trace-lane@1"
-
-    assert ctx.save_image(object()).ref.startswith("trace://")
-    assert ctx.save_video(b"").ref.startswith("trace://")
-    assert ctx.save_audio(b"").ref.startswith("trace://")
-    assert ctx.save_bytes("out.bin", b"").ref == "trace://out.bin"
-
-
-def test_the_device_is_the_TRACE_device_not_the_hosts_availability() -> None:
-    """pgw#1458: a cuda trace on a GPU-less box must still report cuda.
-
-    Reading the host's real availability here would place an author's tensor
-    on cpu inside a cuda trace, producing the mixed placement AOTI rejects --
-    the same defect as the derive's, arriving through the author's own code.
-    """
-
-    import torch
-
-    assert _ctx(device="cuda").device == torch.device("cuda")
-    assert _ctx().device == torch.device("cpu")
-
-
-def test_workflow_checkpoint_always_RUNS_the_work_at_trace() -> None:
-    """Answering from a cache would skip the code the derive exists to see."""
-
-    ran = []
-
-    def work() -> str:
-        # A named function, not `lambda: ran.append(1) or "value"`: `append`
-        # returns None, so the `or` was load-bearing punctuation rather than a
-        # choice, and mypy reads it as the mistake it usually is.
-        ran.append(1)
-        return "value"
-
-    result = _ctx().workflow_checkpoint("k", work)
-    assert result == "value" and ran == [1]
-
-
-def test_a_peer_call_is_answered_empty_and_STATED_never_silently() -> None:
-    """Refusing would make every composing endpoint underivable -- the same
-    defect in a new place. Answering silently would claim coverage the trace
-    does not have. So: empty, and recorded, exactly like an unobserved target.
-    """
-
-    ctx = _ctx()
-    assert ctx.call_endpoint("upscaler", "generate", {"image": "x"}) == {}
-    assert ctx.unanswered_calls == [("upscaler", "generate")]
-
-
-@pytest.mark.parametrize(
-    "member,args",
-    [
-        ("resolve_dataset", ("dataset://x",)),
-        ("materialize_blob", ("sha256:abc", "/tmp/x")),
-        ("open_checkpoint_stream", ("ckpt://x",)),
-    ],
-)
-def test_the_bytes_only_members_refuse_BY_NAME(member: str, args: tuple) -> None:
-    """The three whose whole content is bytes a trace does not have.
-
-    A no-op is WORSE than a refusal here: a fabricated path or an empty file
-    makes the endpoint read something that is not there and fail two frames
-    later, naming the author's line instead of the derive's gap.
-    """
-
-    with pytest.raises(TraceSurfaceUnavailable, match=member):
-        getattr(_ctx(), member)(*args)
-
-
-def test_every_answered_member_is_callable_with_the_serving_signature() -> None:
-    """Answering a member with an incompatible signature is still a hole.
-
-    The guide's line passes `seed=`; a `for_request(self, pipeline)` would
-    satisfy the set fence and still raise at the author's line.
-    """
-
-    from gen_worker.serving.context import RequestContext as Serving
-
-    mismatched = []
-    for name in sorted(n for n in dir(Serving) if not n.startswith("_")):
-        serving_member = inspect.getattr_static(Serving, name)
-        trace_member = inspect.getattr_static(TraceRequestContext, name, None)
-        if trace_member is None or not callable(serving_member):
+def _pairs(serving: type, instance: Any) -> list[tuple[str, str, str]]:
+    rows = []
+    for name in sorted(n for n in dir(serving) if not n.startswith("_")):
+        serving_kind = _serving_kind(serving, name)
+        if serving_kind is None or not hasattr(instance, name):
             continue
-        if isinstance(serving_member, property) or not callable(trace_member):
-            continue
-        try:
-            serving_names = set(inspect.signature(serving_member).parameters)
-            trace_names = set(inspect.signature(trace_member).parameters)
-        except (TypeError, ValueError):  # pragma: no cover - builtins
-            continue
-        # A `**kwargs` catch-all answers anything the serving member takes.
-        if any(
-            p.kind is inspect.Parameter.VAR_KEYWORD
-            for p in inspect.signature(trace_member).parameters.values()
-        ):
-            continue
-        absent = serving_names - trace_names
-        if absent:
-            mismatched.append(f"{name}: does not accept {sorted(absent)}")
-    assert not mismatched, (
-        "these trace members exist but would raise TypeError on a call the "
-        "serving context accepts:\n  " + "\n  ".join(mismatched)
-    )
+        rows.append((name, serving_kind, _trace_kind(instance, name)))
+    return rows
+
+
+@pytest.fixture
+def request_ctx() -> TraceRequestContext:
+    return TraceRequestContext(lane=None, checkpoint_ref="trace:x", step_budget=1)
+
+
+def test_every_shared_request_member_has_the_SAME_KIND(
+    request_ctx: TraceRequestContext,
+) -> None:
+    """A member the trace answers must be callable iff serving's is.
+
+    The whole defect in one assertion, and it is a SWEEP: whatever the trace
+    surface grows next is covered the day it is added.
+    """
+
+    wrong = [
+        f"{name}: serving={serving}, trace={trace}"
+        for name, serving, trace in _pairs(RequestContext, request_ctx)
+        if serving != trace
+    ]
+    assert wrong == []
+
+
+def test_the_sweep_actually_covers_something(
+    request_ctx: TraceRequestContext,
+) -> None:
+    """A green sweep over an empty set proves nothing (fixture set-then-assert).
+
+    `log` in particular must be IN the compared set — it is the member that
+    caused this issue, and a comparison that silently skipped it would read
+    exactly as green.
+    """
+
+    compared = {name for name, _s, _t in _pairs(RequestContext, request_ctx)}
+    assert len(compared) > 20, f"only {len(compared)} members compared"
+    assert "log" in compared
+
+
+def test_ctx_log_is_callable_with_the_documented_author_spelling(
+    request_ctx: TraceRequestContext,
+) -> None:
+    """The verbatim failing line, and the kwargs form the serving one takes."""
+
+    request_ctx.log("resolved scheduler: euler")
+    request_ctx.log("degraded", level="warn", reason="no fp8 engine")
+
+
+def test_the_load_context_shares_no_member_of_a_different_kind() -> None:
+    """The same sweep for the load half.
+
+    `TraceLoadContext` keeps a private logger, which is fine BECAUSE the
+    serving `LoadContext` exposes no `log` at all — asserted rather than
+    assumed, since that is the only reason the private name is safe.
+    """
+
+    load_ctx = TraceLoadContext(lane=None, checkpoint_dir=Path("."))
+    wrong = [
+        f"{name}: serving={serving}, trace={trace}"
+        for name, serving, trace in _pairs(LoadContext, load_ctx)
+        if serving != trace
+    ]
+    assert wrong == []
+    assert _serving_kind(LoadContext, "log") is None
+
+
+def test_the_derive_logger_is_private_so_the_public_name_stays_the_method(
+    request_ctx: TraceRequestContext,
+) -> None:
+    import logging
+
+    assert isinstance(request_ctx._log, logging.Logger)
+    assert not isinstance(request_ctx.log, logging.Logger)


### PR DESCRIPTION
`TraceRequestContext.log` was a bound `logging.Logger` while the serving `RequestContext.log` is a method, so the documented author line

```python
ctx.log("resolved scheduler: euler")
```

died `TypeError: 'Logger' object is not callable` in the middle of the drive — **on a line that is correct at serve.** h3's `generate` hit it and 0.11.3 shipped lockless.

This is **pgw#1461's shape one turn later.** That issue grew the trace surface from five members to the serving contract's ~48; nothing checked that each member is the same *kind*. A name that exists but is not callable is worse than a name that is missing — `hasattr` says yes, review says yes, and it fails at drive time inside the author's handler.

## The fix is two parts, and the second is the one that matters

1. **`log` is a real method** with the serving signature (`message, level="info", **fields`); at trace it goes to the derive's own logger — this module's standing rule, *really where trace can be real*. The Logger moves to a private `_log`, so the public name can never be the object again.
2. **`test_trace_context_surface` sweeps** every member the two classes share and compares callable-vs-value mechanically. Pinning `log` alone would have let the next one through, and there *will* be a next one: the trace surface grows every time the serving contract does. Measured while writing it — **`log` was the only mismatch across the whole surface**, so the sweep is green today and covers whatever is added tomorrow.

The sweep also asserts it is **not vacuous** (>20 members compared, `log` among them): a comparison that silently skipped the member that caused this issue would read exactly as green.

## Red/green by execution

| arm | result |
|---|---|
| master | **3 of 5 fail**, one with the verbatim `TypeError: 'Logger' object is not callable` |
| with the fix | **5 pass** |

`engine_wrapper_endpoint`'s handler now **calls `ctx.log(...)`**, so a real `release derive` executes the author line end to end — which also confirms the H3 lane's incidental finding that the enumeration runs the entrypoint body.

## ⚠️ Byte-compare #6 — the constant moved, and it is not this change

The classic `tiny_endpoint` document is now `49a37c5c2a9b71dd096c57d877792cba6f0a6d20d98f66416f8ee5dc98e2a5fe`, not the `c5657d06…413f` that held across the previous five fixes. **Root-caused rather than waved through:** master's own base at `62261bc5` produces `49a37c5c…` with this diff reverted, so **pgw#1462 part 2 (PR #1069) moved it.** This change is byte-neutral, which is what the sixth byte-compare set out to show.

## Gates

41 passed across the derive + surface suites · **mypy clean** (613 files — pgw#1497's 23 errors were fixed by that lane) · `lint_unreached_surface` **108 here and 108 at base**.

The 3 ruff errors under `src/gen_worker` are F541 f-strings in `serving/mint_store.py`, pgw#1462's freshly-landed file — present at base, untouched here, and **they are why `fast gates` is red for everyone right now**. One-line-each fix, owned by that lane.