### PR TITLE
pgw#1521: delist five CLI rows that acquired production callers — unblock pgw master's `fast gates`

### DIFF
--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -373,11 +373,24 @@ gen_worker.boot_phases.render_phase_table()
 gen_worker.boot_stages.emit()
 gen_worker.capability.HardwareUnmetError.axes()
 gen_worker.capability.InsufficientDiskError.axes()
-gen_worker.cli.args.build_payload()
-gen_worker.cli.protocol.gen_worker_version()
-gen_worker.cli.sockaddr.cleanup_listener()
-gen_worker.cli.sockaddr.create_client()
-gen_worker.cli.sockaddr.create_listener()
+# ✅ DELISTED 2026-08-20 — the CLI surface acquired production callers, which is
+# this ratchet's NICEST failure mode and the outcome it exists to produce.
+#
+#     cli.args.build_payload · cli.protocol.gen_worker_version
+#     cli.sockaddr.cleanup_listener · create_client · create_listener
+#
+# pgw#1491's `up`/`down`/`run` verbs wired all five: `up -d` needs a listener,
+# `run` needs a client and the payload builder, and the protocol handshake
+# names the version. The guard went red on STALE ("the symbol still exists and
+# now HAS a production caller"), which is the ratchet turning the RIGHT way.
+#
+# Delisted by the th#2204 lane rather than by pgw#1491's, because the wiring
+# landed WITHOUT its baseline update and left pgw master red on `fast gates`
+# for every lane — the fourth such event of the night, and the exact shape
+# pgw#1521 was filed about. The rule the header states is the remedy: a lane
+# that gives a baselined symbol a caller MUST delete its line in the same
+# commit as the wiring. That did not happen, so it happens here.
+
 gen_worker.cli.sockaddr.display()
 gen_worker.compile_posture.install()
 gen_worker.cuda_root.torch_cuda_home()


### PR DESCRIPTION
pgw master is red on `fast gates` (pgw's ONLY required context) on **pgw#849 guard 2**, so no lane can merge. Verified on a clean `c29fc060` checkout with no other changes: **5 STALE rows**.

pgw#1491's `up`/`down`/`run` verbs wired all five — `up -d` needs a listener, `run` needs a client and the payload builder, the protocol handshake names the version. The guard's message is *"the symbol still exists and now HAS a production caller"*, i.e. **the ratchet turning the right way**. The baseline header states the remedy: delete the line in the same commit as the wiring. That did not ride along.

Baseline **102 → 97**, matching the guard's own count. Delisted with a note naming who wired them, per the file's convention.

Not my rows — done because master is red for everyone. **Fourth green-PR-to-red-master event tonight**, and the exact shape documented in pgw#1521 (ruled: option 2, diff-local guards should report which side they failed on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)