### PR TITLE
pgw#1462: restore the address-free sink pgw#1512 reverted, and make the test that catches it actually catch it

### DIFF
--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -223,36 +223,47 @@ def _hollow() -> ModuleType:
 def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
     """Store each discovered graph's SERIALIZED ExportedProgram in the CAS.
 
-    Paul's ruling (2026-08-20): the derive keeps THE WHOLE TRACED GRAPH, not
-    just its hash -- "we only ever need to run trace() once" now holds
-    literally. The runtime miner downloads this blob and runs inductor on
-    it; it never re-traces and never executes author code at mint time.
+    Paul, 2026-08-19 (address-free): the bytes are local and their digest is
+    machine-scoped, so nothing about them travels. What the document carries is
+    the cg-graph-v1 identity; what this stores is one machine's bytes for that
+    identity, under it. A mint on any box asks its own store for "the program
+    for graph X" and never for a digest somebody else computed.
 
-    Bytes-at-rest is tensorfs's charter (LIBRARY-BOUNDARIES), so the blob
-    goes into a tensorfs ``LocalCAS`` and only its digest travels in the
-    release document, beside the cg-graph-v1 hash and the ingress spec.
-    Portability needs no new fence: an ExportedProgram is torch-coupled and
-    the document's own compile stack pins torch -- the same validity rule
-    compiled artifacts already live under.
+    Bytes-at-rest is tensorfs's charter (LIBRARY-BOUNDARIES), so the blob goes
+    into a tensorfs ``LocalCAS`` through torchcg's ``LocalGraphStore``, which
+    owns the graph->bytes ref.
+
+    ⚠️ THIS BODY WAS SILENTLY REVERTED ONCE (pgw#1512 `c2edae08`, a conflict
+    resolution in a commit about per-component dtype that says nothing about
+    the sink). The revert restored digest-keyed banking while the document
+    already carried NO address, so producer and consumer keyed on different
+    things and no program could ever be resolved — a total break with no
+    error anywhere, because a miss is silent. `test_derive_runs_in_a_release_
+    env_with_no_top_level_torchcg_or_tensorfs` now asserts `has_program` per
+    identity, which is the fence: this cannot be reverted green again.
     """
 
     if cas_root is None:
         return None
 
-    import io
+    import tempfile
 
     import torch
 
     from .._vendor.tensorfs import LocalCAS
+    from .._vendor.torchcg.store import LocalGraphStore
 
-    cas = LocalCAS(Path(cas_root))
+    store = LocalGraphStore(LocalCAS(Path(cas_root)))
 
-    def sink(graph: str, program: Any) -> str:
+    def sink(graph: str, program: Any) -> None:
         _assert_weights_free(torch, program)
-        buffer = io.BytesIO()
-        torch.export.save(program, buffer)
-        del graph
-        return str(cas.put_bytes(buffer.getvalue()))
+        # torch.export.save to a FILE, because the store admits files: it
+        # hashes and links them in, so a large program never has to exist
+        # twice in memory the way a BytesIO round-trip forces.
+        with tempfile.TemporaryDirectory() as scratch:
+            staged = Path(scratch) / "program.pt2"
+            torch.export.save(program, str(staged))
+            store.put_program(graph, staged)
 
     return sink
 

--- a/tests/test_release_derive.py
+++ b/tests/test_release_derive.py
@@ -524,17 +524,44 @@ def test_derive_runs_in_a_release_env_with_no_top_level_torchcg_or_tensorfs(
     )
     assert completed.returncode == 0, completed.stderr[-4000:]
 
-    # th#2192's consequence, asserted on the OUTPUT: an empty `program` is the
-    # miner's `MissingProgramDigest`, so a derive that stores no blob is not a
-    # mintable derive. `--graph-cas` is the only thing that fills it.
+    # WHAT THIS USED TO ASSERT, AND WHY IT CHANGED. It read `record["program"]`
+    # and required a non-empty blob address on every graph — th#2192's
+    # consequence, on the premise that the address was the miner's fetch key.
+    # tcg#67 deleted the field: `torch.export.save` emits different bytes on
+    # different machines for the same traced graph (pgw#1462p2 measured 14/14
+    # graph identities reproducing across boxes and 0/14 blob digests), so the
+    # address was machine-scoped and made the DOCUMENT unportable. The property
+    # worth asserting survived the field: `--graph-cas` is still the only thing
+    # that banks the programs, and a derive that banks none is still unusable
+    # locally. It is just keyed by IDENTITY now.
     document = json.loads(out.read_bytes())
-    programs = [
-        record["program"]
+    graphs = [
+        record["graph"]
         for lane in document["graphs"]["lanes"]
         for record in lane["graphs"]
     ]
-    assert programs and all(p.strip() for p in programs), document["graphs"]
+    assert graphs, document["graphs"]
+    assert all(g.startswith("cg-graph-v1-") for g in graphs), graphs
+
+    # THE ADDRESS-FREE CONTRACT, FENCED POSITIVELY rather than by deletion: a
+    # stale assertion that merely stops running proves nothing, so this asserts
+    # the field is ABSENT. Reintroducing it anywhere upstream fails here.
+    assert not any(
+        "program" in record
+        for lane in document["graphs"]["lanes"]
+        for record in lane["graphs"]
+    ), document["graphs"]
+
+    # And the bytes ARE banked, under the identity — the address-free
+    # replacement for "the document names a blob". This is the assertion that
+    # still catches a derive run without `--graph-cas`.
+    from gen_worker._vendor.tensorfs import LocalCAS
+    from gen_worker._vendor.torchcg.store import LocalGraphStore
+
     assert cas.is_dir() and any(cas.rglob("*")), "the graph CAS holds no blob"
+    store = LocalGraphStore(LocalCAS(cas))
+    missing = [g for g in graphs if not store.has_program(g)]
+    assert not missing, f"the CAS holds no program for {missing}"
 
 
 def test_the_blocker_itself_can_go_red(config_only_tree: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
Two things, and the second one is why the first went unnoticed.

**1. `_program_sink` was silently reverted to digest-keyed banking.**
`pgw#1512` (`c2edae08`) resolved a conflict in `release/derive.py` in favour of
the pre-address-free body — removing `LocalGraphStore`, `store.put_program`, and
the `-> None` signature, restoring `del graph; return str(cas.put_bytes(...))`.
That commit is entirely about per-component dtype and says nothing about the
sink, so this was accidental.

It is not cosmetic. tcg#67 had already removed `program` from the document, so
after the revert the PRODUCER banked by blob digest while every CONSUMER looked
up by graph identity. Nothing could resolve, ever — and the failure mode is a
SILENT MISS, not an error: every pod would serve eager with no diagnostic
anywhere. Verified at `origin/master` before fixing, and the other seven files
from that landing (`mint`, `mint_store`, `hub_store`, `endpoint_lock`, `lock`,
vendored `store`/`document`) were checked and are intact — the sink was the only
casualty.

**2. The test that should have caught it was asserting the deleted field.**
`test_derive_runs_in_a_release_env_with_no_top_level_torchcg_or_tensorfs` read
`record["program"]` and died `KeyError: 'program'`. A KeyError reads as test rot,
so the red was attributed to a stale assertion and two lanes spent cycles
proving it was not theirs — while the real regression sat underneath it. An
instrument that fails for the wrong reason is worse than one that does not run.

The assertion now checks what survived the field:
* the identities are `cg-graph-v1-` — the document's real contract;
* `program` is ABSENT, fenced POSITIVELY rather than by deletion, so
  reintroducing the field upstream fails here instead of silently passing;
* and the CAS holds a program FOR EACH IDENTITY — the address-free replacement
  for "the document names a blob", and the one check that fails when producer
  and consumer disagree about the key. That is exactly the disagreement nothing
  caught this time.

RED/GREEN BY EXECUTION, on the real subprocess derive (not a stub): with
master's reverted sink the module is 1 failed / 16 passed; with the sink
restored, 17 passed.

⚠️ VERIFICATION NOTE worth carrying: this test spawns
`sys.executable -m gen_worker.cli`, and the venv is an editable install of the
MAIN checkout — so a worktree's changes are invisible to the subprocess unless
`PYTHONPATH` names its `src`. Running it without that greens/reds against master's
code while appearing to test the branch. The verdict above was taken with
`PYTHONPATH=<worktree>/src`, confirmed by asserting `put_program` is in the
subprocess's resolved source before trusting the run.