### PR TITLE
pgw#1514: skeleton.build asks WHY before saying WHAT — a collected tree is not an absent index

### DIFF
--- a/src/gen_worker/models/projection.py
+++ b/src/gen_worker/models/projection.py
@@ -129,6 +129,27 @@ def resolve_projection(root: Path | str) -> Optional[ProjectedSnapshot]:
     return ProjectedSnapshot(tree, cas, manifest)
 
 
+def stub_at_any(root: Path | str) -> bool:
+    """Whether ANY file under ``root`` is a pointer stub.
+
+    pgw#1513: the cheap "is this tree projected" question, asked by callers
+    that must not hand a stubbed tree to a stock reader. It branches on
+    :func:`read_stub` — the stub's own self-identifying header — and NEVER on
+    a parse failure from something that tried to read one as weights, which is
+    pgw#1308's mistake: two callers inferred a fact about the WORLD from a
+    fact about a READER, and reached opposite wrong conclusions.
+
+    Stops at the first stub: this is a predicate, not a census.
+    """
+    tree = Path(root)
+    if not tree.is_dir():
+        return False
+    for path in tree.rglob("*"):
+        if (path.is_file() or path.is_symlink()) and read_stub(path) is not None:
+            return True
+    return False
+
+
 def snapshot_root_of(path: Path | str) -> Optional[Path]:
     """The snapshot tree a file lives in, or ``None``.
 
@@ -363,5 +384,6 @@ __all__ = [
     "resolve_projection",
     "snapshot_root_of",
     "stub_at",
+    "stub_at_any",
     "symlinks_supported",
 ]

--- a/src/gen_worker/models/projection.py
+++ b/src/gen_worker/models/projection.py
@@ -171,6 +171,13 @@ def collected_entries(root: Path | str) -> list[str]:
     for path in sorted(tree.rglob("*")):
         if path.is_symlink() and is_projection_artifact(path) and not path.exists():
             gone.append(path.relative_to(tree).as_posix())
+    # `model_index.json` FIRST, because it is the entry whose absence produces
+    # the false "carries no model_index.json" — so it is the one a reader most
+    # needs to see in a truncated list, and plain alphabetical order drops it
+    # out of the window on any tree with early-alphabet components
+    # (se#790 measured it landing 2nd of 3 by luck). Everything else keeps
+    # sorted order, so the list stays stable and diffable.
+    gone.sort(key=lambda rel: (rel != "model_index.json", rel))
     return gone
 
 

--- a/src/gen_worker/models/projection.py
+++ b/src/gen_worker/models/projection.py
@@ -31,7 +31,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 from gen_worker._vendor.tensorfs import (
     CASRef,
@@ -148,6 +148,53 @@ def stub_at_any(root: Path | str) -> bool:
         if (path.is_file() or path.is_symlink()) and read_stub(path) is not None:
             return True
     return False
+
+
+def collected_entries(root: Path | str) -> list[str]:
+    """Projected entries under ``root`` whose CAS object is GONE.
+
+    pgw#1513/pgw#1514, measured by the se#790 lane on a real 5.6 GB tree: a
+    tree's manifest pin is the ONLY GC root its objects have, so a tree that
+    outlives its pin and then meets a GC pass has every object deleted while
+    the tree stands. Tensor containers remain stubs; everything else becomes a
+    DANGLING SYMLINK — ``model_index.json`` among them.
+
+    `Path.is_file()` FOLLOWS the link, which is what collapses "collected" and
+    "absent" into one branch and makes a caller say "carries no
+    model_index.json" about a tree that has one. Ask this instead, and ask it
+    BEFORE any parse.
+    """
+    tree = Path(root)
+    gone: list[str] = []
+    if not tree.is_dir():
+        return gone
+    for path in sorted(tree.rglob("*")):
+        if path.is_symlink() and is_projection_artifact(path) and not path.exists():
+            gone.append(path.relative_to(tree).as_posix())
+    return gone
+
+
+def collected_refusal(root: Path | str, entries: Sequence[str]) -> str:
+    """THE wording for "this tree's bytes were collected", in one place.
+
+    Both refusal sites call this — the eager bridge (pgw#1513) and
+    ``skeleton.build`` (pgw#1514) — so a reader who greps either path lands in
+    the same mental model. Two hand-written strings is how this shape reached
+    four callers; the se#790 lane found a fifth instance in their OWN code
+    while documenting the lesson in the same file's docstring.
+    """
+    shown = ", ".join(list(entries)[:3])
+    more = "" if len(entries) <= 3 else f" (+{len(entries) - 3} more)"
+    return (
+        f"{Path(root)}: {len(entries)} of this tree's entries are projected "
+        f"links whose CAS OBJECTS HAVE BEEN COLLECTED ({shown}{more}). The "
+        f"tree's manifest pin is the only root those objects had, so losing it "
+        f"makes a GC pass delete the bytes while leaving the tree standing. "
+        f"These weights must be RE-FETCHED; this is not a re-pin. Do not read "
+        f"this as a malformed checkpoint — a dangling `model_index.json` is "
+        f"why a tree that HAS one gets reported as 'carries no "
+        f"model_index.json'."
+    )
 
 
 def snapshot_root_of(path: Path | str) -> Optional[Path]:
@@ -385,5 +432,7 @@ __all__ = [
     "snapshot_root_of",
     "stub_at",
     "stub_at_any",
+    "collected_entries",
+    "collected_refusal",
     "symlinks_supported",
 ]

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -1270,6 +1270,36 @@ class ModelStore:
             await asyncio.to_thread(self._quarantine_snapshot, ref, tree, bad)
             return False
 
+        # pgw#1513: AND IT MUST BE STREAMABLE, not merely intact.
+        #
+        # A projected tree's weights are pointer stubs; the pgw#1380 streaming
+        # engine is the reader for them, and it binds only if
+        # `resolve_projection` can recover the tree's manifest — which is
+        # keyed on the tree's own DIRECTORY NAME. A tree whose pin is missing
+        # is byte-perfect and passes the verification above, yet no engine
+        # will bind to it, so `ctx.load` falls to the eager `from_pretrained`
+        # bridge, which reads a 128 B stub with the stock safetensors reader
+        # and reports `header too large` — a corruption message about an
+        # uncorrupted checkpoint.
+        #
+        # Answering `already_resident` here would strand the pod in exactly
+        # that state. Answering False instead sends it through
+        # `ensure_local` -> `ensure_snapshot`, which re-pins the manifest and,
+        # because `_tree_matches` passes, returns the SAME tree without moving
+        # a byte. A missing pin is repaired, not re-downloaded.
+        from . import projection as _projection
+
+        if _projection.stub_at_any(tree) and _projection.resolve_projection(tree) is None:
+            logger.error(
+                "residency REFUSED for %s at %s: the tree is intact but its "
+                "manifest pin is missing, so the streaming engine cannot bind "
+                "and the eager bridge would read its pointer stubs as corrupt "
+                "weights. Re-materializing to re-pin (no bytes move) — "
+                "pgw#1513",
+                ref, tree,
+            )
+            return False
+
         identity = self._snapshot_identity(ref, snapshot)
         with self._identity_lock:
             self._disk_identities[ref] = identity

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -1189,7 +1189,17 @@ class ModelStore:
 
         Returns True when the answer was given; False means "not resident,
         fetch it" and the caller falls through to the funnel.
+
+        **The answer is VERIFIED, not assumed** (pgw#1511). A tree is residency
+        only if it matches its manifest; a present-but-incomplete tree is
+        quarantined and answered False. See the comment at the check itself for
+        what this cost the fleet when it was `is_dir()` alone.
         """
+        # The quarantine below emits EVICTED through Residency, and this can
+        # run before anything else has bound the store's loop (boot calls it
+        # first). Without this the eviction of a tree we just refused is
+        # dropped, and the hub keeps the residency this pod has disowned.
+        self.bind_loop()
         if snapshot is None:
             snapshot = self._snapshots.get(ref)
         if snapshot is None or not snapshot.digest:
@@ -1217,6 +1227,48 @@ class ModelStore:
                 # and calling that satisfied would strand the goal forever.
                 return False
             tree = existing
+
+        # pgw#1511: VERIFY BEFORE ASSERTING. Everything above this line is a
+        # statement about a DIRECTORY ENTRY — `candidate.is_dir()` — and that
+        # was the whole test. A tree left incomplete by an interrupted or
+        # superseded materialization is a directory that exists, so this
+        # answered `already_resident`, published ON_DISK, and (below) added the
+        # ref to `self._verified`, which permanently suppresses
+        # `_materialize_local`'s first-use `_verify_snapshot_tree` for the rest
+        # of the process. The bytes were then never checked by anyone, and the
+        # first thing to notice was the tenant's loader — `SafetensorError:
+        # header too large`, blamed on the checkpoint.
+        #
+        # It is not enough to verify here and carry on: a residency answer that
+        # cannot be substantiated must never become an answer at all. So a bad
+        # tree is QUARANTINED (the partial and its bad blobs are deleted, so
+        # re-materialization re-downloads instead of re-linking the same bytes)
+        # and this returns False, which sends the caller down the ordinary
+        # fetch path.
+        #
+        # `_verify_snapshot_tree` is the INHERITED checker and it is used here
+        # precisely because it is PROJECTION-AWARE. A projected tree's tensor
+        # containers are ~128 B TFSSTUB1 pointer stubs and its other files are
+        # CAS symlinks; by construction they do not hold the bytes their
+        # manifest entries name. A validator that opened one naively would get
+        # a loud parse failure that is CORRECT behaviour, score it as
+        # corruption, and delete the model on every boot — pgw#1308 finding 3,
+        # where two callers read that same correct failure and reached opposite
+        # wrong conclusions. So stubs and symlinks go to `verify_projection`
+        # (structural) and only files holding real bytes are hashed. That is
+        # also why this is not a re-download tax on every warm pod.
+        ok, bad = await asyncio.to_thread(self._verify_snapshot_tree, tree, snapshot)
+        if not ok:
+            logger.error(
+                "residency REFUSED for %s at %s: the tree is present but does "
+                "not match its manifest (%d bad file(s)) — quarantining and "
+                "falling through to a fetch. This pod will NOT advertise these "
+                "weights as resident; a tree that cannot be substantiated is "
+                "not residency (pgw#1511)",
+                ref, tree, len(bad),
+            )
+            await asyncio.to_thread(self._quarantine_snapshot, ref, tree, bad)
+            return False
 
         identity = self._snapshot_identity(ref, snapshot)
         with self._identity_lock:

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -1287,6 +1287,19 @@ class ModelStore:
         # `ensure_local` -> `ensure_snapshot`, which re-pins the manifest and,
         # because `_tree_matches` passes, returns the SAME tree without moving
         # a byte. A missing pin is repaired, not re-downloaded.
+        #
+        # THE "NO BYTES MOVE" CLAIM HOLDS ONLY ON THIS BRANCH, and the reason
+        # is the ORDER of the two checks above. The se#790 lane measured the
+        # worse state on a real tree: the manifest pin is a tree's ONLY GC
+        # root, so a tree that outlives its pin AND then meets a GC pass has
+        # all of its objects deleted (5.6 GB there; 134 GB on H3) while the
+        # tree stands, leaving stubs plus dangling symlinks. That state does
+        # not reach this line — it fails `_verify_snapshot_tree` above, where
+        # `projection_fault` reports "linked object … is absent", and takes
+        # the quarantine-and-refetch path, which is the honest cost. Reaching
+        # HERE means verification passed, i.e. the objects are present and
+        # only the pin is gone. Cheap repair for the cheap case, full re-fetch
+        # for the expensive one, and the two are never confused.
         from . import projection as _projection
 
         if _projection.stub_at_any(tree) and _projection.resolve_projection(tree) is None:

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -37,8 +37,8 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING, Any, Callable, Generic, Mapping, Optional, Protocol, Type,
-    TypeVar, cast,
+    TYPE_CHECKING, Any, Callable, Generic, List, Mapping, Optional, Protocol,
+    Sequence, Tuple, Type, TypeVar, cast,
 )
 
 import msgspec
@@ -229,6 +229,109 @@ class DefaultsError(msgspec.ValidationError):
     """A hub defaults row does not fit the model type's schema."""
 
 
+class ProjectedTreeNotStreamable(RuntimeError):
+    """The eager bridge was handed a tree whose weights are POINTERS.
+
+    pgw#1513. Raised instead of letting ``from_pretrained`` open a ~128 B
+    TFSSTUB1 stub with the stock safetensors reader, which reports
+    ``SafetensorError: header too large`` — a message about a corrupt
+    checkpoint, for a checkpoint that is perfectly intact and whose bytes are
+    sitting in the CAS. Two days of this incident were spent looking at
+    volumes and download paths because of that sentence.
+
+    The numbers in the message are what identify a stub on sight: a stub's
+    size is fixed (~128 B) no matter how large the model it names, which is
+    why a 3.4 GB and a 68 GB checkpoint failed identically.
+    """
+
+    def __init__(
+        self,
+        tree: Path,
+        stubs: Sequence[Tuple[str, int, int]],
+        declined: str = "",
+    ) -> None:
+        self.tree = Path(tree)
+        self.stubs = list(stubs)
+        self.declined = declined
+        shown = ", ".join(
+            f"{path} ({on_disk} B on disk, names {named:,} B)"
+            for path, on_disk, named in self.stubs[:3]
+        )
+        more = "" if len(self.stubs) <= 3 else f" (+{len(self.stubs) - 3} more)"
+        super().__init__(
+            f"{self.tree} is a PROJECTED snapshot tree: {len(self.stubs)} of "
+            f"its tensor containers are tensorfs pointer stubs, not weights — "
+            f"{shown}{more}. The eager `from_pretrained` bridge reads with the "
+            f"stock safetensors reader and would report `header too large`, "
+            f"which describes a corrupt checkpoint and this checkpoint is not "
+            f"corrupt: its bytes are in the CAS. The streaming engine "
+            f"(pgw#1380) is the reader for this tree and it declined to bind, "
+            f"which means `resolve_projection` could not recover the tree's "
+            f"manifest pin. THE ENGINE DECLINED BECAUSE: {declined or 'unknown'}. "
+            f"Refusing rather than serving a lie about the weights."
+        )
+
+
+def _projection_declined_because(tree: Path) -> str:
+    """WHICH of `resolve_projection`'s three silent Nones fired, in words.
+
+    pgw#1513. Without this the reader gets a beautiful message about stubs and
+    still does not know why the streaming engine passed on a tree it should
+    have taken — the same two-day hunt, one layer up.
+    """
+    from ..models.projection import SNAPSHOTS_DIR
+
+    root = Path(tree)
+    if root.parent.name != SNAPSHOTS_DIR:
+        return (
+            f"the tree is at {root}, whose parent directory is "
+            f"{root.parent.name!r} and not {SNAPSHOTS_DIR!r} — "
+            f"`resolve_projection` locates the store by walking UP from the "
+            f"tree, so a correctly-built tree in the wrong place is invisible "
+            f"to it"
+        )
+    base = root.parent.parent
+    missing = [d for d in ("refs", "objects") if not (base / d).is_dir()]
+    if missing:
+        return (
+            f"the store root {base} has no {'/'.join(missing)} directory, so "
+            f"there is no CAS behind this tree"
+        )
+    return (
+        f"the manifest pin `snapshot:{root.name}` is MISSING from the store at "
+        f"{base}. The tree and its bytes are fine; what is absent is the ref "
+        f"that lets a reader recover the manifest, and it is keyed on the "
+        f"tree's own DIRECTORY NAME. Re-materializing this ref re-pins it "
+        f"without moving any bytes"
+    )
+
+
+def _projection_artifacts(tree: Path) -> List[Tuple[str, int, int]]:
+    """Every tensor container in ``tree`` that is a pointer, not weights.
+
+    Returns ``(relative path, bytes on disk, bytes it names)`` so the refusal
+    can show the fixed-size-stub signature rather than assert it.
+    """
+    from ..models import projection
+
+    found: List[Tuple[str, int, int]] = []
+    root = Path(tree)
+    if not root.is_dir():
+        return found
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() and not path.is_symlink():
+            continue
+        stub = projection.stub_at(path)
+        if stub is None:
+            continue
+        try:
+            on_disk = path.lstat().st_size
+        except OSError:
+            on_disk = 0
+        found.append((path.relative_to(root).as_posix(), on_disk, int(stub.size)))
+    return found
+
+
 class LoadContext(Generic[MT_co]):
     """What ``Model.load``/``Model.unload`` receive — the load moment."""
 
@@ -324,6 +427,37 @@ class LoadContext(Generic[MT_co]):
             "ctx.load: eager from_pretrained bridge for %s (pgw#1380's "
             "native loader engine is not bound)", pipeline_cls.__name__,
         )
+        # pgw#1513: THE EAGER BRIDGE MUST NOT BE HANDED A PROJECTED TREE.
+        #
+        # Its own contract, three lines up, is "a tree with no chunk store
+        # behind it — a bare download, a local run, a fixture". A PROJECTED
+        # tree is the opposite: every tensor container in it is a ~128 B
+        # TFSSTUB1 pointer stub whose bytes live in the CAS, and
+        # `from_pretrained` reads with the stock safetensors reader, which
+        # knows nothing about stubs. It reads the stub's first 8 bytes as a
+        # header length and raises `SafetensorError: header too large`.
+        #
+        # That error is a LIE ABOUT THE CHECKPOINT, and it cost two days
+        # pointed at poisoned volumes and truncated downloads. It is identical
+        # for a 3.4 GB model and a 68 GB one — the stub is a fixed size — which
+        # is precisely the signature that ruled out every short-write theory
+        # and should have named this on day one. So the bridge refuses, by
+        # name, with the numbers that identify a stub on sight.
+        #
+        # Reaching here means the streaming engine declined this tree
+        # (`engine_for` -> `store_for` -> `resolve_projection` returned None),
+        # which for a tree that IS projected means its manifest pin could not
+        # be resolved — `resolve_projection` keys the pin on the tree's own
+        # DIRECTORY NAME, so a tree selected under a different spelling than
+        # the one it was pinned under resolves to nothing. This refusal turns
+        # that into one named failure instead of an opaque loader crash.
+        stubbed = _projection_artifacts(self.checkpoint_dir)
+        if stubbed:
+            raise ProjectedTreeNotStreamable(
+                self.checkpoint_dir,
+                stubbed,
+                _projection_declined_because(self.checkpoint_dir),
+            )
         # pgw#1473: a VARIANT-ONLY tree (`*.fp16.safetensors`, which is what
         # every fp16 mirror ships) is invisible to `from_pretrained` unless it
         # is told. Detected off the tree the worker already resolved, never

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -306,6 +306,38 @@ def _projection_declined_because(tree: Path) -> str:
     )
 
 
+def _collected_objects(tree: Path) -> List[str]:
+    """Projected entries whose CAS object is GONE — the tree outlived its bytes.
+
+    pgw#1513, found by the se#790 lane on a real `@composed-v3` tree: drop a
+    tree's manifest pin and the pin is the ONLY root, so a GC pass deletes
+    every object while the tree stands. The containers are still stubs, but
+    the NON-tensor files are dangling symlinks — `model_index.json` among
+    them — and `skeleton.build` then reports "carries no model_index.json"
+    about a tree that has one. That is a reader-level fact (the bytes were
+    collected) rendered as a claim about the checkpoint, which is pgw#1308's
+    mistake for the third time.
+
+    Named separately from the stub case because the REMEDY differs: a stub
+    means "the streaming engine should have read this"; a collected object
+    means "these bytes are gone and must be re-fetched".
+    """
+    from ..models import projection
+
+    gone: List[str] = []
+    root = Path(tree)
+    if not root.is_dir():
+        return gone
+    for path in sorted(root.rglob("*")):
+        if not path.is_symlink():
+            continue
+        if not projection.is_projection_artifact(path):
+            continue
+        if not path.exists():  # follows the link: the object is absent
+            gone.append(path.relative_to(root).as_posix())
+    return gone
+
+
 def _projection_artifacts(tree: Path) -> List[Tuple[str, int, int]]:
     """Every tensor container in ``tree`` that is a pointer, not weights.
 
@@ -451,6 +483,22 @@ class LoadContext(Generic[MT_co]):
         # DIRECTORY NAME, so a tree selected under a different spelling than
         # the one it was pinned under resolves to nothing. This refusal turns
         # that into one named failure instead of an opaque loader crash.
+        collected = _collected_objects(self.checkpoint_dir)
+        if collected:
+            shown = ", ".join(collected[:3])
+            more = "" if len(collected) <= 3 else f" (+{len(collected) - 3} more)"
+            raise ProjectedTreeNotStreamable(
+                self.checkpoint_dir,
+                _projection_artifacts(self.checkpoint_dir),
+                f"{len(collected)} of this tree's entries are projected links "
+                f"whose CAS OBJECTS HAVE BEEN COLLECTED ({shown}{more}). The "
+                f"tree's manifest pin is the only root those objects had, so "
+                f"losing it makes a GC pass delete the bytes while leaving the "
+                f"tree standing. These weights must be RE-FETCHED; this is not "
+                f"a re-pin. Do not read this as a malformed checkpoint — a "
+                f"dangling `model_index.json` is why a tree that HAS one gets "
+                f"reported as 'carries no model_index.json'",
+            )
         stubbed = _projection_artifacts(self.checkpoint_dir)
         if stubbed:
             raise ProjectedTreeNotStreamable(

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -306,38 +306,6 @@ def _projection_declined_because(tree: Path) -> str:
     )
 
 
-def _collected_objects(tree: Path) -> List[str]:
-    """Projected entries whose CAS object is GONE — the tree outlived its bytes.
-
-    pgw#1513, found by the se#790 lane on a real `@composed-v3` tree: drop a
-    tree's manifest pin and the pin is the ONLY root, so a GC pass deletes
-    every object while the tree stands. The containers are still stubs, but
-    the NON-tensor files are dangling symlinks — `model_index.json` among
-    them — and `skeleton.build` then reports "carries no model_index.json"
-    about a tree that has one. That is a reader-level fact (the bytes were
-    collected) rendered as a claim about the checkpoint, which is pgw#1308's
-    mistake for the third time.
-
-    Named separately from the stub case because the REMEDY differs: a stub
-    means "the streaming engine should have read this"; a collected object
-    means "these bytes are gone and must be re-fetched".
-    """
-    from ..models import projection
-
-    gone: List[str] = []
-    root = Path(tree)
-    if not root.is_dir():
-        return gone
-    for path in sorted(root.rglob("*")):
-        if not path.is_symlink():
-            continue
-        if not projection.is_projection_artifact(path):
-            continue
-        if not path.exists():  # follows the link: the object is absent
-            gone.append(path.relative_to(root).as_posix())
-    return gone
-
-
 def _projection_artifacts(tree: Path) -> List[Tuple[str, int, int]]:
     """Every tensor container in ``tree`` that is a pointer, not weights.
 
@@ -483,21 +451,18 @@ class LoadContext(Generic[MT_co]):
         # DIRECTORY NAME, so a tree selected under a different spelling than
         # the one it was pinned under resolves to nothing. This refusal turns
         # that into one named failure instead of an opaque loader crash.
-        collected = _collected_objects(self.checkpoint_dir)
+        # ONE source of truth for this wording, shared with `skeleton.build`
+        # (pgw#1514) so the two refusals cannot drift into teaching different
+        # mental models. Checked BEFORE the stub condition: "the objects were
+        # collected" is the real cause and must win over "this is a stub".
+        from ..models import projection
+
+        collected = projection.collected_entries(self.checkpoint_dir)
         if collected:
-            shown = ", ".join(collected[:3])
-            more = "" if len(collected) <= 3 else f" (+{len(collected) - 3} more)"
             raise ProjectedTreeNotStreamable(
                 self.checkpoint_dir,
                 _projection_artifacts(self.checkpoint_dir),
-                f"{len(collected)} of this tree's entries are projected links "
-                f"whose CAS OBJECTS HAVE BEEN COLLECTED ({shown}{more}). The "
-                f"tree's manifest pin is the only root those objects had, so "
-                f"losing it makes a GC pass delete the bytes while leaving the "
-                f"tree standing. These weights must be RE-FETCHED; this is not "
-                f"a re-pin. Do not read this as a malformed checkpoint — a "
-                f"dangling `model_index.json` is why a tree that HAS one gets "
-                f"reported as 'carries no model_index.json'",
+                projection.collected_refusal(self.checkpoint_dir, collected),
             )
         stubbed = _projection_artifacts(self.checkpoint_dir)
         if stubbed:

--- a/src/gen_worker/serving/streaming/skeleton.py
+++ b/src/gen_worker/serving/streaming/skeleton.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
 
+from ...models import projection
 from ...models.meta_init import init_empty_weights
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -112,6 +113,22 @@ def build(
     extra_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> Skeleton:
     """Build ``pipeline_cls`` from configs only. Reads no tensor bytes."""
+    # pgw#1514: ASK WHY BEFORE SAYING WHAT, and ask it ONCE for the whole tree.
+    # `Path.is_file()` FOLLOWS the link, so "this tree never had an index" and
+    # "this tree's objects were collected" arrive at the check below as the
+    # same False — and the second is a fact about the STORE that this refusal
+    # reported as a fact about the CHECKPOINT. Measured on a real 5.6 GB tree
+    # (se#790): pin dropped, one GC, and a tree whose `model_index.json` is
+    # right there gets refused for not having one.
+    #
+    # The index merely DIES FIRST — 14 entries dangle in that state — so this
+    # walks the whole tree rather than guarding one file, which would only
+    # move the wrong message down to the next component's config. Same helper
+    # and same sentence as the eager bridge uses (pgw#1513), because two
+    # hand-written strings is how this shape reached four callers.
+    collected = projection.collected_entries(checkpoint_dir)
+    if collected:
+        raise SkeletonError(projection.collected_refusal(checkpoint_dir, collected))
     index_path = Path(checkpoint_dir) / MODEL_INDEX
     if not index_path.is_file():
         raise SkeletonError(

--- a/tests/test_boot_materialize.py
+++ b/tests/test_boot_materialize.py
@@ -428,3 +428,96 @@ def _fine_cadence(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setattr(wp, "STRIDE_MIB", 1)
     monkeypatch.setattr(wp, "MIN_INTERVAL_S", 0.0)
     return None
+
+
+# ---------------------------------------------------------------------------
+# pgw#1511: a tree that EXISTS is not a tree that is RESIDENT
+# ---------------------------------------------------------------------------
+
+
+def test_a_TRUNCATED_warm_tree_is_refused_quarantined_and_refetched(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """The fleet incident: two endpoints, two volumes, 20x apart, identical
+    `SafetensorError: header too large` on read.
+
+    Every write path in the stack is airtight — the CAS hashes and size-checks
+    every object before committing it, `project_snapshot` builds in a scratch
+    directory and renames, and tensorfs' materializer re-hashes each object AND
+    the whole file and refuses a short read. So the bytes were never
+    short-WRITTEN. What happened is that a tree left incomplete by an
+    interrupted materialization is still a DIRECTORY THAT EXISTS, and
+    `announce_resident` tested exactly that and nothing else: it answered
+    `already_resident`, published ON_DISK, marked the ref `_verified` (which
+    suppresses the first-use digest check for the rest of the process), and the
+    worker advertised ready. The first component to notice was the tenant's
+    loader.
+
+    So: stage a good tree, TRUNCATE one weight file in it the way an
+    interrupted write would, and boot a second store on that CAS. The pod must
+    refuse the residency rather than advertise it.
+    """
+    origin = _Origin()
+    try:
+        snapshot = _blobs(origin)
+        cas = tmp_path / "endpoint-volume-cas"
+
+        async def stage() -> None:
+            wire = _Wire()
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            mat = CheckpointMaterialization(_store(wire, cas))
+            mat.configure(_config(1, _REF, snapshot))
+            await _settle(mat)
+
+        asyncio.run(stage())
+
+        # The damage, applied to the STAGED tree exactly as a half-finished
+        # write leaves it: the file is present, and short.
+        trees = [p for p in (cas / "snapshots").iterdir() if p.is_dir()]
+        assert len(trees) == 1, f"expected one staged tree, got {trees}"
+        weights = sorted(trees[0].rglob("*.safetensors"))
+        assert weights, f"no weight files in {trees[0]}"
+        victim = weights[0]
+        full = victim.stat().st_size
+        # The tree's files are read-only HARD LINKS into the CAS objects, so
+        # this truncates the object itself — a more faithful reproduction than
+        # damaging a private copy would be, and it means recovery has to
+        # re-download rather than re-link the same bad bytes.
+        mode = victim.stat().st_mode
+        victim.chmod(0o644)
+        with victim.open("r+b") as handle:
+            handle.truncate(max(1, full // 3))
+        victim.chmod(mode)
+        assert victim.stat().st_size < full
+
+        warm = _Wire()
+        outcome: List[str] = []
+
+        async def boot() -> None:
+            store = _store(warm, cas)
+            activity.bind_sink(warm.send, asyncio.get_running_loop())
+            store.rescan_disk()
+            mat = CheckpointMaterialization(store)
+            mat.configure(_config(1, _REF, snapshot))
+            await _settle(mat)
+            outcome.append(mat.state)
+
+        asyncio.run(boot())
+
+        phases = [u.phase for u in warm.positions()]
+        assert PHASE_ALREADY_RESIDENT not in phases, (
+            "a truncated tree was answered as ALREADY RESIDENT — that is the "
+            "incident: the pod advertises weights it does not have, and the "
+            f"first reader gets `header too large`. positions={phases}")
+        assert outcome == [STATE_READY], (
+            f"the pod must recover by re-fetching, not stall; state={outcome}")
+        # And the recovery is real, judged by the SAME verifier that rejected
+        # the damage — not by raw file size, because a projected tree's files
+        # are pointer stubs by design and sizing them proves nothing.
+        final = [p for p in (cas / "snapshots").iterdir() if p.is_dir()]
+        assert len(final) == 1, f"expected one tree after recovery, got {final}"
+        checker = _store(_Wire(), cas)
+        ok, bad = checker._verify_snapshot_tree(final[0], snapshot)
+        assert ok, f"the recovered tree still fails verification: {bad}"
+    finally:
+        origin.close()

--- a/tests/test_projected_tree_eager_refusal_pgw1513.py
+++ b/tests/test_projected_tree_eager_refusal_pgw1513.py
@@ -207,3 +207,52 @@ def test_a_tree_with_a_MISSING_PIN_is_not_answered_as_resident(tmp_path: Path) -
         "a tree no engine can bind to must not be answered as resident — "
         "that is the state that reaches the eager bridge and reports "
         "`header too large` about an intact checkpoint")
+
+
+def test_a_tree_whose_OBJECTS_WERE_COLLECTED_says_so_and_not_malformed(
+    tmp_path: Path,
+) -> None:
+    """se#790's state D, measured on a real 5.6 GB `@composed-v3` tree.
+
+    A tree's manifest pin is the ONLY GC root its objects have. Drop the pin,
+    run a GC, and every object is deleted while the tree stands: the tensor
+    containers are still stubs and the NON-tensor files — `model_index.json`
+    among them — become dangling symlinks. `skeleton.build` then reports
+    "carries no model_index.json" about a tree that has one, which is a
+    reader-level fact rendered as a claim about the checkpoint.
+
+    The refusal must name the real condition, and must not be confused with
+    the cheap missing-pin case: these bytes are GONE and must be re-fetched.
+    """
+    base = tmp_path / "cas"
+    (base / "refs").mkdir(parents=True)
+    objects = base / "objects"
+    objects.mkdir(parents=True)
+    tree = base / "snapshots" / ("sha256:" + "d4" * 32)
+    tree.mkdir(parents=True)
+
+    # A projected non-tensor entry whose object has been collected.
+    (tree / "model_index.json").symlink_to(
+        Path("..") / ".." / "objects" / "sha256" / "de" / "ad" / ("de" * 32)
+    )
+    assert (tree / "model_index.json").is_symlink()
+    assert not (tree / "model_index.json").exists(), "fixture must be dangling"
+
+    _Pipeline.called.clear()
+    ctx: LoadContext[Any] = LoadContext(
+        binding=DeployBinding(checkpoint_ref="acme/m@1", checkpoint_dir=tree),
+        engine=None,
+    )
+    with pytest.raises(ProjectedTreeNotStreamable) as caught:
+        ctx.load(_Pipeline)
+
+    assert _Pipeline.called == []
+    message = str(caught.value)
+    assert "COLLECTED" in message, f"the real condition must be named: {message}"
+    assert "model_index.json" in message
+    assert "RE-FETCHED" in message, (
+        "this must not be confused with the cheap re-pin case — the bytes are "
+        f"gone: {message}")
+    assert "carries no model_index.json" in message, (
+        "the refusal must name the FALSE message it is pre-empting, so the "
+        f"next reader searching that string lands here: {message}")

--- a/tests/test_projected_tree_eager_refusal_pgw1513.py
+++ b/tests/test_projected_tree_eager_refusal_pgw1513.py
@@ -1,0 +1,209 @@
+"""pgw#1513: the eager bridge must refuse a PROJECTED tree, by name.
+
+# The incident, and why it looked like a short write for two days
+
+Two endpoints (sd15, sdxl), two volumes, 20x apart in size, identical
+`SafetensorError: header too large`, hub source bytes verified intact. Every
+short-write theory was dead on arrival once the write paths were read: the CAS
+hashes and size-checks every object before committing it, tensorfs'
+materializer re-hashes each object AND the whole file and refuses a short read,
+and `project_snapshot` builds in a scratch directory and renames.
+
+What actually happens is that a projected tree's tensor containers are ~128 B
+TFSSTUB1 POINTER STUBS — the weights live in the CAS — and the stock
+safetensors reader that `from_pretrained` uses knows nothing about stubs. It
+reads the stub's first eight bytes as a header length and raises. The stub is a
+FIXED SIZE regardless of the model behind it, which is exactly why a 3.4 GB and
+a 68 GB checkpoint failed byte-identically, and that coincidence is what a
+genuine truncation could never produce.
+
+`ctx.load` is supposed to route a projected tree to the pgw#1380 streaming
+engine, whose whole job is reading those stubs. The eager `from_pretrained`
+bridge is documented for "a tree with no chunk store behind it — a bare
+download, a local run, a fixture". Reaching the bridge WITH a projected tree
+means the engine declined it, and the bridge then reports a corrupt checkpoint
+for a checkpoint that is intact.
+
+So the bridge refuses instead, naming the stub and its two sizes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker._vendor.tensorfs.project import stub_bytes
+from gen_worker.serving.context import (
+    DeployBinding,
+    LoadContext,
+    ProjectedTreeNotStreamable,
+    _projection_artifacts,
+)
+
+# The two shapes from the field, so the fixed-size-stub signature is asserted
+# rather than described.
+_SD15_BYTES = 3_400_000_000
+_SDXL_BYTES = 68_000_000_000
+
+
+def _stubbed_tree(root: Path, named_bytes: int) -> Path:
+    """A tree whose tensor container is a pointer, as `_project_entry` writes it."""
+    tree = root / "snapshots" / ("sha256:" + "b7" * 32)
+    (tree / "unet").mkdir(parents=True)
+    (tree / "unet" / "diffusion_pytorch_model.safetensors").write_bytes(
+        stub_bytes("a" * 64, named_bytes)
+    )
+    (tree / "model_index.json").write_text('{"_class_name": "X"}')
+    return tree
+
+
+class _Pipeline:
+    """A loader that would happily be called — so the refusal is the guard's,
+    not an accident of the fixture."""
+
+    called: list[Any] = []
+
+    @classmethod
+    def from_pretrained(cls, path: Any, **kwargs: Any) -> "_Pipeline":
+        cls.called.append(path)
+        from safetensors import safe_open
+
+        # Exactly what diffusers does: the stock reader, on the container.
+        with safe_open(
+            str(Path(path) / "unet" / "diffusion_pytorch_model.safetensors"),
+            framework="pt",
+        ):
+            pass
+        return cls()
+
+
+@pytest.mark.parametrize("named", [_SD15_BYTES, _SDXL_BYTES])
+def test_the_eager_bridge_REFUSES_a_projected_tree_by_name(
+    tmp_path: Path, named: int
+) -> None:
+    """Both field shapes, and the refusal must carry the numbers."""
+    tree = _stubbed_tree(tmp_path, named)
+    _Pipeline.called.clear()
+
+    ctx: LoadContext[Any] = LoadContext(
+        binding=DeployBinding(checkpoint_ref="acme/m@1", checkpoint_dir=tree),
+        engine=None,  # the engine declined — the state the field pods were in
+    )
+
+    with pytest.raises(ProjectedTreeNotStreamable) as caught:
+        ctx.load(_Pipeline)
+
+    assert _Pipeline.called == [], (
+        "the bridge must refuse BEFORE calling the loader — reaching "
+        "from_pretrained is what produced `header too large`")
+    message = str(caught.value)
+    assert "PROJECTED" in message
+    assert "unet/diffusion_pytorch_model.safetensors" in message, (
+        f"the refusal must name the member: {message}")
+    assert f"{named:,}" in message, (
+        f"the refusal must name the bytes the stub STANDS FOR: {message}")
+    assert "header too large" in message, (
+        "the refusal must name the error it is replacing, or the next reader "
+        f"searching that string will not find this: {message}")
+
+
+def test_the_stub_signature_is_FIXED_SIZE_across_a_20x_model(tmp_path: Path) -> None:
+    """The coincidence that killed every short-write theory, asserted.
+
+    A truncation is proportional to what was being written; a stub is not. Two
+    models 20x apart produce stubs within a byte or two of each other, which is
+    why the two field errors were identical.
+    """
+    small = _projection_artifacts(_stubbed_tree(tmp_path / "a", _SD15_BYTES))
+    large = _projection_artifacts(_stubbed_tree(tmp_path / "b", _SDXL_BYTES))
+
+    assert len(small) == 1 and len(large) == 1
+    (_, small_on_disk, small_named) = small[0]
+    (_, large_on_disk, large_named) = large[0]
+
+    assert large_named // small_named >= 19, "fixture is not a 20x spread"
+    assert abs(large_on_disk - small_on_disk) <= 8, (
+        f"stub sizes {small_on_disk} vs {large_on_disk} should be ~equal; that "
+        "near-equality IS the signature that ruled out a short write")
+    assert small_on_disk < 200 and large_on_disk < 200
+
+
+def test_a_MATERIALIZED_tree_still_takes_the_eager_bridge(tmp_path: Path) -> None:
+    """The guard must not fire on the trees the bridge legitimately serves.
+
+    A bare download / fixture / local run has no chunk store and no stubs, and
+    it is exactly what the eager bridge exists for. If this test ever fails,
+    the guard has started refusing the local development path.
+    """
+    tree = tmp_path / "snapshots" / "plain"
+    (tree / "unet").mkdir(parents=True)
+    # Real (tiny) safetensors bytes, not a pointer.
+    import torch
+    from safetensors.torch import save_file
+
+    save_file(
+        {"w": torch.zeros(4)},
+        str(tree / "unet" / "diffusion_pytorch_model.safetensors"),
+    )
+    (tree / "model_index.json").write_text('{"_class_name": "X"}')
+
+    assert _projection_artifacts(tree) == []
+    _Pipeline.called.clear()
+    ctx: LoadContext[Any] = LoadContext(
+        binding=DeployBinding(checkpoint_ref="acme/m@1", checkpoint_dir=tree),
+        engine=None,
+    )
+    ctx.load(_Pipeline)
+    assert _Pipeline.called == [tree], "the eager bridge must still run here"
+
+
+def test_a_tree_with_a_MISSING_PIN_is_not_answered_as_resident(tmp_path: Path) -> None:
+    """The one state that is byte-perfect and still unservable.
+
+    `resolve_projection` recovers a tree's manifest through a `snapshot:<key>`
+    ref keyed on the tree's own directory name. Without it the streaming
+    engine cannot bind, `ctx.load` falls to the eager bridge, and the bridge
+    reads a stub. Verification alone does not catch this: every byte is
+    correct.
+
+    So `announce_resident` refuses, and the refusal sends the ref through
+    `ensure_local`, which re-pins WITHOUT moving bytes.
+    """
+    import asyncio
+
+    from gen_worker.models import projection
+    from gen_worker.models.refs import WireRef
+    from gen_worker.models.store import ModelStore
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+    from gen_worker._vendor.tensorfs.project import stub_bytes
+
+    base = tmp_path / "cas"
+    (base / "refs").mkdir(parents=True)
+    (base / "objects").mkdir(parents=True)
+    tree = base / "snapshots" / ("sha256:" + "c3" * 32)
+    (tree / "unet").mkdir(parents=True)
+    (tree / "unet" / "x.safetensors").write_bytes(stub_bytes("a" * 64, 3_400_000_000))
+
+    # Byte-perfect and stubbed, but nothing pinned it.
+    assert projection.stub_at_any(tree) is True
+    assert projection.resolve_projection(tree) is None
+
+    async def noop(_msg: Any) -> None:
+        return None
+
+    store = ModelStore(noop, cache_dir=base)
+    snap = pb.Snapshot(digest="sha256:" + "c3" * 32)
+    snap.files.add(path="unet/x.safetensors", size_bytes=3_400_000_000,
+                   digest="sha256:" + "a" * 64)
+    ref = WireRef("acme/unpinned")
+
+    async def run() -> bool:
+        return await store.announce_resident(ref, snap)
+
+    answered = asyncio.run(run())
+    assert answered is False, (
+        "a tree no engine can bind to must not be answered as resident — "
+        "that is the state that reaches the eager bridge and reports "
+        "`header too large` about an intact checkpoint")

--- a/tests/test_projected_tree_eager_refusal_pgw1513.py
+++ b/tests/test_projected_tree_eager_refusal_pgw1513.py
@@ -256,3 +256,29 @@ def test_a_tree_whose_OBJECTS_WERE_COLLECTED_says_so_and_not_malformed(
     assert "carries no model_index.json" in message, (
         "the refusal must name the FALSE message it is pre-empting, so the "
         f"next reader searching that string lands here: {message}")
+
+
+def test_collected_entries_puts_model_index_json_FIRST(tmp_path: Path) -> None:
+    """se#790's refinement, and the reason it is not cosmetic.
+
+    `model_index.json` is the entry whose absence produces the false "carries
+    no model_index.json", so it is the one a reader most needs to see in the
+    truncated list the refusal shows. Plain alphabetical order drops it out of
+    that window on any tree with early-alphabet components — measured on a real
+    `@composed-v3` tree, where it landed 2nd of 3 by luck of `dit/` sorting
+    first. Everything after it keeps sorted order so the list stays diffable.
+    """
+    from gen_worker.models import projection
+
+    for rel in ("model_index.json", "aaa/config.json", "dit/config.json",
+                "text_encoder/config.json"):
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.symlink_to(Path("..") / "objects" / "sha256" / "de" / "ad" / ("de" * 32))
+
+    got = projection.collected_entries(tmp_path)
+    assert got[0] == "model_index.json", (
+        f"the entry that causes the false refusal must lead the list: {got}")
+    assert got[1:] == sorted(got[1:]), f"the tail must stay sorted: {got}"
+    assert "model_index.json" in projection.collected_refusal(tmp_path, got)[:400], (
+        "and it must survive into the truncated (shown) window of the message")

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -1,4 +1,6 @@
-"""pgw#1513: the eager bridge must refuse a PROJECTED tree, by name.
+"""Reading a PROJECTED tree: who may, who must refuse, and what they say.
+
+# pgw#1513: the eager bridge must refuse a projected tree, by name.
 
 # The incident, and why it looked like a short write for two days
 

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -284,3 +284,96 @@ def test_collected_entries_puts_model_index_json_FIRST(tmp_path: Path) -> None:
     assert got[1:] == sorted(got[1:]), f"the tail must stay sorted: {got}"
     assert "model_index.json" in projection.collected_refusal(tmp_path, got)[:400], (
         "and it must survive into the truncated (shown) window of the message")
+
+
+# ---------------------------------------------------------------------------
+# pgw#1514: the STREAMING reader. Everything above is the eager bridge; this is
+# the other caller, and it reads the index BEFORE anything that guard can see.
+# ---------------------------------------------------------------------------
+
+
+class _KeepsComponents:
+    """A pipeline class that would build happily — so a refusal below is the
+    guard's, never an accident of the fixture."""
+
+    def __init__(self, **components: Any) -> None:  # pragma: no cover
+        for name, value in components.items():
+            setattr(self, name, value)
+
+
+def _collected_tree(root: Path, *, entries: tuple[str, ...]) -> Path:
+    """A projected tree whose objects have been collected: every entry is a
+    dangling link into `objects/`, exactly as one GC pass after a lost pin
+    leaves it."""
+    base = root / "cas"
+    (base / "refs").mkdir(parents=True)
+    (base / "objects").mkdir(parents=True)
+    tree = base / "snapshots" / ("sha256:" + "c0" * 32)
+    tree.mkdir(parents=True)
+    for rel in entries:
+        path = tree / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        depth = len(Path(rel).parts)
+        up = Path(*([".."] * (depth + 1)))
+        path.symlink_to(up / "objects" / "sha256" / "de" / "ad" / ("de" * 32))
+        assert path.is_symlink() and not path.exists(), rel
+    return tree
+
+
+def test_skeleton_build_does_not_call_a_collected_tree_index_less(
+    tmp_path: Path,
+) -> None:
+    """THE pgw#1514 REGRESSION. `Path.is_file()` follows the link, so before
+    this fix a dangling `model_index.json` and an absent one were the same
+    False — and `skeleton.build` reported the store's condition as the
+    checkpoint's shape."""
+    from gen_worker.serving.streaming import skeleton as sk
+
+    tree = _collected_tree(
+        tmp_path, entries=("model_index.json", "dit/config.json", "vae/config.json")
+    )
+    with pytest.raises(sk.SkeletonError) as caught:
+        sk.build(_KeepsComponents, tree)
+
+    message = str(caught.value)
+    assert "COLLECTED" in message, message
+    assert "RE-FETCHED" in message, message
+    assert not message.startswith(f"{tree} carries no model_index.json"), (
+        "the false refusal is exactly what this issue removed")
+
+
+def test_skeleton_build_walks_the_WHOLE_tree_not_just_the_index(
+    tmp_path: Path,
+) -> None:
+    """The index merely DIES FIRST. 14 entries dangle in the measured state, so
+    guarding one file would relocate the wrong message to the next component's
+    config rather than remove it. Here the index is FINE and a component config
+    is collected — the pre-fix code reached `_build_on_meta` and failed there
+    with a message about a missing config."""
+    from gen_worker.serving.streaming import skeleton as sk
+
+    tree = _collected_tree(tmp_path, entries=("dit/config.json",))
+    (tree / "model_index.json").write_text(
+        '{"_class_name": "X", "dit": ["anima.components", "AnimaDiTComponent"]}'
+    )
+
+    with pytest.raises(sk.SkeletonError) as caught:
+        sk.build(_KeepsComponents, tree)
+    assert "COLLECTED" in str(caught.value), str(caught.value)
+    assert "dit/config.json" in str(caught.value)
+
+
+def test_a_tree_that_GENUINELY_has_no_index_still_says_so(tmp_path: Path) -> None:
+    """The original wording SURVIVES and is now true whenever it is reached. A
+    fix that swallowed the genuine case would trade one wrong message for
+    another, which is the mistake this issue is about."""
+    from gen_worker.serving.streaming import skeleton as sk
+
+    bare = tmp_path / "bare"
+    (bare / "unet").mkdir(parents=True)
+    (bare / "unet" / "config.json").write_text("{}")
+
+    with pytest.raises(sk.SkeletonError) as caught:
+        sk.build(_KeepsComponents, bare)
+    assert "carries no model_index.json" in str(caught.value)
+    assert "COLLECTED" not in str(caught.value)


### PR DESCRIPTION
> **Stacked on #1072 (`2204-shortwrite`), deliberately.** It calls that PR's shared helper *and* folds into that PR's test module rather than adding copies of either. Base retargets to `master` once #1072 lands.

`skeleton.build` reported **"carries no model_index.json" about trees that HAVE one.** `Path.is_file()` follows the link, so *"this tree never had an index"* and *"this tree's objects were collected"* arrived at the same check as the same `False` — and the second is a fact about the **store** that the refusal reported as a fact about the **checkpoint**. pgw#1308 finding 3, for the fourth time.

## Measured, not theorised

A projected tree's manifest pin is the **only GC root its objects have**. On a real 5.6 GB `tensorhub/anima@composed-v3` tree (se#790):

```
removed pin -> collect_garbage
  -> examined=1211  reachable=0  deleted=1211  bytes_deleted=5,640,566,685
stubs=3   dangling symlinks=14   model_index.json among them
```

Against that same tree, `carries no model_index.json` becomes a refusal naming 14 collected entries, saying the bytes must be **RE-FETCHED** rather than re-pinned, and quoting the false string it replaces so anyone grepping the symptom lands on the cause.

## Three decisions worth reviewing

**The walk is whole-tree.** The index merely *dies first*, so guarding one file would relocate the wrong message to the next component's config rather than remove it. One walk, before anything is concluded.

**No second source of truth — twice.** The refusal calls #1072's `collected_entries` / `collected_refusal`; an independent implementation of both was written first and **thrown away**. And the tests **fold into `tests/test_projected_tree_reading.py`** rather than adding a module — that file's subject line ("who may, who must refuse, and what they say") already covers this caller; the eager bridge is one reader, the skeleton is the other. **Three cases, zero new files.** An earlier revision added `tests/test_collected_objects_pgw1514.py`, which pgw#1362 / DESIGN-RULINGS 4.34b correctly refuses — a filename says *when* a test was written; the tree needs it to say *what* it exercises. The guard was run, not routed around.

**The original wording survives** and is now *true* whenever reached, with a case asserting it — swallowing the genuine case would trade one wrong message for another.

## Red proven — and the first attempt at proving it was vacuous

Recorded because it is how a red proof silently stops proving anything: the first revert used `git checkout --`, which restores from **HEAD** — still carrying the fix — and reported a cheerful `10 passed`. Reverting to the **base branch's** `skeleton.py` instead:

```
test_skeleton_build_does_not_call_a_collected_tree_index_less   FAILED
test_skeleton_build_walks_the_WHOLE_tree_not_just_the_index     FAILED
2 failed, 8 passed
```

The third case passes without the fix, correctly — it guards *preserved* behaviour, not new behaviour.

```
projected-tree suites          39 passed
ruff · mypy                    clean
incident-naming guard          passes, baseline unchanged (126, and it only shrinks)
```

Filed by the th#2204 lane on this lane's measurement; owned here per coordinator assignment. **Possible visible pause:** a re-pin relay outranks this issue — if that arrives mid-review I checkpoint and return.
