### PR TITLE
pgw#1512: three F541 f-strings in mint_store — unblock pgw master's `fast gates` for every lane

### DIFF
--- a/src/gen_worker/serving/mint_store.py
+++ b/src/gen_worker/serving/mint_store.py
@@ -174,9 +174,9 @@ class TieredGraphStore:
             raise ProgramBlobUnreachable(
                 f"graph blob {digest} is present but does not survive its own "
                 f"integrity scrub in " + "; ".join(rotten) + " — the object was "
-                f"truncated or corrupted at rest, and no other tier holds a good "
-                f"copy. Refusing to compile bytes that are not the graph the "
-                f"release stamped."
+                "truncated or corrupted at rest, and no other tier holds a good "
+                "copy. Refusing to compile bytes that are not the graph the "
+                "release stamped."
             )
         raise ProgramBlobUnreachable(
             f"graph blob {digest} is in neither this pod's CAS nor the image's "


### PR DESCRIPTION
`ruff check src/gen_worker` is a CI step and fails on three f-strings-without-placeholders from pgw#1462 part 2 (PR #1069), present from base `62261bc5`. Owner lane is closed; it blocks the required check on every open PR.

**Path-limited on purpose** — one file, nothing else riding, so it lands immediately and puts every lane back on a green base.

Pure lint: the three lines are string continuations inside a concatenation whose other parts are real f-strings, so no byte of the message changes. `ruff check src/gen_worker` clean after.

Split out of pgw#1511 (the fleet-blocking materialization fix) at the coordinator's direction so that fix lands on a green base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)