### PR TITLE
pgw#1510 follow-up: the load half carried the same hazard, and the sweep only closed half the class

### DIFF
--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -51,7 +51,15 @@ class TraceLoadContext:
         self.checkpoint_dir = Path(checkpoint_dir)
         self.model_type = model_type
         self.defaults_instance = defaults_instance
-        self.log = logging.getLogger("gen_worker.release.trace")
+        # pgw#1510 follow-up: PRIVATE, for the same reason the request half's
+        # is. The serving `LoadContext` exposes no `log` at all, so a public
+        # one here is a name the author can reach at trace and not at serve --
+        # and it answered a Logger, so an author who logged inside `load()`
+        # got "'Logger' object is not callable" where serve gives a plain
+        # AttributeError. Now both say the same thing. Kept (rather than
+        # deleted) under the private name so the next internal log line does
+        # not re-add `self.log` by muscle memory.
+        self._log = logging.getLogger("gen_worker.release.trace")
         #: Modules the author marked via ctx.compile() -- discovery hooks
         #: exactly these during the payload drives.
         self.marked_modules: list[Any] = []

--- a/tests/test_trace_context_surface.py
+++ b/tests/test_trace_context_surface.py
@@ -22,13 +22,14 @@ pinning the instance would have let the next one through.
 from __future__ import annotations
 
 import inspect
+import logging
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from gen_worker.release.trace_context import TraceLoadContext, TraceRequestContext
-from gen_worker.request_context import RequestContext
+from gen_worker.request_context import JobContext, RequestContext
 from gen_worker.serving.context import LoadContext
 
 
@@ -107,12 +108,7 @@ def test_ctx_log_is_callable_with_the_documented_author_spelling(
 
 
 def test_the_load_context_shares_no_member_of_a_different_kind() -> None:
-    """The same sweep for the load half.
-
-    `TraceLoadContext` keeps a private logger, which is fine BECAUSE the
-    serving `LoadContext` exposes no `log` at all — asserted rather than
-    assumed, since that is the only reason the private name is safe.
-    """
+    """The same sweep for the load half."""
 
     load_ctx = TraceLoadContext(lane=None, checkpoint_dir=Path("."))
     wrong = [
@@ -121,13 +117,94 @@ def test_the_load_context_shares_no_member_of_a_different_kind() -> None:
         if serving != trace
     ]
     assert wrong == []
-    assert _serving_kind(LoadContext, "log") is None
 
 
-def test_the_derive_logger_is_private_so_the_public_name_stays_the_method(
-    request_ctx: TraceRequestContext,
+#: The serving classes each trace class is the trace-time counterpart of.
+#: The request side is a FAMILY: `JobContext` carries members `RequestContext`
+#: does not (`checkpoint_dir`), and an entrypoint can receive either.
+_COUNTERPARTS: dict[str, tuple[type, ...]] = {
+    "load": (LoadContext,),
+    "request": (RequestContext, JobContext),
+}
+
+
+def _family_kind(family: tuple[type, ...], name: str) -> str | None:
+    for owner in family:
+        kind = _serving_kind(owner, name)
+        if kind is not None:
+            return kind
+    return None
+
+
+def _sibling(which: str) -> tuple[type, ...]:
+    return _COUNTERPARTS["request" if which == "load" else "load"]
+
+
+@pytest.mark.parametrize("which", ["load", "request"])
+def test_a_trace_context_never_borrows_a_name_the_contract_gave_ITS_SIBLING(
+    which: str,
 ) -> None:
-    import logging
+    """The fence the first pass missed, and the reason it missed it.
 
-    assert isinstance(request_ctx._log, logging.Logger)
-    assert not isinstance(request_ctx.log, logging.Logger)
+    The shared-member sweep compares only names present on BOTH sides, so a
+    trace class carrying a name its OWN counterpart does not define is
+    invisible to it. `TraceLoadContext.log` was exactly that: serving
+    `LoadContext` has no `log`, so nothing paired with it, while
+    `RequestContext.log` IS a method — an author who logged inside `load()`
+    got "'Logger' object is not callable" where serve gives a plain
+    AttributeError.
+
+    So: a name its own counterpart does not define, but the SIBLING context
+    does, must not be public here at all. The authoring contract already gave
+    that word a meaning; a trace context answering something else under it is
+    the trap.
+
+    Deliberately NOT a flat union of both contexts — that produced a false
+    positive on `checkpoint_dir`, which genuinely means two different things
+    (a bound-tree property on `LoadContext`, a keyed scratch method on
+    `RequestContext`). Each trace class is judged against ITS OWN counterpart
+    first; the sibling only decides whether a name is spoken for.
+    """
+
+    instance: Any = (
+        TraceLoadContext(lane=None, checkpoint_dir=Path("."))
+        if which == "load"
+        else TraceRequestContext(lane=None, checkpoint_ref="x", step_budget=1)
+    )
+    own, sibling = _COUNTERPARTS[which], _sibling(which)
+    borrowed = [
+        f"{name}: the contract calls it {_family_kind(sibling, name)}, "
+        f"this context answers {_trace_kind(instance, name)}"
+        for name in sorted(n for n in dir(instance) if not n.startswith("_"))
+        if _family_kind(own, name) is None
+        and _family_kind(sibling, name) is not None
+        and _family_kind(sibling, name) != _trace_kind(instance, name)
+    ]
+    assert borrowed == []
+
+
+def test_that_fence_would_have_CAUGHT_the_defect_it_was_written_for() -> None:
+    """Red-proof the fence itself, or it is decoration.
+
+    A sweep that cannot go red is worth nothing, and this one is a sweep over
+    a `dir()` — the easiest kind to make vacuously green.
+    """
+
+    # The precondition the rule rests on: `log` is spoken for on the request
+    # context and absent from the load one. If that ever stops being true the
+    # fence stops meaning anything, so it is asserted rather than assumed.
+    assert _family_kind(_COUNTERPARTS["request"], "log") == "callable"
+    assert _family_kind(_COUNTERPARTS["load"], "log") is None
+
+    class Regressed:
+        log = logging.getLogger("would-be-regression")
+
+    borrowed = [
+        name
+        for name in dir(Regressed())
+        if not name.startswith("_")
+        and _family_kind(_COUNTERPARTS["load"], name) is None
+        and _family_kind(_COUNTERPARTS["request"], name) == "callable"
+        and _trace_kind(Regressed(), name) != "callable"
+    ]
+    assert borrowed == ["log"]


### PR DESCRIPTION
Two misses in the original fix, both mine.

**1. `TraceLoadContext.log` (trace_context.py:54) was still a bound Logger.** The filing named that exact line; I fixed the request half and read the load half as safe because serving `LoadContext` exposes no `log` at all. That reasoning was wrong in an interesting way: it means an author who logs inside `load()` gets `'Logger' object is not callable` at trace where serve gives a plain `AttributeError` — two different failures for one mistake, the same "the trace lies about the surface" defect one level down. It has **zero internal users**, so it becomes `_log`.

**2. The sweep only compared names present on both sides**, so a trace class carrying a name its *own* counterpart does not define was invisible to it — precisely `log`, since `LoadContext` has none to pair with. A sweep with a blind spot exactly where the defect lives is worse than no sweep, because it reads as coverage.

The new fence is **per-name across the contract**: a name a trace context's own counterpart does not define, but the **sibling** context does, must not answer a different **kind** here. `log` is caught; harness-private recorders (`marked_modules`, `unanswered_calls`, `progress_events`) are correctly ignored — the contract never gave those words a meaning.

**Red-proven** against the real defect: reverted, the fence fails naming `log`. The red-proof also asserts its own precondition (`log` is callable on the request family, absent from the load one), so it cannot pass vacuously if that changes.

## Two things the fence found while being written

- **A false positive in my first version**, which flattened both serving contexts into one name→kind map: `checkpoint_dir` genuinely means two different things — a bound-tree **property** on `LoadContext`, a keyed scratch **method** on `JobContext` — so the flat map collapsed two contract members into one. Each trace class is now judged against its own counterpart **family** (`RequestContext` + `JobContext`) first; the sibling only decides whether a word is spoken for. Reason written down so the next reader doesn't re-flatten it.
- **`TraceRequestContext` publicly answers `checkpoint_ref` and `lane`, which neither serving request class defines** — and `tests/release_fixtures` handlers call `ctx.checkpoint_ref`. Same kind on both sides, so not this issue's hazard and the fence does not fire; but it is either a real gap in the serving surface or fixtures written against a member serving lacks. **Not fixed here** — that is pgw#1461's question, wider than a follow-up, and guessing would repeat the overreach that produced the false positive above.

## Gates

Byte-compare #7: `49a37c5c2a9b71dd096c57d877792cba6f0a6d20d98f66416f8ee5dc98e2a5fe` — the constant pgw#1462 part 2 moved it to, unchanged by this. mypy clean (615 files); ruff clean in my scope. The 3 F541s in `serving/mint_store.py` are still at base (pgw#1072 not merged yet) and untouched here.