### PR TITLE
pgw#1525 (store half): re-vendor tcg#69 — the graph store heals itself, and the remedy is printed for the MISS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,7 +696,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "9fc1f2ac93a1a3976090c77ca27297e68dbfa88e" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "f45fc64a9ba1323e0a44975565d822517aab8058" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -306,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "9fc1f2ac93a1a3976090c77ca27297e68dbfa88e"
+rev = "f45fc64a9ba1323e0a44975565d822517aab8058"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -548,5 +548,5 @@ rewrites = [
 "serve.py" = "a1f3b6fe5e46305bc9aea9848ac5935537b7bb37e2586ae3f0393f66cead2ade"
 "spans.py" = "4776fac2006967b1f17ffcbec03e50147d511120fd50cf085ac3b6b4702e5539"
 "storage.py" = "ccc9d6f8ac1a242b493028eaeed6a1fcd3a02a885c99ba2223bc71df7b69efe4"
-"store.py" = "8251cd638da88152a73309fb2017d62d2ca4b2a46676fc525e81f5c4ffbbd7a0"
+"store.py" = "3a0b389b910d098dbc492c95cb4b8ffeb25028ca0caddf733a375018950ddc42"
 "transform.py" = "34a82af6cbf7def844730b0a21416e478e81684b92480b6055d177d5f3219071"

--- a/src/gen_worker/_vendor/torchcg/store.py
+++ b/src/gen_worker/_vendor/torchcg/store.py
@@ -11,12 +11,37 @@ lifecycle test double -- same lifecycle code, any store.
 Addresses live under ``torchcg/v2`` -- a NEW address space for the two-level
 identity scheme. ``torchcg/v1`` (exact cg-key rows, ``storage.py``) is the
 prior grammar; nothing reads both.
+
+## A graph-set document this build cannot read is ABSENT, and it is discarded
+
+tcg#69. Every byte in this store is DERIVED: a graph-set document is a
+statement about programs that can be re-traced and artifacts that can be
+re-minted from sources the store does not own. So a document written by an
+older ``DOCUMENT_FORMAT`` is not a fault to report, it is a document this
+build does not have -- ``get_graphs`` returns ``None``, the caller registers
+holes and serves eager while a background mint refills, and the unreadable
+bytes are dropped. That is the SAME path a store with no document at all
+takes, which is what makes it safe: the miss branch is the one every caller
+already exercises on a fresh box.
+
+There is NO migration machinery here and there never will be (Paul,
+2026-08-19: *"weights migrate/normalize once at ingest; graphs regenerate"*).
+A format bump costs one re-mint, and code that translates old graph documents
+would be a permanent tax paid to avoid a one-time cost that the store is
+designed to absorb.
+
+What this replaces: raising ``StoreError`` at ADOPT time. It was typed and
+loud, so it was never silent -- but it landed on every local user's first
+cold start after an upgrade, at serving time, on a machine that could simply
+have rebuilt. The condition was diagnosed correctly and handled at the wrong
+altitude.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 import shutil
@@ -31,6 +56,8 @@ from .document import DocumentError, GraphSetDocument, LaneGraphs
 from .graph_identity import EnvIdentity, is_graph_hash
 from .lane import LaneError, require_pass_ref
 from .requirements import RequirementsError, RequirementsManifest
+
+logger = logging.getLogger(__name__)
 
 _REF_PREFIX = "torchcg/v2"
 _READ_BUFFER = 1 << 20
@@ -61,9 +88,7 @@ class GraphStore(Protocol):
         """Whether an artifact exists at (graph, env) -- the hole probe."""
         ...
 
-    def fetch_artifact(
-        self, graph: str, env: EnvIdentity, destination: str | Path
-    ) -> Path | None:
+    def fetch_artifact(self, graph: str, env: EnvIdentity, destination: str | Path) -> Path | None:
         """Verify and copy the (graph, env) artifact out, or a clean miss."""
         ...
 
@@ -90,9 +115,7 @@ def holes(store: GraphStore, lane: LaneGraphs, env: EnvIdentity) -> tuple[str, .
     """
 
     return tuple(
-        record.graph
-        for record in lane.graphs
-        if not store.has_artifact(record.graph, env)
+        record.graph for record in lane.graphs if not store.has_artifact(record.graph, env)
     )
 
 
@@ -104,9 +127,7 @@ def _require_graph(graph: str) -> str:
 
 def _document_ref(name: str) -> str:
     clean = str(name).strip()
-    if not clean or "\\" in clean or any(
-        part in ("", ".", "..") for part in clean.split("/")
-    ):
+    if not clean or "\\" in clean or any(part in ("", ".", "..") for part in clean.split("/")):
         raise StoreError(f"unsafe graph-set name {name!r}")
     return f"{_REF_PREFIX}/graphsets/{clean}"
 
@@ -147,9 +168,7 @@ def _side_table_ref(pass_name: str, key: str) -> str:
     except LaneError as exc:
         raise StoreError(str(exc)) from exc
     if not re.fullmatch(r"[0-9a-f]{8,64}", str(key)):
-        raise StoreError(
-            f"a side-table key is the canonical hex domain-key address, got {key!r}"
-        )
+        raise StoreError(f"a side-table key is the canonical hex domain-key address, got {key!r}")
     return f"{_REF_PREFIX}/sidetables/{pass_name}/{key}"
 
 
@@ -185,14 +204,107 @@ class LocalGraphStore:
     # -- graph-set documents ------------------------------------------------
 
     def get_graphs(self, name: str) -> GraphSetDocument | None:
-        ref = self.cas.read_ref(_document_ref(name))
+        """The named document, or a clean miss -- including when it is stale.
+
+        A document this build cannot decode is a MISS, not an error: see the
+        module docstring. It is discarded on the way out so the next call is
+        an ordinary miss against an empty position rather than a second
+        discard, and so the box does not carry the dead bytes forever.
+        """
+
+        ref_name = _document_ref(name)
+        ref = self.cas.read_ref(ref_name)
         if ref is None:
             return None
         try:
             blob = self.cas.verify_object(ref)
             return GraphSetDocument.decode(Path(blob).read_bytes())
         except (DigestMismatch, FileNotFoundError, ValueError, DocumentError) as exc:
-            raise StoreError(f"graph-set document {name!r} is unreadable: {exc}") from exc
+            self._discard_graphs(ref_name, name, ref, exc)
+            return None
+
+    def _discard_graphs(self, ref_name: str, name: str, ref: CASRef, cause: Exception) -> None:
+        """Drop an unreadable graph-set document and delete its bytes.
+
+        ONE warning, and it names all three things a reader needs: which
+        graph-set went away, which bytes were dropped, and why they could not
+        be read. Silence here would turn a rebuild into an unexplained one.
+
+        The ref goes first: it is the compare-and-swap, so a peer that
+        replaced or discarded the same document a moment earlier simply wins,
+        and this call does nothing but return the miss it already decided on.
+
+        The bytes go second and ONLY if nothing else names them. This is a
+        content-addressed store, so an object is shared the instant two
+        positions hold identical bytes; deleting one position's object without
+        that check would punch a hole under a live position. The scan is over
+        ``refs`` -- small JSON records, one per position -- never over
+        ``objects``, whose layout belongs to tensorfs and not to this module.
+        """
+
+        try:
+            self.cas.compare_and_swap_ref(ref_name, None, expected=ref)
+        except RefConflict:
+            # A concurrent writer already replaced or dropped it. Whatever
+            # stands now is theirs; this call's only job was to stop reading
+            # the stale bytes, and returning a miss has done that.
+            logger.warning(
+                "torchcg: graph-set %r was unreadable by this build (%s) and a "
+                "concurrent writer replaced it; serving as ABSENT this call",
+                name,
+                cause,
+            )
+            return
+        reclaimed = self._discard_object(ref)
+        logger.warning(
+            "torchcg: DISCARDED graph-set %r (%s) -- unreadable by this build: "
+            "%s. Compiled graphs are derived and disposable, so it is treated "
+            "as ABSENT and will be re-minted; no migration is attempted. "
+            "Reclaimed %d byte(s).",
+            name,
+            ref,
+            cause,
+            reclaimed,
+        )
+
+    def _discard_object(self, ref: CASRef) -> int:
+        """Delete ``ref``'s bytes if no logical ref still names them.
+
+        Returns the bytes reclaimed, 0 when the object is still shared or is
+        already gone. Never raises: this runs on the way out of a read that
+        has already decided its answer, and failing to reclaim a few kilobytes
+        must not turn a clean miss back into an exception.
+        """
+
+        try:
+            if any(self._targets(record) == ref for record in self._ref_records()):
+                return 0
+            path = self.cas.object_path(ref)
+            size = path.stat().st_size
+            path.unlink()
+        except OSError:
+            return 0
+        return size
+
+    def _ref_records(self) -> list[dict[str, object]]:
+        records: list[dict[str, object]] = []
+        for path in self.cas.refs.iterdir():
+            if not path.is_file():
+                continue
+            try:
+                raw = json.loads(path.read_bytes())
+            except (OSError, ValueError):
+                continue
+            if isinstance(raw, dict):
+                records.append(raw)
+        return records
+
+    @staticmethod
+    def _targets(record: dict[str, object]) -> CASRef | None:
+        try:
+            return CASRef.parse(str(record.get("target", "")))
+        except ValueError:
+            return None
 
     def put_graphs(self, name: str, document: GraphSetDocument) -> None:
         ref_name = _document_ref(name)
@@ -212,9 +324,7 @@ class LocalGraphStore:
     def has_artifact(self, graph: str, env: EnvIdentity) -> bool:
         return self.cas.read_ref(_artifact_ref(graph, env)) is not None
 
-    def fetch_artifact(
-        self, graph: str, env: EnvIdentity, destination: str | Path
-    ) -> Path | None:
+    def fetch_artifact(self, graph: str, env: EnvIdentity, destination: str | Path) -> Path | None:
         ref = self.cas.read_ref(_artifact_ref(graph, env))
         if ref is None:
             return None
@@ -229,9 +339,7 @@ class LocalGraphStore:
     def _copy_out(self, blob: str | Path, destination: str | Path) -> Path:
         target = Path(destination)
         target.parent.mkdir(parents=True, exist_ok=True)
-        descriptor, temporary_name = tempfile.mkstemp(
-            prefix=f".{target.name}.", dir=target.parent
-        )
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
         os.close(descriptor)
         temporary = Path(temporary_name)
         try:
@@ -285,9 +393,7 @@ class LocalGraphStore:
         """First manifest wins; an interrupted earlier publish is repaired."""
 
         try:
-            self.cas.compare_and_swap_ref(
-                _manifest_ref(graph, env), candidate, expected=None
-            )
+            self.cas.compare_and_swap_ref(_manifest_ref(graph, env), candidate, expected=None)
         except RefConflict:
             # An existing manifest beside the same artifact bytes stands; the
             # mint that wrote it stated what it linked, and restating differs
@@ -308,9 +414,7 @@ class LocalGraphStore:
             ValueError,
             RequirementsError,
         ) as exc:
-            raise StoreError(
-                f"manifest ({graph}, {env.value}) is unreadable: {exc}"
-            ) from exc
+            raise StoreError(f"manifest ({graph}, {env.value}) is unreadable: {exc}") from exc
 
     # -- transform side tables (tcg#52) -------------------------------------
 
@@ -330,9 +434,7 @@ class LocalGraphStore:
         try:
             blob = self.cas.verify_object(ref)
         except (DigestMismatch, FileNotFoundError, ValueError) as exc:
-            raise StoreError(
-                f"program for {graph} failed CAS verification: {exc}"
-            ) from exc
+            raise StoreError(f"program for {graph} failed CAS verification: {exc}") from exc
         return self._copy_out(blob, destination)
 
     def put_program(self, graph: str, path: str | Path) -> str:
@@ -364,9 +466,7 @@ class LocalGraphStore:
     def has_side_table(self, pass_name: str, key: str) -> bool:
         return self.cas.read_ref(_side_table_ref(pass_name, key)) is not None
 
-    def fetch_side_table(
-        self, pass_name: str, key: str, destination: str | Path
-    ) -> Path | None:
+    def fetch_side_table(self, pass_name: str, key: str, destination: str | Path) -> Path | None:
         ref = self.cas.read_ref(_side_table_ref(pass_name, key))
         if ref is None:
             return None

--- a/src/gen_worker/cli/daemon.py
+++ b/src/gen_worker/cli/daemon.py
@@ -232,7 +232,7 @@ def _adoption_source(spec: BootSpec, module_name: str) -> Tuple[Any, Any]:
 
     store = LocalGraphStore(LocalCAS(Path(spec.graph_store)))
     try:
-        return store, store.get_graphs(module_name)
+        document = store.get_graphs(module_name)
     except StoreError as exc:
         # LOUD and typed: silence here would read as "this endpoint compiles to
         # nothing", which is a different fact with the same shape.
@@ -253,6 +253,33 @@ def _adoption_source(spec: BootSpec, module_name: str) -> Tuple[Any, Any]:
         # ref and does not care that the old bytes are undecodable, so a re-mint
         # can refill this very store rather than needing it deleted first.
         return store, None
+    if document is None:
+        # THE REMEDY IS PRINTED FOR THE MISS ITSELF, not only for a raise.
+        #
+        # tcg#69 made `LocalGraphStore` answer a clean miss and discard the
+        # stale bytes, so the branch above no longer fires for the local store
+        # — it survives for backends that still raise (the hub-backed one).
+        # Printing the remedy only there would have silently retired the
+        # operator-facing line on the exact path pgw#1525 exists to fix.
+        #
+        # Naming ONE outcome for both states is not a loss of information, it
+        # is this issue's own conclusion: an undecodable document and an empty
+        # store are the same fact — this box holds nothing usable — and the
+        # remedy is the same verb. WHICH of the two it was is still said, by
+        # torchcg's discard WARNING, which names the graph-set, the bytes and
+        # the decode failure. That warning reaches the terminal even with no
+        # logging configured (`logging.lastResort` handles WARNING+), which
+        # was verified rather than assumed.
+        print(
+            f"adopt: no compiled-graph document for {module_name} in "
+            f"{spec.graph_store}.\n"
+            f"adopt: SERVING EAGER. Compiled graphs are derived and "
+            f"disposable, so this costs speed, never correctness.\n"
+            f"adopt: remedy — `gen-worker compile` mints this endpoint's "
+            f"graphs for this card in the current format.",
+            file=sys.stderr,
+        )
+    return store, document
 
 
 def _stated_stack(spec: BootSpec, document: Any) -> Optional[Any]:

--- a/tests/test_cli_adopt_degradation.py
+++ b/tests/test_cli_adopt_degradation.py
@@ -52,9 +52,109 @@ def test_an_unreadable_graph_document_serves_eager_instead_of_killing_boot(
         "THIS store rather than requiring it be deleted first"
     )
     said = capsys.readouterr().err
-    assert "graph_store_unreadable" in said      # typed, not a bare traceback
     assert "SERVING EAGER" in said               # states the outcome
     assert "gen-worker compile" in said          # names the remedy
+
+
+def test_the_discard_itself_is_announced_and_names_what_went_away(
+    tmp_path, caplog
+):
+    """WHICH of the two "nothing usable" states it was is still stated.
+
+    The adopt lines deliberately say the same thing for a stale store and an
+    empty one -- that is this issue's conclusion, not an omission. The
+    difference is not lost: torchcg's discard WARNING names the graph-set, the
+    bytes it dropped and the decode failure. This asserts the operator gets
+    BOTH, because the adopt line alone would leave a silent deletion.
+    """
+    import logging
+
+    store = tmp_path / "graph-cas"
+    _store_with_unreadable_document(store, "toy.main")
+    spec = BootSpec(endpoint_dir=tmp_path, graph_store=store, sm="sm_89")
+
+    with caplog.at_level(
+        logging.WARNING, logger="gen_worker._vendor.torchcg.store"
+    ):
+        _adoption_source(spec, "toy.main")
+
+    said = "\n".join(
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "gen_worker._vendor.torchcg.store"
+    )
+    assert "DISCARDED" in said
+    assert "toy.main" in said                    # which graph-set
+    assert "sha256:" in said                     # which bytes
+    assert "unreadable by this build" in said    # why
+
+
+def test_the_shape_actually_found_on_disk_is_the_version_mismatch(
+    tmp_path, caplog
+):
+    """The document that blocked va#3's arm 2 was v=2 with a VALID field set.
+
+    Worth its own case because the fixture above fails on the field set and
+    would pass a reader that only rejected unknown fields. This one can only
+    fail on the version, which is the shape a re-vendor actually produces.
+    """
+    import logging
+
+    from gen_worker._vendor.tensorfs import LocalCAS
+    from gen_worker._vendor.torchcg.store import _document_ref
+
+    store = tmp_path / "graph-cas"
+    store.mkdir(parents=True)
+    cas = LocalCAS(store)
+    ref = cas.put_bytes(b'{"lanes":[],"stack":[],"v":2}')
+    cas.compare_and_swap_ref(_document_ref("toy.main"), ref, expected=None)
+
+    spec = BootSpec(endpoint_dir=tmp_path, graph_store=store, sm="sm_89")
+    with caplog.at_level(
+        logging.WARNING, logger="gen_worker._vendor.torchcg.store"
+    ):
+        _, document = _adoption_source(spec, "toy.main")
+
+    assert document is None
+    said = "\n".join(r.getMessage() for r in caplog.records)
+    assert "document v must be 3" in said
+    assert cas.read_ref(_document_ref("toy.main")) is None
+
+
+def test_a_store_that_still_raises_keeps_the_typed_refusal(
+    tmp_path, capsys, monkeypatch
+):
+    """The `StoreError` branch is NOT dead -- it guards the other backends.
+
+    tcg#69 taught the LOCAL store to answer a clean miss, so that branch no
+    longer fires for `LocalGraphStore`. The hub-backed store is a different
+    implementation of the same protocol and still raises, and a `up` must
+    degrade on it too rather than die. Driven through a store double so this
+    is a test of the CALL SITE, which is what owns the outcome.
+    """
+    import gen_worker._vendor.torchcg.store as store_module
+    from gen_worker._vendor.torchcg.store import StoreError
+
+    class RaisingStore:
+        def get_graphs(self, name: str) -> None:
+            raise StoreError(f"graph-set document {name!r} is unreadable: nope")
+
+    store = tmp_path / "graph-cas"
+    store.mkdir(parents=True)
+    spec = BootSpec(endpoint_dir=tmp_path, graph_store=store, sm="sm_89")
+
+    # `_adoption_source` imports the class inside the function, so the module
+    # attribute is what it resolves at call time.
+    monkeypatch.setattr(store_module, "LocalGraphStore", lambda _cas: RaisingStore())
+
+    adopted_store, document = _adoption_source(spec, "toy.main")
+
+    assert document is None
+    assert adopted_store is not None
+    said = capsys.readouterr().err
+    assert "graph_store_unreadable" in said
+    assert "SERVING EAGER" in said
+    assert "gen-worker compile" in said
 
 
 def test_an_unreadable_document_lands_where_an_empty_store_lands(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=9fc1f2ac93a1a3976090c77ca27297e68dbfa88e" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=f45fc64a9ba1323e0a44975565d822517aab8058" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=9fc1f2ac93a1a3976090c77ca27297e68dbfa88e#9fc1f2ac93a1a3976090c77ca27297e68dbfa88e" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=f45fc64a9ba1323e0a44975565d822517aab8058#f45fc64a9ba1323e0a44975565d822517aab8058" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
Consumer half of **[tcg#69](https://github.com/cozy-creator/torchcg/pull/66)** (torchcg `f45fc64a`, merged, CI green). `LocalGraphStore.get_graphs` now answers a clean **MISS** on a document this build cannot decode, discards the stale bytes, and says so once. Re-vendored as one act (`task vendor`) so `pyproject.toml`, `uv.lock` and `VENDORED.toml` name the same rev.

### Why upstream and not the vendor copy

`tests/test_vendored_snapshot_pgw1310.py` fences the snapshot per-file sha256 — a hand-patched vendor tree is refused by construction. And this repo runs **two** torchcg copies on purpose: the snapshot serves the mint and the serving path, the `dev` git pin serves the derive. A vendor-only fix leaves the derive on the old behaviour, with the failure landing two tools from the cause — the wound `VENDORED.toml` documents.

### Relationship to #1090 — which is merged and is NOT superseded

#1090 is the CLI half, and its own commit message names the split: *"The STORE side — answering a clean miss and GCing the unreadable leftover — is torchcg's and is deliberately not in this diff."* This is that side. #1090 fixed **one** call site; `serving/serve_adoption.py`, `serving/__main__.py` and `mint_store.py` all call `get_graphs` bare and were still exposed. Fixing the store fixes them together.

### The part that is not mechanical

Once the local store stops raising, #1090's `except StoreError` branch stops firing for it — **and the operator-facing lines that named the remedy went with it.** Printing them only on a raise would silently retire the message on the exact path pgw#1525 exists to fix. So the remedy is printed for the MISS itself:

```
adopt: no compiled-graph document for <module> in <store>.
adopt: SERVING EAGER. Compiled graphs are derived and disposable, so this
       costs speed, never correctness.
adopt: remedy — `gen-worker compile` mints this endpoint's graphs for this
       card in the current format.
```

Saying one thing for a stale store and an empty one is not lost information — it is #1090's own conclusion that the two are the same fact. WHICH it was is still stated by torchcg's discard warning, naming the graph-set, the bytes and the decode failure. **Verified rather than assumed** that this reaches a terminal with no logging configured (`logging.lastResort` handles WARNING+).

The `except StoreError` branch **stays** — the hub-backed store is a different implementation of the same protocol and still raises. It now has a test driving it through a store double, so the call site is covered independently of the backend.

### Tests

The assertion that could no longer be true (`graph_store_unreadable` on the local path) is **replaced, not deleted**: one test asserts the discard IS announced with what / which bytes / why, and one plants **the shape actually found on disk**. That shape is `v=2` with a *valid* field set; the existing fixture is `{"v": 1, ...}` and fails on the FIELD SET, so it would have passed a reader that only rejected unknown fields.

22 passed in the touched suites · 37 across the adopt-adjacent suites · `mypy` clean over 633 files · `ruff check src/gen_worker` clean · `task lock-check` green.

Field evidence (pgw#1525's own box): `~/.cache/cozy/graph-cas` held `sd15.main` + `sdxl.main` at `v=2` → `StoreError: document v must be 3` at adopt time. 1.08 GiB stranded, 144 of 193 objects unreachable from any ref.