### PR TITLE
tcg#56: retired 'graph class' spelling in the two lines pgw#1497 wrote

### DIFF
--- a/src/gen_worker/models/stream_residency.py
+++ b/src/gen_worker/models/stream_residency.py
@@ -236,8 +236,8 @@ def plan_residency(
 
     Deterministic: ties break on name, so the same tree and the same budget
     always produce the same split. That is a hard requirement, not a
-    nicety — a mint's traced graph class and a residency reservation both
-    depend on the answer.
+    nicety — a mint's traced graph specializations and a residency reservation
+    both depend on the answer.
     """
     streams = max(1, int(streams))
     pair = MemoryBudget.of(budget_bytes)

--- a/tests/test_stream_residency.py
+++ b/tests/test_stream_residency.py
@@ -102,7 +102,7 @@ def test_budget_split_is_deterministic_and_largest_first() -> None:
     costs = _pyramid()
     first = plan_residency(costs, budget_bytes=14_000_000, min_stream_bytes=1)
     # Same inputs in a different order must give the same answer: a mint's
-    # traced graph class and a residency reservation both depend on it.
+    # traced graph specializations and a residency reservation both depend on it.
     shuffled = plan_residency(
         list(reversed(costs)), budget_bytes=14_000_000, min_stream_bytes=1
     )


### PR DESCRIPTION
The last of master's `fast gates` reds that belongs to this lane (step 22, `tcg#56 guard - no retired graph-class spelling survives`).

tcg#56 renamed the compiled-graph vocabulary — a target has ONE graph and MANY graph **specializations** — and pgw#1497 wrote the retired spelling into `plan_residency`'s determinism note and the test that pins it. Both lines say what they said before; the claim (a deterministic split is load-bearing for what a mint traces *and* for a residency reservation) is unchanged.

**Verified:** guard clean, `--selftest` OK, 40 tests pass.