### PR TITLE
pgw#1518: a model_index.json library entry may be a diffusers PIPELINE SUBMODULE

### DIFF
--- a/src/gen_worker/serving/streaming/skeleton.py
+++ b/src/gen_worker/serving/streaming/skeleton.py
@@ -56,13 +56,40 @@ class Skeleton:
 
 
 def _resolve(library: str, class_name: str) -> type:
+    """The class a ``model_index.json`` entry names.
+
+    A library entry is EITHER an importable module (``transformers``,
+    ``diffusers``) OR a diffusers PIPELINE SUBMODULE name — ``stable_diffusion``
+    for ``StableDiffusionSafetyChecker``, which is not importable as a
+    top-level module and never was. diffusers' own loader tests exactly this,
+    in this order (`hasattr(diffusers.pipelines, library_name)` →
+    ``getattr(pipeline_module, class_name)``), so this mirrors it rather than
+    inventing a second rule for the same file format.
+
+    Found by RUNNING it (pgw#1518, via pgw#1491's acceptance): every sd15 checkpoint on the
+    hub names ``stable_diffusion.StableDiffusionSafetyChecker``, and
+    `gen-worker up` died on it. It had gone unseen because the eager bridge
+    (``from_pretrained``) resolves it correctly and this skeleton is reached
+    ONLY when the tree has a chunk store behind it — i.e. exactly the
+    production-shaped path, and never the bare-tree local one the campaign
+    used.
+    """
+    module: Any
     try:
         module = importlib.import_module(library)
-    except ImportError as exc:
+    except ImportError:
+        module = None
+    if module is None or not hasattr(module, class_name):
+        pipelines = _diffusers_pipelines()
+        submodule = getattr(pipelines, library, None) if pipelines else None
+        if submodule is not None and hasattr(submodule, class_name):
+            module = submodule
+    if module is None:
         raise SkeletonError(
             f"{MODEL_INDEX} names component class {library}.{class_name}, "
-            f"but {library!r} is not importable in this image"
-        ) from exc
+            f"but {library!r} is neither importable in this image nor a "
+            f"diffusers pipeline submodule"
+        )
     found = getattr(module, class_name, None)
     if found is None or not isinstance(found, type):
         raise SkeletonError(
@@ -70,6 +97,20 @@ def _resolve(library: str, class_name: str) -> type:
             f"{library} version"
         )
     return found
+
+
+def _diffusers_pipelines() -> Any:
+    """``diffusers.pipelines``, or ``None`` when diffusers is absent.
+
+    Absent is legal: a non-diffusers endpoint's model_index names no pipeline
+    submodule, and importing diffusers to prove that would be a hard dependency
+    this module does not otherwise have.
+    """
+    try:
+        import diffusers.pipelines as pipelines
+    except ImportError:
+        return None
+    return pipelines
 
 
 def _is_module(cls: type) -> bool:

--- a/tests/test_skeleton_pipeline_submodule_pgw1518.py
+++ b/tests/test_skeleton_pipeline_submodule_pgw1518.py
@@ -1,0 +1,40 @@
+"""pgw#1518: a model_index.json library entry may be a diffusers PIPELINE
+SUBMODULE, not an importable module. Every sd15 checkpoint on the hub names
+one, and the streaming skeleton refused all of them."""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from gen_worker.serving.streaming.skeleton import SkeletonError, _resolve
+
+
+def test_pipeline_submodule_library_resolves() -> None:
+    """`stable_diffusion` is not importable as a top-level module; it is a
+    diffusers pipeline submodule. This is the exact entry every sd15
+    model_index.json carries, and the boot that found it died here."""
+    cls = _resolve("stable_diffusion", "StableDiffusionSafetyChecker")
+    assert cls.__name__ == "StableDiffusionSafetyChecker"
+    with pytest.raises(ImportError):
+        __import__("stable_diffusion")
+
+
+def test_ordinary_module_libraries_still_resolve() -> None:
+    assert _resolve("transformers", "CLIPTextModel").__name__ == "CLIPTextModel"
+    assert _resolve("diffusers", "UNet2DConditionModel").__name__ == "UNet2DConditionModel"
+
+
+def test_unknown_library_still_refuses_by_name() -> None:
+    """A genuinely absent library must still be a typed refusal — the fallback
+    widens what resolves, it must not turn a miss into a silent None."""
+    with pytest.raises(SkeletonError) as caught:
+        _resolve("no_such_library_anywhere", "Thing")
+    assert "no_such_library_anywhere" in str(caught.value)
+
+
+def test_known_library_unknown_class_refuses_by_name() -> None:
+    with pytest.raises(SkeletonError) as caught:
+        _resolve("diffusers", "NoSuchClassInThisVersion")
+    assert "NoSuchClassInThisVersion" in str(caught.value)


### PR DESCRIPTION
`serving/streaming/skeleton.py::_resolve` resolved every `model_index.json` library entry with a bare `importlib.import_module(library)`. A library entry is EITHER an importable module (`transformers`, `diffusers`) OR a diffusers **pipeline submodule** name — `stable_diffusion` for `StableDiffusionSafetyChecker`, which is not importable as a top-level module and never was. diffusers' own loader tests `hasattr(diffusers.pipelines, library_name)` first; we had invented a second, stricter rule for a file format that already has one.

**Every sd15 checkpoint on the hub names it**, so the streaming loader could not build a skeleton for any of them:

```
SkeletonError: model_index.json names component class
stable_diffusion.StableDiffusionSafetyChecker, but 'stable_diffusion'
is not importable in this image
```

This is a hard boot failure, not a degradation — nothing swallows `SkeletonError`, and `engine_for` returns `None` only when there is no chunk store at all.

## Why it was never seen, and why it matters now

The skeleton is reached **only when the checkpoint tree has a chunk store behind it**. The eager bridge resolves the same entry correctly through `from_pretrained`, and every local drive so far — the image campaign included — used BARE trees, which cannot reach this code. Production could not reach it either: until tonight no release was stamped, so no pod ever took adopt-first on a chunk-store-backed tree.

So it was latent by construction and is about to become live — sd15 `61aeac79` is stamped and route-1/route-2 pods drive exactly this path. Found by running `gen-worker up` against a CAS-backed sd15 tree (pgw#1491's acceptance), which was the first thing ever to do so.

## The fix

Mirror diffusers' rule rather than adding a third one: try the module, then `diffusers.pipelines.<library>`. Both refusals stay typed — an absent library and a known library missing the class each still say so by name, so widening what resolves does not turn a miss into a silent `None`. Absent diffusers is legal (a non-diffusers endpoint names no pipeline submodule, and importing diffusers to prove that would add a dependency this module does not have).

## Verification

- New test `tests/test_skeleton_pipeline_submodule_pgw1514.py` goes **red without the fix** (1 failed, 3 passed) and green with it. It asserts the trap directly: `import stable_diffusion` raises while `_resolve("stable_diffusion", ...)` succeeds.
- Also covers the ordinary-module case and both typed refusals, so the fallback cannot silently swallow a real miss.
- `ruff` and `mypy` clean on the changed file.
- Proven end-to-end on an RTX 4070: `gen-worker up -d` against a CAS-backed `tensorhub/sd15-base@prod` tree boots and serves (`compiled_graph_calls=31 eager_calls=0`) with this fix; without it the boot dies at first load.

Carved deliberately out of the pgw#1491 CLI-surface branch so it can land ahead of that work: this is a production serve-path fix and none of the CLI surface rides with it.