### PR TITLE
pgw#1523: `up -d` hung forever on a child that refused, and a bare `up` could not start anything

### DIFF
--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -490,24 +490,12 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
     parser.set_defaults(_handler=run_compile)
 
 
-def _this_sm() -> str:
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return ""
-        major, minor = torch.cuda.get_device_capability()
-        return f"sm_{major}{minor}"
-    except Exception:  # noqa: BLE001
-        return ""
-
-
 def run_compile(args: argparse.Namespace) -> int:
     logging.basicConfig(
         level=logging.INFO, format="%(message)s", stream=sys.stderr, force=False,
     )
     endpoint_dir = Path(args.endpoint_dir).resolve()
-    sm = args.sm or _this_sm()
+    sm = args.sm or workspace.host_sm()
     if not sm:
         sys.stderr.write(
             "gen-worker compile: no --sm and no visible CUDA device. Compiled "

--- a/src/gen_worker/cli/endpoint_state.py
+++ b/src/gen_worker/cli/endpoint_state.py
@@ -35,7 +35,7 @@ import signal
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 #: Per-user root for RESIDENT-endpoint state. Config key
 #: ``COZY_ENDPOINT_STATE`` (Settings field ``endpoint_state_root``), never
@@ -183,7 +183,7 @@ def clear_handle(handle: EndpointHandle) -> None:
 def wait_for_handle(
     handle: EndpointHandle,
     *,
-    child_pid: int,
+    still_running: Callable[[], bool],
     poll_s: float = 0.1,
 ) -> Dict[str, Any]:
     """Block until the daemon publishes a READY handle, or it dies.
@@ -193,12 +193,22 @@ def wait_for_handle(
     distinguishes that from a hang. The loop's terminating condition is the
     CHILD — if it exits without publishing, that is a boot failure and the log
     says why. Progress is observed, not clocked.
+
+    ``still_running`` is a CALLABLE, not a pid, and that is the whole fix for
+    pgw#1523. Signalling a pid cannot answer this question for one's OWN child:
+    an exited-but-unreaped child is a ZOMBIE, and `os.kill(pid, 0)` on a zombie
+    SUCCEEDS. So a pid-based check reports a child that died in its first
+    second as alive forever, and this loop — correctly having no timeout —
+    spins until the caller gives up. Measured: `gen-worker up -d` against an
+    endpoint whose boot refused immediately hung for the full 10-minute test
+    timeout with the refusal already sitting in its log. The caller passes
+    `Popen.poll`, which REAPS and therefore reports the truth.
     """
     while True:
         document = read_handle(handle)
         if document is not None and document.get("state") == "ready":
             return document
-        if not pid_alive(child_pid):
+        if not still_running():
             tail = ""
             try:
                 tail = "\n".join(

--- a/src/gen_worker/cli/up.py
+++ b/src/gen_worker/cli/up.py
@@ -110,16 +110,32 @@ def _spec(args: argparse.Namespace) -> BootSpec:
     refs = tuple(args.checkpoint_ref) or (
         () if args.checkpoint else runtime_config_refs(endpoint_dir)
     )
+    sm = args.sm or workspace.host_sm()
     graph_store: Optional[Path] = None
     if args.graph_store:
+        # STATED explicitly. If the sm cannot be resolved, adoption is
+        # impossible and refusing is right — the user asked for a store.
         graph_store = Path(args.graph_store)
     else:
         default = workspace.graph_cas_root()
-        # Absent = the eager bridge, stated rather than defaulted into: a
-        # store that does not exist yet would make every graph a hole and turn
-        # a plain `up` into a compile.
-        if default.is_dir():
+        # DEFAULTED. Two defaults have to agree, and they did not: the store
+        # defaulted ON whenever the box CAS existed while the sm defaulted to
+        # empty, so `_adoption_source` refused and a bare `gen-worker up`
+        # could not bring ANY endpoint up on a machine that had ever compiled
+        # anything (pgw#1523, measured on the echo example: "--sm is required
+        # to adopt"). A default that makes the common invocation refuse is not
+        # a default. With no sm there is nothing to adopt FOR, so the eager
+        # bridge is the honest answer and the log says so.
+        if default.is_dir() and sm:
             graph_store = default
+        elif default.is_dir():
+            print(
+                "gen-worker up: a compiled-graph store exists at "
+                f"{default} but this host's sm could not be determined, so "
+                "nothing can be adopted for it — serving EAGER. Pass --sm to "
+                "adopt.",
+                file=sys.stderr,
+            )
     return BootSpec(
         endpoint_dir=endpoint_dir,
         checkpoint_refs=refs,
@@ -128,7 +144,7 @@ def _spec(args: argparse.Namespace) -> BootSpec:
         model=args.model,
         defaults=args.defaults,
         lane=args.lane,
-        sm=args.sm,
+        sm=sm,
         graph_store=graph_store,
         artifacts_dir=Path(args.artifacts_dir),
         output_dir=Path(args.output_dir),
@@ -205,7 +221,11 @@ def _detach(args: argparse.Namespace, handle: Any) -> int:
     )
     sys.stderr.flush()
     try:
-        document = endpoint_state.wait_for_handle(handle, child_pid=child.pid)
+        # `child.poll` REAPS; a bare pid check would see the zombie of a child
+        # that already refused and wait forever (pgw#1523).
+        document = endpoint_state.wait_for_handle(
+            handle, still_running=lambda: child.poll() is None
+        )
     except EndpointStateError as exc:
         sys.stderr.write(f"gen-worker up: {exc}\n")
         return 1

--- a/src/gen_worker/cli/workspace.py
+++ b/src/gen_worker/cli/workspace.py
@@ -69,6 +69,28 @@ def graph_cas_root() -> Path:
     return Path(_settings().graph_cas_root or DEFAULT_GRAPH_CAS)
 
 
+def host_sm() -> str:
+    """This host's CUDA compute capability as ``sm_XY``, or ``""``.
+
+    ONE implementation, here, because `compile` and `up` both need it and they
+    must not disagree: `compile` builds artifacts FOR an sm and `up` adopts
+    artifacts BY it, so two spellings would silently split the pool — build for
+    one key, look up another, and every hit reads as a miss.
+
+    ``""`` means "no CUDA device visible", which is a legal state (a CPU-only
+    box, a laptop with the driver absent) and is never rendered as a guess.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return ""
+        major, minor = torch.cuda.get_device_capability()
+        return f"sm_{major}{minor}"
+    except Exception:  # noqa: BLE001 - absence is an answer, not an error
+        return ""
+
+
 def trace_device() -> str:
     """The device CLASS a trace states. ``derive._trace_device`` IS the law.
 
@@ -205,6 +227,7 @@ __all__ = [
     "CheckpointRef",
     "WorkspaceError",
     "graph_cas_root",
+    "host_sm",
     "local_cas",
     "parse_checkpoint_ref",
     "resolve_checkpoint",

--- a/tests/test_cli_endpoint_lifecycle.py
+++ b/tests/test_cli_endpoint_lifecycle.py
@@ -1,0 +1,101 @@
+"""The `up`/`down`/`run` handle: liveness, staleness, and the readiness wait.
+
+Subject-named, not incident-named (pgw#1362 / DESIGN-RULINGS 4.34b): the
+lineage rides as a one-line comment on each test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from gen_worker.cli import endpoint_state
+
+
+def test_an_exited_child_ends_the_readiness_wait(tmp_path, monkeypatch):
+    """# pgw#1523: `up -d` hung forever when its child refused at boot.
+
+    The wait is deliberately UNTIMED — a cold boot legitimately spends minutes
+    pulling weights, and no elapsed-time threshold separates that from a hang.
+    Its only terminating condition is therefore the child, which makes the
+    liveness check load-bearing: get it wrong and "no timeout" becomes "no
+    exit".
+    """
+    monkeypatch.setattr(endpoint_state, "state_root", lambda: tmp_path)
+    handle = endpoint_state.handle_for(tmp_path / "ep")
+
+    child = subprocess.Popen([sys.executable, "-c", "raise SystemExit(1)"])
+    with pytest.raises(endpoint_state.EndpointStateError) as caught:
+        endpoint_state.wait_for_handle(
+            handle, still_running=lambda: child.poll() is None, poll_s=0.01
+        )
+    assert "exited during boot" in str(caught.value)
+
+
+def test_signalling_a_pid_cannot_answer_liveness_for_your_own_child():
+    """# pgw#1523: why the wait takes a callable and not a pid.
+
+    An exited-but-unreaped child is a ZOMBIE, and `os.kill(pid, 0)` on a zombie
+    SUCCEEDS — the pid is still allocated until someone reaps it. So a
+    pid-based liveness check reports a child that died in its first second as
+    alive forever. This asserts the platform behaviour the design depends on,
+    so a future refactor back to a pid check fails here instead of in the field.
+    """
+    child = subprocess.Popen([sys.executable, "-c", "raise SystemExit(1)"])
+    while child.returncode is None and not _exited(child.pid):
+        pass
+    # Not yet reaped: still signalable, so pid_alive() cannot tell the truth.
+    assert endpoint_state.pid_alive(child.pid) is True
+    assert child.poll() is not None          # poll() reaps and reports honestly
+    assert endpoint_state.pid_alive(child.pid) is False
+
+
+def _exited(pid: int) -> bool:
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as handle:
+            return handle.read().rsplit(")", 1)[1].split()[0] == "Z"
+    except OSError:
+        return True
+
+
+def test_a_handle_whose_process_is_gone_reads_as_absent(tmp_path, monkeypatch):
+    """# pgw#1491: a crashed daemon leaves its handle behind.
+
+    Treating the file's presence as evidence would make `run` connect to a
+    socket nobody is listening on.
+    """
+    monkeypatch.setattr(endpoint_state, "state_root", lambda: tmp_path)
+    handle = endpoint_state.handle_for(tmp_path / "ep")
+    endpoint_state.write_handle(handle, {"state": "ready", "pid": 0x7FFFFFFF})
+
+    assert endpoint_state.read_handle(handle) is None
+    assert not handle.handle_path.exists()   # and it cleans the stale file up
+
+
+def test_a_live_handle_reads_back(tmp_path, monkeypatch):
+    monkeypatch.setattr(endpoint_state, "state_root", lambda: tmp_path)
+    handle = endpoint_state.handle_for(tmp_path / "ep")
+    endpoint_state.write_handle(
+        handle, {"state": "ready", "pid": os.getpid(), "functions": ["generate"]}
+    )
+    document = endpoint_state.read_handle(handle)
+    assert document is not None and document["functions"] == ["generate"]
+
+
+def test_a_handle_from_a_future_version_refuses_rather_than_guessing(
+    tmp_path, monkeypatch
+):
+    """# pgw#1491: the handle is a wire contract between two gen-workers."""
+    monkeypatch.setattr(endpoint_state, "state_root", lambda: tmp_path)
+    handle = endpoint_state.handle_for(tmp_path / "ep")
+    handle.state_dir.mkdir(parents=True, exist_ok=True)
+    handle.handle_path.write_text(
+        json.dumps({"handle_version": 99, "state": "ready", "pid": os.getpid()}),
+        encoding="utf-8",
+    )
+    with pytest.raises(endpoint_state.EndpointStateError):
+        endpoint_state.read_handle(handle)


### PR DESCRIPTION
Two defects in the pgw#1491 surface, both found by **running** it. Bumping `examples/echo`'s gen-worker pin turned cl#85's delegation test from SKIP to **HANG** — failing at go's 10-minute timeout. Reproduced by hand immediately: `gen-worker up -d` on the echo endpoint never returns.

## 1. The readiness wait could not see its child die

The wait is deliberately **untimed** (no-magic-timeouts: a cold boot legitimately spends minutes pulling weights, and no elapsed threshold separates that from a hang). That makes its *only* terminating condition the child — so the liveness check is load-bearing, and it was wrong.

An exited-but-unreaped child is a **zombie**, and `os.kill(pid, 0)` on a zombie **succeeds**: the pid stays allocated until someone reaps it. So `pid_alive()` reported a child that died in its first second as alive forever, and *"no timeout"* became *"no exit"* — with the refusal sitting in the log the whole time.

`pid_alive`'s own docstring argued that `ESRCH` is the only answer meaning "gone". That is true for an **arbitrary** pid and false for one's **own child**, and that difference is the entire bug. Another absent-renders-as-present.

Fixed structurally: `wait_for_handle` takes a liveness **callable**, and the caller passes `Popen.poll`, which reaps and therefore reports the truth. A test asserts the zombie platform behaviour directly, so a refactor back to a pid check fails *there* instead of in the field.

## 2. A bare `gen-worker up` refused on any machine that had ever compiled

Two defaults disagreed: `--graph-store` defaulted **on** whenever the box graph CAS existed, while `--sm` defaulted to empty. So `_adoption_source` refused with `--sm is required to adopt (artifacts are per-sm)` and no endpoint could come up at all.

**A default that makes the common invocation refuse is not a default.** Now the two agree — a *defaulted* store with no resolvable sm serves eager and says so; an *explicitly stated* `--graph-store` with no sm still refuses, because the user asked for adoption and should be told it cannot happen.

`host_sm()` moves into `cli/workspace.py` as one implementation: `compile` builds artifacts **for** an sm and `up` adopts them **by** it, so two spellings would split the artifact pool silently — build under one key, look up another, and every hit reads as a miss.

## Verified

End-to-end on the echo example — a **torchless, weightless CPU endpoint**, which is useful breadth for this surface: `up -d` returns ready instead of hanging, `run` returns the right result and correctly reports `eager (no compiled graph armed)`, `down` stops it, and `run` afterwards refuses by name.

The new regression module is **subject-named** with lineage in comments (pgw#1362 / DESIGN-RULINGS 4.34b), and the naming guard was run explicitly and is green — that guard is what went red on #1079.

Full `fast gates` lint sweep run locally with **exit codes read**: all green. The single non-zero (`lint_skip_census.py` exit 2) is a usage error from invoking it without its required argument, identical on clean master. `mypy` clean (353 files), `ruff` clean, new tests 5 passed.

Rebased onto `dfac34e2`. Unblocks cl#85's `examples/echo` pin bump, which is gated on this landing rather than on master-green.