### PR TITLE
pgw#1462: program blobs are ADDRESS-FREE — holes resolve by GRAPH IDENTITY

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,7 +696,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "20e54d41c7f853e809fc985e795e1cdd539b3215" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "09c09b7a0f3578248d8873759a1c466c63e89662" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -306,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "20e54d41c7f853e809fc985e795e1cdd539b3215"
+rev = "09c09b7a0f3578248d8873759a1c466c63e89662"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -529,8 +529,8 @@ rewrites = [
 "contracts/recipe_v1.json" = "d319b5f2e4a3d5c13587da2b7d7cdc25c83b92e0b5b22311c317948c3e610d1a"
 "contracts/toolchain_identity_v1.json" = "f4114c38ae373f62ddcb2aae5498ffbee30630e80adf11fee99e68bcbdb24282"
 "declaration.py" = "8b42bae864a4127cc5e418915f8395d980b8a439a51fd4d6f5ecbb42ba613b21"
-"discovery.py" = "a73e4173677b0e60d9574b1606696c82160830b8a34dea66ba14fd7fd5f7606f"
-"document.py" = "797a3f17f46e971ce165c7c64503efece8219c04c80530036727d7c838f173f7"
+"discovery.py" = "57050c017eba40e0caca94d2df798c149b988764d2eaef2d84fb1e60dc04aad5"
+"document.py" = "a70f4e53d75dd4cdc5fb6f52be4c8c105e49efee168ab6c295094a09f779d0ad"
 "engine.py" = "d8275ad146c73ae5516ea7d60acc1fd63cdddb3036f4833f7741913fe340a1a9"
 "graph_identity.py" = "88c731a681eb1e0b878f30bc33fcaa4efdbfc16bdc612fd6d406a088e299e567"
 "hollow.py" = "d0654b626ce367535e9a0f0782fb952e52128c395316932f4c5ad973b260429b"
@@ -548,5 +548,5 @@ rewrites = [
 "serve.py" = "a1f3b6fe5e46305bc9aea9848ac5935537b7bb37e2586ae3f0393f66cead2ade"
 "spans.py" = "4776fac2006967b1f17ffcbec03e50147d511120fd50cf085ac3b6b4702e5539"
 "storage.py" = "ccc9d6f8ac1a242b493028eaeed6a1fcd3a02a885c99ba2223bc71df7b69efe4"
-"store.py" = "60b12c4f36b40ea4f48464821367852df8bb530294f5535319cfe48aa3adbebb"
+"store.py" = "8251cd638da88152a73309fb2017d62d2ca4b2a46676fc525e81f5c4ffbbd7a0"
 "transform.py" = "34a82af6cbf7def844730b0a21416e478e81684b92480b6055d177d5f3219071"

--- a/src/gen_worker/_vendor/torchcg/discovery.py
+++ b/src/gen_worker/_vendor/torchcg/discovery.py
@@ -172,7 +172,7 @@ def discover_lane(
     drive: Callable[[], object],
     *,
     strict: bool = False,
-    program_sink: Callable[[str, Any], str] | None = None,
+    program_sink: Callable[[str, Any], object] | None = None,
     transforms: TransformSet | None = None,
     session: HollowSession | None = None,
 ) -> LaneGraphs:
@@ -266,7 +266,7 @@ def discover_modules(
     drive: Callable[[], object],
     *,
     strict: bool = False,
-    program_sink: Callable[[str, Any], str] | None = None,
+    program_sink: Callable[[str, Any], object] | None = None,
     transforms: TransformSet | None = None,
     session: HollowSession | None = None,
 ) -> LaneGraphs:
@@ -278,12 +278,13 @@ def discover_modules(
     caller (the derive) names each marked module for the document's
     provenance and hands them here keyed by that name.
 
-    ``program_sink`` (Paul, 2026-08-20) receives ``(graph_hash,
-    ExportedProgram)`` for each NEW graph specialization and returns the CAS digest it
-    stored the serialized program under. The whole traced graph is kept, not
-    just its hash: trace() runs once, ever, and the runtime miner downloads
-    the graph and runs inductor rather than re-tracing author code. torchcg
-    holds no opinion on WHERE the bytes go -- bytes-at-rest is tensorfs's
+    ``program_sink`` receives ``(graph_hash, ExportedProgram)`` for each NEW
+    graph specialization so the caller can bank this machine's serialized
+    program under that identity. **Its return value is discarded** (Paul,
+    2026-08-19, address-free): the bytes are local and their digest is
+    machine-scoped, so nothing about them enters the document -- the graph
+    hash is the identity, and a mint on any box resolves its own bytes by it.
+    torchcg holds no opinion on WHERE they go: bytes-at-rest is tensorfs's
     charter, so the caller owns the sink.
 
     ``session`` (pgw#1458, tcg#64) is the :class:`~torchcg.hollow.
@@ -406,20 +407,23 @@ def discover_modules(
                 # class -- dedup is the point of content identity.
                 continue
             seen_graphs.add(graph)
-            program_digest = ""
+            # THE SINK'S RETURN IS DISCARDED, and that is the address-free
+            # ruling in one line (Paul, 2026-08-19). The sink still banks this
+            # machine's serialized program -- keyed by `graph`, which it is
+            # handed precisely so it can -- but nothing about those bytes
+            # enters the document. A blob digest is machine-scoped
+            # (pgw#1462p2: 14/14 identities reproduce across boxes, 0/14 blob
+            # digests do), so putting one in a document every machine must
+            # agree on is what made the document unportable.
             if program_sink is not None:
                 try:
-                    program_digest = program_sink(graph, program)
+                    program_sink(graph, program)
                 except Exception as exc:
                     raise DiscoveryError(
                         f"lane {contract!r} target {path!r}: graph {graph} "
                         f"could not be stored: {type(exc).__name__}: {exc}"
                     ) from exc
-            records.append(
-                GraphRecord(
-                    graph=graph, target=path, ingress=ingress, program=program_digest
-                )
-            )
+            records.append(GraphRecord(graph=graph, target=path, ingress=ingress))
 
     unobserved = tuple(sorted(path for path, calls in observed.items() if not calls))
     return LaneGraphs(

--- a/src/gen_worker/_vendor/torchcg/document.py
+++ b/src/gen_worker/_vendor/torchcg/document.py
@@ -27,12 +27,12 @@ from .graph_identity import (
 from .ingress import CallIngress, IngressError
 from .lane import LaneError, require_contract_ref, require_passes, require_targets
 
-DOCUMENT_FORMAT = 2
+DOCUMENT_FORMAT = 3
 _DOCUMENT_FIELDS = frozenset(("v", "stack", "lanes"))
 _LANE_FIELDS = frozenset(
     ("contract", "targets", "graphs", "unobserved_targets", "passes")
 )
-_GRAPH_FIELDS = frozenset(("graph", "target", "ingress", "program"))
+_GRAPH_FIELDS = frozenset(("graph", "target", "ingress"))
 
 
 class DocumentError(ValueError):
@@ -46,17 +46,28 @@ class GraphRecord:
     graph: str
     target: str
     ingress: CallIngress
-    #: CAS digest of the SERIALIZED ExportedProgram for this graph specialization
-    #: (Paul, 2026-08-20: the derive stores the whole traced graph, not just
-    #: its hash -- "we only ever need to run trace() once" now holds
-    #: literally, and the runtime miner downloads this blob and runs inductor
-    #: instead of re-tracing author code). **The NAME is the contract with
-    #: the mint lane**, which reads it as `PROGRAM_DIGEST_FIELD = "program"`
-    #: (pgw#962) and raises `MissingProgramDigest` on an empty one. Empty
-    #: only when the producer stored no blob. Portability is fenced by the
-    #: document's own compile stack: an ExportedProgram is torch-coupled, and
-    #: the stack pins torch.
-    program: str = ""
+
+    # NO `program` FIELD, AND ITS ABSENCE IS THE CONTRACT (Paul, 2026-08-19:
+    # "program blobs are ADDRESS-FREE -- the identity is the contract, bytes
+    # are local"). It used to carry the CAS digest of this specialization's
+    # serialized ExportedProgram, on the premise that the blob would travel
+    # and the miner would download rather than re-trace.
+    #
+    # THE PREMISE WAS FALSE, and it was measured rather than argued
+    # (pgw#1462 part 2): sd15 re-traced at its own pinned gen-worker, with a
+    # byte-identical 17-row compile stack, reproduced 14/14 GRAPH HASHES and
+    # 0/14 program digests. `torch.export.save` is deterministic within a
+    # machine and different across machines whose declared inputs are
+    # identical. So the digest was a machine-scoped address inside a document
+    # every machine is supposed to agree on -- it made the document itself
+    # unportable, which is why `lock --check` reported drift on unchanged
+    # trees.
+    #
+    # What replaces it: nothing in the document. The GRAPH HASH is the
+    # identity a mint matches on, and each machine keeps its own serialized
+    # programs in its own store, keyed by that hash (`LocalGraphStore
+    # .put_program`). Bytes stay local, exactly as the author-time-lock
+    # ruling always said they should.
 
     def __post_init__(self) -> None:
         if not is_graph_hash(self.graph):
@@ -65,15 +76,12 @@ class GraphRecord:
             raise DocumentError("graph record must name its target module path")
         if not isinstance(self.ingress, CallIngress):
             raise DocumentError("graph record must carry its CallIngress contract")
-        if not isinstance(self.program, str):
-            raise DocumentError("graph program digest must be a string")
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "graph": self.graph,
             "target": self.target,
             "ingress": self.ingress.as_dict(),
-            "program": self.program,
         }
 
 
@@ -261,7 +269,6 @@ class GraphSetDocument:
                         graph=raw_record["graph"],
                         target=raw_record["target"],
                         ingress=ingress,
-                        program=raw_record["program"],
                     )
                 )
             lanes.append(

--- a/src/gen_worker/_vendor/torchcg/store.py
+++ b/src/gen_worker/_vendor/torchcg/store.py
@@ -119,6 +119,20 @@ def _manifest_ref(graph: str, env: EnvIdentity) -> str:
     return f"{_REF_PREFIX}/manifests/{_require_graph(graph)}/{env.value}"
 
 
+def _program_ref(graph: str) -> str:
+    """This machine's serialized ExportedProgram for one graph specialization.
+
+    KEYED BY THE GRAPH HASH, never by the blob's own digest, and that is the
+    whole of the address-free ruling (Paul, 2026-08-19). `torch.export.save`
+    emits different bytes on different machines for the same traced graph
+    (pgw#1462p2: 14/14 identities, 0/14 blob digests), so the blob digest is a
+    machine-scoped fact and cannot appear in a document every machine must
+    agree on. The graph hash IS reproducible, so it is the key here and the
+    identity in the document, and the bytes never leave the box that made them.
+    """
+    return f"{_REF_PREFIX}/programs/{_require_graph(graph)}"
+
+
 def _side_table_ref(pass_name: str, key: str) -> str:
     """A transform pass's minted side table, addressed by (pass, domain key).
 
@@ -299,6 +313,53 @@ class LocalGraphStore:
             ) from exc
 
     # -- transform side tables (tcg#52) -------------------------------------
+
+    def has_program(self, graph: str) -> bool:
+        return self.cas.read_ref(_program_ref(graph)) is not None
+
+    def fetch_program(self, graph: str, destination: str | Path) -> Path | None:
+        """This machine's serialized program for ``graph``, or None.
+
+        None is an ordinary answer: a box that has not traced this endpoint
+        yet simply has no programs, and the caller's remedy is to derive
+        rather than to fetch from anywhere.
+        """
+        ref = self.cas.read_ref(_program_ref(graph))
+        if ref is None:
+            return None
+        try:
+            blob = self.cas.verify_object(ref)
+        except (DigestMismatch, FileNotFoundError, ValueError) as exc:
+            raise StoreError(
+                f"program for {graph} failed CAS verification: {exc}"
+            ) from exc
+        return self._copy_out(blob, destination)
+
+    def put_program(self, graph: str, path: str | Path) -> str:
+        """Bank this machine's serialized program for ``graph``.
+
+        LAST WRITE WINS, and this is deliberately NOT the side table's
+        "divergence refuses" rule. Two traces of one graph on one machine
+        produce identical bytes, but a torch upgrade in place legitimately
+        produces different ones for the same graph identity, and refusing
+        would strand the box on its first re-derive after an upgrade. The
+        bytes are local and cheap to recreate; the identity is what is
+        protected, and it is protected by the key.
+        """
+        source = Path(path)
+        if not source.is_file():
+            raise StoreError(f"program {source} is not a file")
+        candidate = self._admit_file(source)
+        ref_name = _program_ref(graph)
+        while True:
+            current = self.cas.read_ref(ref_name)
+            if current == candidate:
+                return str(candidate)
+            try:
+                self.cas.compare_and_swap_ref(ref_name, candidate, expected=current)
+            except RefConflict:
+                continue
+            return str(candidate)
 
     def has_side_table(self, pass_name: str, key: str) -> bool:
         return self.cas.read_ref(_side_table_ref(pass_name, key)) is not None

--- a/src/gen_worker/cli/endpoint_lock.py
+++ b/src/gen_worker/cli/endpoint_lock.py
@@ -21,7 +21,7 @@ Two rules this module exists to enforce, both from the 2026-08-19
    digests up to the top level for convenience. Every such copy is a second
    place a producer can lie, and a reader that trusts the copy over the document
    is the bug. Callers that want a specialization read it back OUT of the
-   document (:func:`program_digests`), which is why that function parses rather
+   document (:func:`graph_identities`), which is why that function parses rather
    than looks up.
 2. **Hashes are opaque addresses.** ``specialization_hash`` folds
    ``specialization_dims`` into itself and is the graph axis of every cg-key. We
@@ -197,23 +197,26 @@ def tracer_digest() -> str:
     return h.hexdigest()
 
 
-def program_digests(document: Mapping[str, Any]) -> tuple[str, ...]:
-    """Every exported-program CAS digest the document names, deduped + sorted.
+def graph_identities(document: Mapping[str, Any]) -> tuple[str, ...]:
+    """Every graph IDENTITY the document names, deduped + sorted.
 
     Parsed out of the document on demand and deliberately NOT stored beside it:
     a stored copy is a fact that can disagree with its source. The walk is
-    structural (any ``program`` key under ``graphs``) rather than a fixed path,
+    structural (any ``graph`` key under ``graphs``) rather than a fixed path,
     because the graph document's nesting is torchcg's to change and this reader
     must not encode a second copy of its schema.
+
+    This used to collect ``program`` blob ADDRESSES. It cannot: a blob digest is
+    machine-scoped (pgw#1462p2 measured 14/14 identities reproducing across
+    boxes and 0/14 blob digests), so it is not in the document any more. The
+    identity is, and it is what a local store is keyed by.
     """
     found: set[str] = set()
 
     def walk(node: Any) -> None:
         if isinstance(node, dict):
             for key, value in node.items():
-                # torchcg spells the exported-program address `program` (the
-                # digest `_program_sink` returned). Anything else recurses.
-                if key == "program" and isinstance(value, str) and value:
+                if key == "graph" and isinstance(value, str) and value:
                     found.add(value)
                 else:
                     walk(value)
@@ -335,12 +338,12 @@ def derive_is_reusable(
 ) -> Reuse:
     """The skip check: can we serve this lock's trace instead of re-deriving?
 
-    ``cas_has`` is a predicate over an exported-program digest (typically
-    ``LocalCAS.contains``). It is checked because the document and the blobs are
-    stored SEPARATELY by design — a garbage-collected CAS leaves a lock whose
-    document is intact and whose programs are gone, and re-deriving is the only
-    correct response. Pass ``None`` to skip the blob check when the caller does
-    not need the programs (e.g. `run`, which never compiles).
+    ``cas_has`` is a predicate over a GRAPH IDENTITY (typically
+    ``LocalGraphStore.has_program``). It is checked because the document and the
+    bytes are stored SEPARATELY by design — a garbage-collected CAS leaves a
+    lock whose document is intact and whose programs are gone, and re-deriving
+    is the only correct response. Pass ``None`` to skip the check when the
+    caller does not need the programs (e.g. `run`, which never compiles).
     """
     if block is None:
         return Reuse(False, "no [derive] block — the trace was never saved")
@@ -373,13 +376,14 @@ def derive_is_reusable(
     except LockError as exc:
         return Reuse(False, str(exc))
     if cas_has is not None:
-        missing = [d for d in program_digests(document) if not cas_has(d)]
+        missing = [g for g in graph_identities(document) if not cas_has(g)]
         if missing:
             return Reuse(
                 False,
-                f"{len(missing)} exported-program blob(s) named by the document "
-                f"are not in the CAS (first: {missing[0]}) — the document "
-                f"survived a GC its programs did not",
+                f"this box holds no serialized program for {len(missing)} of "
+                f"the graphs the document names (first: {missing[0]}) — the "
+                f"document survived a GC its programs did not, or it was "
+                f"derived on another box",
             )
     return Reuse(True, "inputs unchanged and every program blob present",
                  block=block, document=document)
@@ -451,7 +455,7 @@ __all__ = [
     "Reuse",
     "derive_is_reusable",
     "inputs_digest",
-    "program_digests",
+    "graph_identities",
     "read_derive_block",
     "read_lock",
     "source_files",

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -297,12 +297,15 @@ def run_lock(args: argparse.Namespace) -> int:
             slot_trees,
         )
 
-    cas = ws.local_cas(graph_cas_root)
+    store = ws.local_graph_store(graph_cas_root)
     reuse = el.derive_is_reusable(
         existing,
         want_inputs_digest=want,
         want_trace_device=device,
-        cas_has=lambda digest: bool(cas.contains(digest)),
+        # BY GRAPH IDENTITY. The saved trace is reusable only if THIS box still
+        # holds a serialized program for every graph the document names — a
+        # question about local bytes, asked with the one key that is portable.
+        cas_has=lambda graph: bool(store.has_program(graph)),
     )
     if reuse.ok and not args.force:
         # The whole point of the verb. Rewrite the lock so freshly-discovered
@@ -355,7 +358,7 @@ def run_lock(args: argparse.Namespace) -> int:
     el.write_lock(out, manifest, block)
 
     graphs = sum(len(h) for h in result.lane_graphs.values())
-    programs = el.program_digests(json.loads(result.document))
+    programs = el.graph_identities(json.loads(result.document))
     _say_posture(result)
     # pgw#1449: an entrypoint the enumerator could not reach no longer kills
     # the lock — it is written with everything that COULD be enumerated and
@@ -365,7 +368,9 @@ def run_lock(args: argparse.Namespace) -> int:
         _say(f"lock: entrypoint {name} NOT enumerated -- {reason}")
     _say(
         f"lock: traced {graphs} specialization(s), {len(programs)} exported "
-        f"program(s) in the CAS at {graph_cas_root} ({elapsed:.1f}s)"
+        f"program(s) banked BY GRAPH IDENTITY in the CAS at {graph_cas_root} "
+        f"({elapsed:.1f}s) — the bytes stay on this box; the document carries "
+        f"identities, never their addresses"
     )
     _say(f"lock: wrote {out}")
     print(json.dumps({

--- a/src/gen_worker/cli/workspace.py
+++ b/src/gen_worker/cli/workspace.py
@@ -170,6 +170,18 @@ def tree_bytes(tree: Path) -> int:
     return sum(p.stat().st_size for p in tree.rglob("*") if p.is_file())
 
 
+def local_graph_store(root: Path) -> Any:
+    """torchcg's ``LocalGraphStore`` over the graph CAS at ``root``.
+
+    The store, not the bare CAS, because since the address-free ruling the
+    programs are addressed BY GRAPH IDENTITY and the graph->bytes ref is the
+    store's to own (``has_program`` / ``fetch_program`` / ``put_program``).
+    """
+    from .._vendor.torchcg.store import LocalGraphStore
+
+    return LocalGraphStore(local_cas(root))
+
+
 def local_cas(root: Path) -> Any:
     """A tensorfs ``LocalCAS`` at ``root``, created if absent.
 

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -221,38 +221,47 @@ def _hollow() -> ModuleType:
 
 
 def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
-    """Store each discovered graph's SERIALIZED ExportedProgram in the CAS.
+    """Bank each discovered graph's SERIALIZED ExportedProgram, KEYED BY GRAPH.
 
-    Paul's ruling (2026-08-20): the derive keeps THE WHOLE TRACED GRAPH, not
-    just its hash -- "we only ever need to run trace() once" now holds
-    literally. The runtime miner downloads this blob and runs inductor on
-    it; it never re-traces and never executes author code at mint time.
+    Paul, 2026-08-19 (address-free): the bytes are local and their digest is
+    machine-scoped, so nothing about them travels. What the document carries
+    is the cg-graph-v1 identity; what this stores is one machine's bytes for
+    that identity, under it. A mint on any box asks its own store for
+    "the program for graph X" and never for a digest somebody else computed.
 
-    Bytes-at-rest is tensorfs's charter (LIBRARY-BOUNDARIES), so the blob
-    goes into a tensorfs ``LocalCAS`` and only its digest travels in the
-    release document, beside the cg-graph-v1 hash and the ingress spec.
-    Portability needs no new fence: an ExportedProgram is torch-coupled and
-    the document's own compile stack pins torch -- the same validity rule
-    compiled artifacts already live under.
+    Measured reason (pgw#1462p2): sd15 re-traced at its own pinned gen-worker,
+    with a byte-identical 17-row compile stack, reproduced 14/14 GRAPH HASHES
+    and 0/14 blob digests. `torch.export.save` is deterministic within a
+    machine and different across machines, so a blob digest in a shared
+    document is an address nobody else can resolve — and it made the document
+    itself unportable.
+
+    Bytes-at-rest is tensorfs's charter (LIBRARY-BOUNDARIES), so the blob goes
+    into a tensorfs ``LocalCAS`` through torchcg's ``LocalGraphStore``, which
+    owns the graph->bytes ref.
     """
 
     if cas_root is None:
         return None
 
-    import io
+    import tempfile
 
     import torch
 
     from .._vendor.tensorfs import LocalCAS
+    from .._vendor.torchcg.store import LocalGraphStore
 
-    cas = LocalCAS(Path(cas_root))
+    store = LocalGraphStore(LocalCAS(Path(cas_root)))
 
-    def sink(graph: str, program: Any) -> str:
+    def sink(graph: str, program: Any) -> None:
         _assert_weights_free(torch, program)
-        buffer = io.BytesIO()
-        torch.export.save(program, buffer)
-        del graph
-        return str(cas.put_bytes(buffer.getvalue()))
+        # torch.export.save to a FILE, because the store admits files: it
+        # hashes and links them in, so a large program never has to exist
+        # twice in memory the way a BytesIO round-trip forces.
+        with tempfile.TemporaryDirectory() as scratch:
+            staged = Path(scratch) / "program.pt2"
+            torch.export.save(program, str(staged))
+            store.put_program(graph, staged)
 
     return sink
 

--- a/src/gen_worker/serving/__init__.py
+++ b/src/gen_worker/serving/__init__.py
@@ -60,7 +60,7 @@ from .mint import (
     MintOutcome,
     MintProgress,
     MintedHole,
-    MissingProgramDigest,
+    MissingProgram,
     mint_holes,
 )
 from .loader import (
@@ -142,7 +142,7 @@ __all__ = [
     "MintOutcome",
     "MintProgress",
     "MintedHole",
-    "MissingProgramDigest",
+    "MissingProgram",
     "Model",
     "ModelDeclarationError",
     "ModelInstance",

--- a/src/gen_worker/serving/hub_store.py
+++ b/src/gen_worker/serving/hub_store.py
@@ -27,8 +27,7 @@ and the route answers something else::
      "sm": "sm_89", "empty": false, "hits": 30, "misses": 6,
      "graphs": [{"graph_hash": "cg-graph-v1:...", "graph_specialization": "...",
                  "status": "hit"|"miss"|"transport_unavailable",
-                 "found": true, "program": "sha256:...",
-                 "module_path": "...", "ingress": {...},
+                 "found": true, "module_path": "...", "ingress": {...},
                  "content_digest": "...", "artifact_path": "...",
                  "requirements_manifest": {...},
                  "transport": {"snapshot_digest": ..., "files": [...]}}, ...],
@@ -47,7 +46,11 @@ import tempfile
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Protocol
 
-from .._vendor.torchcg.document import DocumentError, GraphSetDocument
+from .._vendor.torchcg.document import (
+    DOCUMENT_FORMAT,
+    DocumentError,
+    GraphSetDocument,
+)
 from .._vendor.torchcg.graph_identity import EnvIdentity
 from .._vendor.torchcg.requirements import RequirementsError, RequirementsManifest
 from .._vendor.torchcg.store import PublishOutcome, StoreError
@@ -279,11 +282,15 @@ class HubGraphStore:
                         f"{row.get('graph_hash')!r} carries no ingress contract; "
                         f"the adopt answer cannot be dispatched against"
                     )
+                # NO `program`: the reconstructed document is address-free
+                # (Paul, 2026-08-19). The hub may still send the key on rows it
+                # stamped before the ruling; it is not read, because a
+                # serialized program's digest is machine-scoped and this pod
+                # can only use bytes it made — found by the graph identity.
                 records.append({
                     "graph": str(row.get("graph_hash") or ""),
                     "target": str(row.get("module_path") or ""),
                     "ingress": ingress,
-                    "program": str(row.get("program") or ""),
                 })
             observed = {record["target"] for record in records}
             declared = [
@@ -315,8 +322,14 @@ class HubGraphStore:
                 ],
             })
         try:
+            # DOCUMENT_FORMAT, never a literal: this reconstructs a document
+            # for torchcg's own decoder, so the version is torchcg's to state.
+            # A hardcoded 2 here silently stopped decoding the moment the
+            # address-free change bumped it to 3, and the only symptom was
+            # `sink_for` returning None — i.e. a pod serving eager for a reason
+            # nothing printed.
             self._document = GraphSetDocument.decode(
-                {"v": 2, "stack": stack, "lanes": lanes}
+                {"v": DOCUMENT_FORMAT, "stack": stack, "lanes": lanes}
             )
         except DocumentError as exc:
             raise StoreError(

--- a/src/gen_worker/serving/mint.py
+++ b/src/gen_worker/serving/mint.py
@@ -735,30 +735,30 @@ def _version(raw: str) -> Tuple[int, ...]:
 
 #: The field on a ``GraphRecord`` carrying the CAS digest of that graph's
 #: SERIALIZED ``ExportedProgram`` (Paul, 2026-08-18). The derive lane emits
-#: it; this lane consumes it; the name is the contract between them and is
-#: stated in one place so neither side spells it twice.
-PROGRAM_DIGEST_FIELD = "program"
+#: THE HOLE'S KEY IS ITS GRAPH HASH, not a blob digest (Paul, 2026-08-19:
+#: "program blobs are ADDRESS-FREE — the identity is the contract, bytes are
+#: local"). The document states the identity; every box resolves its own
+#: serialized program under it.
+PROGRAM_GRAPH_FIELD = "graph"
 
 
-class MissingProgramDigest(RuntimeError):
-    """A hole names no serialized graph — there is nothing to compile.
+class MissingProgram(RuntimeError):
+    """This box holds no serialized graph for the identity this hole names.
 
-    Never a re-trace: running author code at mint time is exactly what the
-    blob-in design removes. A record without its digest is a DERIVE defect,
-    reported against that graph and costing only that graph.
+    NOT a derive defect and NOT a broken document: the ordinary cause is a box
+    that has not derived this endpoint yet, and the remedy is local — derive
+    (`gen-worker lock`, or `compile`) so the programs land in this machine's
+    own store. Costs its own graph and never the boot.
     """
 
 
-def program_digest(record: Any) -> str:
-    """The serialized-``ExportedProgram`` digest this hole must compile."""
-    value = str(getattr(record, PROGRAM_DIGEST_FIELD, "") or "")
+def program_graph(record: Any) -> str:
+    """The GRAPH IDENTITY this hole must compile, as the document states it."""
+    value = str(getattr(record, PROGRAM_GRAPH_FIELD, "") or "")
     if not value:
-        raise MissingProgramDigest(
-            f"graph {getattr(record, 'graph', '?')} carries no "
-            f"{PROGRAM_DIGEST_FIELD!r} digest, so the mint has no serialized "
-            f"graph to compile. The worker NEVER re-traces (author code does "
-            f"not run at mint time): re-emit the release document with the "
-            f"graph blob published to the CAS"
+        raise MissingProgram(
+            "a mint hole carries no graph identity at all, so nothing can be "
+            "resolved for it — the release document is malformed"
         )
     return value
 
@@ -853,8 +853,11 @@ class BackgroundMint:
     cas_dir: Optional[Path] = None
     target_arch: str = ""
     toolchain: Mapping[str, str] = field(default_factory=dict)
-    #: Fetch one serialized graph by digest: (digest, destination) -> path.
-    #: Defaults to the store's own ``fetch_program``.
+    #: Resolve one serialized graph BY GRAPH IDENTITY:
+    #: (graph_hash, destination) -> path. Defaults to the store's own
+    #: ``fetch_program``. Keyed by identity and not by a blob digest because a
+    #: blob digest is machine-scoped (pgw#1462p2) and this box's bytes are the
+    #: only ones it can use.
     program_source: Optional[Callable[[str, Path], Path]] = None
     posture: compile_posture.CompilePosture = compile_posture.FLEET
     reserve: int = SERVING_RESERVE_CPUS
@@ -1024,24 +1027,30 @@ class BackgroundMint:
         any point leaves the fleet strictly better off and never leaves a
         dispatcher pointed at bytes nobody else can fetch.
 
-        Step one is a DOWNLOAD, not a trace (Paul, 2026-08-18): the release
-        holds each graph's serialized ``ExportedProgram`` and the document
-        pins it by digest, so the worker runs inductor over bytes it fetched.
-        No author code runs at mint time, no weights are read, and a mint can
-        no longer diverge from the graph the release actually shipped.
+        Step one RESOLVES this box's serialized ``ExportedProgram`` for the
+        graph IDENTITY the document names (Paul, 2026-08-19, address-free).
+        The document pins the identity, not an address: `torch.export.save`
+        emits different bytes on different machines for the same traced graph
+        (pgw#1462p2 — 14/14 identities reproduce, 0/14 blob digests do), so an
+        address in a shared document is unresolvable by construction. Matching
+        on the identity is what makes a stamped release mintable on a box that
+        did not produce it.
+
+        No weights are read here, and a mint still cannot diverge from the
+        graph the release shipped: the identity IS the graph.
         """
         env = self.host.adoption.env
         destination = self.artifacts_dir / env.value / f"{record.graph}.so"
         destination.parent.mkdir(parents=True, exist_ok=True)
 
-        digest = program_digest(record)
+        graph = program_graph(record)
         if self.program_source is None:
-            raise MissingProgramDigest(
-                f"graph {record.graph} names program {digest} but this mint "
-                f"has no source to fetch it from (the store exposes no "
-                f"`fetch_program` and no `program_source` was stated)")
+            raise MissingProgram(
+                f"graph {graph} has no program source on this mint (the store "
+                f"exposes no `fetch_program` and no `program_source` was "
+                f"stated)")
         blob = Path(self.program_source(
-            digest, self.artifacts_dir / "programs" / f"{digest}.pt2"))
+            graph, self.artifacts_dir / "programs" / f"{graph}.pt2"))
 
         assert self.compiler is not None  # __post_init__ guarantees it
         artifact = Path(self.compiler(blob, record, destination))
@@ -1180,8 +1189,8 @@ __all__ = [
     "ArtifactUnreadable",
     "ChildCompileFailed",
     "ContractModuleMissing",
-    "MissingProgramDigest",
-    "PROGRAM_DIGEST_FIELD",
+    "MissingProgram",
+    "PROGRAM_GRAPH_FIELD",
     "artifact_constraints",
     "assert_satisfied",
     "present_libraries",
@@ -1192,5 +1201,5 @@ __all__ = [
     "entry_workers",
     "hole_work_list",
     "mint_holes",
-    "program_digest",
+    "program_graph",
 ]

--- a/src/gen_worker/serving/mint_store.py
+++ b/src/gen_worker/serving/mint_store.py
@@ -44,6 +44,17 @@ from .. import activity as activity_mod
 
 logger = logging.getLogger(__name__)
 
+
+def _store_faults() -> tuple[type[BaseException], ...]:
+    """The store's own "these bytes are bad" vocabulary, imported not guessed."""
+    from .._vendor.tensorfs.local import DigestMismatch
+    from .._vendor.torchcg.store import StoreError
+
+    return (StoreError, DigestMismatch, FileNotFoundError, ValueError)
+
+
+_STORE_FAULTS = _store_faults()
+
 #: The typed fact: this pod minted a graph and the FLEET does not have it.
 #: A mint that is only pod-local is not the mint this program promises, so it
 #: says so on the wire rather than reading as a clean publish.
@@ -114,83 +125,94 @@ class TieredGraphStore:
             return found
         return self.upstream.get_manifest(graph, env)
 
-    def fetch_program(self, digest: str, destination: Path) -> Path:
-        """One graph's serialized ``ExportedProgram`` — the mint's INPUT.
+    def fetch_program(self, graph: str, destination: Path) -> Path:
+        """This box's serialized ``ExportedProgram`` for one GRAPH IDENTITY.
 
-        THREE tiers, cheapest-and-most-trusted first: an upstream that can
-        serve one, then the pod's own CAS, then the IMAGE's baked CAS. All
-        three are keyed by CONTENT ADDRESS, so the order is a cost decision
-        and never a correctness one — a digest is a digest.
+        KEYED BY IDENTITY, NOT BY ADDRESS (Paul, 2026-08-19, address-free). The
+        document states which graph a hole is; it states nothing about where
+        bytes live, because a serialized program's digest is machine-scoped —
+        pgw#1462p2 measured 14/14 graph identities reproducing across boxes and
+        0/14 blob digests. A box can only use bytes it made, and the identity is
+        the one key every box agrees on, so it is the key here.
 
-        **THE BAKED TIER IS pgw#1462 PART 2, and it closes a gap that was
-        assumed closed.** th#2162 argued no hub route was needed because
-        *"pgw's miner already falls through to its local CAS by content
-        address"*. The fallthrough is real; the directory was wrong. The pod's
-        CAS is ``<TENSORHUB_CACHE_DIR>/cas`` (``/tmp/tensorhub-cache/cas``) and
-        the builder bakes to ``/app/.tensorhub/derive-cas``, so every baked blob
-        has been unreachable since the first image carried one — a permanent
-        silent miss, which is why nothing ever reported it.
+        Two tiers, cheapest first: this pod's own store, then the IMAGE's baked
+        one. Both answer the same question under the same key, so the order is a
+        cost decision and never a correctness one.
 
-        **THE BYTES ARE VERIFIED BEFORE THEY ARE TRUSTED, BY THE STORE'S OWN
-        SCRUB.** These bytes are fed straight to a compiler, so each tier is
-        probed with ``verify_object`` — presence AND integrity in one call —
-        rather than with ``contains`` plus a hash written here. Two reasons it
-        is that call and not the obvious one: a second implementation of
-        integrity checking is a second thing that can disagree, and the two
-        tensorfs snapshots in this tree DISAGREE about ``contains`` — the
-        vendored one rehashes and RAISES ``DigestMismatch``, tensorfs master's
-        is "presence, not integrity" and answers True for bytes corrupted in
-        place. ``verify_object`` means the same thing in both, so this code
-        does not silently change behaviour when the vendor is re-synced.
+        **THE BAKED TIER (pgw#1462 part 2) STAYS, with its scope narrowed.** The
+        pod's store is ``<TENSORHUB_CACHE_DIR>/cas`` and the builder bakes to
+        ``/app/.tensorhub/derive-cas`` — two directories, which is why baked
+        programs were unreachable for as long as they existed. It is still
+        exactly right for the REGENERATE arm, where the build container derived
+        the document and the bytes together so its programs answer for the
+        identities the document names. It cannot serve a release stamped from a
+        committed lock — those bytes were never on this machine — and that case
+        is rescued by the identity instead, which lets a LOCAL derive supply
+        them.
+
+        **THE BYTES ARE VERIFIED BEFORE THEY ARE TRUSTED**, by the store's own
+        scrub: ``LocalGraphStore.fetch_program`` verifies the object behind the
+        graph ref and raises rather than hand back bytes that no longer hash to
+        what was banked. These go straight to a compiler.
 
         **A CORRUPT TIER IS A MISS, NOT A DEATH** — the next tier may hold a
-        good copy, and preferring it is strictly better than refusing. But the
-        corruption is REMEMBERED: if nothing serves the blob, the refusal names
-        it, because "no tier had it" and "a tier had it and it was rotten" have
-        very different remedies.
+        good copy. The corruption is REMEMBERED: if nothing serves the program,
+        the refusal names it, because "no tier had it" and "a tier had it and it
+        was rotten" have very different remedies.
 
-        A blob no tier holds stays a TYPED PER-GRAPH refusal — it costs its own
-        graph and never the boot.
+        A program no tier holds stays a TYPED PER-GRAPH refusal — it costs its
+        own graph and never the boot.
         """
+        # A MALFORMED KEY IS NOT CORRUPT BYTES. The store validates the graph
+        # spelling and raises `StoreError` for a bad one — indistinguishable,
+        # inside the loop below, from "these bytes are rotten", which would
+        # send the reader to scrub a disk over a wrong argument. Checked once,
+        # here, against torchcg's own predicate.
+        from .._vendor.torchcg import is_graph_hash
+
+        if not is_graph_hash(graph):
+            raise ProgramBlobUnreachable(
+                f"{graph!r} is not a cg-graph-v1 identity, so no store can be "
+                f"asked for a program under it. A mint hole is keyed by the "
+                f"graph the document names — not by a blob digest, which since "
+                f"the address-free ruling is not in the document at all."
+            )
         fetch = getattr(self.upstream, "fetch_program", None)
         if fetch is not None:
-            return Path(fetch(digest, destination))
+            return Path(fetch(graph, destination))
         rotten: list[str] = []
-        for tier, cas in (("this pod's own", getattr(self.local, "cas", None)),
-                          ("the image's baked", self.baked)):
-            if cas is None:
+        for tier, store in (("this pod's own", self.local),
+                            ("the image's baked", self.baked)):
+            if store is None:
                 continue
             try:
-                source = Path(cas.verify_object(digest))
-            except FileNotFoundError:
-                continue  # an ordinary miss: this tier does not hold it
-            except Exception as exc:  # noqa: BLE001 - any scrub failure is an answer
-                rotten.append(f"{tier} CAS ({type(exc).__name__}: {exc})")
+                found = store.fetch_program(graph, destination)
+            except _STORE_FAULTS as exc:
+                # NARROW ON PURPOSE. A blanket `except Exception` here reported
+                # an `AttributeError` — a wiring mistake — as "corrupted at
+                # rest", which sends the reader to scrub a disk over a typo.
+                # Only the store's OWN failure vocabulary means "these bytes
+                # are bad"; anything else is this code being wrong and must
+                # surface as itself.
+                rotten.append(f"{tier} store ({type(exc).__name__}: {exc})")
                 continue
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_bytes(source.read_bytes())
-            return destination
+            if found is not None:
+                return Path(found)
         if rotten:
             raise ProgramBlobUnreachable(
-                f"graph blob {digest} is present but does not survive its own "
-                f"integrity scrub in " + "; ".join(rotten) + " — the object was "
-                "truncated or corrupted at rest, and no other tier holds a good "
-                "copy. Refusing to compile bytes that are not the graph the "
-                "release stamped."
+                f"the serialized program for {graph} is present but does not "
+                f"survive its own integrity scrub in " + "; ".join(rotten) +
+                " — truncated or corrupted at rest, and no other tier holds a "
+                "good copy."
             )
         raise ProgramBlobUnreachable(
-            f"graph blob {digest} is in neither this pod's CAS nor the image's "
-            f"baked program CAS, and the adopt answer offers no transport for "
-            f"it: th#2133's per-graph rows carry the `program` DIGEST but "
-            f"presign only the compiled artifact. An image whose build used a "
-            f"COMMITTED endpoint.lock bakes no programs (th#2162 renders no "
-            f"derive step for it), which is the ordinary way to reach this, and "
-            f"the blobs are NOT regenerable here: a re-trace reproduces the "
-            f"graph identity but not the serialized bytes, so it would address "
-            f"different digests than the release stamped. pgw#1370 owns "
-            f"emitting these blobs where the pod can reach them. "
-            f"This mint will NEVER re-trace to work around it (author code "
-            f"does not run at mint time)."
+            f"this box holds no serialized program for graph {graph}. That is "
+            f"ORDINARY on a pod that has not derived this endpoint yet, and the "
+            f"remedy is LOCAL: derive here (`gen-worker lock`, or `compile`) so "
+            f"the programs land in this machine's own store under the identity "
+            f"the release stamped. Nothing is fetched from anywhere — a "
+            f"serialized program's bytes are machine-scoped (pgw#1462p2), so "
+            f"the only ones this box can compile are the ones it made."
         )
 
     # -- the mint's publish -------------------------------------------------
@@ -255,10 +277,15 @@ def worker_store(
     from .._vendor.torchcg.store import LocalGraphStore
 
     root = baked_program_cas_dir() if baked_root is None else Path(baked_root)
-    # A read-only tier: LocalCAS is opened on an EXISTING directory only, so a
-    # missing bake never creates one. `LocalCAS.__init__` mkdirs, so absence is
-    # decided before it is constructed, not by it.
-    baked = LocalCAS(root) if root is not None and Path(root).is_dir() else None
+    # A read-only tier, and a GraphStore rather than a bare CAS because the
+    # programs are addressed by graph identity now. Opened on an EXISTING
+    # directory only: `LocalCAS.__init__` mkdirs, so absence is decided before
+    # it is constructed, not by it.
+    baked = (
+        LocalGraphStore(LocalCAS(root))
+        if root is not None and Path(root).is_dir()
+        else None
+    )
     return TieredGraphStore(LocalGraphStore(LocalCAS(Path(cas_dir))), upstream, baked)
 
 

--- a/tests/test_mint_publish_shape.py
+++ b/tests/test_mint_publish_shape.py
@@ -192,8 +192,7 @@ def test_mint_one_compiles_publishes_and_manifests_through_the_REAL_store(
         def arm(self, record: Any, artifact: Path) -> None:
             armed.append(record.graph)
 
-    record = SimpleNamespace(
-        graph=GRAPH, target="unet", program="sha256:" + "0" * 64)
+    record = SimpleNamespace(graph=GRAPH, target="unet")
     host = SimpleNamespace(holes=(SimpleNamespace(record=record),),
                            adoption=_Adoption())
 

--- a/tests/test_program_blob_tiers.py
+++ b/tests/test_program_blob_tiers.py
@@ -1,12 +1,13 @@
-"""The mint's INPUT: where a serialized ExportedProgram is found, and refused.
+"""The mint's INPUT: which serialized ExportedProgram a hole gets, and why.
 
-# pgw#1462 part 2: the image bakes the release's graph blobs and the pod's own
-# CAS is a different directory, so the miner's content-address fallthrough has
-# never reached them.
+# pgw#1462 part 2: the image bakes the release's programs and the pod's own
+# store is a different directory, so the miner's fallthrough never reached them.
+# pgw#1462 address-free: the key is the GRAPH IDENTITY, never a blob digest.
 
-The defect these fence is a SILENT one, which is why it survived: a cache miss
-reports nothing, so a tier looking in the wrong directory and a release with no
-blobs at all produce the same observable — an eager pod.
+Two defects meet here and both were SILENT, which is why they survived: a miss
+reports nothing, so a tier looking in the wrong directory, a release whose
+programs were made on another machine, and an endpoint with no graphs at all all
+produced one observable — an eager pod.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from gen_worker._vendor.tensorfs import LocalCAS
+from gen_worker._vendor.torchcg.store import LocalGraphStore
 from gen_worker.models.cache_paths import BAKED_PROGRAM_CAS_DIR, baked_program_cas_dir
 from gen_worker.serving.mint_store import (
     ProgramBlobUnreachable,
@@ -26,23 +28,28 @@ from gen_worker.serving.mint_store import (
 
 PROGRAM = b"\x80\x05serialized-exported-program-bytes" * 64
 
+#: A real cg-graph-v1 identity, the shape torchcg emits and the ONLY key a
+#: document carries since the address-free ruling.
+GRAPH = "cg-graph-v1-" + "9715a0114f7aef25b359294fea1c1b0ca33c3d3e7e17cccabaaa942d"
 
-def _seed(root: Path, blob: bytes = PROGRAM) -> str:
-    """Put ``blob`` in a real LocalCAS and return its ``sha256:`` address."""
-    cas = LocalCAS(root)
-    ref = cas.put_bytes(blob)
-    digest = f"sha256:{hashlib.sha256(blob).hexdigest()}"
-    assert str(ref) in (digest, digest.split(":", 1)[1]), f"unexpected ref {ref}"
-    return digest
+#: torchcg's own ref spelling for a graph's serialized program. Restated here
+#: ONLY to corrupt an object on purpose; production code never spells it.
+_PROGRAM_REF = "torchcg/v2/programs/%s"
+
+
+def _seed(root: Path, blob: bytes = PROGRAM, graph: str = GRAPH) -> str:
+    """Bank ``blob`` as the serialized program for ``graph``, by IDENTITY."""
+    store = LocalGraphStore(LocalCAS(root))
+    staged = root.parent / f"staged-{abs(hash(graph)) % 10000}.pt2"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.write_bytes(blob)
+    store.put_program(graph, staged)
+    return graph
 
 
 def _local_tier(root: Path) -> object:
-    """A stand-in for LocalGraphStore: the mint reads only its `.cas`."""
-
-    class _Store:
-        cas = LocalCAS(root)
-
-    return _Store()
+    """The pod's own store — a real LocalGraphStore over a real CAS."""
+    return LocalGraphStore(LocalCAS(root))
 
 
 def test_a_baked_blob_is_unreachable_without_the_image_tier(tmp_path: Path) -> None:
@@ -60,11 +67,11 @@ def test_a_baked_blob_is_unreachable_without_the_image_tier(tmp_path: Path) -> N
         without.fetch_program(digest, tmp_path / "out" / "p.pt2")
     # The message has to name the ordinary cause, because the ordinary cause is
     # a build that used a committed lock and therefore baked nothing.
-    assert "COMMITTED endpoint.lock" in str(refusal.value)
+    assert "no serialized program" in str(refusal.value)
 
     # …and the GREEN arm is the same store with the tier wired.
     with_tier = TieredGraphStore(
-        _local_tier(pod_cas), upstream=None, baked=LocalCAS(image_cas)
+        _local_tier(pod_cas), upstream=None, baked=LocalGraphStore(LocalCAS(image_cas))
     )
     got = with_tier.fetch_program(digest, tmp_path / "out" / "p.pt2")
     assert Path(got).read_bytes() == PROGRAM
@@ -73,9 +80,9 @@ def test_a_baked_blob_is_unreachable_without_the_image_tier(tmp_path: Path) -> N
 def test_the_pods_own_cas_still_wins_and_needs_no_image(tmp_path: Path) -> None:
     """The new tier is additive: a pod that already holds the blob never looks."""
     pod_cas = tmp_path / "cas"
-    digest = _seed(pod_cas)
+    graph = _seed(pod_cas)
     store = TieredGraphStore(_local_tier(pod_cas), upstream=None, baked=None)
-    assert Path(store.fetch_program(digest, tmp_path / "p.pt2")).read_bytes() == PROGRAM
+    assert Path(store.fetch_program(graph, tmp_path / "p.pt2")).read_bytes() == PROGRAM
 
 
 def test_corrupted_baked_bytes_are_refused_not_compiled(tmp_path: Path) -> None:
@@ -87,27 +94,33 @@ def test_corrupted_baked_bytes_are_refused_not_compiled(tmp_path: Path) -> None:
     reach inductor.
     """
     image_cas = tmp_path / "derive-cas"
-    digest = _seed(image_cas)
+    graph = _seed(image_cas)
     cas = LocalCAS(image_cas)
-    target = Path(cas.object_path(digest))
+    banked = LocalGraphStore(cas).fetch_program(graph, tmp_path / "peek.pt2")
+    assert banked is not None
+    ref = cas.read_ref(_PROGRAM_REF % graph)
+    assert ref is not None
+    target = Path(cas.object_path(ref))
     target.chmod(0o644)
     target.write_bytes(b"not the graph the release stamped" * 64)
 
     store = TieredGraphStore(
-        _local_tier(tmp_path / "pod"), upstream=None, baked=LocalCAS(image_cas)
+        _local_tier(tmp_path / "pod"), upstream=None,
+        baked=LocalGraphStore(LocalCAS(image_cas)),
     )
     with pytest.raises(ProgramBlobUnreachable) as refusal:
-        store.fetch_program(digest, tmp_path / "p.pt2")
+        store.fetch_program(graph, tmp_path / "p.pt2")
     assert "integrity scrub" in str(refusal.value)
 
     # NEGATIVE CONTROL: without the corruption the same call succeeds, so the
     # assertion above is about the scrub and not about a broken fixture.
     clean = tmp_path / "clean-cas"
-    clean_digest = _seed(clean)
+    clean_graph = _seed(clean)
     ok = TieredGraphStore(
-        _local_tier(tmp_path / "pod2"), upstream=None, baked=LocalCAS(clean)
+        _local_tier(tmp_path / "pod2"), upstream=None,
+        baked=LocalGraphStore(LocalCAS(clean)),
     )
-    assert Path(ok.fetch_program(clean_digest, tmp_path / "ok.pt2")).exists()
+    assert Path(ok.fetch_program(clean_graph, tmp_path / "ok.pt2")).exists()
 
 
 def test_an_upstream_that_can_serve_one_still_wins(tmp_path: Path) -> None:
@@ -119,19 +132,20 @@ def test_an_upstream_that_can_serve_one_still_wins(tmp_path: Path) -> None:
     calls: list[str] = []
 
     class _Upstream:
-        def fetch_program(self, digest: str, destination: Path) -> Path:
-            calls.append(digest)
+        def fetch_program(self, graph: str, destination: Path) -> Path:
+            calls.append(graph)
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(PROGRAM)
             return destination
 
     image_cas = tmp_path / "derive-cas"
-    digest = _seed(image_cas)
+    graph = _seed(image_cas)
     store = TieredGraphStore(
-        _local_tier(tmp_path / "pod"), upstream=_Upstream(), baked=LocalCAS(image_cas)
+        _local_tier(tmp_path / "pod"), upstream=_Upstream(),
+        baked=LocalGraphStore(LocalCAS(image_cas)),
     )
-    store.fetch_program(digest, tmp_path / "p.pt2")
-    assert calls == [digest]
+    store.fetch_program(graph, tmp_path / "p.pt2")
+    assert calls == [graph]
 
 
 def test_a_missing_bake_is_absence_and_never_a_created_directory(

--- a/tests/test_runtime_mint.py
+++ b/tests/test_runtime_mint.py
@@ -55,7 +55,7 @@ class _Adoption:
 def _host(graphs: int, *, arm_raises: BaseException | None = None) -> Any:
     holes = tuple(
         SimpleNamespace(record=SimpleNamespace(
-            graph=f"unet/class={i}", target="unet", program=f"sha256:{i:064x}"))
+            graph=f"unet/class={i}", target="unet"))
         for i in range(graphs))
     return SimpleNamespace(holes=holes, adoption=_Adoption(arm_raises))
 

--- a/tests/test_self_mint_wiring.py
+++ b/tests/test_self_mint_wiring.py
@@ -101,11 +101,11 @@ def document(binding: DeployBinding, tmp_path: Path) -> GraphSetDocument:
 
     lane = discover_lane(LANE, ("unet",), {"unet": model.pipe.unet}, drive)
     host.teardown()
+    # NO program address: the document is address-free, and the mint resolves
+    # this box's own serialized program by the GRAPH IDENTITY below.
     stamped = tuple(
         GraphRecord(
             graph=record.graph, target=record.target, ingress=record.ingress,
-            program="sha256:" + hashlib.sha256(
-                record.graph.encode()).hexdigest(),
         )
         for record in lane.graphs
     )
@@ -445,7 +445,6 @@ def all_miss_answer(document: GraphSetDocument) -> dict:
             {
                 "graph_hash": record.graph,
                 "graph_specialization": "",
-                "program": record.program,
                 "module_path": record.target,
                 "ingress_digest": record.ingress.digest(),
                 "ingress": record.ingress.as_dict(),
@@ -615,27 +614,37 @@ def test_a_minted_artifact_the_fleet_cannot_take_is_still_banked_and_stated(
     assert len(said) == 1 and "pgw#1368" in said[0][2]
 
 
-def test_a_graph_blob_with_no_route_costs_its_graph_and_names_its_owner(
+def test_a_program_this_box_never_made_is_a_typed_per_graph_refusal(
     tmp_path: Path,
 ) -> None:
-    """The mint's INPUT leg is the third unwired one, and it must fail TYPED.
+    """The mint's INPUT leg must fail TYPED, and its remedy is LOCAL.
 
-    th#2133's adopt answer carries each graph's ``program`` digest and presigns
-    only the compiled ARTIFACT, so a pod whose CAS has never seen the
-    serialized graph has no route to it. That is a per-graph refusal naming its
-    owner — never an ``AttributeError``, and never a re-trace.
+    This test used to assert the refusal named pgw#1370 as the owner of
+    PUBLISHING the blob somewhere fetchable. There is no such owner and no such
+    route: a serialized program's bytes are machine-scoped (pgw#1462p2 measured
+    14/14 graph identities reproducing across boxes and 0/14 blob digests), so
+    nothing can ship them and the remedy is to derive here. The refusal says
+    that instead — per graph, never an ``AttributeError``, never a boot failure.
     """
     from gen_worker.serving.mint_store import ProgramBlobUnreachable
 
     cas = LocalCAS(tmp_path / "cas")
     store = TieredGraphStore(LocalGraphStore(cas), None)
-    with pytest.raises(ProgramBlobUnreachable, match="pgw#1370"):
+    graph = "cg-graph-v1-" + "0" * 56
+    with pytest.raises(ProgramBlobUnreachable, match="gen-worker lock"):
+        store.fetch_program(graph, tmp_path / "blob.pt2")
+
+    # A BLOB DIGEST IS NOT A KEY ANY MORE, and asking with one is a caller
+    # error rather than a missing blob — it must not read as corruption.
+    with pytest.raises(ProgramBlobUnreachable, match="not a cg-graph-v1 identity"):
         store.fetch_program("sha256:" + "0" * 64, tmp_path / "blob.pt2")
 
-    # A blob this pod ALREADY holds needs no route: a digest is a digest.
-    ref = cas.put_bytes(b"a serialized ExportedProgram")
-    got = store.fetch_program(str(ref), tmp_path / "have.pt2")
-    assert got.read_bytes() == b"a serialized ExportedProgram"
+    # A program this box MADE needs nothing: it is found by the identity.
+    staged = tmp_path / "staged.pt2"
+    staged.write_bytes(b"a serialized ExportedProgram")
+    LocalGraphStore(cas).put_program(graph, staged)
+    got = store.fetch_program(graph, tmp_path / "have.pt2")
+    assert Path(got).read_bytes() == b"a serialized ExportedProgram"
 
 
 def test_the_reuse_hit_is_a_wire_fact_a_rental_can_capture(

--- a/tests/test_serving_adopt_first.py
+++ b/tests/test_serving_adopt_first.py
@@ -412,7 +412,6 @@ def _adopt_answer(
         base: dict[str, Any] = {
             "graph_hash": record.graph,
             "graph_specialization": "",
-            "program": record.program,
             "module_path": record.target,
             "ingress_digest": record.ingress.digest(),
             # THE CONTRACT ITSELF. Without it the lane document cannot be

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=20e54d41c7f853e809fc985e795e1cdd539b3215" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=09c09b7a0f3578248d8873759a1c466c63e89662" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=20e54d41c7f853e809fc985e795e1cdd539b3215#20e54d41c7f853e809fc985e795e1cdd539b3215" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=09c09b7a0f3578248d8873759a1c466c63e89662#09c09b7a0f3578248d8873759a1c466c63e89662" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
Paul, 2026-08-19: *"drop `program` blob addresses from the document contract.
Pods re-derive exported programs locally from committed source+lock and mint
from their own bytes; the graph HASH in the stamped document is what must
match."* This is the pgw consumer half; torchcg `09c09b7a` and tensorhub #1540
are the matched pair.

THE MEASUREMENT THAT RULED IT (this lane, pgw#1462p2): sd15 re-traced at its own
pinned gen-worker, same fixture tree, compared against the release the hub
stamped from the AUTHOR's lock —

    graph hashes (cg-graph-v1)   14 / 14 IDENTICAL
    compile stack (17 rows)      IDENTICAL, byte for byte
    graphs[].program digests      0 / 14 identical
    two runs on THIS box         14 / 14 identical

`torch.export.save` is deterministic within a machine and different across
machines. The address was unresolvable by anyone who did not already hold the
bytes, and it made the DOCUMENT unportable.

WHAT CHANGED

* the sink banks each program through `LocalGraphStore.put_program(graph, …)`
  and its return is DISCARDED — bytes local, identity in the document;
* `program_digest`/`MissingProgramDigest` become `program_graph`/
  `MissingProgram`; `_mint_one` resolves `record.graph`;
* `TieredGraphStore.fetch_program(graph, dest)` keys both tiers by identity;
  the baked tier from part 2 STAYS, scope narrowed to the regenerate arm (the
  build container derived document and bytes together, so its programs answer);
* `endpoint_lock.program_digests` -> `graph_identities`, so the reuse check asks
  "does THIS box hold a program for every graph" — the one portable key;
* `hub_store` stops reading `program` off adopt rows.

TWO DEFECTS THE WORK SURFACED, both silent, both fixed here:

1. `hub_store` reconstructed the document with a HARDCODED `{"v": 2}`. The
   moment torchcg bumped DOCUMENT_FORMAT to 3 it stopped decoding, and the only
   symptom was `sink_for` returning None — a pod serving eager for a reason
   nothing printed. Now `DOCUMENT_FORMAT`, imported.
2. `fetch_program` classified ANY exception from a tier as "corrupted at rest",
   so an `AttributeError` (a wiring bug) and a malformed key both read as bad
   bytes and sent the reader to scrub a disk. The fault set is now the store's
   own vocabulary, and a non-`cg-graph-v1` key is refused up front by name.

GREEN ARM — the case that was "unmintable by any fetch tier" (executed, $0):
sd15's REAL stamped document (`61aeac79ffeaa0cfe8ed6d8a`, 14 identities from the
author's machine) against a FRESH pod store on this box:

    RED  : 14/14 typed per-graph refusals before deriving
    GREEN: 14/14 resolved from this box's own store (46.2 MB)
    MINT : holes=14, reached-the-compiler=14

The red arm's emptiness is ENFORCED, not assumed — a reused store root silently
turned it from 14/14 into 0/14 on a second run, and a red arm that quietly stops
being red proves nothing. Compile is stubbed via the `compiler` seam per the
shared-box rule; publish then fails by construction (the stub is not an ELF),
which is downstream of everything under test.

`lock --check` IS PORTABLE AGAIN, measured on the same two real traces: with
addresses, author `dba595a6…` vs this box `415cf697…` — DRIFT on an unchanged
tree, the false positive that made it useless as a CI gate. Address-free, both
derive `cf3d934d…`. Stripping `program` ALONE reconciles them, which is also the
byte-compare proof that it was the only non-portable field in the document.

Gates (scoped per the CPU-minimal ruling, `CUDA_VISIBLE_DEVICES=""`): mypy
Success, 613 files. ratchet / config-reads / settings-writers / lock-pin-agreement
/ compiled-graph-key-layout-fence all OK. 56 passed across the seven modules the
diff touches, 0 failures.