### PR TITLE
pgw#1522: the output-integrity floor judges RENDERS, and a trace produces no render

### DIFF
--- a/src/gen_worker/output_integrity.py
+++ b/src/gen_worker/output_integrity.py
@@ -454,8 +454,31 @@ def judged(ctx: Any) -> bool:
     from a degenerate input is the expected result there, not a defect, and
     refusing it turned a valid warm into a FATAL on the paying request that
     happened to wake the pod (minimax-h3 `reference-to-video`, measured).
+
+    **A TRACE is the same shape, and pgw#1522 is the same lesson twice.** The
+    publish derive runs the author's handler under a HOLLOW session: every
+    parameter is a fake tensor carrying no bytes, so every frame it renders is
+    exactly blank — `adjacent_frame_corr` and `frame_std_min` are
+    mathematically ZERO, the signature of virtualized weights rather than a
+    marginal render. Its output is discarded by construction too: `ctx.save_*`
+    is a stub that returns `trace://…` and uploads nothing, banks nothing.
+    Degenerate output from a degenerate input, again.
+
+    So the floor is NOT weakened here and its threshold is untouched — this
+    says WHOSE outputs it judges, which is the question this predicate exists
+    to answer. It is the one place that answers it, so the module-level
+    `gw_io.write_*` writers and the `ctx.save_*` path cannot disagree about it
+    the way they did (the writers enforced it under a trace that `ctx.save_*`
+    had already stubbed, which is why every `ctx.save_*` endpoint derived and
+    the first `gw_io` one could not).
     """
-    return not bool(getattr(ctx, "boot_warmup", False))
+    if bool(getattr(ctx, "boot_warmup", False)):
+        return False
+    # Duck-typed and PRIVATE on purpose. The trace context sets it; nothing on
+    # the author surface exposes "am I a trace" (Paul deleted that spelling —
+    # author code branching on it corrupts compilation coverage), and this is
+    # a platform fact about where the output GOES, not an author input.
+    return not bool(getattr(ctx, "_outputs_discarded", False))
 
 
 def guard_frames(frames: Any, *, ref: str) -> OutputIntegrity:

--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -457,6 +457,18 @@ class TraceRequestContext:
 
         return ImageAsset(ref=f"trace://image.{format}")
 
+    #: pgw#1522. This context's outputs are DISCARDED BY CONSTRUCTION — every
+    #: `save_*` below is a stub returning a `trace://` ref, so nothing is
+    #: uploaded and nothing banks. The output-integrity floor reads this to
+    #: know it is not judging a render (`output_integrity.judged`): under a
+    #: hollow session the parameters carry no bytes, so a blank frame is the
+    #: only possible output and the floor's verdict, while TRUE, is about the
+    #: substrate rather than the endpoint.
+    #:
+    #: Private because it is a platform fact, not an author input: there is
+    #: deliberately no `ctx.is_trace` for author code to branch on.
+    _outputs_discarded = True
+
     def save_video(self, video: Any, ref: Optional[str] = None, *, format: str = "mp4",
                    **_: Any) -> Any:
         del video

--- a/tests/test_eager_bridge_dtype.py
+++ b/tests/test_eager_bridge_dtype.py
@@ -196,7 +196,21 @@ def test_a_model_with_no_lane_never_mentions_dtype_at_all():
 # cannot drift apart again.
 
 
-def test_the_derive_bridge_also_survives_a_loader_that_refuses_torch_dtype():
+def test_the_derive_bridge_NEVER_OFFERS_torch_dtype_so_it_cannot_be_refused():
+    """pgw#1512 SUPERSEDES the retry this used to assert, and strengthens it.
+
+    This test pinned the pgw#1447 rescue: the derive bridge offered
+    `torch_dtype=` first, a strict `ModularPipeline` refused it by TypeError,
+    and the bridge retried without and cast afterwards. Paul's per-component
+    passthrough ruling DELETED the offer — the lane's dtype governs only the
+    component its contract describes, resolved per component inside the hollow
+    session — so there is no longer a global cast to be refused.
+
+    The hazard is therefore DESIGNED OUT rather than handled, which is why the
+    assertion inverts instead of relaxing: exactly one attempt, carrying no
+    `torch_dtype` at all. A loader that refuses it is never given the chance.
+    """
+
     from gen_worker.release.trace_context import TraceLoadContext
 
     calls: Dict[str, Any] = {"attempts": []}
@@ -223,8 +237,11 @@ def test_the_derive_bridge_also_survives_a_loader_that_refuses_torch_dtype():
     got = ctx.load(RefusesLikeModularPipeline)
 
     assert isinstance(got, RefusesLikeModularPipeline)
-    assert calls["attempts"] == [["torch_dtype"], []]
-    assert repr(calls["to"]) == "torch.bfloat16", "the derive must honour the lane dtype too"
+    # ONE attempt, and it carried no dtype — so the refusal above never fires.
+    assert calls["attempts"] == [[]]
+    # And no blanket `.to(dtype)` afterwards either: casting the whole object
+    # is the same fabrication by another route (pgw#1512).
+    assert "to" not in calls
 
 
 # ==========================================================================

--- a/tests/test_output_integrity_trace_exempt.py
+++ b/tests/test_output_integrity_trace_exempt.py
@@ -1,0 +1,156 @@
+"""The floor judges RENDERS, and a trace produces no render (pgw#1522).
+
+Two output paths existed and only one was trace-aware. `ctx.save_image` /
+`ctx.save_video` are STUBBED under `TraceRequestContext` — they return a
+`trace://` ref and upload nothing — so every endpoint that saves through the
+context derived fine. The module-level `gw_io.write_video` / `write_image`
+writers ran the output-integrity floor FIRST, before delegating to that same
+stub, so the first endpoint to reach the output step through them died:
+
+    OutputIntegrityError: blank: video video failed the output-integrity floor
+      (adjacent_frame_corr 0.000, frame_std_min 0.00000)
+
+The verdict is TRUE. Under a hollow session every parameter is a fake tensor
+carrying no bytes, so the frames are EXACTLY zero — the signature of
+virtualized weights, not a marginal render. minimax-h3 has no choice about the
+path: only `gw_io.write_video` muxes the soundtrack into one `VideoAsset`.
+
+The floor is not weakened and its threshold is untouched. `judged()` — the one
+predicate that already answered "whose outputs are subject to this?" for the
+boot-warmup case — now answers it for the trace case too, so the two paths
+cannot disagree.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from gen_worker.api.errors import OutputIntegrityError
+from gen_worker.output_integrity import check_frames, enforce, judged
+from gen_worker.release.trace_context import TraceRequestContext
+
+
+def _trace_ctx() -> TraceRequestContext:
+    return TraceRequestContext(lane=None, checkpoint_ref="trace:x", step_budget=1)
+
+
+class _Serve:
+    """A serving context as far as the floor is concerned."""
+
+    boot_warmup = False
+
+
+def test_a_trace_context_is_not_judged() -> None:
+    assert judged(_trace_ctx()) is False
+
+
+def test_a_serve_context_is_STILL_judged() -> None:
+    """The floor stays armed where it exists to be armed."""
+
+    assert judged(_Serve()) is True
+    assert judged(object()) is True
+
+
+def test_the_boot_warmup_exemption_is_untouched() -> None:
+    """th#1771's exemption shares the predicate and must not regress."""
+
+    class Warm:
+        boot_warmup = True
+
+    assert judged(Warm()) is False
+
+
+def test_the_FLOOR_ITSELF_still_rejects_a_blank_render() -> None:
+    """The guard is not weakened — only its audience is stated.
+
+    A blank clip is still refused with the same verdict and the same
+    threshold; nothing about this change makes a bad render bankable.
+    """
+
+    numpy = pytest.importorskip("numpy")
+
+    blank = numpy.zeros((10, 32, 32, 3), dtype=numpy.uint8)
+    result = check_frames(blank)
+    assert result.rejected
+    with pytest.raises(OutputIntegrityError) as refusal:
+        enforce(result, ref="ref", kind="video")
+    assert "blank" in str(refusal.value)
+
+
+def test_the_marker_is_PRIVATE_so_no_author_can_branch_on_it() -> None:
+    """There is deliberately no `ctx.is_trace` on the author surface.
+
+    Author code branching on trace-ness corrupts compilation coverage, which
+    is why that spelling was deleted. This fact is the platform's, about where
+    the output goes — so it must not arrive as a public member.
+    """
+
+    ctx = _trace_ctx()
+    assert ctx._outputs_discarded is True
+    assert not hasattr(ctx, "is_trace")
+    assert "_outputs_discarded".startswith("_")
+
+
+def test_the_module_level_writer_reaches_the_ctx_stub_under_a_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """H3's actual path, end to end: gw_io.write_image -> ctx.save_bytes.
+
+    The floor used to fire BEFORE the encode and the delegation, so the trace
+    stub was never reached. This drives the REAL `gw_io` writer with a blank
+    image — the only thing a hollow session can produce — and asserts it lands
+    on the stub instead of raising.
+    """
+
+    numpy = pytest.importorskip("numpy")
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    from gen_worker import io as gw_io
+
+    ctx = _trace_ctx()
+    blank = Image.fromarray(numpy.zeros((32, 32, 3), dtype=numpy.uint8))
+
+    saved: dict[str, Any] = {}
+    original = ctx.save_bytes
+
+    def record(ref: str, data: bytes, **kwargs: Any) -> Any:
+        saved["reached"] = True
+        return original(ref, data, **kwargs)
+
+    monkeypatch.setattr(ctx, "save_bytes", record)
+
+    asset = gw_io.write_image(ctx, "clip", blank)
+
+    assert saved.get("reached") is True
+    assert str(getattr(asset, "ref", "")).startswith("trace://")
+
+
+def test_the_same_writer_STILL_refuses_a_blank_render_at_SERVE(
+    tmp_path: Any,
+) -> None:
+    """The other half: the writer must not have gone soft.
+
+    Same call, same blank image, a context that is not a trace — the floor
+    fires exactly as before. Without this the fix could have been "delete the
+    guard" and every test above would still pass.
+    """
+
+    numpy = pytest.importorskip("numpy")
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    from gen_worker import io as gw_io
+
+    class Serve:
+        boot_warmup = False
+
+        def save_bytes(self, ref: str, data: bytes, **_: Any) -> Any:
+            raise AssertionError("the floor must refuse before the save")
+
+    blank = Image.fromarray(numpy.zeros((32, 32, 3), dtype=numpy.uint8))
+
+    with pytest.raises(OutputIntegrityError):
+        gw_io.write_image(Serve(), "clip", blank)


### PR DESCRIPTION
H3's lock now runs the full 29-step denoise (pgw#1512) and died on the last step, at the output:

```
OutputIntegrityError: blank: video failed the output-integrity floor
  (adjacent_frame_corr 0.000, frame_std_min 0.00000)
```

**The verdict is true and the floor is untouched.** Under a hollow session every parameter is a fake tensor carrying no bytes, so the frames are *exactly* zero — the signature of virtualized weights, not a marginal render. The guard was simply running somewhere it cannot be satisfied.

Two output paths existed and only **one** was trace-aware: `ctx.save_image` / `ctx.save_video` are stubbed under `TraceRequestContext` (they return a `trace://` ref and upload nothing), while the module-level `gw_io.write_*` writers ran the floor **before** delegating to those same stubs. That is the whole reason every `ctx.save_*` endpoint derives and the first `gw_io` one could not — and h3 has no choice, because only `gw_io.write_video` muxes the soundtrack into a single `VideoAsset`.

## The fix is one predicate, not three edits

`judged()` already existed to answer *"whose outputs are subject to this floor"*, and already excluded the boot-warmup case for a precisely analogous reason recorded in its own docstring: **output discarded by construction, degenerate output from a degenerate input.** A trace is the same shape, so it gets the same answer in the same place — which is why all three `io.py` sites (`:242`, `:382`, `:393`) *and* the `ctx.save_*` site (`request_context:1293`) are fixed at once and cannot drift apart again.

## What was not done — both held as filed

- **The floor is not weakened and its threshold is not moved.** One test drives a blank clip straight through `check_frames`/`enforce` and asserts it is still refused; another drives the **real** `gw_io.write_image` with a non-trace context and asserts it still raises. Without those, *"delete the guard"* would pass every other test here.
- **H3 is not switched to `ctx.save_video`** — a product regression to satisfy a tracer, the pgw#1506 inversion.

The marker is **private** (`_outputs_discarded`) and duck-typed, exactly as `boot_warmup` is read. There is deliberately no `ctx.is_trace` on the author surface — author code branching on trace-ness corrupts compilation coverage — and this is a platform fact about where the output *goes*, not an author input. A test pins that it stays private and that `is_trace` does not appear.

## Gates

| arm | result |
|---|---|
| master | **2 of 7 fail**, verbatim `OutputIntegrity(verdict='blank', frame_std_min=0.0)` |
| with the fix | **7 pass** |

Byte-compare #8: `b6d23f8e01acc8528be773f70a57bcd0cacf4fec4e703d0a6b4e56b16b309f5c` — unchanged; the classic endpoints save through the already-stubbed ctx path, so their documents cannot move.

41 passed across floor / warm-exemption / derive / surface suites · mypy clean (631 files) · ruff clean · `lint_unreached_surface` **97 here and 97 at base**.

⚠️ **One pre-existing red, not mine**, re-verified at today's tip: `test_derive_runs_in_a_release_env_with_no_top_level_torchcg_or_tensorfs` fails `KeyError: 'program'` — tcg#67 removed the field and this assertion was not adapted. Fails identically at `origin/master` with this diff absent. Owed by tcg#67's consumer lane.