### PR TITLE
pgw#1527: an unservable payload costs ONE payload, not the document

### DIFF
--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -366,6 +366,8 @@ def run_lock(args: argparse.Namespace) -> int:
     # operator running this verb is the one who can reshape the signature.
     for name, reason in result.unenumerable_entrypoints:
         _say(f"lock: entrypoint {name} NOT enumerated -- {reason}")
+    for skipped in result.unservable_payloads:
+        _say(f"lock: payload SKIPPED (unservable) -- {skipped}")
     _say(
         f"lock: traced {graphs} specialization(s), {len(programs)} exported "
         f"program(s) banked BY GRAPH IDENTITY in the CAS at {graph_cas_root} "
@@ -385,6 +387,7 @@ def run_lock(args: argparse.Namespace) -> int:
         "unenumerable_entrypoints": [
             name for name, _reason in result.unenumerable_entrypoints
         ],
+        "unservable_payloads": list(result.unservable_payloads),
         "seconds": round(elapsed, 1),
     }))
     return 0

--- a/src/gen_worker/cli/release.py
+++ b/src/gen_worker/cli/release.py
@@ -144,6 +144,10 @@ def _run_derive(args: argparse.Namespace) -> int:
     # be able to see without parsing prose.
     for name, reason in result.unenumerable_entrypoints:
         print(f"entrypoint {name}: NOT enumerated -- {reason}", file=sys.stderr)
+    # pgw#1527: named separately from the warnings for the same reason — a
+    # payload with no graphs is a property of the document, not prose.
+    for skipped in result.unservable_payloads:
+        print(f"payload SKIPPED (unservable): {skipped}", file=sys.stderr)
     if result.eager_permanent:
         # pgw#1392: two different reasons reach "no lanes" and the log must
         # not conflate them — a model held eagerly (`lanes=()`), or NO MODEL

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -62,6 +62,7 @@ import inspect
 import itertools
 import json
 import types
+import traceback
 import typing
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -187,6 +188,10 @@ class ReleaseDeriveResult:
     #: for, name -> the typed reason. They are STATED, not silently dropped,
     #: and they no longer take the module's other entrypoints down with them.
     unenumerable_entrypoints: tuple[tuple[str, str], ...] = ()
+    #: pgw#1527: enumerated payloads the ENDPOINT's own code refused to serve.
+    #: One line each, naming the author frame — a skipped payload has to be
+    #: louder than a missing one.
+    unservable_payloads: tuple[str, ...] = ()
 
     @property
     def eager_permanent(self) -> bool:
@@ -1250,6 +1255,76 @@ def _resolve_lane(torchcg: ModuleType, cls: type, lane: Any) -> Any:
     return torchcg.LaneRef(handle, dtype=_torch_dtype(dtype))
 
 
+def endpoint_source_root(module: ModuleType) -> Optional[Path]:
+    """The directory the AUTHOR's code lives in, or None if it cannot be told.
+
+    The top-level package of the endpoint's main module: `minimax_h3.main` ->
+    `<repo>/src/minimax_h3`, a bare fixture module -> the directory holding it.
+    None when the module has no file (namespace/frozen), and None is treated as
+    "cannot prove endpoint-owned", which keeps the conservative default.
+    """
+
+    import sys
+
+    name = (getattr(module, "__package__", "") or module.__name__).split(".")[0]
+    top = sys.modules.get(name) or module
+    path = getattr(top, "__file__", None) or getattr(module, "__file__", None)
+    if not path:
+        return None
+    try:
+        return Path(path).resolve().parent
+    except OSError:
+        return None
+
+
+def _sdk_root() -> Path:
+    import gen_worker
+
+    return Path(gen_worker.__file__).resolve().parent
+
+
+def deepest_endpoint_frame(
+    exc: BaseException, endpoint_root: Optional[Path]
+) -> Optional[traceback.FrameSummary]:
+    """The DEEPEST frame of ``exc``, but only if the author's code raised it.
+
+    pgw#1527, and the narrowness IS the ruling. A payload the endpoint cannot
+    serve is a product fact and should cost ONE payload; an SDK defect is the
+    derive's whole point and must still kill it loudly. Walls 1-8 were every
+    one of them an SDK-frame exception (torchcg's hollow session, the trace
+    context, the provenance walk, the output floor) — a blanket catch would
+    have swallowed all eight and turned each into a quiet coverage gap, which
+    is exactly the counter-argument the filer raised against themselves.
+
+    So the test is positive and it is on the DEEPEST frame only: the innermost
+    thing that actually raised must be a file under the endpoint's own source
+    root. Author code that calls into torch and trips a shape error there
+    reports a TORCH frame, and stays fatal — deliberately, because this cannot
+    tell that apart from an SDK-induced one without guessing.
+
+    Never endpoint-owned: anything under the SDK, even if the two roots
+    somehow overlap. Returns None whenever it cannot PROVE the frame is the
+    author's, so "unsure" always means "fatal".
+    """
+
+    if endpoint_root is None:
+        return None
+    frames = traceback.extract_tb(exc.__traceback__)
+    if not frames:
+        return None
+    deepest = frames[-1]
+    try:
+        where = Path(deepest.filename).resolve()
+    except OSError:
+        return None
+    sdk = _sdk_root()
+    if where.is_relative_to(sdk):
+        return None
+    if not where.is_relative_to(endpoint_root):
+        return None
+    return deepest
+
+
 def _derive_lane(
     torchcg: ModuleType,
     cls: type,
@@ -1259,6 +1334,8 @@ def _derive_lane(
     warnings: list[str],
     program_sink: Optional[Any] = None,
     slot_checkpoints: Mapping[str, Path] = MappingProxyType({}),
+    endpoint_root: Optional[Path] = None,
+    unservable: Optional[list[dict[str, Any]]] = None,
 ) -> Optional[Any]:
     """One lane's instrumented runs, merged across defaults variants.
 
@@ -1426,14 +1503,40 @@ def _derive_lane(
                                 # derive failure.
                                 refused += 1
                             except Exception as exc:
-                                raise DeriveError(
-                                    f"lane {handle!r}: entrypoint "
-                                    f"{plan.name!r} failed on auto-enumerated "
-                                    f"payload {index} ({payload!r}) with "
-                                    f"binding {dict(binding)!r} under the "
-                                    f"trace session: "
-                                    f"{type(exc).__name__}: {exc}"
-                                ) from exc
+                                # pgw#1527: ONE unservable payload costs one
+                                # payload, not the document — but only when the
+                                # AUTHOR's code is what raised. Anything deeper
+                                # in the SDK, torch or diffusers is still fatal:
+                                # the derive exists to find those, and walls 1-8
+                                # were every one of them.
+                                frame = deepest_endpoint_frame(exc, endpoint_root)
+                                if frame is None or unservable is None:
+                                    raise DeriveError(
+                                        f"lane {handle!r}: entrypoint "
+                                        f"{plan.name!r} failed on auto-enumerated "
+                                        f"payload {index} ({payload!r}) with "
+                                        f"binding {dict(binding)!r} under the "
+                                        f"trace session: "
+                                        f"{type(exc).__name__}: {exc}"
+                                    ) from exc
+                                row = {
+                                    "entrypoint": plan.name,
+                                    "payload": index,
+                                    "binding": {
+                                        str(k): str(v)
+                                        for k, v in dict(binding).items()
+                                    },
+                                    # WHERE the author's code raised, so a
+                                    # skipped payload points at the line that
+                                    # has to change.
+                                    "frame": (
+                                        f"{Path(frame.filename).name}:"
+                                        f"{frame.lineno} in {frame.name}"
+                                    ),
+                                    "error": f"{type(exc).__name__}: {exc}",
+                                }
+                                if row not in unservable:
+                                    unservable.append(row)
 
             try:
                 lane_graphs = torchcg.discover_modules(
@@ -1525,6 +1628,8 @@ def derive_release(
     warnings: list[str] = []
     plans: list[tuple[_Entrypoint, tuple[Any, ...]]] = []
     unenumerable: list[tuple[str, str]] = []
+    #: pgw#1527: payloads the ENDPOINT could not serve, one row each.
+    unservable_payloads: list[dict[str, Any]] = []
     for plan in _entrypoints(module, cls):
         owner = f"@entrypoint {plan.name}"
         refusal: Optional[PayloadEnumerationRefused] = None
@@ -1595,6 +1700,8 @@ def derive_release(
                 torchcg, cls, lane, plans, checkpoint_dir, warnings,
                 program_sink=program_sink,
                 slot_checkpoints=slot_checkpoints,
+                endpoint_root=endpoint_source_root(module),
+                unservable=unservable_payloads,
             )
             if lane_graphs is None:
                 # Traced, nothing marked (pgw#1488). No lane row: an empty one
@@ -1633,6 +1740,23 @@ def derive_release(
             if floor is not None:
                 entry["requires"] = floor.render()
             lane_contracts[lane_graphs.contract] = entry
+
+    # pgw#1527: a skipped payload is STATED, per entrypoint, and is absent
+    # entirely when nothing was skipped — so a document with no unservable
+    # payload is byte-identical to one derived before this existed.
+    for row in unservable_payloads:
+        row_entry = entrypoints.get(str(row["entrypoint"]))
+        if row_entry is None:
+            continue
+        skipped: list[Any] = row_entry.setdefault("unservable", [])
+        skipped.append({k: v for k, v in row.items() if k != "entrypoint"})
+    for row in unservable_payloads:
+        warnings.append(
+            f"@entrypoint {row['entrypoint']}: payload {row['payload']} is "
+            f"UNSERVABLE and was skipped — {row['error']} (at {row['frame']}). "
+            f"Its graphs are not in this document; every other payload is "
+            f"unaffected."
+        )
 
     graphs_document = torchcg.GraphSetDocument(stack=stack, lanes=tuple(lanes))
     payload_dict: dict[str, Any] = {
@@ -1675,6 +1799,10 @@ def derive_release(
         derived_lanes=tuple(derived_lanes),
         unmarked_lanes=tuple(unmarked_lanes),
         unenumerable_entrypoints=tuple(unenumerable),
+        unservable_payloads=tuple(
+            f"{r['entrypoint']}[{r['payload']}]: {r['error']} (at {r['frame']})"
+            for r in unservable_payloads
+        ),
     )
 
 

--- a/tests/release_fixtures/unservable_payload_endpoint.py
+++ b/tests/release_fixtures/unservable_payload_endpoint.py
@@ -1,0 +1,73 @@
+"""One enumerated payload the ENDPOINT cannot serve (pgw#1527).
+
+h3's shape: `fps=60` was mathematically unservable, so one member of a
+7-payload sweep raised from the author's own code and cost every graph the
+other six would have produced.
+
+`Size.LARGE` here is that payload — the author's own arithmetic refuses it,
+from a frame in THIS file. `Size.SMALL` serves and produces graphs.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class Size(StrEnum):
+    SMALL = "small"
+    LARGE = "large"
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    size: Size = Size.SMALL
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class UnservableModel(Model[SDXL], lanes=(TINY_DIFFUSERS_FP32,)):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+def _side_for(size: Size) -> int:
+    """The author's own arithmetic, and it refuses one of its own enum values.
+
+    Deliberately raised from ENDPOINT code, at a line in this file — that is
+    the whole predicate under test.
+    """
+
+    if size is Size.LARGE:
+        raise ValueError("this checkpoint cannot serve the large bucket")
+    return 32
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In, model: UnservableModel) -> Out:
+    ctx.raise_if_cancelled()
+    side = _side_for(payload.size)
+    with torch.inference_mode():
+        model.pipe(
+            prompt=payload.prompt,
+            num_inference_steps=2,
+            guidance_scale=0.0,
+            width=side,
+            height=side,
+            callback_on_step_end=ctx.step_callback(2),
+            output_type="latent",
+        )
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_release_derive_unservable_payload.py
+++ b/tests/test_release_derive_unservable_payload.py
@@ -1,0 +1,202 @@
+"""pgw#1527: an unservable payload costs ONE payload, not the document.
+
+A single member of a 7-payload sweep that the endpoint cannot serve used to
+cost every graph the other six would produce — against the enumeration's own
+"pre-warming completeness aid, never a correctness gate" doctrine and against
+pgw#1449's skip-and-count precedent for entrypoints.
+
+**The cut is deliberately narrow and the narrowness IS the fix.** Catch-and-
+count only where the DEEPEST traceback frame is ENDPOINT-owned. An SDK-frame
+exception stays fatal, because walls 1-8 were every one of them an SDK defect
+surfacing exactly this way (the hollow session, the trace context, the
+provenance walk, the output-integrity floor) and a blanket catch would have
+turned all eight into quiet coverage gaps instead of the refusals that got
+them fixed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+
+from gen_worker.release.derive import (  # noqa: E402
+    deepest_endpoint_frame,
+    endpoint_source_root,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+LOCK = (
+    "version = 1\n"
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+
+@pytest.fixture(scope="module")
+def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return tiny_tree.save_config_only(tmp_path_factory.mktemp("unservable-configs"))
+
+
+def _derive(tree: Path, out: Path, module: str) -> int:
+    from gen_worker.cli import main
+
+    lockfile = out.parent / "uv.lock"
+    lockfile.write_text(LOCK)
+    return main([
+        "release", "derive",
+        "--dir", str(FIXTURES),
+        "--module", module,
+        "--checkpoint", str(tree),
+        "--lockfile", str(lockfile),
+        "--out", str(out),
+    ])
+
+
+def test_the_servable_payload_still_produces_its_graphs(
+    tree: Path, tmp_path: Path
+) -> None:
+    """Two payloads, one unservable: the document exists and carries the other."""
+
+    out = tmp_path / "release.json"
+    assert _derive(tree, out, "unservable_payload_endpoint") == 0
+
+    (lane,) = json.loads(out.read_bytes())["graphs"]["lanes"]
+    assert lane["unobserved_targets"] == []
+    assert len(lane["graphs"]) >= 1
+
+
+def test_the_skipped_payload_is_STATED_with_the_author_frame(
+    tree: Path, tmp_path: Path
+) -> None:
+    """Louder than a missing one: index, frame and exception, per entrypoint."""
+
+    out = tmp_path / "release.json"
+    assert _derive(tree, out, "unservable_payload_endpoint") == 0
+
+    row = json.loads(out.read_bytes())["entrypoints"]["generate"]["unservable"]
+    assert len(row) == 1
+    (skipped,) = row
+    assert skipped["payload"] == 1
+    assert "cannot serve the large bucket" in skipped["error"]
+    assert skipped["error"].startswith("ValueError:")
+    # The line that has to change, in the AUTHOR's file.
+    assert skipped["frame"].startswith("unservable_payload_endpoint.py:")
+    assert "_side_for" in skipped["frame"]
+
+
+def test_an_endpoint_with_NOTHING_skipped_carries_no_such_key(
+    tree: Path, tmp_path: Path
+) -> None:
+    """Absent, not empty — so existing documents cannot move."""
+
+    out = tmp_path / "release.json"
+    assert _derive(tree, out, "tiny_endpoint") == 0
+
+    for entry in json.loads(out.read_bytes())["entrypoints"].values():
+        assert "unservable" not in entry
+
+
+# ---------------------------------------------------------------------------
+# The predicate itself. These are the assertions that keep the cut narrow.
+
+
+def _raise_from(where: Any) -> BaseException:
+    try:
+        where()
+    except Exception as exc:  # noqa: BLE001 - the subject
+        return exc
+    raise AssertionError("expected a raise")
+
+
+def test_an_SDK_frame_is_NEVER_endpoint_owned() -> None:
+    """Walls 1-8 all looked like this, and all of them must stay fatal."""
+
+    from gen_worker.release.derive import _auto_payloads
+
+    class NotAStruct:
+        pass
+
+    # A REAL raise from inside gen_worker: the deepest frame is derive.py's
+    # own line, not this file's. (Raising an SDK-defined exception FROM here
+    # would prove nothing — the frame is what is classified, not the class.)
+    import traceback
+
+    import gen_worker
+
+    exc = _raise_from(lambda: _auto_payloads("@entrypoint x", NotAStruct))
+    sdk = Path(gen_worker.__file__).resolve().parent
+    # Pin the PREMISE, or the assertions below could pass for the wrong
+    # reason: the deepest frame really is inside the SDK.
+    deepest = Path(traceback.extract_tb(exc.__traceback__)[-1].filename).resolve()
+    assert deepest.is_relative_to(sdk), deepest
+
+    # Even with the endpoint root set to the SDK's OWN directory — the most
+    # permissive root that could possibly be passed — an SDK frame is refused.
+    assert deepest_endpoint_frame(exc, sdk) is None
+    assert deepest_endpoint_frame(exc, Path(__file__).resolve().parent) is None
+
+
+def test_a_frame_OUTSIDE_the_endpoint_root_is_not_claimed() -> None:
+    """torch/diffusers/stdlib raise from their own files: still fatal.
+
+    Conservative on purpose: author code that trips a shape error inside torch
+    reports a TORCH frame, and this cannot tell that apart from an SDK-induced
+    one without guessing.
+    """
+
+    exc = _raise_from(lambda: json.loads("{bad"))
+    assert deepest_endpoint_frame(exc, FIXTURES) is None
+
+
+def test_an_ENDPOINT_frame_IS_claimed() -> None:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import unservable_payload_endpoint as ep
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+    exc = _raise_from(lambda: ep._side_for(ep.Size.LARGE))
+    frame = deepest_endpoint_frame(exc, endpoint_source_root(ep))
+    assert frame is not None
+    assert frame.name == "_side_for"
+    assert Path(frame.filename).name == "unservable_payload_endpoint.py"
+
+
+def test_an_UNKNOWABLE_root_means_fatal() -> None:
+    """"Unsure" must always resolve to "fatal", never to "skip"."""
+
+    exc = _raise_from(lambda: 1 / 0)
+    assert deepest_endpoint_frame(exc, None) is None
+
+
+def test_the_endpoint_root_is_the_TOP_LEVEL_package_directory() -> None:
+    """A package endpoint's helpers count as its own code.
+
+    h3 raises from `long_video.py`, not from `main.py`, so a root narrowed to
+    the main module's file would miss every real case.
+    """
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import unservable_payload_endpoint as ep
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+    assert endpoint_source_root(ep) == FIXTURES


### PR DESCRIPTION
A single member of an enumerated sweep that the endpoint cannot serve took every graph the other members would have produced — h3's `fps=60` cost all six of its siblings. That contradicts the enumeration's own doctrine (*"a pre-warming completeness aid, never a correctness gate"*) and pgw#1449's skip-and-count precedent, which already applies it one level up at the entrypoint.

## The cut is deliberately narrow, and the narrowness is the fix

Catch-and-count **only where the deepest traceback frame is endpoint-owned.** An SDK-frame exception stays fatal.

That answers the counter-argument the filer raised against themselves: **walls 1–8 were every one of them an SDK defect surfacing at exactly this call** — the hollow session's meta re-home, the lazy-component registry, the provenance walk, the per-component dtype cast, the output-integrity floor. A blanket catch would have converted all eight into quiet coverage gaps instead of the loud refusals that got them fixed, and the derive would have kept "succeeding" while producing nothing.

`deepest_endpoint_frame` is a **positive** test that returns `None` whenever it cannot *prove* the author's code raised — "unsure" always resolves to fatal:

- **the deepest frame only.** Author code that calls torch and trips a shape error there reports a *torch* frame and stays fatal, deliberately: this cannot tell that apart from an SDK-induced one without guessing;
- **never anything under the SDK**, even when the endpoint root passed in *is* the SDK's own directory (tested);
- `None` when the endpoint root cannot be determined at all.

The root is the endpoint's **top-level package** directory, not the main module's file — h3 raises from `long_video.py`, not `main.py`, so a narrower root would miss every real case.

## A skipped payload is louder than a missing one

Each carries a typed row — payload index, binding, the author frame as `file:line in function`, and the exception — written per entrypoint into the document (`entrypoints.<name>.unservable`), repeated as a warning, and printed by **both** verbs; `lock`'s JSON summary carries `unservable_payloads`. The key is **absent** when nothing was skipped, so a document with no unservable payload is byte-identical to one derived before this existed.

## Red/green through the real CLI

Fixture with h3's shape — one servable payload, one the author's own arithmetic refuses:

| arm | result |
|---|---|
| master | `derive error: … payload 1 … ValueError: this checkpoint cannot serve the large bucket` → **exit 1, no document on disk** |
| with the fix | `payload SKIPPED (unservable): generate[1]: ValueError: … (at unservable_payload_endpoint.py:55 in _side_for)` · `lane tiny.diffusers-fp32@1: 1 graph specialization(es)` → **exit 0, document written** |

## Gates

Byte-compare #9: `b6d23f8e01acc8528be773f70a57bcd0cacf4fec4e703d0a6b4e56b16b309f5c`, unchanged · 69 passed across derive / floor / eager-bridge suites · mypy clean (635 files) · ruff clean on `src/gen_worker` and both new files · `lint_unreached_surface` 97 = base.

Nothing gates on this tonight — wall 9 was h3's own `fps=60` and se#793 fixes that by dropping it. This is the durable version of that lesson.