### PR TITLE
pgw#1491: gen-worker IS the endpoint CLI — download · compile · up[-d]/down · run · login · publish

### DIFF
--- a/src/gen_worker/cli/__init__.py
+++ b/src/gen_worker/cli/__init__.py
@@ -1,25 +1,41 @@
-"""gen-worker CLI — top-level argparse dispatcher.
+"""gen-worker CLI — top-level argparse dispatcher. THE endpoint interface.
 
-Subcommands:
+pgw#1491, Paul's ruling 2026-08-19: gen-worker IS the endpoint CLI. Every
+endpoint-scoped verb lives here because every one of them must run INSIDE the
+endpoint's venv against its pinned torch — ``lock`` needs its tracer,
+``compile`` its inductor, ``up`` its runtime. An external tool could only ever
+shell in and invoke this.
 
-- ``models export`` — emit this package's model vocabulary.
-- ``release derive`` — run the instrumented derive inside the release env and
-  emit the release metadata document.
+The surface, in the order a user meets it::
 
-pgw#1373 deleted the v1 subcommands (``run``, ``serve``, ``invoke``,
-``prefetch``, ``families``, ``model``, ``job``) with the declaration surface
-they drove. Local serving is ``python -m gen_worker.serving``.
+    login       authenticate to the hub (credentials USER-GLOBAL, shared by
+                every endpoint venv on this machine)
+    lock        AUTHOR-time: trace the endpoint, write endpoint.lock (committed)
+    download    fetch a checkpoint onto this machine
+    compile     pre-warm compiled graphs for this card: fetch else build
+    up [-d]     bring the endpoint up resident (foreground; -d detaches)
+    run         send one request to the endpoint that is up
+    down        stop it
+    publish     push this endpoint's source to the hub; the hub builds
 
-See ``docs/local-dev.md``.
+plus ``models export`` and ``release derive``, which are machinery rather than
+user surface.
+
+HARDCUT (pgw#1491): ``sync``, ``serve`` (as a verb) and ``gen`` are DELETED
+spellings, not aliases. ``sync`` was incoherent once checkpoints became runtime
+config — deps are ``uv sync``, artifacts are ``compile``, weights are
+``download``. ``serve`` split into ``up``/``down`` so that starting an endpoint
+and sending it work are different acts. Pre-launch, a compatibility alias would
+only preserve the confusion it renames.
 
 Exit codes (mirrored by every subcommand):
 
 - ``0``    success
-- ``1``    user-code exception (traceback to stderr)
+- ``1``    the command failed (message to stderr)
 - ``2``    CLI usage / validation error (help / message to stderr)
-- ``3``    model resolution failure (tensorhub unreachable AND cache miss,
-           or ``--offline`` with cache miss)
+- ``3``    model resolution failure (tensorhub unreachable AND cache miss)
 - ``130``  SIGINT (Ctrl-C; standard shell convention)
+
 """
 
 from __future__ import annotations
@@ -35,31 +51,43 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="gen-worker",
         description=(
-            "Develop and dogfood gen-worker endpoints locally. "
-            "Sub-command 'run' executes one endpoint method against a JSON payload "
-            "in the local Python interpreter, mirroring production behavior for "
-            "model resolution, payload validation, and context wiring."
+            "The endpoint CLI. Download a checkpoint, compile for this card, "
+            "bring the endpoint up, run requests against it, publish it."
         ),
     )
     sub = parser.add_subparsers(dest="command", metavar="<command>")
     sub.required = False  # so `gen-worker --help` works without a sub
 
-    # Lazy-import the subcommand wiring so the cli stays cheap to import
-    # for `gen-worker --help` in CI. pgw#1373 deleted the v1 subcommands
-    # (`run`, `serve`, `invoke`, `prefetch`, `families`, `model`, `job`) with
-    # the declaration surface they drove; local serving is
-    # `python -m gen_worker.serving`.
+    # Lazy-imported so the cli stays cheap for `gen-worker --help`: `up` pulls
+    # in torch, and a user asking for help must not pay for it.
     from . import models_export as _models_mod
     _models_mod.add_subparser(sub)
 
     from . import release as _release_mod
     _release_mod.add_subparser(sub)
 
-    # pgw#1466 — the endpoint-level surface: lock pins, sync materializes,
-    # serve stays resident, run executes one. Four front doors onto ONE
-    # serving core; see each module's docstring.
+    # The endpoint surface (pgw#1491). Every one of these is a front door onto
+    # ONE serving core — `run` in particular executes nothing itself.
     from . import lock as _lock_mod
     _lock_mod.add_subparser(sub)
+
+    from . import download as _download_mod
+    _download_mod.add_subparser(sub)
+
+    from . import compile as _compile_mod
+    _compile_mod.add_subparser(sub)
+
+    from . import up as _up_mod
+    _up_mod.add_subparser(sub)
+
+    from . import run as _run_mod
+    _run_mod.add_subparser(sub)
+
+    from . import login as _login_mod
+    _login_mod.add_subparser(sub)
+
+    from . import publish as _publish_mod
+    _publish_mod.add_subparser(sub)
 
     return parser
 

--- a/src/gen_worker/cli/args.py
+++ b/src/gen_worker/cli/args.py
@@ -164,15 +164,26 @@ def build_payload(
     struct_type: Any,
     *,
     base: Optional[Dict[str, Any]] = None,
+    primary: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Assemble a payload dict from ergonomic tokens, coerced via ``struct_type``.
 
     ``base`` (e.g. a ``--payload`` JSON object) is the starting point; tokens
     merge over it. Raises :class:`ArgError` on a malformed token.
+
+    ``struct_type`` may be ``None``: that is the SOCKET CLIENT case (pgw#1491's
+    ``gen-worker run``), which holds no struct because importing the endpoint
+    to send a string would mean importing torch. It then guesses scalar shapes
+    httpie-style and accepts any field name, and ``primary`` supplies the one
+    fact it cannot guess — which field a bare positional fills — published by
+    the daemon from the live struct. The authoritative decode still happens
+    there, so a bad field is a typed refusal from the real decode path rather
+    than from a client-side copy of the schema.
     """
     out: Dict[str, Any] = dict(base or {})
-    field_types = _struct_field_types(struct_type)
-    primary = primary_field(struct_type)
+    field_types = _struct_field_types(struct_type) if struct_type is not None else {}
+    if primary is None and struct_type is not None:
+        primary = primary_field(struct_type)
     primary_set = False
 
     for tok in tokens:

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -77,7 +77,6 @@ class Spec:
 
     contract: str
     graph: str
-    program: str
     target: Any
     ingress: Any
 
@@ -122,7 +121,6 @@ def specializations(lock_path: Path) -> Tuple[Spec, ...]:
                 Spec(
                     contract=str(lane.get("contract") or ""),
                     graph=str(record.get("graph") or ""),
-                    program=str(record.get("program") or ""),
                     target=record.get("target"),
                     ingress=record.get("ingress"),
                 )
@@ -230,73 +228,36 @@ def _store(cas_root: Path) -> Any:
 # --------------------------------------------------------------------------
 
 
-def _ensure_program(spec: Spec, store: Any, cas: Any, rederive: Any) -> Path:
+def _ensure_program(spec: Spec, store: Any, rederive: Any, scratch: Path) -> Path:
     """The exported program for ``spec``, re-deriving it when this box lacks it.
 
     ADDRESS-FREE (Paul, 2026-08-19): ``torch.export.save`` is deterministic per
     machine but produces DIFFERENT bytes across machines for the same traced
-    graph — 14/14 graph identities reproduce, 0/14 blob digests do. So a
-    serialized program is a LOCAL derived artifact, its identity is the graph,
-    and ``graphs[].program`` is leaving the document contract entirely
-    (torchcg 09c09b7a).
+    graph — 14/14 graph identities reproduce, 0/14 blob digests do. A serialized
+    program is therefore a LOCAL derived artifact whose only portable name is
+    the GRAPH, and ``graphs[].program`` has left the document contract
+    entirely (torchcg 09c09b7a; `document.py` now contains zero occurrences).
 
-    Two store generations, and the newer one is asked FIRST so this needs no
-    edit when the re-vendor lands: a store that exposes ``fetch_program(graph,
-    destination)`` is asked BY GRAPH IDENTITY, which is the only portable key
-    there is. Older stores are addressed by digest, and then the lock's
-    ``program`` is the address. Either way a miss is answered by re-deriving
-    locally — never by fetching, because there is nothing portable to fetch.
+    So there is exactly one lookup and it is by identity. A miss is answered by
+    re-deriving locally — never by fetching, because there is nothing portable
+    to fetch. A malformed key is a typed refusal from the store rather than a
+    miss, so a wiring bug can never spend a pointless two-minute derive.
     """
-    fetch_by_identity = getattr(store, "fetch_program", None)
-    if callable(fetch_by_identity) and _keys_programs_by_graph(store):
-        destination = Path(cas.root if hasattr(cas, "root") else ".") / "programs"
-        destination.mkdir(parents=True, exist_ok=True)
-        found = fetch_by_identity(spec.graph, destination / spec.short)
-        if found is not None:
-            return Path(found)
-        rederive()
-        found = fetch_by_identity(spec.graph, destination / spec.short)
-        if found is None:
-            raise CompileError(
-                f"no exported program for graph {spec.short} after re-deriving: "
-                f"this source tree does not produce that graph. The committed "
-                f"lock and this checkout disagree; `gen-worker lock --check` "
-                f"names the drift."
-            )
+    destination = scratch / f"{spec.short}.pt2"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    found = store.fetch_program(spec.graph, destination)
+    if found is not None:
         return Path(found)
-
-    address = spec.program
-    if address:
-        path = Path(cas.object_path(address))
-        if path.exists():
-            return path
-    address = rederive().get(spec.graph, "") or address
-    if not address:
+    rederive()
+    found = store.fetch_program(spec.graph, destination)
+    if found is None:
         raise CompileError(
-            f"graph {spec.short} has no exported program and this store keys "
-            f"programs by DIGEST, so there is no identity to ask it for. This "
-            f"is the address-free transition: re-vendor torchcg (>= 09c09b7a) "
-            f"so the store answers `fetch_program(graph, destination)`."
+            f"no exported program for graph {spec.short} even after re-deriving "
+            f"from this source tree: the committed lock and this checkout "
+            f"disagree about what this endpoint traces to. "
+            f"`gen-worker lock --check` names the drift."
         )
-    path = Path(cas.object_path(address))
-    if not path.exists():
-        raise CompileError(
-            f"re-derive named exported program {address[:16]} for graph "
-            f"{spec.short} but it is not in the graph CAS."
-        )
-    return path
-
-
-def _keys_programs_by_graph(store: Any) -> bool:
-    """Does this store address programs by GRAPH IDENTITY (not by digest)?
-
-    The distinction is invisible in the method NAME — both generations spell it
-    ``fetch_program`` — so it is answered by the presence of ``has_program``,
-    which only the identity-keyed generation carries. Guessing from the name
-    would hand a graph hash to a digest-keyed store, which reports a wiring bug
-    as "corrupted at rest".
-    """
-    return callable(getattr(store, "has_program", None))
+    return Path(found)
 
 
 def _build(
@@ -352,8 +313,6 @@ def compile_all(
     only: int = 0,
     vram_budget_gb: float = 0.0,
 ) -> List[Outcome]:
-    from .._vendor.tensorfs import LocalCAS
-
     specs = specializations(lock_path)
     if only:
         specs = specs[:only]
@@ -387,19 +346,21 @@ def compile_all(
 
     env = _env_identity(endpoint_dir, sm, lockfile)
     store = _store(cas_root)
-    cas = LocalCAS(Path(cas_root))
     artifacts_dir = Path(endpoint_dir) / ".compiled-graphs"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-    rederived: Dict[str, str] = {}
     rederive_ran = [False]
 
-    def rederive() -> Dict[str, str]:
-        """This machine's own graph -> program-address map, derived ONCE."""
+    def rederive() -> None:
+        """Regenerate this box's exported programs into the graph store, ONCE.
+
+        Once per compile run, not once per specialization: one derive emits
+        every graph the endpoint traces to, so a second call would re-pay a
+        two-minute trace to produce bytes already on disk.
+        """
         if not rederive_ran[0]:
             rederive_ran[0] = True
-            rederived.update(_rederive_programs(endpoint_dir, cas_root, lockfile))
-        return rederived
+            _rederive_programs(endpoint_dir, cas_root, lockfile)
 
     outcomes: List[Outcome] = []
     for index, spec in enumerate(specs, start=1):
@@ -425,7 +386,7 @@ def compile_all(
                     )
                     continue
                 logger.info("%s: building", label)
-                program = _ensure_program(spec, store, cas, rederive)
+                program = _ensure_program(spec, store, rederive, artifacts_dir)
                 _build(
                     spec, program=program, cas_root=Path(cas_root), sm=sm,
                     destination=destination,
@@ -450,12 +411,13 @@ def compile_all(
 
 def _rederive_programs(
     endpoint_dir: Path, cas_root: Path, lockfile: Optional[Path]
-) -> Dict[str, str]:
-    """Regenerate this machine's exported-program blobs into the graph CAS.
+) -> None:
+    """Regenerate this machine's exported programs into the graph store.
 
-    Returns ``{graph hash: program address}`` read off the document THIS derive
-    just produced — the local, honest source of an address that is not portable
-    by construction.
+    Returns nothing: since the address-free ruling the derive PUTS each program
+    under its graph identity, and the caller asks the store by that identity.
+    Handing back a map of addresses would be re-introducing exactly the
+    per-machine address the ruling deleted.
     """
     import importlib
 
@@ -475,7 +437,7 @@ def _rederive_programs(
     # second load, and it keeps this file from parsing endpoint.toml itself.
     module = importlib.import_module(load_endpoint(endpoint_dir).module_name)
     try:
-        result = derive_release(
+        derive_release(
             module,
             checkpoint_dir=endpoint_dir,
             lockfile=lockfile or lockfile_beside(str(endpoint_dir)),
@@ -484,15 +446,6 @@ def _rederive_programs(
         )
     except DeriveError as exc:
         raise CompileError(f"re-derive failed: {exc}") from exc
-    addresses: Dict[str, str] = {}
-    document = json.loads(bytes(result.document).decode("utf-8"))
-    for lane in ((document.get("graphs") or {}).get("lanes")) or []:
-        for record in lane.get("graphs") or ():
-            graph = str(record.get("graph") or "")
-            program = str(record.get("program") or "")
-            if graph and program:
-                addresses[graph] = program
-    return addresses
 
 
 # --------------------------------------------------------------------------

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -1,0 +1,536 @@
+"""``gen-worker compile`` — pre-warm this card's compiled graphs.
+
+pgw#1491. Paul: *"compile all graph-specializations for this card, if they
+cannot be fetched already."* Three properties, all load-bearing:
+
+**FETCH-FIRST.** Per specialization the hub is asked before anything is built —
+it is the fleet artifact pool, so one machine's compile is every same-env
+machine's fetch. Only a genuine miss pays for a build.
+
+**NEVER BLOCKS SERVING.** This is a separate process. An endpoint that is up
+keeps serving throughout, and its own background mint and this command key work
+by the SAME CAS entries through the work ledger (``cli/work_ledger``): each
+skips what the other landed, and whichever survives finishes the remainder.
+That is Paul's "take over the running compile" implemented as a ledger rather
+than as process adoption.
+
+**WEIGHTLESS.** Nothing here downloads a checkpoint. The exported program is a
+weightless trace and the mint runs against it, so ``compile`` legitimately runs
+before ``download``.
+
+## Address-free programs
+
+Paul ruled the exported-program blob ADDRESS-FREE: ``torch.export.save`` is
+deterministic per machine but produces different bytes across machines (14/14
+graph identities matched, 0/14 blob digests did), so the blob is a local derived
+artifact and only the graph HASH is portable. Consequently, when this machine's
+graph CAS does not hold the program for a specialization, ``compile``
+RE-DERIVES it locally from the committed source + lock (~2 min CPU) instead of
+fetching one. There is no program-blob route to call and there must never be.
+
+## The compiled floor
+
+A graph executes atomically with by-reference weights — nothing pages
+mid-graph — so below a certain grant no compiled specialization can ever be
+armed. Under such a grant this command NO-OPS by name rather than minting
+artifacts that could not be used. The floor is read from the endpoint's own
+declared lane floor today; a measured peak-VRAM stamp (pgw#1494) supersedes it
+when one exists. An UNKNOWN floor never reads as zero and never reads as
+infinite: it simply does not fire the refusal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import endpoint_lock as el
+from . import work_ledger, workspace
+
+logger = logging.getLogger(__name__)
+
+#: Outcome vocabulary. Closed: every specialization ends in exactly one of
+#: these and the summary counts them.
+PRESENT = "present"        # already in this machine's CAS
+FETCHED = "fetched"        # pulled from the hub's fleet pool
+BUILT = "built"            # compiled here
+CLAIMED = "claimed"        # another process holds the lease; it is doing it
+BELOW_FLOOR = "below_floor"  # no grant this run targets could arm it
+FAILED = "failed"
+
+
+class CompileError(RuntimeError):
+    """Compile could not start. Always names what was missing."""
+
+
+@dataclass(frozen=True, slots=True)
+class Spec:
+    """One graph specialization to satisfy."""
+
+    contract: str
+    graph: str
+    program: str
+    target: Any
+    ingress: Any
+
+    @property
+    def short(self) -> str:
+        return self.graph[:16]
+
+
+@dataclass(frozen=True, slots=True)
+class Outcome:
+    spec: Spec
+    state: str
+    detail: str = ""
+    wall_s: float = 0.0
+
+
+# --------------------------------------------------------------------------
+# Enumeration
+# --------------------------------------------------------------------------
+
+
+def specializations(lock_path: Path) -> Tuple[Spec, ...]:
+    """Every specialization the committed lock claims, in document order.
+
+    Read out of ``[derive].document`` rather than from a lifted top-level
+    table, because nothing derivable is restated in the lock — a second list
+    would be a second answer to what this endpoint compiles to.
+    """
+    block = el.read_derive_block(lock_path)
+    if block is None:
+        raise CompileError(
+            f"{lock_path} carries no derive block — this endpoint has not been "
+            f"traced.\n  Run `gen-worker lock` (author-time) first; the lock is "
+            f"committed to the endpoint repo and distributed with it."
+        )
+    document = block.decoded()
+    lanes = ((document.get("graphs") or {}).get("lanes")) or []
+    out: List[Spec] = []
+    for lane in lanes:
+        for record in lane.get("graphs") or ():
+            out.append(
+                Spec(
+                    contract=str(lane.get("contract") or ""),
+                    graph=str(record.get("graph") or ""),
+                    program=str(record.get("program") or ""),
+                    target=record.get("target"),
+                    ingress=record.get("ingress"),
+                )
+            )
+    return tuple(out)
+
+
+# --------------------------------------------------------------------------
+# The compiled floor
+# --------------------------------------------------------------------------
+
+
+def declared_floor_gb(endpoint_dir: Path) -> Optional[float]:
+    """The endpoint's declared per-lane VRAM floor, or ``None`` if it declares
+    none. ``None`` means UNKNOWN and is never treated as 0 or as infinite."""
+    try:
+        from ..discovery.discover import prime_sys_path
+        from ..serving.loader import load_endpoint
+        from ..serving.model import model_requires
+    except Exception:  # noqa: BLE001 - an import failure is not a floor
+        return None
+    try:
+        prime_sys_path(endpoint_dir)
+        loaded = load_endpoint(endpoint_dir)
+    except Exception:  # noqa: BLE001
+        return None
+    floors: List[float] = []
+    for cls in loaded.models:
+        for requirements in (model_requires(cls) or {}).values():
+            # `model_requires` answers LayoutRequirements, whose floor lives on
+            # `.minimum` (a RequirementTerms). Reading `min_vram_gb` off the
+            # outer object returns None — which this function would have
+            # rendered as "no floor declared" and the caller as "proceed". A
+            # missing floor and a floor read one level too shallow are
+            # indistinguishable downstream, so the access is explicit here.
+            terms = getattr(requirements, "minimum", None) or requirements
+            value = float(getattr(terms, "min_vram_gb", 0.0) or 0.0)
+            if value > 0.0:
+                floors.append(value)
+    return min(floors) if floors else None
+
+
+def grant_gb(stated: float) -> Optional[float]:
+    """This run's VRAM grant: the stated one, else what the card has free.
+
+    Probed ONCE and frozen (pgw#1495's shape), because a grant re-probed later
+    is a grant that can disagree with the decision it justified.
+    """
+    if stated > 0.0:
+        return stated
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        free, _total = torch.cuda.mem_get_info()
+        return float(free) / float(1024 ** 3)
+    except Exception:  # noqa: BLE001 - absent never renders as zero
+        return None
+
+
+# --------------------------------------------------------------------------
+# Store + env
+# --------------------------------------------------------------------------
+
+
+def _env_identity(endpoint_dir: Path, sm: str, lockfile: Optional[Path]) -> Any:
+    from .._vendor.torchcg.graph_identity import EnvIdentity
+    from ..env_identity import (
+        EnvIdentityError,
+        compile_stack_from_lockfile,
+        cuda_bucket,
+        lockfile_beside,
+    )
+
+    resolved = lockfile or lockfile_beside(str(endpoint_dir))
+    if resolved is None:
+        raise CompileError(
+            f"no uv.lock beside {endpoint_dir}: the artifact key carries the "
+            f"COMPILE STACK (torch/triton/nvidia-*), and the lockfile is where "
+            f"those versions are pinned. There is no second source."
+        )
+    try:
+        stack = compile_stack_from_lockfile(Path(resolved), bucket=cuda_bucket())
+    except EnvIdentityError as exc:
+        raise CompileError(f"{resolved}: {exc}") from exc
+    return EnvIdentity(stack=stack, sm=sm)
+
+
+def _store(cas_root: Path) -> Any:
+    """This machine's graph store, tiered under the hub when one is configured.
+
+    The hub tier is READ-ONLY here: publishing a locally-built artifact back to
+    the fleet pool is the pod-side mint's job (pgw#1471), which stamps driver
+    range and measured peak. A CLI publishing unstamped artifacts would fill
+    the pool with rows nothing can safely admit.
+    """
+    from ..serving.mint_store import worker_store
+
+    return worker_store(Path(cas_root), None)
+
+
+# --------------------------------------------------------------------------
+# Per-specialization work
+# --------------------------------------------------------------------------
+
+
+def _ensure_program(spec: Spec, cas: Any, rederive: Any) -> Path:
+    """The exported program blob for ``spec``, re-deriving it if absent.
+
+    ADDRESS-FREE (Paul, 2026-08-19): the blob is a local derived artifact.
+    Absent locally, it is regenerated from committed source + lock — never
+    fetched, because the bytes differ per machine while the identity does not.
+    """
+    path = cas.object_path(spec.program)
+    if Path(path).exists():
+        return Path(path)
+    rederive()
+    path = cas.object_path(spec.program)
+    if not Path(path).exists():
+        raise CompileError(
+            f"re-derive did not produce the exported program {spec.program[:16]} "
+            f"for graph {spec.short}. The committed lock and this source tree "
+            f"disagree; `gen-worker lock --check` names the drift."
+        )
+    return Path(path)
+
+
+def _build(
+    spec: Spec, *, program: Path, cas_root: Path, sm: str, destination: Path,
+) -> None:
+    """Compile one specialization in its OWN process.
+
+    A child, not a thread: inductor keeps process-global mutable state, and a
+    mint that dies must not take the driver with it. ``destination`` is
+    deliberately NOT created here — torchcg refuses a destination that already
+    exists unless every byte matches, so an empty directory made "for tidiness"
+    reads as occupied by something that is not the artifact.
+    """
+    from ..compile_cache import toolchain_digest
+
+    request = {
+        "blob": str(program),
+        "graph": spec.graph,
+        "target": spec.target,
+        "ingress": spec.ingress,
+        "target_arch": sm,
+        "toolchain": dict(toolchain_digest()),
+        "cas": str(cas_root),
+        "destination": str(destination),
+        "result": str(destination.parent / f"{spec.short}.result.json"),
+    }
+    request_path = destination.parent / f"{spec.short}.request.json"
+    request_path.parent.mkdir(parents=True, exist_ok=True)
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    argv = [
+        "nice", "-n", "19",
+        sys.executable, "-m", "gen_worker.serving.mint_child", str(request_path),
+    ]
+    completed = subprocess.run(argv, check=False, env=dict(os.environ))
+    if completed.returncode != 0:
+        raise CompileError(
+            f"mint child exited {completed.returncode} for graph {spec.short}"
+        )
+
+
+# --------------------------------------------------------------------------
+# The driver
+# --------------------------------------------------------------------------
+
+
+def compile_all(
+    *,
+    endpoint_dir: Path,
+    lock_path: Path,
+    cas_root: Path,
+    sm: str,
+    lockfile: Optional[Path],
+    only: int = 0,
+    vram_budget_gb: float = 0.0,
+) -> List[Outcome]:
+    from .._vendor.tensorfs import LocalCAS
+
+    specs = specializations(lock_path)
+    if only:
+        specs = specs[:only]
+    if not specs:
+        logger.info(
+            "compile: this endpoint's lock claims no compiled specializations "
+            "— nothing to build (it serves eager by declaration)"
+        )
+        return []
+
+    floor = declared_floor_gb(endpoint_dir)
+    grant = grant_gb(vram_budget_gb)
+    if floor is not None and grant is not None and grant < floor:
+        logger.info(
+            "compile: grant_below_compiled_floor(grant=%.1f GiB, floor=%.1f GiB) "
+            "— a compiled graph executes atomically with by-reference weights, "
+            "so nothing this endpoint compiles to could be armed under this "
+            "grant. NO-OP: %d specialization(s) left unbuilt on purpose.",
+            grant, floor, len(specs),
+        )
+        return [
+            Outcome(spec, BELOW_FLOOR, f"grant {grant:.1f} GiB < floor {floor:.1f} GiB")
+            for spec in specs
+        ]
+    if floor is None:
+        logger.info(
+            "compile: compiled floor UNKNOWN for this endpoint (no declared "
+            "lane floor, no measured stamp) — proceeding; an unknown floor is "
+            "not a floor of zero"
+        )
+
+    env = _env_identity(endpoint_dir, sm, lockfile)
+    store = _store(cas_root)
+    cas = LocalCAS(Path(cas_root))
+    artifacts_dir = Path(endpoint_dir) / ".compiled-graphs"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    rederived = {"done": False}
+
+    def rederive() -> None:
+        if rederived["done"]:
+            return
+        rederived["done"] = True
+        _rederive_programs(endpoint_dir, cas_root, lockfile)
+
+    outcomes: List[Outcome] = []
+    for index, spec in enumerate(specs, start=1):
+        started = time.monotonic()
+        label = f"[{index}/{len(specs)}] {spec.contract} {spec.short}"
+        try:
+            if store.has_artifact(spec.graph, env):
+                logger.info("%s: present", label)
+                outcomes.append(Outcome(spec, PRESENT, wall_s=time.monotonic() - started))
+                continue
+        except Exception as exc:  # noqa: BLE001 — a store miss is not fatal
+            logger.warning("%s: store lookup failed (%s); treating as a miss", label, exc)
+
+        destination = artifacts_dir / spec.short
+        try:
+            with work_ledger.lease(Path(cas_root), f"{spec.graph}/{env.value}"):
+                # Re-check under the lease: the holder we queued behind may
+                # have landed exactly this artifact while we waited.
+                if store.has_artifact(spec.graph, env):
+                    logger.info("%s: present (landed while claimed)", label)
+                    outcomes.append(
+                        Outcome(spec, PRESENT, wall_s=time.monotonic() - started)
+                    )
+                    continue
+                logger.info("%s: building", label)
+                program = _ensure_program(spec, cas, rederive)
+                _build(
+                    spec, program=program, cas_root=Path(cas_root), sm=sm,
+                    destination=destination,
+                )
+                outcomes.append(
+                    Outcome(spec, BUILT, wall_s=time.monotonic() - started)
+                )
+        except work_ledger.Busy:
+            logger.info(
+                "%s: claimed by another process — skipping (the work ledger is "
+                "how compile and a serving mint share this)", label,
+            )
+            outcomes.append(Outcome(spec, CLAIMED, wall_s=time.monotonic() - started))
+        except Exception as exc:  # noqa: BLE001 — one failure is not the run
+            logger.error("%s: FAILED: %s: %s", label, type(exc).__name__, exc)
+            outcomes.append(
+                Outcome(spec, FAILED, f"{type(exc).__name__}: {exc}",
+                        wall_s=time.monotonic() - started)
+            )
+    return outcomes
+
+
+def _rederive_programs(
+    endpoint_dir: Path, cas_root: Path, lockfile: Optional[Path]
+) -> None:
+    """Regenerate this machine's exported-program blobs into the graph CAS."""
+    import importlib
+
+    from ..discovery.discover import prime_sys_path
+    from ..env_identity import lockfile_beside
+    from ..release.derive import DeriveError, derive_release
+    from ..serving.loader import load_endpoint
+
+    logger.info(
+        "compile: exported program absent locally — re-deriving from committed "
+        "source + lock (address-free blobs: the identity travels, the bytes "
+        "do not)"
+    )
+    prime_sys_path(endpoint_dir)
+    # `load_endpoint` is the ONE reader of endpoint.toml's `main =` and it has
+    # already imported the module; re-importing by name is a dict lookup, not a
+    # second load, and it keeps this file from parsing endpoint.toml itself.
+    module = importlib.import_module(load_endpoint(endpoint_dir).module_name)
+    try:
+        derive_release(
+            module,
+            checkpoint_dir=endpoint_dir,
+            lockfile=lockfile or lockfile_beside(str(endpoint_dir)),
+            graph_cas=Path(cas_root),
+            slot_checkpoints={},
+        )
+    except DeriveError as exc:
+        raise CompileError(f"re-derive failed: {exc}") from exc
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
+    parser = sub.add_parser(
+        "compile",
+        help="Pre-warm this card's compiled graphs: fetch else build.",
+        description=(
+            "Satisfy every graph specialization the committed endpoint.lock "
+            "claims, for this card's sm and this venv's compile stack. Fetches "
+            "from the hub's fleet pool when it can, builds when it must, and "
+            "shares the work with any serving process's background mint "
+            "through the CAS work ledger. Weightless — no checkpoint needed."
+        ),
+    )
+    parser.add_argument("endpoint_dir", nargs="?", default=".",
+                        help="directory holding endpoint.toml (default: .)")
+    parser.add_argument("--sm", default="",
+                        help="target sm (e.g. sm_89); default: this card's")
+    parser.add_argument("--graph-store", default="", metavar="DIR",
+                        help="graph CAS root (default: the box graph CAS)")
+    parser.add_argument("--lock", default="", metavar="PATH",
+                        help="endpoint.lock (default: the one beside the endpoint)")
+    parser.add_argument("--env-lockfile", default="", metavar="PATH",
+                        help="uv.lock stating the compile stack (default: the "
+                             "endpoint's own)")
+    parser.add_argument("--only", type=int, default=0, metavar="N",
+                        help="stop after N specializations (bring-up aid)")
+    parser.add_argument("--vram-budget", type=float, default=0.0, metavar="GB",
+                        help="the grant this compile targets; below the "
+                             "endpoint's compiled floor it no-ops by name. "
+                             "0 = probe this card once.")
+    parser.set_defaults(_handler=run_compile)
+
+
+def _this_sm() -> str:
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return ""
+        major, minor = torch.cuda.get_device_capability()
+        return f"sm_{major}{minor}"
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def run_compile(args: argparse.Namespace) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(message)s", stream=sys.stderr, force=False,
+    )
+    endpoint_dir = Path(args.endpoint_dir).resolve()
+    sm = args.sm or _this_sm()
+    if not sm:
+        sys.stderr.write(
+            "gen-worker compile: no --sm and no visible CUDA device. Compiled "
+            "artifacts are keyed per-sm, so there is nothing to compile FOR. "
+            "Pass --sm sm_89 to build for a card you will serve on.\n"
+        )
+        return 2
+    lock_path = Path(args.lock) if args.lock else endpoint_dir / el.LOCK_FILENAME
+    cas_root = Path(args.graph_store) if args.graph_store else workspace.graph_cas_root()
+    try:
+        outcomes = compile_all(
+            endpoint_dir=endpoint_dir,
+            lock_path=lock_path,
+            cas_root=cas_root,
+            sm=sm,
+            lockfile=Path(args.env_lockfile) if args.env_lockfile else None,
+            only=int(args.only or 0),
+            vram_budget_gb=float(args.vram_budget or 0.0),
+        )
+    except CompileError as exc:
+        sys.stderr.write(f"gen-worker compile: {exc}\n")
+        return 1
+    counts: Dict[str, int] = {}
+    for outcome in outcomes:
+        counts[outcome.state] = counts.get(outcome.state, 0) + 1
+    sys.stderr.write(
+        "gen-worker compile: "
+        + ", ".join(f"{state}={counts[state]}" for state in sorted(counts))
+        + f" (of {len(outcomes)})\n"
+    )
+    return 1 if counts.get(FAILED) else 0
+
+
+__all__ = [
+    "BELOW_FLOOR",
+    "BUILT",
+    "CLAIMED",
+    "CompileError",
+    "FAILED",
+    "FETCHED",
+    "Outcome",
+    "PRESENT",
+    "Spec",
+    "add_subparser",
+    "compile_all",
+    "run_compile",
+    "specializations",
+]

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -230,25 +230,73 @@ def _store(cas_root: Path) -> Any:
 # --------------------------------------------------------------------------
 
 
-def _ensure_program(spec: Spec, cas: Any, rederive: Any) -> Path:
-    """The exported program blob for ``spec``, re-deriving it if absent.
+def _ensure_program(spec: Spec, store: Any, cas: Any, rederive: Any) -> Path:
+    """The exported program for ``spec``, re-deriving it when this box lacks it.
 
-    ADDRESS-FREE (Paul, 2026-08-19): the blob is a local derived artifact.
-    Absent locally, it is regenerated from committed source + lock — never
-    fetched, because the bytes differ per machine while the identity does not.
+    ADDRESS-FREE (Paul, 2026-08-19): ``torch.export.save`` is deterministic per
+    machine but produces DIFFERENT bytes across machines for the same traced
+    graph — 14/14 graph identities reproduce, 0/14 blob digests do. So a
+    serialized program is a LOCAL derived artifact, its identity is the graph,
+    and ``graphs[].program`` is leaving the document contract entirely
+    (torchcg 09c09b7a).
+
+    Two store generations, and the newer one is asked FIRST so this needs no
+    edit when the re-vendor lands: a store that exposes ``fetch_program(graph,
+    destination)`` is asked BY GRAPH IDENTITY, which is the only portable key
+    there is. Older stores are addressed by digest, and then the lock's
+    ``program`` is the address. Either way a miss is answered by re-deriving
+    locally — never by fetching, because there is nothing portable to fetch.
     """
-    path = cas.object_path(spec.program)
-    if Path(path).exists():
-        return Path(path)
-    rederive()
-    path = cas.object_path(spec.program)
-    if not Path(path).exists():
+    fetch_by_identity = getattr(store, "fetch_program", None)
+    if callable(fetch_by_identity) and _keys_programs_by_graph(store):
+        destination = Path(cas.root if hasattr(cas, "root") else ".") / "programs"
+        destination.mkdir(parents=True, exist_ok=True)
+        found = fetch_by_identity(spec.graph, destination / spec.short)
+        if found is not None:
+            return Path(found)
+        rederive()
+        found = fetch_by_identity(spec.graph, destination / spec.short)
+        if found is None:
+            raise CompileError(
+                f"no exported program for graph {spec.short} after re-deriving: "
+                f"this source tree does not produce that graph. The committed "
+                f"lock and this checkout disagree; `gen-worker lock --check` "
+                f"names the drift."
+            )
+        return Path(found)
+
+    address = spec.program
+    if address:
+        path = Path(cas.object_path(address))
+        if path.exists():
+            return path
+    address = rederive().get(spec.graph, "") or address
+    if not address:
         raise CompileError(
-            f"re-derive did not produce the exported program {spec.program[:16]} "
-            f"for graph {spec.short}. The committed lock and this source tree "
-            f"disagree; `gen-worker lock --check` names the drift."
+            f"graph {spec.short} has no exported program and this store keys "
+            f"programs by DIGEST, so there is no identity to ask it for. This "
+            f"is the address-free transition: re-vendor torchcg (>= 09c09b7a) "
+            f"so the store answers `fetch_program(graph, destination)`."
         )
-    return Path(path)
+    path = Path(cas.object_path(address))
+    if not path.exists():
+        raise CompileError(
+            f"re-derive named exported program {address[:16]} for graph "
+            f"{spec.short} but it is not in the graph CAS."
+        )
+    return path
+
+
+def _keys_programs_by_graph(store: Any) -> bool:
+    """Does this store address programs by GRAPH IDENTITY (not by digest)?
+
+    The distinction is invisible in the method NAME — both generations spell it
+    ``fetch_program`` — so it is answered by the presence of ``has_program``,
+    which only the identity-keyed generation carries. Guessing from the name
+    would hand a graph hash to a digest-keyed store, which reports a wiring bug
+    as "corrupted at rest".
+    """
+    return callable(getattr(store, "has_program", None))
 
 
 def _build(
@@ -343,13 +391,15 @@ def compile_all(
     artifacts_dir = Path(endpoint_dir) / ".compiled-graphs"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-    rederived = {"done": False}
+    rederived: Dict[str, str] = {}
+    rederive_ran = [False]
 
-    def rederive() -> None:
-        if rederived["done"]:
-            return
-        rederived["done"] = True
-        _rederive_programs(endpoint_dir, cas_root, lockfile)
+    def rederive() -> Dict[str, str]:
+        """This machine's own graph -> program-address map, derived ONCE."""
+        if not rederive_ran[0]:
+            rederive_ran[0] = True
+            rederived.update(_rederive_programs(endpoint_dir, cas_root, lockfile))
+        return rederived
 
     outcomes: List[Outcome] = []
     for index, spec in enumerate(specs, start=1):
@@ -375,7 +425,7 @@ def compile_all(
                     )
                     continue
                 logger.info("%s: building", label)
-                program = _ensure_program(spec, cas, rederive)
+                program = _ensure_program(spec, store, cas, rederive)
                 _build(
                     spec, program=program, cas_root=Path(cas_root), sm=sm,
                     destination=destination,
@@ -400,8 +450,13 @@ def compile_all(
 
 def _rederive_programs(
     endpoint_dir: Path, cas_root: Path, lockfile: Optional[Path]
-) -> None:
-    """Regenerate this machine's exported-program blobs into the graph CAS."""
+) -> Dict[str, str]:
+    """Regenerate this machine's exported-program blobs into the graph CAS.
+
+    Returns ``{graph hash: program address}`` read off the document THIS derive
+    just produced — the local, honest source of an address that is not portable
+    by construction.
+    """
     import importlib
 
     from ..discovery.discover import prime_sys_path
@@ -420,7 +475,7 @@ def _rederive_programs(
     # second load, and it keeps this file from parsing endpoint.toml itself.
     module = importlib.import_module(load_endpoint(endpoint_dir).module_name)
     try:
-        derive_release(
+        result = derive_release(
             module,
             checkpoint_dir=endpoint_dir,
             lockfile=lockfile or lockfile_beside(str(endpoint_dir)),
@@ -429,6 +484,15 @@ def _rederive_programs(
         )
     except DeriveError as exc:
         raise CompileError(f"re-derive failed: {exc}") from exc
+    addresses: Dict[str, str] = {}
+    document = json.loads(bytes(result.document).decode("utf-8"))
+    for lane in ((document.get("graphs") or {}).get("lanes")) or []:
+        for record in lane.get("graphs") or ():
+            graph = str(record.get("graph") or "")
+            program = str(record.get("program") or "")
+            if graph and program:
+                addresses[graph] = program
+    return addresses
 
 
 # --------------------------------------------------------------------------

--- a/src/gen_worker/cli/credentials.py
+++ b/src/gen_worker/cli/credentials.py
@@ -1,0 +1,224 @@
+"""USER-GLOBAL hub credentials, shared by every endpoint venv on the machine.
+
+pgw#1491. Paul's ruling: ``login`` writes credentials user-global "so one login
+serves every endpoint venv on this machine". Each endpoint has its own venv
+with its own pinned torch, so a credential stored per-venv would mean logging
+in once per endpoint — and N copies of one secret is how they diverge.
+
+## This is the store cozy-local already uses, deliberately
+
+``~/.cozy/credentials.d/<name>.<profile>.json``, mode 0600. Not a new location:
+cl#85 requires cozy-local to read the SAME store gen-worker writes, and that
+store is where cozy-local's already is. Choosing a different path would create
+a second home for one secret, which is the exact defect this module's shape
+exists to prevent.
+
+## Machine tokens only — nothing here rotates
+
+The stored credential is a MACHINE TOKEN (``cozy_st_``): long-lived, scoped,
+and carrying no refresh token. That is a deliberate correction, not a
+convenience. On 2026-08-11 eight profiles on one box shared a single rotating
+refresh token; every use invalidated the copy the others held, and 737 of 740
+refresh sessions were revoked server-side. The same mechanism is what kills a
+session token in the middle of a long ``cozy build``. A credential with nothing
+to rotate cannot reproduce either failure — and this module writes a credential
+back exactly never, which is a structural absence rather than a flag.
+
+Precedence, and it matters for pods: ``TENSORHUB_TOKEN`` in the environment
+WINS over the file store, and its presence makes a missing store a non-error.
+A container with the env var and no ``~/.cozy`` at all is a working install.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+#: Marker every machine token carries. Lets a client tell a static credential
+#: from a session token without asking the server.
+MACHINE_TOKEN_MARKER = "cozy_st_"
+
+DEFAULT_HUB_NAME = "tensorhub"
+DEFAULT_PROFILE = "default"
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+class CredentialError(RuntimeError):
+    """The credential store could not be read or written."""
+
+
+def cozy_home() -> Path:
+    """``~/.cozy``, or ``COZY_HOME``. The same root cozy-local resolves."""
+    return Path(os.environ.get("COZY_HOME") or (Path.home() / ".cozy"))
+
+
+def credentials_dir() -> Path:
+    return cozy_home() / "credentials.d"
+
+
+def current_selection() -> tuple[str, str]:
+    """``(name, profile)`` from the SHARED ``~/.cozy/config.json`` pointer.
+
+    Read rather than defaulted, because the store is shared: cozy-local writes
+    ``current_name``/``current_profile`` there when a user switches profiles,
+    and a gen-worker that ignored it would authenticate as a different identity
+    than the tool the user just ran — with both of them reading files out of
+    the same directory. Absent config falls back to the plain defaults.
+    """
+    try:
+        document = json.loads((cozy_home() / "config.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return DEFAULT_HUB_NAME, DEFAULT_PROFILE
+    if not isinstance(document, dict):
+        return DEFAULT_HUB_NAME, DEFAULT_PROFILE
+    return (
+        str(document.get("current_name") or DEFAULT_HUB_NAME),
+        str(document.get("current_profile") or DEFAULT_PROFILE),
+    )
+
+
+def current_hub_url() -> str:
+    """The hub URL the shared config names, or ``""``."""
+    try:
+        document = json.loads((cozy_home() / "config.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    return str(document.get("tensorhub_url") or "") if isinstance(document, dict) else ""
+
+
+def _encode(component: str) -> str:
+    """Percent-encode a path component.
+
+    Without this, ``a/b`` + ``c`` and ``a`` + ``b/c`` collide on one filename
+    and ``..`` escapes the directory — both real, both cheap to prevent here.
+    """
+    return _UNSAFE.sub(lambda m: f"%{ord(m.group()):02X}", component)
+
+
+def credential_path(name: str = DEFAULT_HUB_NAME, profile: str = DEFAULT_PROFILE) -> Path:
+    return credentials_dir() / f"{_encode(name)}.{_encode(profile)}.json"
+
+
+@dataclass(frozen=True, slots=True)
+class Credential:
+    token: str
+    org: str = ""
+    hub_url: str = ""
+
+    @property
+    def is_machine_token(self) -> bool:
+        return self.token.startswith(MACHINE_TOKEN_MARKER)
+
+
+def load(
+    name: str = "", profile: str = ""
+) -> Optional[Credential]:
+    """The stored credential, or the environment's, or ``None``.
+
+    ``TENSORHUB_TOKEN`` wins: a pod is configured by its environment and must
+    not depend on a home directory it does not have. Empty ``name``/``profile``
+    take the shared pointer (:func:`current_selection`), not a local default.
+    """
+    env_token = (os.environ.get("TENSORHUB_TOKEN") or "").strip()
+    if env_token:
+        return Credential(
+            token=env_token,
+            hub_url=(os.environ.get("TENSORHUB_URL") or "").strip() or current_hub_url(),
+        )
+    selected_name, selected_profile = current_selection()
+    name = name or selected_name
+    profile = profile or selected_profile
+    path = credential_path(name, profile)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise CredentialError(f"{path}: {exc}") from exc
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CredentialError(f"{path} is not readable JSON: {exc}") from exc
+    token = str(document.get("token") or "").strip()
+    if not token:
+        return None
+    return Credential(
+        token=token,
+        org=str(document.get("org") or ""),
+        hub_url=str(document.get("hub_url") or "") or current_hub_url(),
+    )
+
+
+def save(
+    credential: Credential,
+    name: str = "",
+    profile: str = "",
+) -> Path:
+    """Write the credential 0600, atomically. Never merges — a login replaces.
+
+    The temp file is created INSIDE the destination directory with 0600 from
+    birth, so the secret is never briefly world-readable and never briefly on a
+    different filesystem where the rename would degrade to a copy.
+    """
+    selected_name, selected_profile = current_selection()
+    name = name or selected_name
+    profile = profile or selected_profile
+    directory = credentials_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    os.chmod(directory, stat.S_IRWXU)
+    path = credential_path(name, profile)
+    document = {
+        "token": credential.token,
+        "org": credential.org,
+        "hub_url": credential.hub_url,
+    }
+    fd, tmp = tempfile.mkstemp(dir=str(directory), prefix=".cred-", suffix=".json")
+    try:
+        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(document, handle)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def clear(name: str = "", profile: str = "") -> bool:
+    """Delete the credential. A logout is a DELETION, never an empty file —
+    an empty file reads as "logged in with nothing" to the next reader."""
+    selected_name, selected_profile = current_selection()
+    name = name or selected_name
+    profile = profile or selected_profile
+    try:
+        credential_path(name, profile).unlink()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise CredentialError(f"{credential_path(name, profile)}: {exc}") from exc
+    return True
+
+
+__all__ = [
+    "DEFAULT_HUB_NAME",
+    "DEFAULT_PROFILE",
+    "MACHINE_TOKEN_MARKER",
+    "Credential",
+    "CredentialError",
+    "clear",
+    "cozy_home",
+    "credential_path",
+    "credentials_dir",
+    "load",
+    "save",
+]

--- a/src/gen_worker/cli/daemon.py
+++ b/src/gen_worker/cli/daemon.py
@@ -1,0 +1,541 @@
+"""The resident endpoint: ONE booted host, one socket, many warm requests.
+
+pgw#1491. This is what ``gen-worker up`` runs and what ``gen-worker run`` is a
+client of. There is exactly one execution path for a request in this package and
+it is here — ``run`` does not boot, does not load, and does not dispatch. That
+is not tidiness: two paths that both "run a request" drift, and the drift is
+invisible because both of them keep producing images (measured three times in
+one day, pgw#1491).
+
+## Wire
+
+NDJSON over a Unix socket, one request per connection, response on the same
+connection:
+
+* request   ``{"function": str, "payload": {...}, "request_id": str?}``
+* ok        ``{"ok": true, "result": ..., "warnings": [...], "dispatch": {...}}``
+* refusal   ``{"ok": false, "error": {"kind": str, "message": str}}``
+* control   ``{"status": {}}``  -> the handle document plus live counters
+
+``dispatch`` is :class:`~gen_worker.serving.dispatch_counter.DispatchCounts` —
+every response states whether it was served by a compiled graph or eagerly.
+
+The old ``stream: true`` half of this protocol is NOT restored: entrypoints
+return one value today (``EndpointHost.dispatch``/``ServeLoop.invoke`` are not
+generators), so a streaming frame shape would be a wire contract with no
+producer behind it. It comes back with the producer, not before.
+
+## Requests are serialized
+
+One request at a time, on the accept thread's worker. The card is one lane and
+``ModelInstance.admission`` already single-flights per model; a second dispatch
+would queue on that lock anyway, so serializing here keeps the counters
+attributable to the request that produced them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import sys
+import threading
+import time
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import msgspec
+
+from . import endpoint_state, sockaddr
+from .endpoint_state import EndpointHandle
+from .protocol import PROTOCOL_VERSION, gen_worker_version
+
+#: How long a client has to finish sending its request line. The long wait is
+#: the DISPATCH, which happens after this and is not bounded here.
+REQUEST_LINE_TIMEOUT_S = 30.0
+
+
+class BootError(RuntimeError):
+    """The endpoint could not be brought up. Always names what failed."""
+
+
+@dataclass(slots=True)
+class BootSpec:
+    """Everything ``up`` decided, frozen before anything is loaded."""
+
+    endpoint_dir: Path
+    #: Checkpoint refs this endpoint serves — RUNTIME CONFIG, never a
+    #: declaration by the endpoint (DESIGN-RULINGS 2026-08-19). Materialized
+    #: through the same code path `gen-worker download` uses.
+    checkpoint_refs: Tuple[str, ...] = ()
+    #: An already-materialized tree, bypassing the ref resolution entirely.
+    checkpoint_dir: Optional[Path] = None
+    checkpoint_ref_label: str = "local/checkpoint"
+    model: str = ""
+    defaults: str = "{}"
+    lane: str = ""
+    sm: str = ""
+    graph_store: Optional[Path] = None
+    artifacts_dir: Path = Path(".compiled-graphs")
+    output_dir: Path = Path("outputs")
+    #: Background pre-warm posture: "auto" mints the adopt session's holes in
+    #: the background, "off" never compiles. `gen-worker compile` is the
+    #: explicit front door; this is the serve-coordinated half of the same
+    #: work ledger (DESIGN-RULINGS compile addendum 2).
+    compile_policy: str = "auto"
+    idle_timeout_s: float = 0.0
+    env_lockfile: Optional[Path] = None
+
+
+@dataclass(slots=True)
+class Booted:
+    """The live endpoint plus the facts the handle publishes."""
+
+    host: Any
+    loaded: Any
+    counter: Any
+    checkpoint_dir: Path
+    adopted: Tuple[str, ...] = ()
+    holes: Tuple[str, ...] = ()
+    mint: Any = None
+    warnings: List[str] = field(default_factory=list)
+
+
+def boot(spec: BootSpec) -> Booted:
+    """Load the endpoint, materialize its checkpoints, adopt, arm the counter.
+
+    The order is the invariant: bytes on disk BEFORE anything is asked to
+    serve. ``run`` requires ``up`` for exactly this reason, and a pod's boot is
+    the same three steps in one process (th#2204).
+    """
+    from .. import receipts
+    from ..serving.context import DeployBinding
+    from ..serving.dispatch_counter import DispatchCounter
+    from ..serving.host import EndpointHost
+    from ..serving.loader import load_endpoint
+
+    # The store is a directory this operator owns, not a hub delivery: the
+    # receipt gate is DECLARED off rather than left unset, because a process
+    # that declares neither posture refuses.
+    receipts.trust_local_store(
+        "gen-worker up: the compiled-graph store is a local directory the "
+        "operator owns, not a hub delivery"
+    )
+
+    loaded = load_endpoint(spec.endpoint_dir)
+    tree, ref_label = _checkpoint_tree(spec, loaded)
+
+    binding = DeployBinding(
+        checkpoint_ref=ref_label,
+        checkpoint_dir=tree,
+        model=spec.model or None,
+        defaults=json.loads(spec.defaults or "{}"),
+    )
+    host = EndpointHost(
+        loaded,
+        binding,
+        lane_contract=spec.lane,
+        output_dir=spec.output_dir,
+    )
+    store, document = _adoption_source(spec, loaded.module_name)
+    stack = _stated_stack(spec, document)
+    host.setup(
+        store=store,
+        document=document,
+        sm=spec.sm,
+        artifacts_dir=spec.artifacts_dir,
+        stack=stack,
+    )
+    counter = DispatchCounter().install(host)
+
+    adopted: Tuple[str, ...] = ()
+    holes: Tuple[str, ...] = ()
+    if host.adoption is not None:
+        adopted = tuple(record.graph for record in host.adoption.adopted)
+        holes = tuple(hole.record.graph for hole in host.holes)
+
+    booted = Booted(
+        host=host,
+        loaded=loaded,
+        counter=counter,
+        checkpoint_dir=tree,
+        adopted=adopted,
+        holes=holes,
+    )
+    if holes and spec.compile_policy == "auto" and store is not None:
+        booted.mint = _start_background_mint(spec, host, store)
+    return booted
+
+
+def _checkpoint_tree(spec: BootSpec, loaded: Any) -> Tuple[Path, str]:
+    """Put the configured checkpoint on disk and return (tree, ref label).
+
+    A weightless endpoint (zero model slots, pgw#1392) names no checkpoint and
+    is not asked for one — absence is legal exactly when nothing can consume
+    it, and refused BY NAME the moment something can.
+    """
+    if spec.checkpoint_dir is not None:
+        return Path(spec.checkpoint_dir), spec.checkpoint_ref_label
+    if spec.checkpoint_refs:
+        from .download import materialize_refs
+
+        trees = materialize_refs(spec.checkpoint_refs)
+        first = spec.checkpoint_refs[0]
+        return trees[first], first
+    if loaded.models:
+        raise BootError(
+            f"no checkpoint configured: {loaded.module_name} declares model "
+            f"slot(s) on "
+            f"{', '.join(sorted(m.__name__ for m in loaded.models))}, and a "
+            f"model slot is loaded FROM a checkpoint tree.\n"
+            f"  Name one with `--checkpoint-ref owner/name@rev` (or "
+            f"`--checkpoint <dir>` for a tree you already have), or run "
+            f"`gen-worker download` first — it defaults to the endpoint "
+            f"author's recommended checkpoint."
+        )
+    return Path(os.devnull).parent / "__weightless__", spec.checkpoint_ref_label
+
+
+def _adoption_source(spec: BootSpec, module_name: str) -> Tuple[Any, Any]:
+    """(store, document) for this boot, or (None, None) — the eager bridge."""
+    if spec.graph_store is None:
+        return None, None
+    if not spec.sm:
+        raise BootError(
+            "--sm is required to adopt compiled graphs (artifacts are per-sm). "
+            "Omit --graph-store to serve eager."
+        )
+    from .._vendor.tensorfs import LocalCAS
+    from .._vendor.torchcg.store import LocalGraphStore
+
+    store = LocalGraphStore(LocalCAS(Path(spec.graph_store)))
+    return store, store.get_graphs(module_name)
+
+
+def _stated_stack(spec: BootSpec, document: Any) -> Optional[Any]:
+    """This boot's compile stack, off the endpoint's own uv.lock (pgw#1489)."""
+    if document is None:
+        return None
+    from ..env_identity import (
+        EnvIdentityError,
+        compile_stack_from_lockfile,
+        cuda_bucket,
+        lockfile_beside,
+    )
+
+    lockfile = spec.env_lockfile or lockfile_beside(str(spec.endpoint_dir))
+    if lockfile is None:
+        return None
+    try:
+        return dict(compile_stack_from_lockfile(Path(lockfile), bucket=cuda_bucket()))
+    except EnvIdentityError as exc:
+        raise BootError(f"compile stack from {lockfile}: {exc}") from exc
+
+
+def _start_background_mint(spec: BootSpec, host: Any, store: Any) -> Any:
+    """Fill this boot's holes without blocking a single request.
+
+    Paul's "take over the running compile" lands as the WORK LEDGER, not
+    process adoption: this mint and an external ``gen-worker compile`` key work
+    by the same CAS entries, so each skips what the other already landed
+    (skip-if-present measured at ~10 s/hit) and whichever survives finishes the
+    remainder.
+    """
+    from ..compile_cache import toolchain_digest
+    from ..serving.self_mint import SelfMint
+
+    box = SelfMint(
+        store=store,
+        artifacts_dir=Path(spec.artifacts_dir),
+        cas_dir=Path(spec.graph_store or (Path(spec.artifacts_dir) / "cas")),
+        target_arch=spec.sm,
+        toolchain=dict(toolchain_digest()),
+    )
+    box.arm(host)
+    return box
+
+
+# --------------------------------------------------------------------------
+# The resident process
+# --------------------------------------------------------------------------
+
+
+class ResidentEndpoint:
+    """One booted endpoint answering NDJSON requests until told to stop."""
+
+    def __init__(self, booted: Booted, spec: BootSpec, handle: EndpointHandle) -> None:
+        self.booted = booted
+        self.spec = spec
+        self.handle = handle
+        self._stop = threading.Event()
+        self._dispatch_lock = threading.Lock()
+        self._served = 0
+        self._last_activity = time.time()
+        self._booted_at = time.time()
+
+    # -- handle -------------------------------------------------------------
+
+    def _document(self, state: str) -> Dict[str, Any]:
+        return {
+            "protocol_version": PROTOCOL_VERSION,
+            "gen_worker_version": gen_worker_version(),
+            "state": state,
+            "pid": os.getpid(),
+            "endpoint_dir": str(self.spec.endpoint_dir),
+            "module": self.booted.loaded.module_name,
+            "socket": str(self.handle.socket_path),
+            "functions": sorted(self.booted.loaded.entrypoints),
+            # The ONE fact a client needs to turn `run "a cat"` into a payload:
+            # which field a bare positional fills. Published from the live
+            # msgspec struct rather than copied into a schema the client would
+            # then have to keep in step — and it is one name, not a type map,
+            # because the authoritative decode still happens here.
+            "primary_fields": self._primary_fields(),
+            "checkpoint_dir": str(self.booted.checkpoint_dir),
+            "checkpoint_refs": list(self.spec.checkpoint_refs),
+            "output_dir": str(self.spec.output_dir.resolve()),
+            "adopted_graphs": list(self.booted.adopted),
+            "holes": list(self.booted.holes),
+            "sm": self.spec.sm,
+            "lane": self.spec.lane,
+            "booted_at": self._booted_at,
+            "served": self._served,
+        }
+
+    def _primary_fields(self) -> Dict[str, str]:
+        from .args import primary_field
+
+        out: Dict[str, str] = {}
+        for name, spec in self.booted.loaded.entrypoints.items():
+            field_name = primary_field(spec.payload_type)
+            if field_name:
+                out[name] = field_name
+        return out
+
+    def publish(self, state: str) -> None:
+        endpoint_state.write_handle(self.handle, self._document(state))
+
+    # -- serving ------------------------------------------------------------
+
+    def dispatch(self, frame: Dict[str, Any]) -> Dict[str, Any]:
+        """Run one request. Never raises — every failure is a typed envelope,
+        because a transport that dies on a bad payload takes the warm models
+        with it."""
+        function = frame.get("function")
+        payload = frame.get("payload", {})
+        request_id = str(frame.get("request_id") or f"run-{self._served}")
+        with self._dispatch_lock:
+            self._last_activity = time.time()
+            self._served += 1
+            counter = self.booted.counter
+            # A late mint arms artifacts onto the live session; re-wrap before
+            # the request so graphs landed since the last one are counted.
+            counter.rearm()
+            counter.reset()
+            ctx = self.booted.host.make_context(request_id)
+            try:
+                result = self.booted.host.dispatch(
+                    str(function), payload, request_id=request_id, ctx=ctx
+                )
+            except Exception as exc:  # noqa: BLE001 — every failure is a value
+                counts = counter.take()
+                kind = _error_kind(exc)
+                if kind == "user_exception":
+                    traceback.print_exc(file=sys.stderr)
+                return {
+                    "ok": False,
+                    "request_id": request_id,
+                    "error": {"kind": kind, "message": str(exc)},
+                    "dispatch": counts.facts(),
+                }
+            counts = counter.take()
+        sys.stderr.write(f"{counts.summary()}\n")
+        sys.stderr.flush()
+        return {
+            "ok": True,
+            "request_id": request_id,
+            "result": msgspec.to_builtins(result),
+            "warnings": list(getattr(ctx, "warnings", ()) or ()),
+            "dispatch": counts.facts(),
+        }
+
+    def status(self) -> Dict[str, Any]:
+        document = self._document("ready")
+        mint = self.booted.mint
+        if mint is not None:
+            try:
+                document["mint"] = dict(mint.facts())
+            except Exception:  # noqa: BLE001 — status must never fail
+                document["mint"] = {"state": "unreadable"}
+        return {"ok": True, "status": document}
+
+    # -- transport ----------------------------------------------------------
+
+    def serve_forever(self) -> int:
+        listen = str(self.handle.socket_path)
+        server = sockaddr.create_listener(listen, backlog=16)
+        server.settimeout(0.5)
+        self.publish("ready")
+        sys.stderr.write(
+            f"gen-worker up: {self.booted.loaded.module_name} ready on {listen}\n"
+            f"gen-worker up: functions: "
+            f"{', '.join(sorted(self.booted.loaded.entrypoints))}\n"
+            f"gen-worker up: run one with "
+            f"`gen-worker run \"<prompt>\"` in another shell\n"
+        )
+        sys.stderr.flush()
+        try:
+            while not self._stop.is_set():
+                try:
+                    conn, _ = server.accept()
+                except socket.timeout:
+                    if self._idle_expired():
+                        sys.stderr.write(
+                            f"gen-worker up: idle for {self.spec.idle_timeout_s:.0f}s; "
+                            f"shutting down and freeing the card\n"
+                        )
+                        break
+                    continue
+                except OSError:
+                    break
+                threading.Thread(
+                    target=self._handle_conn, args=(conn,), daemon=True
+                ).start()
+        finally:
+            server.close()
+            sockaddr.cleanup_listener(listen)
+            self.teardown()
+        return 0
+
+    def _idle_expired(self) -> bool:
+        timeout = float(self.spec.idle_timeout_s or 0.0)
+        if timeout <= 0.0:
+            return False
+        with self._dispatch_lock:
+            idle_for = time.time() - self._last_activity
+        return idle_for >= timeout
+
+    def _handle_conn(self, conn: socket.socket) -> None:
+        try:
+            frame = _read_frame(conn)
+            if frame is None:
+                return
+            if "status" in frame:
+                response: Dict[str, Any] = self.status()
+            elif "shutdown" in frame:
+                response = {"ok": True, "shutting_down": True}
+                self._stop.set()
+            elif not isinstance(frame.get("function"), str) or not frame["function"]:
+                response = {
+                    "ok": False,
+                    "error": {
+                        "kind": "usage",
+                        "message": "request.function (string) is required",
+                    },
+                }
+            else:
+                response = self.dispatch(frame)
+            _send(conn, response)
+        except OSError:
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def teardown(self) -> None:
+        self.publish("stopping")
+        try:
+            self.booted.counter.close()
+        except Exception:  # noqa: BLE001
+            pass
+        mint = self.booted.mint
+        if mint is not None:
+            try:
+                mint.cancel()
+            except Exception:  # noqa: BLE001 — the mint is best-effort work
+                pass
+        try:
+            self.booted.host.teardown()
+        finally:
+            endpoint_state.clear_handle(self.handle)
+        sys.stderr.write("gen-worker up: down\n")
+        sys.stderr.flush()
+
+
+def _error_kind(exc: BaseException) -> str:
+    """The typed word for a dispatch failure. One vocabulary, closed."""
+    from ..serving.host import ServeDispatchError
+
+    if isinstance(exc, ServeDispatchError):
+        return "no_such_function"
+    if isinstance(exc, msgspec.ValidationError):
+        return "payload_invalid"
+    if isinstance(exc, msgspec.DecodeError):
+        return "payload_invalid"
+    return "user_exception"
+
+
+def _read_frame(conn: socket.socket) -> Optional[Dict[str, Any]]:
+    buf = bytearray()
+    conn.settimeout(REQUEST_LINE_TIMEOUT_S)
+    try:
+        while b"\n" not in buf:
+            chunk = conn.recv(65536)
+            if not chunk:
+                break
+            if len(buf) + len(chunk) > sockaddr.MAX_NDJSON_LINE_BYTES:
+                return None
+            buf.extend(chunk)
+    except (socket.timeout, OSError):
+        return None
+    line = bytes(buf).split(b"\n", 1)[0].strip()
+    if not line:
+        return None
+    try:
+        frame = json.loads(line.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {"function": ""}
+    return frame if isinstance(frame, dict) else {"function": ""}
+
+
+def _send(conn: socket.socket, envelope: Dict[str, Any]) -> None:
+    line = json.dumps(envelope, separators=(",", ":"), default=str) + "\n"
+    conn.settimeout(None)
+    conn.sendall(line.encode("utf-8"))
+
+
+def serve(spec: BootSpec, handle: EndpointHandle) -> int:
+    """Boot and serve until SIGINT/SIGTERM. The body of ``up``, both modes."""
+    booted = boot(spec)
+    resident = ResidentEndpoint(booted, spec, handle)
+
+    def _on_signal(signum: int, _frame: Any) -> None:
+        name = "SIGTERM" if signum == signal.SIGTERM else "SIGINT"
+        sys.stderr.write(f"\ngen-worker up: {name} — tearing down\n")
+        sys.stderr.flush()
+        resident.stop()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _on_signal)
+        except (ValueError, OSError):  # pragma: no cover - non-main thread
+            pass
+    return resident.serve_forever()
+
+
+__all__ = [
+    "BootError",
+    "BootSpec",
+    "Booted",
+    "ResidentEndpoint",
+    "boot",
+    "serve",
+]

--- a/src/gen_worker/cli/download.py
+++ b/src/gen_worker/cli/download.py
@@ -1,0 +1,297 @@
+"""``gen-worker download`` — put a checkpoint on this machine.
+
+pgw#1491. CHECKPOINT-centric, never endpoint-centric: an endpoint declares no
+checkpoints at all (DESIGN-RULINGS 2026-08-19 — "that's runtime config"), so
+the download target is a property of the REF, and the endpoint only ever
+supplies a default for which ref you probably meant.
+
+    gen-worker download tensorhub/sd15-base@1
+    gen-worker download                      # the configured / recommended ref
+
+## One materialization path, and it is the pod's
+
+The bytes land through ``ModelStore.ensure_local`` — the same call
+``boot_materialize`` makes when a pod boots (th#2204). That is not reuse for
+tidiness: a second downloader would be a second answer to "is this tree
+complete and correct", and the integrity gate lives inside this one
+(``_verify_snapshot_tree`` → quarantine → refetch). A CLI that fetched bytes
+its own way would be a CLI whose trees the serving path distrusts.
+
+## Progress is the download's own
+
+Nothing here reports progress separately. ``ModelStore`` emits ``ModelEvent``,
+``weight_fetch`` positions and the ``snapshot_pull`` roll-up through one
+funnel; with no bound transport sink — which is exactly the CLI — every one of
+them lands on the logger as local progress, and on a pod the same events ride
+the worker stream as the subset the hub consumes.
+
+## Where "the recommended checkpoint" comes from
+
+Paul's ruling puts the recommendation on the HUB, ATTACHED to the endpoint
+(never declared BY it). That hub surface DOES NOT EXIST yet — there is no
+endpoint→recommended-checkpoint route in tensorhub (verified 2026-08-19; every
+`recommend*` hit there is resources, civitai settings, or a training best_step).
+So the ladder below is explicit about which rung answered, and the missing rung
+refuses BY NAME instead of guessing:
+
+1. an explicit ref on the command line — always wins;
+2. this machine's runtime config for the endpoint (``cozy.toml``'s
+   ``[runtime] checkpoints``) — which is what "checkpoints are runtime config"
+   means locally;
+3. the hub's recommended-checkpoint metadata — STUBBED: refuses naming the
+   missing hub half rather than silently falling back to a guess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: The per-machine runtime config beside an endpoint. Rung 2 of the ladder.
+RUNTIME_CONFIG_NAME = "cozy.toml"
+
+
+class DownloadError(RuntimeError):
+    """A ref could not be resolved or materialized. Always names which."""
+
+
+class NoRecommendedCheckpoint(DownloadError):
+    """Nothing named a checkpoint and no rung of the ladder could answer."""
+
+
+# --------------------------------------------------------------------------
+# Which checkpoint(s)
+# --------------------------------------------------------------------------
+
+
+def runtime_config_refs(endpoint_dir: Path) -> Tuple[str, ...]:
+    """Checkpoint refs this machine's runtime config names for the endpoint.
+
+    Runtime config, not endpoint declaration — the file is the operator's, sits
+    beside the endpoint, and is not part of what gets published. An absent file
+    is not an error; it means this machine has not been told yet.
+    """
+    import tomllib
+
+    path = Path(endpoint_dir) / RUNTIME_CONFIG_NAME
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return ()
+    except OSError as exc:
+        raise DownloadError(f"{path}: {exc}") from exc
+    try:
+        document = tomllib.loads(raw.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        raise DownloadError(f"{path} is not readable TOML: {exc}") from exc
+    runtime = document.get("runtime")
+    if not isinstance(runtime, dict):
+        return ()
+    refs = runtime.get("checkpoints")
+    if isinstance(refs, str):
+        return (refs,)
+    if isinstance(refs, list) and all(isinstance(r, str) for r in refs):
+        return tuple(refs)
+    if refs is None:
+        return ()
+    raise DownloadError(
+        f"{path}: [runtime].checkpoints must be a ref string or a list of them"
+    )
+
+
+def recommended_refs(endpoint_dir: Path) -> Tuple[str, ...]:
+    """The author's recommended checkpoint(s), by the ladder in the docstring.
+
+    Raises :class:`NoRecommendedCheckpoint` naming every rung it tried, because
+    "download did nothing" must never be a silent outcome.
+    """
+    configured = runtime_config_refs(endpoint_dir)
+    if configured:
+        return configured
+    raise NoRecommendedCheckpoint(
+        f"no checkpoint named, and nothing on this machine says which one.\n"
+        f"  Name one:            gen-worker download owner/name@release\n"
+        f"  Or configure it:     {Path(endpoint_dir) / RUNTIME_CONFIG_NAME} ->\n"
+        f"                         [runtime]\n"
+        f"                         checkpoints = [\"owner/name@release\"]\n"
+        f"  The hub's author-recommended-checkpoint metadata (the third source)\n"
+        f"  is NOT BUILT YET — tensorhub exposes no endpoint->recommended\n"
+        f"  checkpoint route today, so this command will not guess one."
+    )
+
+
+# --------------------------------------------------------------------------
+# Materialization
+# --------------------------------------------------------------------------
+
+
+def _logging_emit() -> Any:
+    """The CLI's transport sink: there isn't one, and that is the design.
+
+    ``ModelStore`` needs an async emitter for the wire messages a pod sends its
+    hub. A CLI has no hub, so the events go where every other unbound sink
+    sends them — the logger — and the SAME funnel serves both.
+    """
+
+    async def emit(_message: Any) -> None:
+        return None
+
+    return emit
+
+
+def _resolve_snapshot(ref_text: str) -> Tuple[Any, Any]:
+    """(WireRef, pb.Snapshot) for a ref, resolved against the hub.
+
+    A tensorhub ref carries no file list of its own; the hub composes the
+    manifest. The worker can never resolve one itself, so a ref with no
+    reachable hub is a refusal here rather than a mysterious
+    ``MissingSnapshotError`` four frames down.
+    """
+    from ..models.hub_client import HubResolveError, resolve_repo
+    from ..models.refs import format_model_ref, parse_model_ref
+    from ..wire_snapshots import snapshot_from_resolved_repo
+
+    try:
+        parsed = parse_model_ref(ref_text)
+    except ValueError as exc:
+        raise DownloadError(f"{ref_text}: {exc}") from exc
+    ref = format_model_ref(parsed)
+    if parsed.tensorhub is None:
+        # A hf/civitai/modelscope ref resolves inside the download layer
+        # itself; no hub manifest exists to fetch, and passing None is how
+        # that is stated rather than synthesizing an empty one.
+        return ref, None
+    try:
+        resolved = resolve_repo(parsed.tensorhub)
+    except HubResolveError as exc:
+        raise DownloadError(f"{ref_text}: {exc}") from exc
+    return ref, snapshot_from_resolved_repo(resolved)
+
+
+async def _materialize(refs: Sequence[str]) -> Dict[str, Path]:
+    from .. import config
+    from ..models.store import ModelStore
+    from . import workspace
+
+    settings = config.current_or(config.Settings())
+    # STATE the box weight CAS; do not inherit ModelStore's default.
+    # `models.cache_paths.tensorhub_cas_dir()` answers `/tmp/tensorhub-cache/cas`
+    # — correct for a pod, where /tmp is the container's own disk and the pod
+    # is thrown away with it. On a workstation it is a SECOND store beside the
+    # box-shared one every other tool reads (`~/.cache/tensorhub/cas`), and
+    # writing there is the failure `cli/workspace` names in its own docstring:
+    # a download that pre-warms a directory the serving path never looks in.
+    # Measured, not reasoned about — the first run of this verb put 2.6 GB in
+    # the wrong place.
+    store = ModelStore(
+        _logging_emit(),
+        hf_home=settings.hf_home,
+        hf_token=settings.hf_token,
+        cache_dir=workspace.weights_cas_root(),
+    )
+    store.bind_loop()
+    trees: Dict[str, Path] = {}
+    for ref_text in refs:
+        ref, snapshot = _resolve_snapshot(ref_text)
+        if snapshot is not None:
+            store.bank_snapshot(ref, snapshot)
+        if await store.announce_resident(ref, snapshot):
+            path = store.local_path(ref)
+            if path is not None:
+                logger.info("checkpoint %s already resident at %s", ref, path)
+                trees[ref_text] = Path(path)
+                continue
+        try:
+            path = await store.ensure_local(ref, snapshot)
+        except Exception as exc:  # noqa: BLE001 — every failure names its ref
+            raise DownloadError(
+                f"{ref_text}: {type(exc).__name__}: {exc}"
+            ) from exc
+        logger.info("checkpoint %s materialized at %s", ref, path)
+        trees[ref_text] = Path(path)
+    return trees
+
+
+def materialize_refs(refs: Sequence[str]) -> Dict[str, Path]:
+    """Put every ref on disk; return ``{ref: tree}``. The shared entry.
+
+    ``up`` calls this at boot for the refs its runtime config names, and
+    ``download`` calls it for the refs on its command line. ONE path, so an
+    endpoint can never be brought up against a tree the download verb would
+    have rejected.
+    """
+    if not refs:
+        return {}
+    return asyncio.run(_materialize(list(refs)))
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
+    parser = sub.add_parser(
+        "download",
+        help="Fetch a checkpoint onto this machine.",
+        description=(
+            "Materialize checkpoint refs into the local weight store, through "
+            "the same path a pod's boot uses (integrity gate included). With "
+            "no ref, uses what this machine's runtime config names for the "
+            "endpoint."
+        ),
+    )
+    parser.add_argument(
+        "refs", nargs="*", metavar="REF",
+        help="checkpoint ref(s), e.g. owner/name@release. Omit to use the "
+             "endpoint's configured/recommended checkpoint(s).",
+    )
+    parser.add_argument(
+        "-C", "--endpoint-dir", default=".",
+        help="endpoint directory (default: the current one) — only read when "
+             "no REF is given.",
+    )
+    parser.set_defaults(_handler=run_download)
+
+
+def run_download(args: argparse.Namespace) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(message)s", stream=sys.stderr, force=False,
+    )
+    refs: Tuple[str, ...] = tuple(args.refs)
+    if not refs:
+        try:
+            refs = recommended_refs(Path(args.endpoint_dir))
+        except NoRecommendedCheckpoint as exc:
+            sys.stderr.write(f"gen-worker download: {exc}\n")
+            return 2
+        sys.stderr.write(
+            f"gen-worker download: {Path(args.endpoint_dir) / RUNTIME_CONFIG_NAME} "
+            f"names {', '.join(refs)}\n"
+        )
+    try:
+        trees = materialize_refs(refs)
+    except DownloadError as exc:
+        sys.stderr.write(f"gen-worker download: {exc}\n")
+        return 1
+    for ref_text in refs:
+        sys.stdout.write(f"{ref_text}\t{trees[ref_text]}\n")
+    return 0
+
+
+__all__ = [
+    "DownloadError",
+    "NoRecommendedCheckpoint",
+    "RUNTIME_CONFIG_NAME",
+    "add_subparser",
+    "materialize_refs",
+    "recommended_refs",
+    "run_download",
+    "runtime_config_refs",
+]

--- a/src/gen_worker/cli/endpoint_state.py
+++ b/src/gen_worker/cli/endpoint_state.py
@@ -8,7 +8,7 @@ of ``up``'s daemon, and refuses by name when nothing is up).
 
 Layout, one endpoint per directory::
 
-    ~/.cache/cozy/endpoints/<slug>-<digest8>/
+    ~/.cache/cozy/resident/<slug>-<digest8>/
         endpoint.json   the handle: pid, listen address, functions, state
         endpoint.sock   the NDJSON socket the daemon accepts on
         up.log          the detached daemon's stdout+stderr
@@ -37,10 +37,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-#: Per-user root for resident-endpoint state. Config key ``COZY_ENDPOINT_STATE``
-#: (Settings field ``endpoint_state_root``), never guessed from the environment
-#: at the call site (§1.18).
-DEFAULT_ENDPOINT_STATE = Path.home() / ".cache" / "cozy" / "endpoints"
+#: Per-user root for RESIDENT-endpoint state. Config key
+#: ``COZY_ENDPOINT_STATE`` (Settings field ``endpoint_state_root``), never
+#: guessed from the environment at the call site (§1.18).
+#:
+#: NOT ``~/.cache/cozy/endpoints`` — that directory is already taken, by
+#: cozy-local, for installed endpoint SOURCE and venvs
+#: (``paths.EndpointsDir()``). Two different things under one name is how a
+#: `down` ends up deleting a checkout. "endpoints" is where they are
+#: INSTALLED; "resident" is which of them are UP right now.
+DEFAULT_ENDPOINT_STATE = Path.home() / ".cache" / "cozy" / "resident"
 
 #: The daemon writes this the moment it is accepting requests. Its presence is
 #: not enough — see :func:`read_handle`.

--- a/src/gen_worker/cli/endpoint_state.py
+++ b/src/gen_worker/cli/endpoint_state.py
@@ -1,0 +1,246 @@
+"""Where a resident endpoint announces itself, and how the client verbs find it.
+
+pgw#1491. ``up`` starts ONE daemon and writes a handle; ``down`` and ``run``
+read that handle and talk to it. The handle is the whole coupling — there is no
+second way to discover a running endpoint, because a second way is how two
+execution paths get built (``run`` executes no inference itself; it is a client
+of ``up``'s daemon, and refuses by name when nothing is up).
+
+Layout, one endpoint per directory::
+
+    ~/.cache/cozy/endpoints/<slug>-<digest8>/
+        endpoint.json   the handle: pid, listen address, functions, state
+        endpoint.sock   the NDJSON socket the daemon accepts on
+        up.log          the detached daemon's stdout+stderr
+
+The key is derived from the endpoint directory's RESOLVED path, so two
+checkouts of the same endpoint are two endpoints and the same checkout reached
+by two spellings is one. The slug is carried alongside the digest purely so a
+human reading ``ls`` can tell which directory a state dir belongs to.
+
+Liveness is PROVEN, never assumed: :func:`read_handle` signal-0s the recorded
+pid and treats a handle whose process is gone as absent (and removes it). A
+stale handle that read as "up" would make ``run`` hang against a socket nobody
+is listening on — the exact shape of failure this module exists to prevent.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+import re
+import signal
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+#: Per-user root for resident-endpoint state. Config key ``COZY_ENDPOINT_STATE``
+#: (Settings field ``endpoint_state_root``), never guessed from the environment
+#: at the call site (§1.18).
+DEFAULT_ENDPOINT_STATE = Path.home() / ".cache" / "cozy" / "endpoints"
+
+#: The daemon writes this the moment it is accepting requests. Its presence is
+#: not enough — see :func:`read_handle`.
+HANDLE_NAME = "endpoint.json"
+SOCKET_NAME = "endpoint.sock"
+LOG_NAME = "up.log"
+
+#: Handle document version. Bump when a field changes meaning; ``run`` refuses
+#: a handle it cannot read rather than guessing.
+HANDLE_VERSION = 1
+
+_SLUG = re.compile(r"[^a-z0-9]+")
+
+
+class EndpointStateError(RuntimeError):
+    """The state directory or handle could not be read/written."""
+
+
+def state_root() -> Path:
+    from .. import config
+
+    settings = config.current_or(config.Settings())
+    return Path(getattr(settings, "endpoint_state_root", "") or DEFAULT_ENDPOINT_STATE)
+
+
+def endpoint_key(endpoint_dir: Path) -> str:
+    """``<slug>-<digest8>`` for a resolved endpoint directory.
+
+    The digest is over the resolved path so the key is stable across cwd and
+    symlink spellings; the slug is a human affordance and carries no meaning.
+    """
+    resolved = Path(endpoint_dir).resolve()
+    digest = hashlib.blake2b(str(resolved).encode("utf-8"), digest_size=4).hexdigest()
+    slug = _SLUG.sub("-", resolved.name.lower()).strip("-") or "endpoint"
+    return f"{slug}-{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointHandle:
+    """The paths one resident endpoint owns. Pure addressing — no I/O."""
+
+    endpoint_dir: Path
+    key: str
+    state_dir: Path
+
+    @property
+    def handle_path(self) -> Path:
+        return self.state_dir / HANDLE_NAME
+
+    @property
+    def socket_path(self) -> Path:
+        return self.state_dir / SOCKET_NAME
+
+    @property
+    def log_path(self) -> Path:
+        return self.state_dir / LOG_NAME
+
+
+def handle_for(endpoint_dir: str | Path) -> EndpointHandle:
+    resolved = Path(endpoint_dir).resolve()
+    key = endpoint_key(resolved)
+    return EndpointHandle(endpoint_dir=resolved, key=key, state_dir=state_root() / key)
+
+
+def pid_alive(pid: int) -> bool:
+    """Is this pid a live process we may signal?
+
+    ``ESRCH`` is the only answer that means "gone". ``EPERM`` means the pid is
+    taken by a process this user may not signal, which is still a live pid and
+    therefore still a reason not to claim the socket.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        return exc.errno != errno.ESRCH
+    return True
+
+
+def write_handle(handle: EndpointHandle, document: Dict[str, Any]) -> None:
+    """Atomically publish the handle. Rename, never truncate-then-write: a
+    reader that catches a half-written handle would refuse a live endpoint."""
+    handle.state_dir.mkdir(parents=True, exist_ok=True)
+    document = dict(document)
+    document.setdefault("handle_version", HANDLE_VERSION)
+    tmp = handle.handle_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(document, default=str), encoding="utf-8")
+    tmp.replace(handle.handle_path)
+
+
+def read_handle(handle: EndpointHandle) -> Optional[Dict[str, Any]]:
+    """The live handle, or ``None`` — with a dead one removed on the way out.
+
+    "Live" is a signal-0 against the recorded pid, not the presence of the
+    file. A crashed daemon leaves both file and socket behind; treating either
+    as evidence is how ``run`` ends up connecting to nothing.
+    """
+    try:
+        raw = handle.handle_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise EndpointStateError(f"{handle.handle_path}: {exc}") from exc
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError:
+        clear_handle(handle)
+        return None
+    if not isinstance(document, dict):
+        clear_handle(handle)
+        return None
+    if int(document.get("handle_version", 0)) != HANDLE_VERSION:
+        raise EndpointStateError(
+            f"{handle.handle_path} states handle_version="
+            f"{document.get('handle_version')!r}; this gen-worker speaks "
+            f"{HANDLE_VERSION}. `gen-worker down` and `up` again."
+        )
+    if not pid_alive(int(document.get("pid", 0) or 0)):
+        clear_handle(handle)
+        return None
+    return document
+
+
+def clear_handle(handle: EndpointHandle) -> None:
+    """Remove the handle and its socket. Idempotent; never raises."""
+    for path in (handle.handle_path, handle.socket_path):
+        try:
+            path.unlink()
+        except OSError:
+            pass
+
+
+def wait_for_handle(
+    handle: EndpointHandle,
+    *,
+    child_pid: int,
+    poll_s: float = 0.1,
+) -> Dict[str, Any]:
+    """Block until the daemon publishes a READY handle, or it dies.
+
+    NO TIMEOUT, deliberately: a cold boot legitimately spends minutes pulling
+    weights and arming graphs, and there is no elapsed-time threshold that
+    distinguishes that from a hang. The loop's terminating condition is the
+    CHILD — if it exits without publishing, that is a boot failure and the log
+    says why. Progress is observed, not clocked.
+    """
+    while True:
+        document = read_handle(handle)
+        if document is not None and document.get("state") == "ready":
+            return document
+        if not pid_alive(child_pid):
+            tail = ""
+            try:
+                tail = "\n".join(
+                    handle.log_path.read_text(encoding="utf-8").splitlines()[-40:]
+                )
+            except OSError:
+                pass
+            raise EndpointStateError(
+                f"the endpoint exited during boot without becoming ready.\n"
+                f"  log: {handle.log_path}\n"
+                + (f"  last lines:\n{tail}\n" if tail else "")
+            )
+        time.sleep(poll_s)
+
+
+def terminate(pid: int, *, poll_s: float = 0.1) -> bool:
+    """SIGTERM ``pid`` and wait for it to go. Returns False if it was not live.
+
+    Unbounded by design, same reason as :func:`wait_for_handle`: a teardown
+    that frees 8 GB of VRAM and calls the author's shutdown takes as long as it
+    takes, and a timer here would leave a half-torn-down process holding the
+    card. The caller (``down``) reports what it is waiting on.
+    """
+    if not pid_alive(pid):
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return False
+        raise
+    while pid_alive(pid):
+        time.sleep(poll_s)
+    return True
+
+
+__all__ = [
+    "DEFAULT_ENDPOINT_STATE",
+    "EndpointHandle",
+    "EndpointStateError",
+    "HANDLE_VERSION",
+    "clear_handle",
+    "endpoint_key",
+    "handle_for",
+    "pid_alive",
+    "read_handle",
+    "state_root",
+    "terminate",
+    "wait_for_handle",
+    "write_handle",
+]

--- a/src/gen_worker/cli/login.py
+++ b/src/gen_worker/cli/login.py
@@ -1,0 +1,259 @@
+"""``gen-worker login`` / ``logout`` — hub auth, once per machine.
+
+pgw#1491. The credential is written USER-GLOBAL (``cli/credentials``), so one
+login serves every endpoint venv on the box.
+
+Two ways in, and the difference is only where the token comes from:
+
+    gen-worker login --token cozy_st_...      # paste a machine token
+    gen-worker login --email you@example.com  # password login, then MINT one
+
+The second path deliberately does not keep what it logged in with. It exchanges
+the session for a MACHINE token (``POST /api/v1/orgs/:org/tokens``) and stores
+only that, discarding the access/refresh pair. A refresh token is rotating
+shared state — the thing that revoked 737 of 740 sessions on this box on
+2026-08-11 and the thing that kills a token in the middle of a long build.
+Nothing this command stores can rotate, so neither failure has a mechanism
+here.
+
+``gen-worker logout`` deletes the file. It does not revoke the token hub-side
+(that is ``tokens revoke``, deliberately separate: forgetting a credential on
+one machine and killing it for every machine are different intentions).
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict
+
+from . import credentials
+from .credentials import Credential, CredentialError
+
+#: One explicit budget per hub hop. A hung login must fail visibly.
+HTTP_TIMEOUT_S = 60.0
+
+#: What a minted machine token is allowed to do. Named, never defaulted: the
+#: hub refuses an empty scope list on purpose, and a token minted with "all"
+#: would be a credential nobody can reason about later.
+PUBLISH_SCOPES = ("org:endpoint:upsert", "org:endpoint:list", "org:endpoint:deploy")
+
+
+class LoginError(RuntimeError):
+    """Authentication failed. Always says which step."""
+
+
+def _hub_url(stated: str) -> str:
+    from .. import config
+
+    base = (stated or config.current_or(config.Settings()).tensorhub_url or "").strip()
+    if not base:
+        raise LoginError(
+            "no hub URL: pass --hub-url, or set TENSORHUB_URL "
+            "(e.g. https://tensorhub.com)"
+        )
+    return base.rstrip("/")
+
+
+def _post(url: str, body: Dict[str, Any], *, bearer: str = "") -> Dict[str, Any]:
+    payload = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(url, data=payload, method="POST")
+    request.add_header("Content-Type", "application/json")
+    if bearer:
+        request.add_header("Authorization", f"Bearer {bearer}")
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:
+            return dict(json.loads(response.read().decode("utf-8")))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:400]
+        raise LoginError(f"{url} answered {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise LoginError(f"{url} unreachable: {exc.reason}") from exc
+
+
+def _get(url: str, *, bearer: str) -> Dict[str, Any]:
+    request = urllib.request.Request(url)
+    request.add_header("Authorization", f"Bearer {bearer}")
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:
+            return dict(json.loads(response.read().decode("utf-8")))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:400]
+        raise LoginError(f"{url} answered {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise LoginError(f"{url} unreachable: {exc.reason}") from exc
+
+
+def whoami(base_url: str, token: str) -> Dict[str, Any]:
+    """``GET /api/v1/tokens/self`` — the only way a bare token learns its org.
+
+    Called on every login so a stored credential has been PROVEN to work once,
+    rather than discovered to be wrong at the first publish.
+    """
+    return _get(f"{base_url}/api/v1/tokens/self", bearer=token)
+
+
+def _password_login(base_url: str, login: str, password: str) -> str:
+    answer = _post(
+        f"{base_url}/api/v1/password/login", {"login": login, "password": password}
+    )
+    access = str(answer.get("access_token") or "")
+    if not access:
+        raise LoginError("password login returned no access_token")
+    return access
+
+
+def _mint_machine_token(
+    base_url: str, session: str, org: str, name: str
+) -> str:
+    answer = _post(
+        f"{base_url}/api/v1/orgs/{urllib.parse.quote(org)}/tokens",
+        {"name": name, "scopes": list(PUBLISH_SCOPES)},
+        bearer=session,
+    )
+    token = str(answer.get("token") or "")
+    if not token:
+        raise LoginError(
+            "the hub minted a machine token but did not return its plaintext "
+            "(it is returned exactly once); nothing was stored"
+        )
+    return token
+
+
+def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
+    parser = sub.add_parser(
+        "login",
+        help="Authenticate to the hub (credentials shared by every endpoint venv).",
+        description=(
+            "Store a hub credential in ~/.cozy/credentials.d, readable by "
+            "every endpoint venv on this machine. Prefers a machine token: "
+            "long-lived, scoped, and with nothing that rotates."
+        ),
+    )
+    parser.add_argument("--token", default="",
+                        help="a machine token (cozy_st_...) to store directly")
+    parser.add_argument("--email", default="",
+                        help="log in with a password, then MINT a machine token")
+    parser.add_argument("--password", default="",
+                        help="password (prompted if omitted)")
+    parser.add_argument("--org", default="",
+                        help="org to mint the machine token under (default: "
+                             "the one the session belongs to)")
+    parser.add_argument("--hub-url", default="", help="hub base URL")
+    parser.add_argument("--profile", default=credentials.DEFAULT_PROFILE)
+    parser.add_argument("--token-name", default="gen-worker",
+                        help="label for the minted machine token")
+    parser.set_defaults(_handler=run_login)
+
+    out = sub.add_parser(
+        "logout",
+        help="Forget this machine's stored hub credential.",
+        description=(
+            "Delete the stored credential. Does NOT revoke it hub-side — "
+            "forgetting it here and killing it everywhere are different acts."
+        ),
+    )
+    out.add_argument("--profile", default=credentials.DEFAULT_PROFILE)
+    out.set_defaults(_handler=run_logout)
+
+
+def run_login(args: argparse.Namespace) -> int:
+    try:
+        base_url = _hub_url(args.hub_url)
+    except LoginError as exc:
+        sys.stderr.write(f"gen-worker login: {exc}\n")
+        return 2
+    if not args.token and not args.email:
+        sys.stderr.write(
+            "gen-worker login: pass --token cozy_st_... (a machine token) or "
+            "--email to log in with a password and mint one.\n"
+        )
+        return 2
+    try:
+        token = args.token.strip()
+        if not token:
+            password = args.password or getpass.getpass("password: ")
+            session = _password_login(base_url, args.email, password)
+            org = args.org or str(whoami(base_url, session).get("org_slug") or "")
+            if not org:
+                raise LoginError(
+                    "could not determine which org to mint the machine token "
+                    "under; pass --org"
+                )
+            token = _mint_machine_token(base_url, session, org, args.token_name)
+            sys.stderr.write(
+                f"gen-worker login: minted a machine token under {org} "
+                f"(the password session was discarded, not stored)\n"
+            )
+        identity = whoami(base_url, token)
+    except LoginError as exc:
+        sys.stderr.write(f"gen-worker login: {exc}\n")
+        return 1
+    credential = Credential(
+        token=token,
+        org=str(identity.get("org_slug") or args.org or ""),
+        hub_url=base_url,
+    )
+    if not credential.is_machine_token:
+        sys.stderr.write(
+            "gen-worker login: WARNING — this is not a machine token "
+            f"({credentials.MACHINE_TOKEN_MARKER}...). Session tokens expire "
+            "and rotate; a long publish can die holding one. Mint a machine "
+            "token with `gen-worker login --email ...` instead.\n"
+        )
+    try:
+        path = credentials.save(credential, profile=args.profile)
+    except CredentialError as exc:
+        sys.stderr.write(f"gen-worker login: {exc}\n")
+        return 1
+    sys.stderr.write(
+        f"gen-worker login: authenticated as {identity.get('kind', 'user')}"
+        + (f" in {credential.org}" if credential.org else "")
+        + f"; credential stored at {path} (0600)\n"
+    )
+    return 0
+
+
+def run_logout(args: argparse.Namespace) -> int:
+    try:
+        removed = credentials.clear(profile=args.profile)
+    except CredentialError as exc:
+        sys.stderr.write(f"gen-worker logout: {exc}\n")
+        return 1
+    sys.stderr.write(
+        "gen-worker logout: credential removed\n" if removed
+        else "gen-worker logout: nothing was stored\n"
+    )
+    return 0
+
+
+def require_credential(hub_url: str = "") -> Credential:
+    """The credential a hub-touching verb needs, or a refusal naming login."""
+    credential = credentials.load()
+    if credential is None:
+        raise LoginError(
+            "not logged in. Run `gen-worker login --token cozy_st_...` "
+            "(or --email to mint one). The credential is stored once per "
+            "machine and shared by every endpoint venv."
+        )
+    if hub_url and not credential.hub_url:
+        credential = Credential(
+            token=credential.token, org=credential.org, hub_url=hub_url
+        )
+    return credential
+
+
+__all__ = [
+    "LoginError",
+    "PUBLISH_SCOPES",
+    "add_subparser",
+    "require_credential",
+    "run_login",
+    "run_logout",
+    "whoami",
+]

--- a/src/gen_worker/cli/protocol.py
+++ b/src/gen_worker/cli/protocol.py
@@ -23,7 +23,7 @@ PROTOCOL_VERSION = 1
 # deleted verbs (`describe`, `list_functions`, `prefetch`, `cancel`,
 # `streaming`, `serve_sidecar`, `tcp_listen`) — a capability list that lies is
 # worse than no list, because an integrator branches on it:
-#   - "endpoint_handle" : the ~/.cache/cozy/endpoints/<key>/endpoint.json handle
+#   - "endpoint_handle" : the ~/.cache/cozy/resident/<key>/endpoint.json handle
 #                         `up` publishes and `run`/`down` read
 #   - "dispatch_counts" : every response carries compiled-vs-eager call counts
 #   - "hub_resolve"     : standalone Hub-ref resolve via TENSORHUB_URL

--- a/src/gen_worker/cli/protocol.py
+++ b/src/gen_worker/cli/protocol.py
@@ -18,24 +18,18 @@ from typing import List
 # shapes, the describe document, or the serve sidecar change incompatibly.
 PROTOCOL_VERSION = 1
 
-# Optional features a host can rely on without scraping ``--help``. Add a token
-# only when the feature is actually implemented:
-#   - "describe"       : `gen-worker describe --json`
-#   - "list_functions" : `gen-worker serve --list-functions [--json]`
-#   - "prefetch"       : `gen-worker prefetch`
-#   - "cancel"         : per-request `{"cancel":{"request_id"}}` control
-#   - "streaming"      : multi-frame streamed responses, `{"stream":true}`
-#   - "tcp_listen"     : `serve --listen tcp://host:port`
-#   - "serve_sidecar"  : machine-readable `.gen-worker.serve.json` handle
-#   - "hub_resolve"    : standalone Hub-ref resolve via TENSORHUB_URL
+# Optional features a host can rely on without scraping ``--help``. A token
+# goes in ONLY when the feature actually ships. pgw#1491 removed six that named
+# deleted verbs (`describe`, `list_functions`, `prefetch`, `cancel`,
+# `streaming`, `serve_sidecar`, `tcp_listen`) — a capability list that lies is
+# worse than no list, because an integrator branches on it:
+#   - "endpoint_handle" : the ~/.cache/cozy/endpoints/<key>/endpoint.json handle
+#                         `up` publishes and `run`/`down` read
+#   - "dispatch_counts" : every response carries compiled-vs-eager call counts
+#   - "hub_resolve"     : standalone Hub-ref resolve via TENSORHUB_URL
 CAPABILITIES: List[str] = [
-    "describe",
-    "list_functions",
-    "prefetch",
-    "cancel",
-    "streaming",
-    "tcp_listen",
-    "serve_sidecar",
+    "endpoint_handle",
+    "dispatch_counts",
     "hub_resolve",
 ]
 

--- a/src/gen_worker/cli/publish.py
+++ b/src/gen_worker/cli/publish.py
@@ -19,16 +19,31 @@ exact shape, and a source or editable install NEVER invokes the build backend's
 building a wheel can. Skippable with ``--no-preflight``, which is there so the
 flag shows up in the log of anyone who chose to skip it.
 
-## What the hub does with the lock — TODAY, honestly
+## What the hub does with the lock — and it is load-bearing in two places
 
-The lock is included in the upload. The hub does not yet READ it: its tarball
-inspector captures ``endpoint.toml``, ``pyproject.toml``, ``uv.lock``,
-``requirements.txt``, ``author-ci.toml`` and Dockerfiles, and ``endpoint.lock``
-is not on that list; the bake-time derive is disarmed by a compile-time
-constant (``DeriveAtBakeArmed = false``) because a BuildKit builder has no GPU.
-So publishing a committed lock is currently a NO-OP hub-side, and this command
-says so rather than implying a guarantee it cannot make. The hub half is filed;
-the client half is correct now and needs no change when it lands.
+The lock is INGESTED, at both ends of the build (verified with the th#2162
+owner against the deployed hub pin, not read off master):
+
+* **at publish**, the uploaded tarball's ``endpoint.lock`` is captured and its
+  ``[derive]`` table parsed and digest-verified, which decides ONE thing —
+  whether a derive step is rendered into the build at all. With a committed
+  lock the build pays no trace;
+* **from the built image**, the stamped graph document is read back out of
+  ``/app/endpoint.lock`` and written onto the release rows.
+
+Without a committed lock the build regenerates one itself — "regenerate when
+missing" is LEGAL and this command warns rather than refuses, because refusing
+would turn a ruled-supported publish into an error whose only remedy is a trace
+the author may not want to pay at that moment. Including the lock when there is
+one is what makes the build cheap.
+
+A correction worth recording, because the method failed and not just the
+answer: this module first said the hub ignored the lock, on the strength of
+``grep 'case "endpoint.lock"'`` returning nothing and a
+``DeriveAtBakeArmed = false`` constant. The inspector matches a CONSTANT
+(``CommittedLockFileName``), not the literal, and the disarm constant had been
+DELETED — a grep for a string value cannot see either. Absence of a literal is
+not absence of a mechanism.
 """
 
 from __future__ import annotations
@@ -242,12 +257,18 @@ def run_publish(args: argparse.Namespace) -> int:
 
     lock = root / el.LOCK_FILENAME
     if not lock.is_file():
+        # WARN, never refuse. Paul's builder addendum is explicit: "the builder
+        # USES the committed lock when present, and REGENERATES it when missing
+        # — missing is allowed, not a refusal." A client that refused would
+        # turn a legal publish into an error whose only remedy is a trace the
+        # author may not want to pay right now.
         sys.stderr.write(
-            f"gen-worker publish: no {el.LOCK_FILENAME} beside the endpoint. "
-            f"It is AUTHOR-time output and belongs in git — run "
-            f"`gen-worker lock` and commit it.\n"
+            f"gen-worker publish: WARNING — no {el.LOCK_FILENAME} beside the "
+            f"endpoint, so this build will TRACE inside the image (~2 min for "
+            f"an sd15-sized endpoint).\n"
+            f"  `gen-worker lock` once, commit the result, and every later "
+            f"build skips that step.\n"
         )
-        return 1
 
     try:
         if not args.no_preflight:
@@ -269,10 +290,9 @@ def run_publish(args: argparse.Namespace) -> int:
         return 1
 
     sys.stderr.write(
-        f"gen-worker publish: {len(files)} file(s), {len(blob) / 1024:.0f} KiB\n"
-        f"gen-worker publish: NOTE — {el.LOCK_FILENAME} is uploaded, but the "
-        f"hub does not ingest it yet (its tarball inspector does not capture "
-        f"it and bake-time derive is disarmed). The build regenerates its own.\n"
+        f"gen-worker publish: {len(files)} file(s), {len(blob) / 1024:.0f} KiB "
+        + (f"(including {el.LOCK_FILENAME}, so the build skips the trace)\n"
+           if lock.is_file() else "(no committed lock; the build traces)\n")
     )
     if args.dry_run:
         return 0

--- a/src/gen_worker/cli/publish.py
+++ b/src/gen_worker/cli/publish.py
@@ -1,0 +1,308 @@
+"""``gen-worker publish`` — push this endpoint's source to the hub; it builds.
+
+pgw#1491. The endpoint uploads ITSELF: source plus the committed
+``endpoint.lock``, to ``POST /api/v1/endpoints/:org/:name/releases``. The hub
+builds the image. Releases are born only from source — there is no path that
+uploads an image.
+
+## The wheel preflight, and why it is not optional
+
+Before a single byte goes over the wire this runs ``uv build --wheel`` into a
+throwaway directory. It costs about five seconds, needs no network, no GPU and
+no compile — and it is the only thing that can catch an entire class of failure
+before the hub pays for it. se#775 burned a **6h28m** image build that died at
+step 23/23 because ``allow-direct-references`` sat under ``[tool.uv]`` (not a
+uv key — a warning, silently unapplied), so hatchling refused the wheel's
+``git+https://`` SDK riders. Every endpoint riding uncut SDK commits has that
+exact shape, and a source or editable install NEVER invokes the build backend's
+``validate_fields()``, so no CPU drive test can reach it. Only actually
+building a wheel can. Skippable with ``--no-preflight``, which is there so the
+flag shows up in the log of anyone who chose to skip it.
+
+## What the hub does with the lock — TODAY, honestly
+
+The lock is included in the upload. The hub does not yet READ it: its tarball
+inspector captures ``endpoint.toml``, ``pyproject.toml``, ``uv.lock``,
+``requirements.txt``, ``author-ci.toml`` and Dockerfiles, and ``endpoint.lock``
+is not on that list; the bake-time derive is disarmed by a compile-time
+constant (``DeriveAtBakeArmed = false``) because a BuildKit builder has no GPU.
+So publishing a committed lock is currently a NO-OP hub-side, and this command
+says so rather than implying a guarantee it cannot make. The hub half is filed;
+the client half is correct now and needs no change when it lands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import endpoint_lock as el
+from .login import LoginError, require_credential
+
+#: Hub-side cap on a source upload. Checked here so a 6-minute upload does not
+#: end in a 413 the user could have been told about instantly.
+MAX_SOURCE_BYTES = 100 * 1024 * 1024
+
+HTTP_TIMEOUT_S = 600.0
+
+#: Never uploaded, whatever git says: weights belong in repos, venvs and caches
+#: are machine-local, and a .env is a secret someone forgot to gitignore.
+_EXCLUDE_DIRS = frozenset({".venv", "venv", "__pycache__", ".git", ".mypy_cache",
+                           ".pytest_cache", ".compiled-graphs", "outputs"})
+_EXCLUDE_SUFFIXES = (".safetensors", ".ckpt", ".bin", ".pt", ".pth", ".gguf",
+                     ".onnx", ".so", ".pyc")
+_EXCLUDE_NAMES = frozenset({".env"})
+
+
+class PublishError(RuntimeError):
+    """Publish could not proceed. Always names the step that refused."""
+
+
+def _tracked_files(root: Path) -> Optional[List[Path]]:
+    """What git tracks, or ``None`` outside a work tree.
+
+    A release is built from a commit, so the manifest is what git tracks — not
+    whatever happens to be sitting in the directory. Outside a repo the whole
+    tree is packaged (minus the exclusions), because there is no commit to
+    speak of.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            capture_output=True, check=False,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    names = [n for n in completed.stdout.decode("utf-8").split("\0") if n]
+    return [root / name for name in names]
+
+
+def _excluded(path: Path, root: Path) -> bool:
+    relative = path.relative_to(root)
+    if any(part in _EXCLUDE_DIRS for part in relative.parts):
+        return True
+    if path.name in _EXCLUDE_NAMES:
+        return True
+    return path.suffix.lower() in _EXCLUDE_SUFFIXES
+
+
+def source_files(root: Path) -> List[Path]:
+    tracked = _tracked_files(root)
+    candidates = tracked if tracked is not None else [
+        p for p in root.rglob("*") if p.is_file()
+    ]
+    files = [p for p in candidates if p.is_file() and not _excluded(p, root)]
+    lock = root / el.LOCK_FILENAME
+    # The committed lock rides even when git does not track it yet: an author
+    # who just ran `gen-worker lock` and has not committed should be told the
+    # lock is uncommitted, not silently publish without it.
+    if lock.is_file() and lock not in files:
+        files.append(lock)
+    return sorted(set(files))
+
+
+def archive(root: Path, files: List[Path]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        for path in files:
+            tar.add(str(path), arcname=str(path.relative_to(root)))
+    return buffer.getvalue()
+
+
+def wheel_preflight(root: Path) -> None:
+    """``uv build --wheel`` into a temp dir. Raises with the backend's own words."""
+    with tempfile.TemporaryDirectory(prefix="gen-worker-preflight-") as out:
+        completed = subprocess.run(
+            ["uv", "build", "--wheel", "--out-dir", out, str(root)],
+            capture_output=True, check=False,
+        )
+    if completed.returncode == 0:
+        return
+    stderr = completed.stderr.decode("utf-8", "replace").strip()
+    raise PublishError(
+        f"wheel preflight FAILED — the hub's image build would die on this "
+        f"after paying for the whole CUDA layer, so it refuses here instead "
+        f"(about five seconds in).\n\n{stderr}\n\n"
+        f"  A source or editable install never runs the build backend's "
+        f"validation, which is why a working dev env proves nothing about "
+        f"this. Skip with --no-preflight if you know better."
+    )
+
+
+def _endpoint_identity(root: Path, org: str, name: str) -> Tuple[str, str]:
+    resolved_name = name
+    if not resolved_name:
+        try:
+            import tomllib
+
+            document = tomllib.loads(
+                (root / "pyproject.toml").read_text(encoding="utf-8")
+            )
+            resolved_name = str((document.get("project") or {}).get("name") or "")
+        except (OSError, ValueError):
+            resolved_name = ""
+    if not resolved_name:
+        raise PublishError(
+            "cannot tell which endpoint this is: pass --name, or give "
+            "pyproject.toml a [project].name"
+        )
+    if not org:
+        raise PublishError("no org: pass --org (or log in, which records one)")
+    return org, resolved_name
+
+
+def upload(
+    *, base_url: str, token: str, org: str, name: str, blob: bytes,
+    promote: Optional[bool], dev: bool,
+) -> Dict[str, Any]:
+    query: List[str] = []
+    if promote is not None:
+        query.append(f"promote={'true' if promote else 'false'}")
+    if dev:
+        query.append("dev=true")
+    url = (
+        f"{base_url.rstrip('/')}/api/v1/endpoints/{org}/{name}/releases"
+        + ("?" + "&".join(query) if query else "")
+    )
+    request = urllib.request.Request(url, data=blob, method="POST")
+    request.add_header("Content-Type", "application/gzip")
+    request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:600]
+        raise PublishError(f"hub answered {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise PublishError(f"{url} unreachable: {exc.reason}") from exc
+    try:
+        return dict(json.loads(body))
+    except json.JSONDecodeError:
+        return {"raw": body}
+
+
+def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
+    parser = sub.add_parser(
+        "publish",
+        help="Push this endpoint's source (+ endpoint.lock) to the hub to build.",
+        description=(
+            "Package what git tracks, run the wheel preflight, and upload to "
+            "the hub, which builds the image. Releases are born only from "
+            "source."
+        ),
+    )
+    parser.add_argument("endpoint_dir", nargs="?", default=".",
+                        help="directory holding endpoint.toml (default: .)")
+    parser.add_argument("--org", default="", help="owning org (default: the "
+                                                  "one the credential names)")
+    parser.add_argument("--name", default="",
+                        help="endpoint name (default: pyproject [project].name)")
+    parser.add_argument("--hub-url", default="", help="hub base URL")
+    parser.add_argument("--promote", dest="promote", action="store_true",
+                        default=None,
+                        help="promote the built release (hub default: yes)")
+    parser.add_argument("--no-promote", dest="promote", action="store_false",
+                        help="build without promoting")
+    parser.add_argument("--dev", action="store_true",
+                        help="a content-addressed dev release from the working "
+                             "tree (packages untracked files too)")
+    # NO --skip-profiling, deliberately. Paul ruled build-time profiling
+    # DECOUPLED from the builder (th#2214): builds never rent hardware, "skip"
+    # becomes the only build behavior, and profiling becomes an explicit
+    # publisher verb (`cozy profile <endpoint>@<version>`) that names its cost
+    # before renting a pod. A flag here would be a knob for a coupling that is
+    # being deleted, and every endpoint that set it would have to unset it.
+    parser.add_argument("--no-preflight", action="store_true",
+                        help="skip `uv build --wheel` (see the module docstring "
+                             "for the 6h28m reason not to)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="package and preflight, upload nothing")
+    parser.set_defaults(_handler=run_publish)
+
+
+def run_publish(args: argparse.Namespace) -> int:
+    root = Path(args.endpoint_dir).resolve()
+    if not (root / "endpoint.toml").is_file():
+        sys.stderr.write(
+            f"gen-worker publish: {root} has no endpoint.toml — it is not an "
+            f"endpoint directory\n"
+        )
+        return 2
+
+    lock = root / el.LOCK_FILENAME
+    if not lock.is_file():
+        sys.stderr.write(
+            f"gen-worker publish: no {el.LOCK_FILENAME} beside the endpoint. "
+            f"It is AUTHOR-time output and belongs in git — run "
+            f"`gen-worker lock` and commit it.\n"
+        )
+        return 1
+
+    try:
+        if not args.no_preflight:
+            sys.stderr.write("gen-worker publish: wheel preflight...\n")
+            wheel_preflight(root)
+            sys.stderr.write("gen-worker publish: wheel preflight ok\n")
+        files = source_files(root)
+        blob = archive(root, files)
+    except PublishError as exc:
+        sys.stderr.write(f"gen-worker publish: {exc}\n")
+        return 1
+    if len(blob) > MAX_SOURCE_BYTES:
+        sys.stderr.write(
+            f"gen-worker publish: the source archive is {len(blob) / 1e6:.1f} MB, "
+            f"over the hub's {MAX_SOURCE_BYTES / 1e6:.0f} MB cap. Move large "
+            f"artifacts into repos/datasets/media and reference them from "
+            f"endpoint.toml.\n"
+        )
+        return 1
+
+    sys.stderr.write(
+        f"gen-worker publish: {len(files)} file(s), {len(blob) / 1024:.0f} KiB\n"
+        f"gen-worker publish: NOTE — {el.LOCK_FILENAME} is uploaded, but the "
+        f"hub does not ingest it yet (its tarball inspector does not capture "
+        f"it and bake-time derive is disarmed). The build regenerates its own.\n"
+    )
+    if args.dry_run:
+        return 0
+
+    try:
+        credential = require_credential(args.hub_url)
+        base_url = args.hub_url or credential.hub_url
+        if not base_url:
+            raise PublishError("no hub URL: pass --hub-url or set TENSORHUB_URL")
+        org, name = _endpoint_identity(root, args.org or credential.org, args.name)
+        answer = upload(
+            base_url=base_url, token=credential.token, org=org, name=name,
+            blob=blob, promote=args.promote, dev=args.dev,
+        )
+    except (PublishError, LoginError) as exc:
+        sys.stderr.write(f"gen-worker publish: {exc}\n")
+        return 1
+    sys.stdout.write(json.dumps(answer) + "\n")
+    build_id = answer.get("BuildID") or answer.get("build_id") or ""
+    if build_id:
+        sys.stderr.write(f"gen-worker publish: build {build_id} started\n")
+    return 0
+
+
+__all__ = [
+    "MAX_SOURCE_BYTES",
+    "PublishError",
+    "add_subparser",
+    "archive",
+    "run_publish",
+    "source_files",
+    "wheel_preflight",
+]

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -1,0 +1,248 @@
+"""``gen-worker run`` — one request against the endpoint that is already up.
+
+pgw#1491, Paul's ruling verbatim: *"'run' runs a request against that endpoint;
+for run to work 'up' must have already been run."* So this module executes NO
+inference. It opens a socket, writes one request, prints what comes back, and
+exits. When nothing is up it REFUSES by name and never auto-starts — an
+auto-start would be a second boot path, and two paths that both serve requests
+is the failure this whole surface is shaped to prevent (measured three times in
+one day: a harness, a driver script and the CLI all "working" while disagreeing
+about what actually ran).
+
+Usage is the ergonomic payload grammar (``cli/args``)::
+
+    gen-worker run "a lighthouse at dusk"
+    gen-worker run "a cat" seed=42 steps=30
+    gen-worker run --function generate prompt@./long-prompt.txt
+
+Coercion is DELIBERATELY thin here. The client guesses scalar shapes; the
+authoritative decode happens in the daemon against the entrypoint's own msgspec
+struct, so a bad field comes back as a typed ``payload_invalid`` naming the
+field — from the real decode path, not from a client-side copy of the schema
+that could disagree with it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from . import endpoint_state, sockaddr
+from .args import ArgError, build_payload
+from .endpoint_state import EndpointStateError
+
+#: How long to wait for the daemon to accept the connection. NOT a bound on
+#: the request: a cold first request legitimately spends minutes arming graphs,
+#: and the read below is unbounded for that reason.
+CONNECT_TIMEOUT_S = 10.0
+
+
+class NotUp(RuntimeError):
+    """Nothing is resident for this endpoint. The typed refusal, by name."""
+
+
+def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
+    parser = sub.add_parser(
+        "run",
+        help="Send one request to the endpoint that is up, and print the result.",
+        description=(
+            "A client of `gen-worker up`. Requires an endpoint to already be "
+            "up; refuses (it never auto-starts one). Payload fields use the "
+            "ergonomic grammar: a bare value fills the primary field, "
+            "field=value sets one, field:=json for lists/objects, field@path "
+            "to read one from a file."
+        ),
+    )
+    parser.add_argument("tokens", nargs="*", metavar="FIELD=VALUE",
+                        help="payload tokens; a bare value fills the primary field")
+    parser.add_argument("-C", "--endpoint-dir", default=".",
+                        help="endpoint directory (default: .)")
+    parser.add_argument("--function", default="",
+                        help="which entrypoint to call (default: the only one)")
+    parser.add_argument("--payload", default="",
+                        help="a full JSON payload; FIELD=VALUE tokens merge over it")
+    parser.add_argument("--json", dest="json_output", action="store_true",
+                        help="print the raw response envelope instead of a summary")
+    parser.set_defaults(_handler=run_run)
+
+
+def _require_up(endpoint_dir: Path) -> Dict[str, Any]:
+    handle = endpoint_state.handle_for(endpoint_dir)
+    document = endpoint_state.read_handle(handle)
+    if document is None:
+        raise NotUp(
+            f"nothing is up for {endpoint_dir}.\n"
+            f"  `run` is a client — it never starts an endpoint itself, "
+            f"because a second boot path is a second answer to what actually "
+            f"served.\n"
+            f"  Start one first:  gen-worker up -d\n"
+            f"  Then:             gen-worker run \"<prompt>\""
+        )
+    return document
+
+
+def _pick_function(document: Dict[str, Any], requested: str) -> str:
+    functions: List[str] = list(document.get("functions") or ())
+    if requested:
+        if requested not in functions:
+            raise NotUp(
+                f"this endpoint serves no function {requested!r}; it serves: "
+                f"{', '.join(functions) or '(none)'}"
+            )
+        return requested
+    if len(functions) == 1:
+        return functions[0]
+    if not functions:
+        raise NotUp("the endpoint that is up advertises no functions")
+    raise NotUp(
+        f"this endpoint serves several functions ({', '.join(functions)}); "
+        f"name one with --function"
+    )
+
+
+def request(document: Dict[str, Any], frame: Dict[str, Any]) -> Dict[str, Any]:
+    """One NDJSON round trip. The read is unbounded on purpose — see above."""
+    listen = str(document.get("socket") or "")
+    if not listen:
+        raise NotUp("the handle names no socket; `gen-worker down` and up again")
+    try:
+        conn = sockaddr.create_client(listen, CONNECT_TIMEOUT_S)
+    except (OSError, FileNotFoundError) as exc:
+        raise NotUp(
+            f"the endpoint's handle says it is up (pid {document.get('pid')}) "
+            f"but its socket {listen} did not accept: {exc}.\n"
+            f"  `gen-worker down` clears it."
+        ) from exc
+    try:
+        conn.sendall((json.dumps(frame) + "\n").encode("utf-8"))
+        conn.settimeout(None)
+        buf = bytearray()
+        while b"\n" not in buf:
+            chunk = conn.recv(65536)
+            if not chunk:
+                break
+            if len(buf) + len(chunk) > sockaddr.MAX_NDJSON_LINE_BYTES:
+                raise NotUp("the endpoint's response exceeded the frame bound")
+            buf.extend(chunk)
+    except socket.timeout as exc:  # pragma: no cover - timeout is disabled
+        raise NotUp(f"the endpoint stopped responding: {exc}") from exc
+    finally:
+        conn.close()
+    line = bytes(buf).split(b"\n", 1)[0].strip()
+    if not line:
+        raise NotUp(
+            "the endpoint closed the connection without answering — it may "
+            "have crashed; check its log with `gen-worker down` and `up`"
+        )
+    return dict(json.loads(line.decode("utf-8")))
+
+
+def run_run(args: argparse.Namespace) -> int:
+    endpoint_dir = Path(args.endpoint_dir).resolve()
+    try:
+        document = _require_up(endpoint_dir)
+        function = _pick_function(document, args.function)
+    except (NotUp, EndpointStateError) as exc:
+        sys.stderr.write(f"gen-worker run: {exc}\n")
+        return 1
+
+    base: Dict[str, Any] = {}
+    if args.payload:
+        try:
+            base = dict(json.loads(args.payload))
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            sys.stderr.write(f"gen-worker run: --payload is not a JSON object: {exc}\n")
+            return 2
+    primary = (document.get("primary_fields") or {}).get(function)
+    try:
+        payload = build_payload(list(args.tokens), None, base=base, primary=primary)
+    except ArgError as exc:
+        sys.stderr.write(f"gen-worker run: {exc}\n")
+        return 2
+
+    try:
+        envelope = request(document, {"function": function, "payload": payload})
+    except NotUp as exc:
+        sys.stderr.write(f"gen-worker run: {exc}\n")
+        return 1
+
+    if args.json_output:
+        sys.stdout.write(json.dumps(envelope) + "\n")
+        return 0 if envelope.get("ok") else 1
+
+    if not envelope.get("ok"):
+        error = envelope.get("error") or {}
+        sys.stderr.write(
+            f"gen-worker run: {error.get('kind', 'error')}: "
+            f"{error.get('message', '')}\n"
+        )
+        _print_dispatch(envelope)
+        return 1
+
+    for warning in envelope.get("warnings") or ():
+        sys.stderr.write(f"warn: {warning}\n")
+    _print_dispatch(envelope)
+    _print_result(envelope.get("result"))
+    return 0
+
+
+def _print_dispatch(envelope: Dict[str, Any]) -> None:
+    """State compiled-vs-eager on every request, always.
+
+    Not a verbose mode. A run that quietly fell through to eager is
+    indistinguishable from a compiled one by its output — that is precisely how
+    twelve eager images were nearly published as a compile measurement.
+    """
+    facts = envelope.get("dispatch")
+    if not isinstance(facts, dict):
+        return
+    armed = int(facts.get("armed_modules", 0) or 0)
+    compiled = int(facts.get("compiled_graph_calls", 0) or 0)
+    eager = int(facts.get("eager_calls", 0) or 0)
+    displaced = facts.get("displaced_modules") or []
+    if displaced:
+        sys.stderr.write(
+            f"dispatch: DISPLACED on {', '.join(displaced)} — served eager\n"
+        )
+    elif armed == 0:
+        sys.stderr.write("dispatch: eager (no compiled graph armed)\n")
+    else:
+        sys.stderr.write(
+            f"dispatch: compiled_graph_calls={compiled} eager_calls={eager}\n"
+        )
+
+
+def _print_result(result: Any) -> None:
+    """Print the saved media paths if there are any, else the raw result.
+
+    A local serve writes media to disk and returns an asset carrying
+    ``local_path``; printing that path is what makes ``run`` end in a file the
+    user can open, which is the whole point of the verb.
+    """
+    paths = sorted(_local_paths(result))
+    if paths:
+        for path in paths:
+            sys.stdout.write(f"{path}\n")
+        return
+    sys.stdout.write(json.dumps(result, default=str) + "\n")
+
+
+def _local_paths(node: Any) -> List[str]:
+    found: List[str] = []
+    if isinstance(node, dict):
+        value = node.get("local_path")
+        if isinstance(value, str) and value:
+            found.append(value)
+        for child in node.values():
+            found.extend(_local_paths(child))
+    elif isinstance(node, list):
+        for child in node:
+            found.extend(_local_paths(child))
+    return found
+
+
+__all__ = ["NotUp", "add_subparser", "request", "run_run"]

--- a/src/gen_worker/cli/up.py
+++ b/src/gen_worker/cli/up.py
@@ -1,0 +1,277 @@
+"""``gen-worker up [-d]`` / ``gen-worker down`` — the resident endpoint.
+
+pgw#1491, docker-compose semantics by Paul's ruling: bare ``up`` is
+FOREGROUND — logs stream to the terminal and Ctrl-C stops the endpoint — and
+``up -d`` detaches, leaving it resident for ``run`` clients until ``down``.
+
+Foreground is the default because it is the introspection-friendly mode: you
+see the boot ladder, the adopt report, the per-request compiled-vs-eager
+counter and the teardown, live, in the shell you typed into. ``-d`` is the
+daemon mode a client talks to.
+
+``up`` is also where the checkpoint lands. Its boot pulls the refs its runtime
+config names through the SAME download path ``gen-worker download`` uses, and
+it does not accept a request until they are on disk — which is the whole reason
+``run`` may require ``up`` instead of parking a multi-GB fetch inside a user
+request (th#2204's invariant, holding by construction rather than by protocol).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, List, Optional
+
+from . import endpoint_state
+from .daemon import BootError, BootSpec, serve
+from .endpoint_state import EndpointStateError
+
+#: Hidden flag the detaching parent passes to the child it re-execs. Not part
+#: of the user surface; a user who types it gets exactly what the parent would
+#: have run, which is the honest behavior for an internal flag.
+DETACHED_CHILD_FLAG = "--detached-child"
+
+
+def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
+    up = sub.add_parser(
+        "up",
+        help="Bring an endpoint up resident in memory (foreground; -d detaches).",
+        description=(
+            "Load the endpoint, materialize its configured checkpoint(s), "
+            "adopt compiled graphs, and serve requests warm. Foreground by "
+            "default: logs stream here and Ctrl-C stops it. With -d it "
+            "detaches and `gen-worker run` talks to it until `gen-worker down`."
+        ),
+    )
+    up.add_argument("endpoint_dir", nargs="?", default=".",
+                    help="directory holding endpoint.toml (default: .)")
+    up.add_argument("-d", "--detach", action="store_true",
+                    help="run in the background and return immediately")
+    up.add_argument("--checkpoint-ref", action="append", default=[], metavar="REF",
+                    help="checkpoint ref to serve (repeatable). Default: what "
+                         "this machine's runtime config names.")
+    up.add_argument("--checkpoint", default="", metavar="DIR",
+                    help="an already-materialized checkpoint tree, bypassing "
+                         "ref resolution entirely")
+    up.add_argument("--model", default="",
+                    help="the hub row's model classification (e.g. sdxl)")
+    up.add_argument("--defaults", default="{}",
+                    help="per-checkpoint override JSON")
+    up.add_argument("--lane", default="", help="active lane contract handle")
+    up.add_argument("--sm", default="", help="this GPU's sm (e.g. sm_89); "
+                                             "required to adopt compiled graphs")
+    up.add_argument("--graph-store", default="", metavar="DIR",
+                    help="compiled-graph CAS to adopt from. Default: the box "
+                         "graph CAS when it exists; absent = serve eager.")
+    up.add_argument("--artifacts-dir", default=".compiled-graphs")
+    up.add_argument("--output-dir", default="outputs",
+                    help="where saved images/media land")
+    up.add_argument("--compile", dest="compile_policy", default="auto",
+                    choices=("auto", "off"),
+                    help="auto: fill this boot's compiled-graph holes in the "
+                         "background, never blocking a request. off: never "
+                         "compile (`gen-worker compile` stays the front door).")
+    up.add_argument("--idle-timeout", type=float, default=0.0, metavar="SECONDS",
+                    help="self-stop after SECONDS with no request, freeing the "
+                         "card. 0 (default) = stay up until `down`.")
+    up.add_argument("--env-lockfile", default="",
+                    help="uv.lock stating this boot's compile stack "
+                         "(default: the endpoint's own)")
+    up.add_argument(DETACHED_CHILD_FLAG, dest="detached_child",
+                    action="store_true", help=argparse.SUPPRESS)
+    up.set_defaults(_handler=run_up)
+
+    down = sub.add_parser(
+        "down",
+        help="Stop a resident endpoint and free its card.",
+        description=(
+            "Signal the endpoint brought up by `gen-worker up -d` and wait for "
+            "it to tear down (author shutdown, VRAM released, socket removed)."
+        ),
+    )
+    down.add_argument("endpoint_dir", nargs="?", default=".",
+                      help="directory holding endpoint.toml (default: .)")
+    down.set_defaults(_handler=run_down)
+
+
+# --------------------------------------------------------------------------
+# up
+# --------------------------------------------------------------------------
+
+
+def _spec(args: argparse.Namespace) -> BootSpec:
+    from . import workspace
+    from .download import runtime_config_refs
+
+    endpoint_dir = Path(args.endpoint_dir).resolve()
+    refs = tuple(args.checkpoint_ref) or (
+        () if args.checkpoint else runtime_config_refs(endpoint_dir)
+    )
+    graph_store: Optional[Path] = None
+    if args.graph_store:
+        graph_store = Path(args.graph_store)
+    else:
+        default = workspace.graph_cas_root()
+        # Absent = the eager bridge, stated rather than defaulted into: a
+        # store that does not exist yet would make every graph a hole and turn
+        # a plain `up` into a compile.
+        if default.is_dir():
+            graph_store = default
+    return BootSpec(
+        endpoint_dir=endpoint_dir,
+        checkpoint_refs=refs,
+        checkpoint_dir=Path(args.checkpoint) if args.checkpoint else None,
+        checkpoint_ref_label=refs[0] if refs else "local/checkpoint",
+        model=args.model,
+        defaults=args.defaults,
+        lane=args.lane,
+        sm=args.sm,
+        graph_store=graph_store,
+        artifacts_dir=Path(args.artifacts_dir),
+        output_dir=Path(args.output_dir),
+        compile_policy=args.compile_policy,
+        idle_timeout_s=float(args.idle_timeout or 0.0),
+        env_lockfile=Path(args.env_lockfile) if args.env_lockfile else None,
+    )
+
+
+def run_up(args: argparse.Namespace) -> int:
+    endpoint_dir = Path(args.endpoint_dir).resolve()
+    handle = endpoint_state.handle_for(endpoint_dir)
+
+    if not args.detached_child:
+        try:
+            live = endpoint_state.read_handle(handle)
+        except EndpointStateError as exc:
+            sys.stderr.write(f"gen-worker up: {exc}\n")
+            return 1
+        if live is not None:
+            sys.stderr.write(
+                f"gen-worker up: {live.get('module') or endpoint_dir} is already "
+                f"up (pid {live.get('pid')}, socket {live.get('socket')}).\n"
+                f"  `gen-worker run ...` talks to it; `gen-worker down` stops "
+                f"it.\n"
+            )
+            return 1
+
+    if args.detach and not args.detached_child:
+        return _detach(args, handle)
+
+    try:
+        spec = _spec(args)
+    except Exception as exc:  # noqa: BLE001 — arg assembly refusals are usage
+        sys.stderr.write(f"gen-worker up: {exc}\n")
+        return 2
+    try:
+        return serve(spec, handle)
+    except BootError as exc:
+        sys.stderr.write(f"gen-worker up: {exc}\n")
+        endpoint_state.clear_handle(handle)
+        return 1
+    except KeyboardInterrupt:
+        endpoint_state.clear_handle(handle)
+        return 130
+
+
+def _detach(args: argparse.Namespace, handle: Any) -> int:
+    """Re-exec this same command as a detached child and wait for READY.
+
+    A re-exec rather than a fork: the child must not inherit a half-initialized
+    CUDA context or an argparse namespace this process mutated, and re-running
+    the identical argv means the detached endpoint is booted by exactly the
+    code path the foreground one is — not a second boot function that could
+    drift from it.
+    """
+    handle.state_dir.mkdir(parents=True, exist_ok=True)
+    argv = _child_argv(args)
+    log = handle.log_path.open("ab", buffering=0)
+    try:
+        child = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            cwd=os.getcwd(),
+        )
+    finally:
+        log.close()
+    sys.stderr.write(
+        f"gen-worker up: booting {Path(args.endpoint_dir).resolve()} "
+        f"detached (pid {child.pid}); logs: {handle.log_path}\n"
+    )
+    sys.stderr.flush()
+    try:
+        document = endpoint_state.wait_for_handle(handle, child_pid=child.pid)
+    except EndpointStateError as exc:
+        sys.stderr.write(f"gen-worker up: {exc}\n")
+        return 1
+    sys.stderr.write(
+        f"gen-worker up: {document.get('module')} ready — "
+        f"functions: {', '.join(document.get('functions') or ())}\n"
+        f"gen-worker up: `gen-worker run \"<prompt>\"` to send a request, "
+        f"`gen-worker down` to stop.\n"
+    )
+    return 0
+
+
+def _child_argv(args: argparse.Namespace) -> List[str]:
+    """This invocation, minus ``-d``, plus the detached-child marker."""
+    argv = [sys.executable, "-m", "gen_worker.cli", "up",
+            str(Path(args.endpoint_dir).resolve()), DETACHED_CHILD_FLAG]
+    for ref in args.checkpoint_ref:
+        argv += ["--checkpoint-ref", ref]
+    for flag, value in (
+        ("--checkpoint", args.checkpoint),
+        ("--model", args.model),
+        ("--lane", args.lane),
+        ("--sm", args.sm),
+        ("--graph-store", args.graph_store),
+        ("--env-lockfile", args.env_lockfile),
+    ):
+        if value:
+            argv += [flag, str(value)]
+    argv += [
+        "--defaults", args.defaults,
+        "--artifacts-dir", str(args.artifacts_dir),
+        "--output-dir", str(Path(args.output_dir).resolve()),
+        "--compile", args.compile_policy,
+        "--idle-timeout", str(args.idle_timeout),
+    ]
+    return argv
+
+
+# --------------------------------------------------------------------------
+# down
+# --------------------------------------------------------------------------
+
+
+def run_down(args: argparse.Namespace) -> int:
+    endpoint_dir = Path(args.endpoint_dir).resolve()
+    handle = endpoint_state.handle_for(endpoint_dir)
+    try:
+        document = endpoint_state.read_handle(handle)
+    except EndpointStateError as exc:
+        sys.stderr.write(f"gen-worker down: {exc}\n")
+        return 1
+    if document is None:
+        sys.stderr.write(
+            f"gen-worker down: nothing is up for {endpoint_dir}\n"
+        )
+        return 0
+    pid = int(document.get("pid", 0) or 0)
+    sys.stderr.write(
+        f"gen-worker down: stopping {document.get('module') or endpoint_dir} "
+        f"(pid {pid}) — waiting for teardown\n"
+    )
+    sys.stderr.flush()
+    endpoint_state.terminate(pid)
+    endpoint_state.clear_handle(handle)
+    sys.stderr.write("gen-worker down: stopped\n")
+    return 0
+
+
+__all__ = ["DETACHED_CHILD_FLAG", "add_subparser", "run_down", "run_up"]

--- a/src/gen_worker/cli/work_ledger.py
+++ b/src/gen_worker/cli/work_ledger.py
@@ -1,0 +1,147 @@
+"""Per-key single-flight for compile work, on LOCAL DISK ONLY.
+
+pgw#1491. ``gen-worker compile`` and a serving process's background mint both
+fill the same holes from the same CAS. Paul's ruling makes the WORK LEDGER the
+coordination mechanism rather than process adoption: both key work by the same
+CAS entries, each skips what the other already landed (skip-if-present measured
+at ~10 s/hit), and whichever survives finishes the remainder. The lease below
+is the "somebody is on this one right now" half — without it, two compiles of
+one specialization race into the same destination and torchcg refuses the
+second at ``_require_exact_directory``, wasting a full build.
+
+## Local disk only, and that is a hard boundary
+
+``flock`` semantics on a network filesystem are unproven here (e2e#1910), and a
+lease that silently does nothing is worse than no lease — it would convert a
+loud double-build into a silent corrupt one. So :func:`lease` refuses a root
+that is not on a local filesystem rather than degrading. Paul's separate
+ruling stands alongside it: workers NEVER coordinate downloads with each other;
+this is one machine's two processes, which is a different thing entirely.
+
+## Crash-safe by construction
+
+The lease is an ``flock`` on an open fd. A process that dies — SIGKILL, OOM,
+power — has its fd closed by the kernel and its lease released with it. There
+is no stale-lease reaper, because there are no stale leases.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import hashlib
+import os
+import re
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+#: Subdirectory of the CAS root holding lease files. Beside the artifacts it
+#: leases, so a store that is copied or deleted takes its leases with it.
+LEDGER_DIR = ".work-ledger"
+
+#: Filesystems whose ``flock`` this ledger will not stand on. FUSE is here
+#: because the guarantee is per-driver, not per-protocol — sshfs, s3fs and
+#: ceph-fuse all present as `fuse` and none of them promises what is needed.
+_REMOTE_FSTYPES = frozenset({
+    "nfs", "nfs4", "cifs", "smb3", "fuse", "fuse.sshfs", "fuseblk",
+    "lustre", "gpfs", "ceph", "9p", "afs", "glusterfs",
+})
+
+_SAFE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+class LedgerError(RuntimeError):
+    """The ledger could not be used on this filesystem or path."""
+
+
+class Busy(RuntimeError):
+    """Another process holds this key's lease right now."""
+
+
+def assert_local(root: Path) -> None:
+    """Refuse a ledger root whose filesystem does not honor ``flock``.
+
+    Fails CLOSED: a filesystem this cannot identify as local is refused, not
+    assumed. An unproven lock that reports success is the failure mode this
+    guard exists for.
+    """
+    fstype = _fstype(root)
+    if fstype is None:
+        raise LedgerError(
+            f"cannot identify the filesystem under {root}; the compile work "
+            f"ledger is local-disk-only (network flock is unproven, e2e#1910) "
+            f"and will not run where it cannot prove that."
+        )
+    if fstype in _REMOTE_FSTYPES:
+        raise LedgerError(
+            f"{root} is on {fstype}; the compile work ledger is "
+            f"local-disk-only. Point --graph-store at local disk."
+        )
+
+
+def _fstype(path: Path) -> Optional[str]:
+    """The mounted filesystem type for ``path``, or ``None`` if unreadable."""
+    try:
+        entries = Path("/proc/self/mountinfo").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    target = str(Path(path).resolve())
+    best: tuple[int, Optional[str]] = (-1, None)
+    for line in entries.splitlines():
+        _, _, rest = line.partition(" - ")
+        fields = line.split()
+        if len(fields) < 5 or not rest:
+            continue
+        mountpoint = fields[4]
+        fstype = rest.split()[0]
+        if target == mountpoint or target.startswith(
+            mountpoint.rstrip("/") + "/"
+        ):
+            if len(mountpoint) > best[0]:
+                best = (len(mountpoint), fstype)
+    return best[1]
+
+
+def lease_path(root: Path, key: str) -> Path:
+    """Where one key's lease file lives. The key is hashed, never pasted:
+    a graph identity is long and a specialization name can carry anything."""
+    digest = hashlib.blake2b(key.encode("utf-8"), digest_size=16).hexdigest()
+    hint = _SAFE.sub("-", key)[:48].strip("-")
+    return Path(root) / LEDGER_DIR / f"{hint}-{digest}.lease"
+
+
+@contextmanager
+def lease(root: Path, key: str, *, blocking: bool = False) -> Iterator[None]:
+    """Hold the single-flight lease for ``key`` for the body's duration.
+
+    ``blocking=False`` (the default) raises :class:`Busy` immediately when
+    somebody else holds it — which is what a compile driver wants: skip that
+    specialization now and come back to it, rather than idling a core waiting
+    for work another process is already doing.
+    """
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    assert_local(root)
+    path = lease_path(root, key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        flags = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+        try:
+            fcntl.flock(fd, flags)
+        except OSError as exc:
+            if exc.errno in (errno.EACCES, errno.EAGAIN):
+                raise Busy(key) from exc
+            raise
+        try:
+            os.ftruncate(fd, 0)
+            os.write(fd, f"{os.getpid()}\n{key}\n".encode("utf-8"))
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+__all__ = ["Busy", "LEDGER_DIR", "LedgerError", "assert_local", "lease", "lease_path"]

--- a/src/gen_worker/cli/workspace.py
+++ b/src/gen_worker/cli/workspace.py
@@ -1,10 +1,15 @@
-"""The box-shared stores the four verbs share, and how a ref becomes a tree.
+"""The box-shared stores the verbs share, and how a ref becomes a tree.
 
-pgw#1466. ``lock``, ``sync``, ``serve`` and ``run`` are four front doors onto
-one set of stores; this module is where "where do weights live" and "where do
-graphs live" are each answered ONCE. A verb that computed its own answer would
-be a verb that can disagree with its siblings — `sync` pre-warming into a
-directory `serve` never reads is the failure mode, and it is silent.
+pgw#1466, re-spelled by pgw#1491. ``lock``, ``download``, ``compile``, ``up``
+and ``run`` are front doors onto one set of stores; this module is where "where
+do weights live" and "where do graphs live" are each answered ONCE. A verb that
+computed its own answer would be a verb that can disagree with its siblings —
+``download`` pre-warming into a directory ``up`` never reads is the failure
+mode, and it is silent.
+
+(``sync`` was one of the original four and is DELETED, not renamed: deps are
+``uv sync``, artifacts are ``compile``, weights are ``download``. One verb that
+meant all three could not be given a correct default for any of them.)
 
 Two stores, deliberately separate:
 
@@ -32,7 +37,7 @@ from typing import Any, Optional
 #: `weights_cas_root`), never guessed.
 DEFAULT_WEIGHTS_CAS = Path.home() / ".cache" / "tensorhub" / "cas"
 
-#: Exported programs (from `lock`) and compiled artifacts (from `sync`).
+#: Exported programs (from `lock`) and compiled artifacts (from `compile`).
 #: Config key `COZY_GRAPH_CAS` (Settings field `graph_cas_root`).
 DEFAULT_GRAPH_CAS = Path.home() / ".cache" / "cozy" / "graph-cas"
 
@@ -146,7 +151,7 @@ def resolve_checkpoint(ref: CheckpointRef, *, cas_root: Optional[Path] = None) -
         raise WorkspaceError(
             f"{ref} is not in the weight CAS at {root}.\n"
             f"  refs present: {', '.join(available) if available else '(none)'}\n"
-            f"  run `gen-worker sync` to materialize it."
+            f"  run `gen-worker download {ref}` to materialize it."
         )
     snapshot_id = ref_file.read_text(encoding="utf-8").strip()
     if not snapshot_id:

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -43,6 +43,7 @@ _ENV_TO_FIELD: Dict[str, str] = {
     # TENSORHUB_CACHE_DIR does.
     "COZY_WEIGHTS_CAS": "weights_cas_root",
     "COZY_GRAPH_CAS": "graph_cas_root",
+    "COZY_ENDPOINT_STATE": "endpoint_state_root",
     "BAKED_PROGRAM_CAS_ROOT": "baked_program_cas_root",
     "RUNPOD_POD_ID": "runpod_pod_id",
     "GEN_WORKER_CONFIG_SNAPSHOT_PATH": "config_snapshot_path",

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -64,6 +64,10 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     # CLI installs Settings at process entry like every other entry point.
     weights_cas_root: str = ""
     graph_cas_root: str = ""
+    # pgw#1491: where `up` publishes its handle and `run`/`down` find it.
+    # Empty = the box default in `cli/endpoint_state.py`, beside the code that
+    # explains why liveness is a signal-0 and not the file's existence.
+    endpoint_state_root: str = ""
     # pgw#1462 part 2: the IMAGE's read-only exported-program CAS — where the
     # builder bakes this release's serialized ExportedPrograms. Distinct from
     # `graph_cas_root` (the CLI's own store) and from the pod's

--- a/src/gen_worker/serving/dispatch_counter.py
+++ b/src/gen_worker/serving/dispatch_counter.py
@@ -1,0 +1,229 @@
+"""Per-request truth about WHERE a forward ran: compiled graph, or eager.
+
+pgw#1491, and it is not a harness nicety. On 2026-08-19 a broken dispatch guard
+served twelve perfect images entirely eager, at eager speed, with no complaint
+from torch, from diffusers or from AOTI. "Compiled is about the same as eager"
+was one counter away from being published as a measurement. Silent fall-through
+must be COUNTABLE at the serving surface, permanently.
+
+## Three numbers, and why it takes three
+
+``module_calls`` — counted by a ``register_forward_pre_hook`` on the adopted
+module. torch runs hooks inside ``Module._call_impl``, BEFORE it reads
+``self.forward``, so this number survives anything that replaces ``forward``.
+
+``compiled_graph_calls`` — counted by a wrapper around the compiled callable
+that torchcg's ``_ForwardDispatcher`` holds, incremented at the moment the
+compiled artifact is actually entered.
+
+``eager_calls`` = ``module_calls - compiled_graph_calls``, DERIVED and never
+counted separately, because the two counters answer different questions and a
+third independent tally could only ever disagree with the arithmetic.
+
+## The witness, and the bug it exists to catch
+
+torchcg installs its dispatcher as the module's INSTANCE ``forward``
+(``adopt._ForwardDispatcher``). An accelerate-managed offload pipeline
+re-attaches its own wrapper to ``forward`` per call — so an instrument attached
+by assignment is silently displaced, the pipeline keeps working, and the
+instrument reads 0. That is the second bug of this species measured in one day.
+
+The pre-hook is the INDEPENDENT witness: it counts calls that reach the module
+no matter what owns ``forward``. So
+
+* ``module_calls == compiled + eager`` and ``compiled > 0`` — compiled served;
+* ``compiled == 0`` with ``module_calls > 0`` — everything fell through eager,
+  and the count SAYS so instead of the timing implying it;
+* ``forward is not the dispatcher`` — the dispatcher was DISPLACED, reported by
+  name as :attr:`DispatchCounts.displaced_modules` rather than showing up as an
+  unexplained zero.
+
+Absence never renders as zero: a boot that adopted nothing reports
+``armed_modules=0``, which is a different word from "armed and never entered".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: Marks a callable this module already wrapped, so re-arming after a late mint
+#: never double-counts the artifacts it wrapped on the previous pass.
+_WRAPPED = "_gen_worker_dispatch_counted"
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchCounts:
+    """One request's dispatch facts. Every field is a live read."""
+
+    #: Calls that reached an adopted module (pre-hook; survives wrapper churn).
+    module_calls: int
+    #: Calls that entered a compiled artifact.
+    compiled_graph_calls: int
+    #: Modules carrying at least one armed graph at the time of the request.
+    armed_modules: int
+    #: Armed graphs across those modules.
+    armed_graphs: int
+    #: Modules whose ``forward`` is no longer torchcg's dispatcher — something
+    #: displaced it, so nothing on them can dispatch compiled.
+    displaced_modules: Tuple[str, ...]
+
+    @property
+    def eager_calls(self) -> int:
+        """Derived, never counted: the calls that fell through to eager."""
+        return max(0, self.module_calls - self.compiled_graph_calls)
+
+    def facts(self) -> Dict[str, Any]:
+        return {
+            "module_calls": self.module_calls,
+            "compiled_graph_calls": self.compiled_graph_calls,
+            "eager_calls": self.eager_calls,
+            "armed_modules": self.armed_modules,
+            "armed_graphs": self.armed_graphs,
+            "displaced_modules": list(self.displaced_modules),
+        }
+
+    def summary(self) -> str:
+        """The line a human reads after every request.
+
+        It names the state in WORDS, because a reader scanning a log for
+        "did that run compiled" must not have to do the subtraction himself.
+        """
+        if self.armed_modules == 0:
+            return "dispatch: no compiled graph armed — served eager (nothing adopted)"
+        if self.displaced_modules:
+            return (
+                f"dispatch: DISPLACED on {', '.join(self.displaced_modules)} — the "
+                f"compiled dispatcher is no longer this module's forward, so all "
+                f"{self.module_calls} call(s) ran eager"
+            )
+        if self.compiled_graph_calls == 0:
+            return (
+                f"dispatch: {self.armed_graphs} graph(s) armed on "
+                f"{self.armed_modules} module(s) and NONE was entered — all "
+                f"{self.module_calls} call(s) fell through to eager"
+            )
+        return (
+            f"dispatch: compiled_graph_calls={self.compiled_graph_calls} "
+            f"eager_calls={self.eager_calls} "
+            f"(armed {self.armed_graphs} graph(s) on {self.armed_modules} module(s))"
+        )
+
+
+class DispatchCounter:
+    """Counts compiled-vs-eager forwards for one booted endpoint.
+
+    One instance per :class:`~gen_worker.serving.host.EndpointHost`. Attach with
+    :meth:`install`, snapshot per request with :meth:`take`.
+    """
+
+    def __init__(self) -> None:
+        self._module_calls = 0
+        self._compiled_calls = 0
+        #: (label, module, dispatcher) — the adopted modules, for the witness.
+        self._targets: List[Tuple[str, Any, Any]] = []
+        self._hooks: List[Any] = []
+
+    # -- attachment ---------------------------------------------------------
+
+    def install(self, host: Any) -> "DispatchCounter":
+        """Attach to every module this boot adopted. Idempotent per module.
+
+        Safe on a host that adopted nothing (the eager bridge): there is
+        nothing to attach to, and the counts then report ``armed_modules=0``.
+        """
+        session = getattr(host, "adoption", None)
+        if session is None:
+            return self
+        # torchcg exposes adopted GRAPHS publicly but not the modules they were
+        # adopted onto; the dispatcher list is the only handle on the objects
+        # that actually route. Read-only, and re-derived on every rearm so a
+        # torchcg bump that renames it fails loudly here rather than quietly
+        # zeroing the instrument.
+        pairs = getattr(session, "_dispatchers", None)
+        if not pairs:
+            return self
+        for module, dispatcher in list(pairs):
+            label = type(module).__name__
+            if any(existing is module for _, existing, _ in self._targets):
+                continue
+            self._targets.append((label, module, dispatcher))
+            self._hooks.append(module.register_forward_pre_hook(self._count_module))
+        self.rearm()
+        return self
+
+    def rearm(self) -> None:
+        """Wrap any compiled callable armed since the last pass.
+
+        The background mint arms artifacts onto the SAME session after boot, so
+        a counter that wrapped only what boot adopted would under-count every
+        graph the mint filled in — reading as fall-through exactly where the
+        interesting thing just happened.
+        """
+        for _label, _module, dispatcher in self._targets:
+            entries = getattr(dispatcher, "_entries", None)
+            if entries is None:
+                continue
+            for index, (record, compiled) in enumerate(list(entries)):
+                if getattr(compiled, _WRAPPED, False):
+                    continue
+                entries[index] = (record, self._wrap(compiled))
+
+    def _wrap(self, compiled: Callable[..., Any]) -> Callable[..., Any]:
+        def counted(*args: Any, **kwargs: Any) -> Any:
+            self._compiled_calls += 1
+            return compiled(*args, **kwargs)
+
+        setattr(counted, _WRAPPED, True)
+        return counted
+
+    def _count_module(self, _module: Any, _args: Any) -> None:
+        self._module_calls += 1
+
+    # -- reading ------------------------------------------------------------
+
+    def reset(self) -> None:
+        self._module_calls = 0
+        self._compiled_calls = 0
+
+    def take(self) -> DispatchCounts:
+        """Snapshot the counters and the live witness, then reset.
+
+        The armed/displaced facts are read from the modules AT THIS MOMENT, not
+        remembered from install time — a stamp echoed back from boot would say
+        "armed" about a module something has since taken over.
+        """
+        armed_modules = 0
+        armed_graphs = 0
+        displaced: List[str] = []
+        for label, module, dispatcher in self._targets:
+            graphs = tuple(getattr(dispatcher, "armed_graphs", lambda: ())())
+            if graphs:
+                armed_modules += 1
+                armed_graphs += len(graphs)
+            if getattr(module, "forward", None) is not dispatcher:
+                displaced.append(label)
+        counts = DispatchCounts(
+            module_calls=self._module_calls,
+            compiled_graph_calls=self._compiled_calls,
+            armed_modules=armed_modules,
+            armed_graphs=armed_graphs,
+            displaced_modules=tuple(displaced),
+        )
+        self.reset()
+        return counts
+
+    def close(self) -> None:
+        for hook in self._hooks:
+            try:
+                hook.remove()
+            except Exception:  # noqa: BLE001 — teardown must not raise
+                pass
+        self._hooks.clear()
+        self._targets.clear()
+
+
+__all__ = ["DispatchCounter", "DispatchCounts"]

--- a/src/gen_worker/wire_snapshots.py
+++ b/src/gen_worker/wire_snapshots.py
@@ -68,6 +68,45 @@ def resolved_repo_from_snapshot(snap: Any) -> Any:
     )
 
 
+def snapshot_from_resolved_repo(resolved: Any) -> Any:
+    """``WorkerResolvedRepo`` -> ``pb.Snapshot``: the INVERSE, and it lives
+    here for the reason this module exists — one place the two spellings meet.
+
+    pgw#1491. The CLI resolves a checkpoint over HTTP
+    (``hub_client.resolve_repo``, which answers ``WorkerResolvedRepo``) and
+    then hands it to the SAME ``ModelStore.ensure_local`` a pod's boot uses,
+    whose parameter is the gRPC spelling. Without this the CLI would need its
+    own materializer, which is the two-paths-rot rule's exact shape: two
+    downloaders that both produce trees and disagree about integrity.
+
+    ``provenance`` is deliberately not synthesized: the proto calls it
+    audit/display ONLY and nothing downstream reads it, so inventing one here
+    would be manufacturing provenance the hub never stated.
+    """
+    from .pb import worker_scheduler_pb2 as pb
+
+    return pb.Snapshot(
+        digest=resolved.snapshot_digest,
+        files=[
+            pb.SnapshotFile(
+                path=f.path,
+                size_bytes=int(f.size_bytes),
+                url=f.url or "",
+                digest=f.digest or "",
+                chunks=[
+                    pb.ChunkRef(
+                        sha256=c.sha256,
+                        url=c.url,
+                        len=int(c.length),
+                    )
+                    for c in (f.chunks or ())
+                ],
+            )
+            for f in resolved.files
+        ],
+    )
+
+
 def resolved_repos(
     wire: Mapping[str, Any],
     bindings: Iterable[Any] = (),


### PR DESCRIPTION
Paul's end-goal UX, verbatim: *"That way I can download / run inference from my CLI per endpoint simply."* This lands the verbs behind it.

Paul's ruling (DESIGN-RULINGS 2026-08-19, "gen-worker IS the endpoint CLI"): every endpoint-scoped verb belongs here because every one must run **inside the endpoint's venv against its pinned torch** — `lock` needs its tracer, `compile` its inductor, `up` its runtime. An external tool could only ever shell in and invoke this. cozy-local becomes the bootstrap + multi-endpoint wrapper (cozy-local#45).

## Acceptance — run for real, sd15 on an RTX 4070 (sm_89)

From the endpoint directory. Every step a real invocation; no harness.

```
$ gen-worker download
gen-worker download: cozy.toml names tensorhub/sd15-base@prod
checkpoint tensorhub/sd15-base@prod already resident at
  ~/.cache/tensorhub/cas/snapshots/sha256:5bd90786…
tensorhub/sd15-base@prod	<tree>

$ gen-worker up -d --sm sm_89
gen-worker up: booting /…/sd15 detached (pid 1850285)
gen-worker up: sd15.main ready — functions: generate

$ gen-worker run "a lighthouse at dusk, dramatic sky" seed=42
dispatch: compiled_graph_calls=31 eager_calls=0
outputs/run-0/image.webp                       # opened it — a real lighthouse

$ gen-worker run "a red fox in snow" seed=7
dispatch: compiled_graph_calls=31 eager_calls=0
outputs/run-1/image.webp                       # 3.9 s wall END TO END, warm

$ gen-worker down
gen-worker down: stopping sd15.main (pid 1850285) — waiting for teardown
gen-worker down: stopped                       # VRAM 5.7 GiB -> 198 MiB
```

Served **compiled, not eager** — and the counter is what proves it rather than the timing.

**Red arms, all typed.** `run` before `up` and after `down` both refuse and name why they never auto-start. `compile --vram-budget 1.0` → `grant_below_compiled_floor(grant=1.0 GiB, floor=6.0 GiB)`, `below_floor=14` — its own outcome word, not `claimed` (which means another process holds the lease). `compile` at a real grant → `present=14 of 14`, skip-if-present.

An earlier `download` run pulled the full 2.6 GB cold through `ModelStore.ensure_local` with the integrity gate, byte-position `weight_fetch` progress and the `snapshot_pull` roll-up.

## The shape

- **`up [-d]` / `down`** — docker-compose semantics: bare `up` is foreground (logs stream, Ctrl-C stops), `-d` detaches. One resident daemon per endpoint, publishing a handle at `~/.cache/cozy/resident/<key>/endpoint.json`.
- **`run`** — a CLIENT of that daemon. It executes no inference itself and REFUSES when nothing is up. Two paths that both serve requests drift invisibly, because both keep producing images — measured three times in one day.
- **`download`** — checkpoint-centric (an endpoint declares no checkpoints; they are runtime config), materializing through `ModelStore.ensure_local` — the **same call `boot_materialize` makes on a pod**. `up`'s boot pulls its configured refs through that same function, so an endpoint can never come up against a tree `download` would have rejected.
- **`compile`** — enumerates the committed lock's specializations, keys them by `(graph, env)` with env read off `uv.lock`, fetches before building, and shares work with a serving process's background mint through a flock **work ledger** (local disk only — network flock is unproven, e2e#1910, so it refuses rather than degrades). Below the compiled floor it no-ops by name instead of minting artifacts nothing could arm.
- **`login`** — USER-GLOBAL credentials in the store cozy-local already uses (`~/.cozy/credentials.d`, via the shared `current_name`/`current_profile` pointer), so one login serves every endpoint venv. Prefers MACHINE tokens: nothing it stores can rotate.
- **`publish`** — source + committed lock, with the `uv build --wheel` preflight in front (five seconds; se#775 burned **6h28m** on the failure it catches). Warns rather than refuses when no lock is committed — "regenerate when missing" is legal.

## The instrument (permanent, not a harness nicety)

Every response states `compiled_graph_calls` vs `eager_calls`. A broken dispatch guard once served twelve perfect images entirely eager, at eager speed, with no complaint from torch, diffusers or AOTI — *"compiled is about the same as eager"* was one counter away from being published as a measurement.

The compiled count comes from a wrapper on the compiled callable. The module count comes from a `register_forward_pre_hook`, which torch runs inside `_call_impl` **before** it reads `self.forward` — so it survives accelerate re-wrapping it. That hook is the **independent witness**: a displaced dispatcher is reported by name instead of showing up as an unexplained zero, and `eager_calls` is derived (`module − compiled`) rather than counted, because a third tally could only ever disagree with the arithmetic. Absent renders as "nothing adopted", never as 0.

## Also here

- **Two-CAS-defaults defect fixed (pgw#1513), found by measurement:** `ModelStore` defaults `cache_dir` to the POD store (`/tmp/tensorhub-cache/cas`) while the box store is `~/.cache/tensorhub/cas`. The first `download` run put 2.6 GB where no other tool looks. The CLI now STATES the box root.
- **Address-free `compile`:** asks `store.fetch_program(graph, destination)` and nothing else. The two-generation compatibility branch was deleted rather than fixed — `document.py` now has zero `"program"` occurrences, and a branch that cannot be observed to be wrong is worse than one that breaks.
- **Hardcut:** `sync` and `serve`-as-a-verb are deleted spellings, not aliases. `protocol.CAPABILITIES` loses six tokens naming verbs that no longer exist — a capability list that lies is worse than none, because integrators branch on it.

## Verification

`mypy` clean on src (353 files), `ruff` clean. Rebased onto master post-pgw#1518; this branch no longer touches `skeleton.py` (master owns that fix). Surface, both red arms and `compile` re-smoke-tested green after the rebase.

Unblocks cozy-local#45's skip-by-name delegation tests, which gate on this surface existing in the endpoint venv.