### PR TITLE
pgw#1521: classify pgw#1491's env reads — by ELIMINATING them, not allowlisting

### DIFF
--- a/scripts/post_connect_resolution_allowlist.txt
+++ b/scripts/post_connect_resolution_allowlist.txt
@@ -31,6 +31,21 @@
 
 src/gen_worker/models/provision.py::resolve_repo  STANDALONE  _local_flavor_fold's own resolve, same containment.
 
+# pgw#1491's CLI verbs. `cli/download.py` resolves a checkpoint ref against the
+# hub's public resolve route so `gen-worker download` (and `up`'s boot, which
+# materializes through the SAME function) can put bytes on disk before anything
+# is asked to serve. It is a FIRST resolver for a machine that has no hub
+# connection at all — an operator naming a ref on a laptop — not a second one
+# reconstructing a decision the hub already made for a connected worker.
+#
+# Containment VERIFIED 2026-08-20 by import, not by assertion: nothing outside
+# `src/gen_worker/cli/` imports `cli.download` or `cli.daemon`, and the
+# connected worker (`worker.py`, `entrypoint.py`, `procsplit/`, `serve/`)
+# does not import `gen_worker.cli` at ALL. A connected pod materializes
+# through `boot_materialize` -> `ModelStore.ensure_local` with the snapshot the
+# hub sent it, and never reaches this call.
+src/gen_worker/cli/download.py::resolve_repo  STANDALONE  the `download`/`up` verbs' own resolve; no connected path imports gen_worker.cli.
+
 # --- PUBLISH ------------------------------------------------------------------
 
 src/gen_worker/convert/publish.py::resolve_repo  PUBLISH  reads the SOURCE repo's classification to stamp the published artifact; best-effort, and the hub's classification gate stays the enforcement. Publish-time metadata, not execution resolution.

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import subprocess
 import sys
 import time
@@ -291,7 +290,13 @@ def _build(
         "nice", "-n", "19",
         sys.executable, "-m", "gen_worker.serving.mint_child", str(request_path),
     ]
-    completed = subprocess.run(argv, check=False, env=dict(os.environ))
+    # NO `env=`: a child inherits this process's environment by default, so
+    # `env=dict(os.environ)` was a no-op that re-exported the whole environment
+    # explicitly — an unresolvable bare `os.environ` binding that §1.18's guard
+    # cannot classify, because "whatever happens to be set" is not a config
+    # value anyone can name. The mint child reads its own inputs from the
+    # request file written above; nothing here needs to hand it an env.
+    completed = subprocess.run(argv, check=False)
     if completed.returncode != 0:
         raise CompileError(
             f"mint child exited {completed.returncode} for graph {spec.short}"

--- a/src/gen_worker/cli/credentials.py
+++ b/src/gen_worker/cli/credentials.py
@@ -38,7 +38,7 @@ import stat
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 #: Marker every machine token carries. Lets a client tell a static credential
 #: from a session token without asking the server.
@@ -54,9 +54,25 @@ class CredentialError(RuntimeError):
     """The credential store could not be read or written."""
 
 
+def _settings() -> Any:
+    """Installed Settings, or a zero-config default.
+
+    §1.18: config is loaded ONCE by the pipeline and PASSED; a module reading
+    `os.environ` itself is a second loader that can disagree with the first.
+    `current_or` takes the fallback AS A VALUE so the zero-config case is
+    visible here rather than hidden in an env read — this module is imported
+    both by the CLI (which installs Settings at process entry) and by scripts
+    that never bring a worker up.
+    """
+    from .. import config
+
+    return config.current_or(config.Settings())
+
+
 def cozy_home() -> Path:
-    """``~/.cozy``, or ``COZY_HOME``. The same root cozy-local resolves."""
-    return Path(os.environ.get("COZY_HOME") or (Path.home() / ".cozy"))
+    """``~/.cozy``, or whatever ``COZY_HOME`` configured. The same root
+    cozy-local resolves, so one login serves both tools."""
+    return Path(_settings().cozy_home or (Path.home() / ".cozy"))
 
 
 def credentials_dir() -> Path:
@@ -122,15 +138,20 @@ def load(
 ) -> Optional[Credential]:
     """The stored credential, or the environment's, or ``None``.
 
-    ``TENSORHUB_TOKEN`` wins: a pod is configured by its environment and must
-    not depend on a home directory it does not have. Empty ``name``/``profile``
-    take the shared pointer (:func:`current_selection`), not a local default.
+    A CONFIGURED token wins over the file store: a pod is configured by its
+    environment and must not depend on a home directory it does not have. It
+    arrives through `Settings.tensorhub_token` rather than an `os.environ` read
+    here — same precedence, but the value now also comes from `.env`, yaml and
+    `/run/secrets` like every other setting, instead of only from the one
+    source this module happened to look at. Empty ``name``/``profile`` take the
+    shared pointer (:func:`current_selection`), not a local default.
     """
-    env_token = (os.environ.get("TENSORHUB_TOKEN") or "").strip()
-    if env_token:
+    settings = _settings()
+    configured_token = (settings.tensorhub_token or "").strip()
+    if configured_token:
         return Credential(
-            token=env_token,
-            hub_url=(os.environ.get("TENSORHUB_URL") or "").strip() or current_hub_url(),
+            token=configured_token,
+            hub_url=(settings.tensorhub_url or "").strip() or current_hub_url(),
         )
     selected_name, selected_profile = current_selection()
     name = name or selected_name

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -44,6 +44,7 @@ _ENV_TO_FIELD: Dict[str, str] = {
     "COZY_WEIGHTS_CAS": "weights_cas_root",
     "COZY_GRAPH_CAS": "graph_cas_root",
     "COZY_ENDPOINT_STATE": "endpoint_state_root",
+    "COZY_HOME": "cozy_home",
     "BAKED_PROGRAM_CAS_ROOT": "baked_program_cas_root",
     "RUNPOD_POD_ID": "runpod_pod_id",
     "GEN_WORKER_CONFIG_SNAPSHOT_PATH": "config_snapshot_path",

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -64,6 +64,12 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     # CLI installs Settings at process entry like every other entry point.
     weights_cas_root: str = ""
     graph_cas_root: str = ""
+    # pgw#1491/cl#85: `~/.cozy` — the USER-GLOBAL root cozy-local also
+    # resolves, holding the shared credential store both tools read. A Settings
+    # field rather than a direct env read (§1.18) because it IS configuration:
+    # one login serves every endpoint venv on the machine, and the location of
+    # that store is exactly the kind of value the pipeline should carry.
+    cozy_home: str = ""            # COZY_HOME
     # pgw#1491: where `up` publishes its handle and `run`/`down` find it.
     # Empty = the box default in `cli/endpoint_state.py`, beside the code that
     # explains why liveness is a signal-0 and not the file's existence.


### PR DESCRIPTION
My pgw#1491 merge (`ce4e8eba`) turned two guards red and blocked four lanes (#1084 → #1072 → #1078 → three held rentals). Both are fixed here, and in both cases the guard was right about something **real** rather than merely procedural.

## pgw#931 config-reads (§1.18) — four sites, **zero allowlist lines**

The guard offers "route through Settings **or** allowlist with a classification". Every one of these belonged on the first branch, so the allowlist gains nothing:

- **`cli/credentials.py`** read `TENSORHUB_TOKEN` and `TENSORHUB_URL` from `os.environ`. Both have been `Settings` fields the whole time (`tensorhub_token`, `tensorhub_url`). Reading the environment directly was not just a §1.18 violation — it was **worse behaviour**: it saw only the one source this module happened to look at, while the loader also carries `.env`, yaml and `/run/secrets`. A pod delivering its token as a mounted secret would have been ignored here and fallen through to the file store. Precedence is unchanged (a configured token still wins over the file store); the value now arrives the way every other setting does.
- **`COZY_HOME`** was read directly *and* was unknown to `config.loader` — the loader's own unknown-key refusal being quietly incomplete. It is now a real `Settings` field (`cozy_home`) with a loader binding. It genuinely is configuration: it locates the user-global credential store that both gen-worker and cozy-local read, and cl#85 depends on the two agreeing.
- **`cli/compile.py`** passed `env=dict(os.environ)` to the mint child. That was a **no-op** — a child inherits the parent environment by default — so it bought nothing and cost an unresolvable bare `os.environ` binding that the guard cannot classify, *correctly*: "whatever happens to be set" is not a config value anyone can name. Deleted rather than classified. The mint child reads its inputs from the request file written beside it.

## pgw#891/904 post-connect resolution — one STANDALONE line, **verified**

`cli/download.py::resolve_repo` is classified STANDALONE, and the containment is verified **by import** rather than asserted:

- nothing outside `src/gen_worker/cli/` imports `cli.download` or `cli.daemon`;
- the connected worker (`worker.py`, `entrypoint.py`, `procsplit/`, `serve/`) does not import `gen_worker.cli` **at all**.

A connected pod materializes through `boot_materialize` → `ModelStore.ensure_local` with the snapshot the hub sent it and never reaches this call. It is a **first** resolver for a machine with no hub connection — an operator naming a ref on a laptop — not a second one reconstructing a decision the hub already made.

## Verification, under the rule this PR exists to establish

Every `fast gates` lint was run locally with its **exit code read**, not grepped for expected vocabulary — that grep habit is exactly what let me miss five `WIRED UP` lines earlier. All green.

The single non-zero, `lint_skip_census.py` exit 2, is a usage error from invoking it without its required argument and is **identical on clean master** — attributed, not assumed.

`mypy` clean (353 files), `ruff` clean. Three test failures in the config/credential/env selection (`test_content_credentials_pgw658`, `test_release_derive`, `test_serve_loop_envelope`) were run against a **clean checkout of current master** and fail identically there — pre-existing, not mine.

**No `--admin` on this one.** It waits for a terminal verdict. My two earlier merges both went in against an *empty or IN_PROGRESS* `statusCheckRollup` — no red existed to attribute — which is the hole this PR's discipline closes: empty or IN_PROGRESS is UNKNOWN, never satisfied.