### PR TITLE
pgw#1525 (CLI half): an unreadable graph document is a MISS, not a dead boot

### DIFF
--- a/src/gen_worker/cli/daemon.py
+++ b/src/gen_worker/cli/daemon.py
@@ -200,7 +200,26 @@ def _checkpoint_tree(spec: BootSpec, loaded: Any) -> Tuple[Path, str]:
 
 
 def _adoption_source(spec: BootSpec, module_name: str) -> Tuple[Any, Any]:
-    """(store, document) for this boot, or (None, None) — the eager bridge."""
+    """(store, document) for this boot, or (None, None) — the eager bridge.
+
+    An UNREADABLE graph-set document is a MISS, never a boot failure (pgw#1525).
+    Compiled graphs are derived and disposable: a document this build's torchcg
+    cannot decode — a v1 document under a v3 decoder, the ordinary shape after a
+    re-vendor — means this box holds nothing usable for this endpoint, which is
+    exactly what an empty store means. Both answers are "serve eager and let the
+    mint refill", so they must not have different outcomes.
+
+    `LocalGraphStore.get_graphs` RAISES `StoreError` on a decode failure rather
+    than answering a clean miss, and this call site used to let it through — so
+    a stale store did not degrade, it killed `up` before any author code ran.
+    That is the cold-start regression pgw#1525 names, and it is worst precisely
+    when recovery matters most: right after the format bump that produced it.
+
+    The refusal is caught HERE and not repaired in the store because the two
+    halves belong to different repos. The store-side fix (answer a clean miss
+    and GC the unreadable leftover) is torchcg's; this is the serving side
+    refusing to die on it either way.
+    """
     if spec.graph_store is None:
         return None, None
     if not spec.sm:
@@ -209,10 +228,31 @@ def _adoption_source(spec: BootSpec, module_name: str) -> Tuple[Any, Any]:
             "Omit --graph-store to serve eager."
         )
     from .._vendor.tensorfs import LocalCAS
-    from .._vendor.torchcg.store import LocalGraphStore
+    from .._vendor.torchcg.store import LocalGraphStore, StoreError
 
     store = LocalGraphStore(LocalCAS(Path(spec.graph_store)))
-    return store, store.get_graphs(module_name)
+    try:
+        return store, store.get_graphs(module_name)
+    except StoreError as exc:
+        # LOUD and typed: silence here would read as "this endpoint compiles to
+        # nothing", which is a different fact with the same shape.
+        print(
+            f"adopt: graph_store_unreadable — the compiled-graph document for "
+            f"{module_name} in {spec.graph_store} cannot be decoded by this "
+            f"build's torchcg ({exc}).\n"
+            f"adopt: SERVING EAGER. Compiled graphs are derived and disposable, "
+            f"so this costs speed, never correctness.\n"
+            f"adopt: remedy — `gen-worker compile` re-mints this endpoint's "
+            f"graphs in the current format; the stale entries are reclaimable.",
+            file=sys.stderr,
+        )
+        # `(store, None)` and NOT `(None, None)`: an undecodable document must
+        # land on the SAME value an empty store produces, or the two "I hold
+        # nothing usable" states diverge again one layer down. The store stays
+        # bound because it is still WRITABLE — `put_graphs` compare-and-swaps a
+        # ref and does not care that the old bytes are undecodable, so a re-mint
+        # can refill this very store rather than needing it deleted first.
+        return store, None
 
 
 def _stated_stack(spec: BootSpec, document: Any) -> Optional[Any]:

--- a/tests/test_cli_adopt_degradation.py
+++ b/tests/test_cli_adopt_degradation.py
@@ -1,0 +1,105 @@
+"""Boot-time adoption degrades; it does not die.
+
+Subject-named, not incident-named (pgw#1362 / 4.34b); lineage in comments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker.cli.daemon import BootSpec, _adoption_source
+
+
+def _store_with_unreadable_document(root: Path, module: str) -> None:
+    """Plant a graph-set document this build's torchcg cannot decode.
+
+    Written through the store's OWN ref/object API rather than by hand, so the
+    fixture is a store that genuinely holds an undecodable document — not a
+    corrupt directory that happens to fail earlier for a different reason.
+    """
+    from gen_worker._vendor.tensorfs import LocalCAS
+    from gen_worker._vendor.torchcg.store import _document_ref
+
+    root.mkdir(parents=True, exist_ok=True)
+    cas = LocalCAS(root)
+    ref = cas.put_bytes(b'{"v": 1, "this is a v1 document": true}')
+    cas.compare_and_swap_ref(_document_ref(module), ref, expected=None)
+
+
+def test_an_unreadable_graph_document_serves_eager_instead_of_killing_boot(
+    tmp_path, capsys
+):
+    """# pgw#1525: the adopt-time StoreError cold-start regression.
+
+    A document this build cannot decode means the box holds nothing usable —
+    the same fact an empty store states. Both must reach the same outcome, or
+    the format bump that produced the stale document also takes the endpoint
+    down, precisely when re-minting it is what the operator is trying to do.
+    """
+    store = tmp_path / "graph-cas"
+    _store_with_unreadable_document(store, "toy.main")
+
+    spec = BootSpec(endpoint_dir=tmp_path, graph_store=store, sm="sm_89")
+    adopted_store, document = _adoption_source(spec, "toy.main")
+
+    assert document is None, (
+        "an undecodable document must read as a MISS — the eager bridge"
+    )
+    assert adopted_store is not None, (
+        "the store stays bound: it is still WRITABLE, so a re-mint can refill "
+        "THIS store rather than requiring it be deleted first"
+    )
+    said = capsys.readouterr().err
+    assert "graph_store_unreadable" in said      # typed, not a bare traceback
+    assert "SERVING EAGER" in said               # states the outcome
+    assert "gen-worker compile" in said          # names the remedy
+
+
+def test_an_unreadable_document_lands_where_an_empty_store_lands(tmp_path):
+    """# pgw#1525: two ways of holding nothing usable, ONE outcome.
+
+    Asserted as equality of the DOCUMENT slot against the empty-store case
+    rather than against a hand-written literal, so the two paths cannot drift
+    apart without this failing.
+    """
+    empty = tmp_path / "empty-cas"
+    empty.mkdir(parents=True)
+    _, empty_doc = _adoption_source(
+        BootSpec(endpoint_dir=tmp_path, graph_store=empty, sm="sm_89"), "toy.main"
+    )
+
+    stale = tmp_path / "stale-cas"
+    _store_with_unreadable_document(stale, "toy.main")
+    _, stale_doc = _adoption_source(
+        BootSpec(endpoint_dir=tmp_path, graph_store=stale, sm="sm_89"), "toy.main"
+    )
+
+    assert stale_doc is empty_doc is None
+
+
+def test_a_clean_empty_store_is_still_a_miss(tmp_path):
+    """A store with no document at all: the ordinary cold start."""
+    store = tmp_path / "graph-cas"
+    store.mkdir(parents=True)
+    spec = BootSpec(endpoint_dir=tmp_path, graph_store=store, sm="sm_89")
+    _, document = _adoption_source(spec, "toy.main")
+    assert document is None
+
+
+def test_adopting_without_an_sm_still_refuses(tmp_path):
+    """# pgw#1523: a STATED graph store with no sm is a real user error.
+
+    Degrading the unreadable-document case must not soften this one: the user
+    asked for adoption and cannot have it, so they are told rather than quietly
+    served eager.
+    """
+    from gen_worker.cli.daemon import BootError
+
+    store = tmp_path / "graph-cas"
+    store.mkdir(parents=True)
+    spec = BootSpec(endpoint_dir=tmp_path, graph_store=store, sm="")
+    with pytest.raises(BootError) as caught:
+        _adoption_source(spec, "toy.main")
+    assert "--sm is required" in str(caught.value)


### PR DESCRIPTION
`gen-worker up` **died** on a stale compiled-graph store instead of serving eager. `torchcg.store.LocalGraphStore.get_graphs` **raises** `StoreError` on a decode failure rather than answering a clean miss, and `cli/daemon.py` called it bare — so a v1 document under a v3 decoder, the ordinary shape after a re-vendor, killed the boot before any author code ran.

That is worst precisely when recovery matters most: **right after the format bump that produced the stale document**, when re-minting is exactly what the operator is trying to do. This is the adopt-time cold-start regression pgw#1525 names, and its red arm requires eager-serve + re-mint, never an error.

## Why a miss and not an error

Compiled graphs are derived and disposable. A document this build cannot decode means the box holds **nothing usable** for this endpoint — which is the same fact an empty store states. Two ways of holding nothing usable must reach one outcome, or they diverge a layer down.

They now land on the **same value**: `(store, None)`, not `(None, None)`. The store stays bound because it is still **writable** — `put_graphs` compare-and-swaps a ref and does not care that the old bytes are undecodable — so a re-mint refills *this* store rather than requiring it be deleted first. The test asserts that equality **against the empty-store case** rather than a hand-written literal, so the two paths cannot drift apart silently.

## Loud and typed

Silence would read as "this endpoint compiles to nothing", a different fact with the same shape:

```
adopt: graph_store_unreadable — the compiled-graph document for echo_ep.main in
       <store> cannot be decoded by this build's torchcg (document fields must
       be exactly ['lanes', 'stack', 'v']).
adopt: SERVING EAGER. Compiled graphs are derived and disposable, so this costs
       speed, never correctness.
adopt: remedy — `gen-worker compile` re-mints this endpoint's graphs in the
       current format; the stale entries are reclaimable.
```

## THE SPLIT — for pgw#1525's owner

This is the **serving side** refusing to die. The **store side** — answering a clean miss and GCing the unreadable leftover — is **torchcg's, and is deliberately not in this diff.** Either half alone fixes the cold start; both are worth having; they are not the same repo. This one unblocks the wipe-then-compile leg immediately without waiting on a re-vendor.

Degrading this case does **not** soften the adjacent one: a *stated* `--graph-store` with no resolvable `--sm` still refuses by name (pgw#1523), because the user asked for adoption and cannot have it. Asserted in the tests.

## Verified on the real verb, not only in unit tests

Planted a v1 document in a graph store, then ran `gen-worker up -d --sm sm_89 --graph-store <stale>` against the `echo` example: **boots ready**, prints the three typed lines above, `run` returns `{"text": "a lighthouse a lighthouse", "times": 2}` and reports `dispatch: eager (no compiled graph armed)`, `down` stops it. **Before this change the same command died.**

Full `fast gates` sweep run locally with exit codes read — green (the one non-zero, `lint_skip_census.py` exit 2, is a usage error from omitting its required argument and is identical on master). `mypy` clean (353 files), `ruff` clean, 4 new tests. Rebased onto master post-pgw#1523.