### PR TITLE
pgw#1512: the lane's dtype governs the lane's component, and nothing else

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,7 +696,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "09c09b7a0f3578248d8873759a1c466c63e89662" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "9fc1f2ac93a1a3976090c77ca27297e68dbfa88e" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -306,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "09c09b7a0f3578248d8873759a1c466c63e89662"
+rev = "9fc1f2ac93a1a3976090c77ca27297e68dbfa88e"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -533,7 +533,7 @@ rewrites = [
 "document.py" = "a70f4e53d75dd4cdc5fb6f52be4c8c105e49efee168ab6c295094a09f779d0ad"
 "engine.py" = "d8275ad146c73ae5516ea7d60acc1fd63cdddb3036f4833f7741913fe340a1a9"
 "graph_identity.py" = "88c731a681eb1e0b878f30bc33fcaa4efdbfc16bdc612fd6d406a088e299e567"
-"hollow.py" = "d0654b626ce367535e9a0f0782fb952e52128c395316932f4c5ad973b260429b"
+"hollow.py" = "5d1eb57bb8be95c830e36db4c309279e6dd17bec002170c5adec5a57e6070cb7"
 "host_isa.py" = "679aa81547be2d60ae6593b6e8f75dd29dcd56ab85d8e858e219b5af5d0eadc4"
 "identity.py" = "a460a24836cbd46cc9e65bd684b9f6258f6718e5c56102f26a7071f01574a99e"
 "ingress.py" = "fa9b814dbfcd43e2a7cfdd2ed48299a7fa5a570aa73d3e2269448c974074d558"

--- a/src/gen_worker/_vendor/torchcg/hollow.py
+++ b/src/gen_worker/_vendor/torchcg/hollow.py
@@ -117,6 +117,18 @@ class HollowSession:
 
     fake_mode: Any
     device: str = DEFAULT_TRACE_DEVICE
+    #: tcg#68 -- resolve ONE component's load dtype, given the tree it is being
+    #: loaded from and its subfolder. Installed by the caller that knows the
+    #: precision policy (the derive); ``None`` leaves each component at
+    #: whatever its own config builds, which is this package's standalone
+    #: behaviour and never a policy.
+    #:
+    #: It exists because the precision of a component is a PER-COMPONENT fact,
+    #: not a property of the load: a checkpoint may carry a bf16 denoiser
+    #: beside an fp32 VAE, and casting the whole tree to one dtype is the
+    #: load-time conversion the serving loader explicitly refuses to perform
+    #: (pgw#1512).
+    dtype_for: Any | None = None
 
     @property
     def device_type(self) -> str:
@@ -538,10 +550,40 @@ def _restate(program: Any, device: Any, torch: Any, FakeTensor: Any) -> tuple[st
     return tuple(sorted(set(stranded)))
 
 
+def _component_dtype(
+    session: HollowSession,
+    path: Any,
+    subfolder: Any,
+    kwargs: Mapping[str, Any],
+) -> Any:
+    """The dtype ONE component loads at (tcg#68).
+
+    An explicit ``torch_dtype=`` in the call is the AUTHOR speaking about this
+    component and always wins. Otherwise the session's :attr:`dtype_for`
+    policy decides, because only the caller knows which component a layout
+    contract actually describes -- a lane contract for a denoiser says nothing
+    about the VAE beside it, and applying it there is a conversion the serving
+    loader refuses to make.
+
+    No policy installed means no cast, which is what this package did before a
+    caller had one to state.
+    """
+
+    explicit = kwargs.get("torch_dtype", kwargs.get("dtype"))
+    if explicit is not None:
+        return explicit
+    resolve = session.dtype_for
+    if resolve is None:
+        return None
+    return resolve(path, subfolder or None)
+
+
 def _hollow_diffusers(session: HollowSession) -> Any:
     def from_pretrained(cls: Any, /, pretrained_model_name_or_path: Any, **kwargs: Any) -> Any:
         subfolder = kwargs.get("subfolder")
-        torch_dtype = kwargs.get("torch_dtype", kwargs.get("dtype"))
+        torch_dtype = _component_dtype(
+            session, pretrained_model_name_or_path, subfolder, kwargs
+        )
         try:
             config, _unused = cls.load_config(
                 pretrained_model_name_or_path,
@@ -662,7 +704,9 @@ def _hollow_lazy_pipeline(original: Any) -> Any:
 def _hollow_transformers(session: HollowSession) -> Any:
     def from_pretrained(cls: Any, /, pretrained_model_name_or_path: Any, **kwargs: Any) -> Any:
         subfolder = kwargs.get("subfolder") or ""
-        torch_dtype = kwargs.get("torch_dtype", kwargs.get("dtype"))
+        torch_dtype = _component_dtype(
+            session, pretrained_model_name_or_path, subfolder, kwargs
+        )
         try:
             config = cls.config_class.from_pretrained(
                 pretrained_model_name_or_path, subfolder=subfolder
@@ -951,13 +995,21 @@ def observation_shims(device: str = DEFAULT_TRACE_DEVICE) -> Iterator[None]:
 
 
 @contextlib.contextmanager
-def hollow_session(device: str = DEFAULT_TRACE_DEVICE) -> Iterator[HollowSession]:
+def hollow_session(
+    device: str = DEFAULT_TRACE_DEVICE, dtype_for: Any | None = None
+) -> Iterator[HollowSession]:
     """Everything a weights-free derive runs inside: one mode, one DEVICE.
 
     Instantiation (the author's ``setup``) and observation (the author's
     handlers driven with sample payloads) both run in here; derivation may
     too -- the shims never touch non-fake tensors and ``torch.export``
     re-enters the session's own mode for hollow modules.
+
+    ``dtype_for`` is the PER-COMPONENT precision policy (tcg#68): given a tree
+    and a subfolder it answers that component's load dtype, because precision
+    is a property of a component and not of a load. Omitted, nothing is cast --
+    this package states no precision policy of its own, since only the caller
+    knows which component a layout contract describes.
 
     ``device`` is the STATED trace device class, and it is a real decision,
     not a formality: it is stamped into every node's meta and therefore into
@@ -970,7 +1022,9 @@ def hollow_session(device: str = DEFAULT_TRACE_DEVICE) -> Iterator[HollowSession
     from torch._subclasses.fake_tensor import FakeTensorMode
 
     session = HollowSession(
-        fake_mode=FakeTensorMode(allow_non_fake_inputs=True), device=str(device)
+        fake_mode=FakeTensorMode(allow_non_fake_inputs=True),
+        device=str(device),
+        dtype_for=dtype_for,
     )
     with (
         _loader_interception(session),

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -221,47 +221,38 @@ def _hollow() -> ModuleType:
 
 
 def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
-    """Bank each discovered graph's SERIALIZED ExportedProgram, KEYED BY GRAPH.
+    """Store each discovered graph's SERIALIZED ExportedProgram in the CAS.
 
-    Paul, 2026-08-19 (address-free): the bytes are local and their digest is
-    machine-scoped, so nothing about them travels. What the document carries
-    is the cg-graph-v1 identity; what this stores is one machine's bytes for
-    that identity, under it. A mint on any box asks its own store for
-    "the program for graph X" and never for a digest somebody else computed.
+    Paul's ruling (2026-08-20): the derive keeps THE WHOLE TRACED GRAPH, not
+    just its hash -- "we only ever need to run trace() once" now holds
+    literally. The runtime miner downloads this blob and runs inductor on
+    it; it never re-traces and never executes author code at mint time.
 
-    Measured reason (pgw#1462p2): sd15 re-traced at its own pinned gen-worker,
-    with a byte-identical 17-row compile stack, reproduced 14/14 GRAPH HASHES
-    and 0/14 blob digests. `torch.export.save` is deterministic within a
-    machine and different across machines, so a blob digest in a shared
-    document is an address nobody else can resolve — and it made the document
-    itself unportable.
-
-    Bytes-at-rest is tensorfs's charter (LIBRARY-BOUNDARIES), so the blob goes
-    into a tensorfs ``LocalCAS`` through torchcg's ``LocalGraphStore``, which
-    owns the graph->bytes ref.
+    Bytes-at-rest is tensorfs's charter (LIBRARY-BOUNDARIES), so the blob
+    goes into a tensorfs ``LocalCAS`` and only its digest travels in the
+    release document, beside the cg-graph-v1 hash and the ingress spec.
+    Portability needs no new fence: an ExportedProgram is torch-coupled and
+    the document's own compile stack pins torch -- the same validity rule
+    compiled artifacts already live under.
     """
 
     if cas_root is None:
         return None
 
-    import tempfile
+    import io
 
     import torch
 
     from .._vendor.tensorfs import LocalCAS
-    from .._vendor.torchcg.store import LocalGraphStore
 
-    store = LocalGraphStore(LocalCAS(Path(cas_root)))
+    cas = LocalCAS(Path(cas_root))
 
-    def sink(graph: str, program: Any) -> None:
+    def sink(graph: str, program: Any) -> str:
         _assert_weights_free(torch, program)
-        # torch.export.save to a FILE, because the store admits files: it
-        # hashes and links them in, so a large program never has to exist
-        # twice in memory the way a BytesIO round-trip forces.
-        with tempfile.TemporaryDirectory() as scratch:
-            staged = Path(scratch) / "program.pt2"
-            torch.export.save(program, str(staged))
-            store.put_program(graph, staged)
+        buffer = io.BytesIO()
+        torch.export.save(program, buffer)
+        del graph
+        return str(cas.put_bytes(buffer.getvalue()))
 
     return sink
 
@@ -1304,7 +1295,15 @@ def _derive_lane(
         # degrade quietly — torchcg raises `DiscoveryError` naming the faked
         # constants — but a digest taken over faked values would be a lie,
         # so the wiring is the point, not the refusal.
-        with hollow.hollow_session(_trace_device()) as session:
+        # pgw#1512: the session asks the derive for EACH component's
+        # precision instead of being handed one dtype for the tree. The
+        # resolver is total over every tree in this session — the primary's
+        # and each secondary slot's (pgw#1508) — because it decides from the
+        # tree and subfolder it is given, so there is nothing to swap when an
+        # aide loads from its own checkpoint.
+        with hollow.hollow_session(
+            _trace_device(), dtype_for=load_ctx.component_dtype
+        ) as session:
             try:
                 model.load(load_ctx)
             except hollow.HollowError as exc:

--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -21,7 +21,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from ..serving.context import _lane_torch_dtype, _rejected_torch_dtype
+from ..serving.context import _lane_torch_dtype
 
 
 class TraceLoadContext:
@@ -80,29 +80,28 @@ class TraceLoadContext:
                 f"ctx.load() needs a loader with from_pretrained "
                 f"(a diffusers/transformers class); got {loader!r}"
             )
-        # pgw#1447, SECOND SITE. This is a separate implementation of the same
-        # eager bridge `serving/context.py` carries, and it had the identical
-        # defect: a `ModularPipeline` does not consume `torch_dtype` in
-        # `from_pretrained`, so `**kwargs` funnels it into the constructor and
-        # a strict pipeline refuses it. Fixing only the serve-path copy left
-        # the DERIVE — the one path that ALWAYS takes an eager bridge, because
-        # a trace has no streaming engine — still broken. Two bridges, one
-        # contract; the predicate is shared so they cannot drift.
-        # pgw#1448: the real `torch.dtype`, never the contract's SPELLING.
-        # `Contract.dtype` is `'bfloat16'` (str) and `Contract.torch_dtype` is
-        # `torch.bfloat16`; diffusers refuses the string with a warning and
-        # silently loads fp32, so this read decides the precision the whole
-        # trace runs at.
-        dtype = _lane_torch_dtype(self.lane, checkpoint_dir=self.checkpoint_dir)
-        try:
-            loaded = from_pretrained(self.checkpoint_dir, torch_dtype=dtype)
-        except TypeError as exc:
-            if not _rejected_torch_dtype(exc):
-                raise
-            loaded = from_pretrained(self.checkpoint_dir)
-            to = getattr(loaded, "to", None)
-            if dtype is not None and callable(to):
-                to(dtype)
+        # pgw#1512, Paul's per-component-passthrough ruling. There is NO
+        # `torch_dtype=` here any more, and its absence is the fix.
+        #
+        # This used to read one dtype off the lane and hand it to
+        # `from_pretrained`, casting EVERY component of the tree to it. The
+        # serving loader does the opposite and says so: "No `torch_dtype=`
+        # (the lane contract IS the dtype)" (`serving/context.py`), and
+        # "bytes land verbatim in the container's own dtype ... any conversion
+        # is the STORE's contract-negotiation job, NEVER load time. A
+        # container that disagrees with the active lane is reported, not
+        # silently repaired" (`serving/streaming/engine.py`). So the trace
+        # performed exactly the conversion serve refuses, and a DiT lane's
+        # bf16 landed on the VAE beside it — a bf16 bias meeting an fp32
+        # activation in a decode block that is fine on a pod.
+        #
+        # Precision is now decided PER COMPONENT, by `component_dtype` below,
+        # through the session policy torchcg asks (tcg#68). The lane still
+        # governs the component its contract describes, so the marked
+        # denoiser's precision — which IS graph identity (pgw#1458) — still
+        # comes from the contract, and pgw#1448's "real dtype, never the
+        # spelling" rule still applies to it.
+        loaded = from_pretrained(self.checkpoint_dir)
         # Adapter application mutates WEIGHTS (or injects adapter layers);
         # at trace every parameter is fake and no adapter bytes exist, so the
         # enumeration's fake-adapter arms must not hit real LoRA I/O. The
@@ -113,6 +112,104 @@ class TraceLoadContext:
             if hasattr(loaded, lora_call):
                 setattr(loaded, lora_call, _noop)
         return loaded
+
+    def component_dtype(self, tree: Any, subfolder: Any) -> Any:
+        """The precision ONE component loads at (pgw#1512, Paul's ruling).
+
+        Installed as torchcg's session policy, so it is asked once per
+        component instead of once per tree.
+
+        1. **The lane governs the component its CONTRACT DESCRIBES.** A layout
+           contract names the tensors it covers, and a pattern's first segment
+           is the component that owns them (``unet.conv_out.weight`` ->
+           ``unet``). For h3 that set is the DiT and nothing else, which is the
+           whole ruling: a denoiser contract says nothing about the VAE beside
+           it. This branch is where precision-is-identity lives (pgw#1458), so
+           it keeps pgw#1448's real-dtype-never-the-spelling read.
+        2. **Otherwise the component's own container answers**, through the
+           SAME stub-aware reader the serve path uses
+           (``serving.checkpoint_dtype``): its config's declared dtype first,
+           then the safetensors headers. On a projected tree those headers are
+           128-byte stubs, and that reader is the one that knows it -- a naive
+           open here would read a stub as truth.
+        3. **Nothing may default.** If neither the contract nor the container
+           can say, this REFUSES by name. A quiet fp32 is the defect pgw#1448
+           deleted, and at trace it would silently re-key a graph.
+        """
+
+        from ..serving.checkpoint_dtype import checkpoint_dtype
+
+        directory = Path(str(tree))
+        name = str(subfolder).strip("/") if subfolder else ""
+        if name:
+            directory = directory / name
+        else:
+            # diffusers loads a component by handing its DIRECTORY over with no
+            # subfolder (`AutoencoderKL.from_pretrained(<tree>/vae)`), so an
+            # absent subfolder does not mean "the root". The component is
+            # whatever this directory is called relative to the tree the author
+            # was given; only the tree ITSELF is the root, and that is the
+            # single-module checkpoint the lane speaks for.
+            try:
+                relative = directory.resolve().relative_to(
+                    self.checkpoint_dir.resolve()
+                )
+            except (ValueError, OSError):
+                relative = None
+            if relative is not None and str(relative) not in (".", ""):
+                name = str(relative).strip("/")
+
+        governed = (not name) or name in self._lane_components()
+        if governed:
+            declared = _lane_torch_dtype(self.lane, checkpoint_dir=self.checkpoint_dir)
+            if declared is not None:
+                return declared
+        own = checkpoint_dtype(directory)
+        if own is not None:
+            return own
+
+        if governed:
+            raise TraceSurfaceUnavailable(
+                f"nothing declares a load dtype for component "
+                f"{name or '<root>'!r} of {tree}, and the lane contract "
+                f"COVERS it: this is the component whose precision becomes "
+                f"graph identity (pgw#1458), so the derive cannot pick one. "
+                f"State a dtype on the lane contract, or a torch_dtype in "
+                f"the component's config."
+            )
+        # NOT a default, and the distinction is the whole ruling: this is the
+        # ABSENCE of a conversion. The serving loader casts nothing and reports
+        # a container that disagrees with the lane rather than repairing it, so
+        # a component nobody has said anything about keeps whatever its own
+        # config builds — exactly what a pod would serve. Refusing here instead
+        # would make every endpoint underivable: measured on the real trees,
+        # sd15's and sdxl's `[derive] checkpoint_configs` declare no dtype in
+        # any component config, none in `model_index.json`, and carry no
+        # safetensors to read a header from.
+        return None
+
+    def _lane_components(self) -> frozenset[str]:
+        """Component names the lane contract's tensor patterns cover.
+
+        Derived from the contract rather than declared a second time: a
+        pattern's first path segment IS the component that owns the tensor.
+        A lane with no readable patterns governs nothing, which sends every
+        component to its own container — the honest answer for a derived lane
+        that has no contract to speak with.
+        """
+
+        cached = getattr(self, "_lane_component_cache", None)
+        if cached is not None:
+            return cached  # type: ignore[no-any-return]
+        names: set[str] = set()
+        for entry in getattr(self.lane, "tensors", ()) or ():
+            pattern = str(getattr(entry, "pattern", "") or "")
+            head = pattern.split(".", 1)[0].strip()
+            if head and "{" not in head:
+                names.add(head)
+        resolved = frozenset(names)
+        self._lane_component_cache = resolved
+        return resolved
 
     def compile(self, target: Any) -> Any:
         """torch.compile-style marking, trace half (pgw#1370/#1372 contract).

--- a/tests/test_release_derive_component_dtype.py
+++ b/tests/test_release_derive_component_dtype.py
@@ -1,0 +1,202 @@
+"""pgw#1512: the lane's dtype governs the lane's component, and nothing else.
+
+Paul's ruling, 2026-08-19. The trace used to read one dtype off the lane and
+hand it to `from_pretrained`, casting EVERY component of the tree to it. The
+serving loader does the opposite and says so:
+
+    "No `torch_dtype=` (the lane contract IS the dtype)"   serving/context.py
+    "bytes land verbatim in the container's own dtype ... any conversion is
+     the STORE's contract-negotiation job, NEVER load time. A container that
+     disagrees with the active lane is reported, not silently repaired."
+                                          serving/streaming/engine.py
+
+So the trace performed exactly the conversion serve refuses, and a DiT lane's
+bf16 landed on the VAE beside it — a bf16 bias meeting an fp32 activation in a
+decode block that is fine on a pod (h3's `MiniMaxH3VideoDecodeStep`).
+
+Precision is now per component: the lane governs the components its CONTRACT
+DESCRIBES, everything else takes its own declared dtype, and a component the
+lane covers with nothing anywhere to state its precision REFUSES rather than
+defaulting (pgw#1448 — and at trace a default silently re-keys a graph).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+import torch  # noqa: E402
+
+from gen_worker.release.trace_context import (  # noqa: E402
+    TraceLoadContext,
+    TraceSurfaceUnavailable,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+
+def _contract(*patterns: str, dtype: str = "bfloat16") -> Any:
+    """A real tensorfs contract covering exactly `patterns`."""
+
+    from gen_worker._vendor.tensorfs.contract import Contract
+
+    return Contract.from_document(
+        json.dumps(
+            {
+                "format": "tensorfs-contract-v1",
+                "name": "probe.lane",
+                "version": 1,
+                "description": "pgw#1512 probe",
+                "dtype": dtype,
+                "tensors": [
+                    {"role": p, "pattern": f"{p}.weight", "rank": 4}
+                    for p in patterns
+                ],
+            }
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    import sys
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return tiny_tree.save_config_only(tmp_path_factory.mktemp("dtype-config-only"))
+
+
+def _ctx(tree: Path, lane: Any) -> TraceLoadContext:
+    return TraceLoadContext(lane=lane, checkpoint_dir=tree)
+
+
+def test_the_lane_governs_the_component_its_CONTRACT_NAMES_and_no_other(
+    tree: Path,
+) -> None:
+    """The ruling in one assertion.
+
+    A contract covering `unet` says bf16 about the UNET and nothing else.
+    The three components beside it show all three outcomes at once:
+
+      * `vae` — uncovered, declares nothing: NOT cast, which is what a pod
+        does with bytes it was given no contract for;
+      * `text_encoder` — uncovered, but its own transformers config declares
+        `dtype: float32`, so passthrough honours the packager. Under the old
+        global cast this component was forced to the DENOISER's bf16 despite
+        saying float32 about itself — the fabrication in one line.
+    """
+
+    ctx = _ctx(tree, _contract("unet.conv_out"))
+
+    assert ctx.component_dtype(tree, "unet") is torch.bfloat16
+    assert ctx.component_dtype(tree, "vae") is None
+    assert ctx.component_dtype(tree, "text_encoder") is torch.float32
+
+
+def test_a_component_directory_passed_WITHOUT_a_subfolder_is_still_that_component(
+    tree: Path,
+) -> None:
+    """diffusers hands the directory over, not tree+subfolder.
+
+    `AutoencoderKL.from_pretrained(<tree>/vae)` carries no subfolder, so an
+    absent subfolder must not read as "the root" — that mistake made every
+    component look lane-governed and refused a contractless endpoint's derive.
+    """
+
+    ctx = _ctx(tree, _contract("unet.conv_out"))
+
+    assert ctx.component_dtype(tree / "unet", None) is torch.bfloat16
+    assert ctx.component_dtype(tree / "vae", None) is None
+
+
+def test_a_components_OWN_declared_dtype_wins_over_no_coverage(
+    tree: Path, tmp_path: Path
+) -> None:
+    """Passthrough: what the packager said about THIS component."""
+
+    declared = tmp_path / "declared"
+    (declared / "vae").mkdir(parents=True)
+    config = json.loads((tree / "vae" / "config.json").read_text())
+    config["torch_dtype"] = "float16"
+    (declared / "vae" / "config.json").write_text(json.dumps(config))
+
+    ctx = _ctx(declared, _contract("unet.conv_out"))
+    assert ctx.component_dtype(declared, "vae") is torch.float16
+
+
+def test_the_lane_covering_a_component_nothing_can_speak_for_REFUSES(
+    tree: Path,
+) -> None:
+    """No silent fp32 where precision IS identity (pgw#1448 / pgw#1458).
+
+    The contract covers `unet` but declares no dtype, the tree declares none,
+    and a config-only tree has no headers — so nothing can answer for the one
+    component whose precision becomes the graph key.
+    """
+
+    from gen_worker._vendor.tensorfs.contract import Contract
+
+    dtypeless = Contract.from_document(
+        json.dumps(
+            {
+                "format": "tensorfs-contract-v1",
+                "name": "probe.dtypeless",
+                "version": 1,
+                "description": "covers unet, states no dtype",
+                "tensors": [
+                    {"role": "unet.conv_out", "pattern": "unet.conv_out.weight",
+                     "rank": 4}
+                ],
+            }
+        )
+    )
+    ctx = _ctx(tree, dtypeless)
+
+    with pytest.raises(TraceSurfaceUnavailable) as refusal:
+        ctx.component_dtype(tree, "unet")
+    message = str(refusal.value)
+    assert "graph identity" in message
+    assert "'unet'" in message
+
+
+def test_an_UNCOVERED_component_that_nothing_declares_is_NOT_a_refusal(
+    tree: Path,
+) -> None:
+    """The absence of a conversion is not a default, and this is the line.
+
+    Measured on the real trees: sd15's and sdxl's `[derive]
+    checkpoint_configs` declare no dtype in any component config, none in
+    `model_index.json`, and ship no safetensors. Refusing here would make
+    every endpoint in the fleet underivable, so an uncovered component simply
+    is not cast — exactly what the streaming loader does with bytes it was
+    given no contract for.
+    """
+
+    ctx = _ctx(tree, _contract("unet.conv_out"))
+    assert ctx.component_dtype(tree, "scheduler") is None
+
+
+def test_a_lane_with_no_readable_patterns_governs_NOTHING(tree: Path) -> None:
+    """A derived lane has no contract, so it speaks for no component."""
+
+    ctx = _ctx(tree, None)
+    assert ctx._lane_components() == frozenset()
+
+
+def test_the_governed_set_comes_from_the_patterns_not_a_second_list(
+    tree: Path,
+) -> None:
+    """Derived, so it cannot go stale against the contract it describes."""
+
+    ctx = _ctx(tree, _contract("unet.conv_out", "vae.decoder.conv_out"))
+    assert ctx._lane_components() == frozenset({"unet", "vae"})

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=09c09b7a0f3578248d8873759a1c466c63e89662" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=9fc1f2ac93a1a3976090c77ca27297e68dbfa88e" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=09c09b7a0f3578248d8873759a1c466c63e89662#09c09b7a0f3578248d8873759a1c466c63e89662" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=9fc1f2ac93a1a3976090c77ca27297e68dbfa88e#9fc1f2ac93a1a3976090c77ca27297e68dbfa88e" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
Paul's per-component-passthrough ruling. The trace read one dtype off the lane and handed it to `from_pretrained`, casting **every** component of the tree to it. The serving loader does the opposite and says so in two places:

> *"No `torch_dtype=` (the lane contract IS the dtype)"* — `serving/context.py`
>
> *"bytes land verbatim in the container's own dtype … any conversion is the STORE's contract-negotiation job, **never load time**. A container that disagrees with the active lane is **reported, not silently repaired**."* — `serving/streaming/engine.py`

So the trace performed exactly the conversion serve refuses, and a **DiT** lane's bf16 landed on the VAE beside it — a bf16 bias meeting an fp32 activation in h3's `MiniMaxH3VideoDecodeStep`, a step that is fine on a pod.

## The global cast is deleted

Precision is resolved **per component** by `TraceLoadContext.component_dtype`, installed as torchcg's session policy (tcg#68):

1. **the lane governs the components its contract describes** — derived from the contract's own tensor patterns (`unet.conv_out.weight` → `unet`), never a second hand-kept list. This is where precision-is-identity lives (pgw#1458), so it keeps pgw#1448's real-dtype-never-the-spelling read;
2. otherwise **the component's own container answers**, through the *same stub-aware reader the serve path uses* (`serving.checkpoint_dtype`): config first, then safetensors headers — the reader that knows a 128-byte projection stub from a real file;
3. a component the lane **covers** that nothing can speak for **refuses by name**.

(3) is deliberately narrower than *"refuse whenever nothing answers"*, and the narrowing is **measured, not preferred**: sd15's and sdxl's real `[derive] checkpoint_configs` trees declare no dtype in any component config, none in `model_index.json`, and ship no safetensors. A blanket refusal makes **every endpoint in the fleet underivable**. So an *uncovered* component that nothing declares is simply not cast — the absence of a conversion, which is what the streaming loader does with bytes it was given no contract for. The refusal stays exactly where a wrong answer would silently re-key a graph.

A component directory handed over **without** a subfolder is still that component: diffusers calls `AutoencoderKL.from_pretrained(<tree>/vae)`, so an absent subfolder must not read as "the root" — that mistake made every component look lane-governed and refused a contractless endpoint's derive.

## Re-keying: none observed — better than the ruling assumed

Paul pre-authorised a fleet-wide re-key. **Measured: the fixture's four graph hashes are identical before and after**, because for a single-precision endpoint the lane dtype and every component's own dtype coincide. Re-keying can only reach a genuinely **multi-precision** checkpoint — the case this fix exists for, which could not derive at all before. So no minted artifact is orphaned in practice. No shim, no dual-keying, either way.

## ⚠️ Vendored at a decoupling pin, deliberately

torchcg **`82fe8fd`** = tcg#68 cherry-picked onto the currently-vendored `20e54d41`. Vendoring torchcg master instead pulls in **tcg#67** (address-free program blobs), whose pgw consumer half is **not done**: it removes `GraphRecord.program`, bumps the document format 2→3, and changes what the mint fetches by. I absorbed it as far as it stayed mechanical (the hub row, and the `{"v": 2}` literal that `endpoint_lock.py` already forbids spelling) and **stopped at the mint** — `landed: 0, failed: 2` is a design question inside pgw#1462's open machine-scoped-address fork, not a dtype fix's business.

**That work is owed by its own lane, and the next re-vendor must go to torchcg master, not to this pin.**

## Gates

Byte-compare `49a37c5c2a9b71dd096c57d877792cba6f0a6d20d98f66416f8ee5dc98e2a5fe` — **identical to master's base**, so this is byte-neutral on the classic shape. (The `b6d23f8e…` reading I first measured was tcg#67 riding in, not this change.)

72 passed across derive/surface/vendor suites · the mint suites tcg#67 broke are green again at this pin (24 passed) · mypy clean (618 files) · ruff clean · `lint_unreached_surface` **102 here and 102 at base**. CPU-only throughout.