### PR TITLE
pgw#1513 follow-up: the decline REASON leads the message — it was truncated off the wire on its first field firing

### DIFF
--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -258,16 +258,31 @@ class ProjectedTreeNotStreamable(RuntimeError):
             for path, on_disk, named in self.stubs[:3]
         )
         more = "" if len(self.stubs) <= 3 else f" (+{len(self.stubs) - 3} more)"
+        # pgw#1513 follow-up: THE DECLINE REASON GOES FIRST, and this ordering
+        # is load-bearing rather than editorial.
+        #
+        # The first field run of this refusal proved the fix works and then
+        # LOST the one clause it exists to deliver: `JobResult.safe_message` is
+        # bounded at 512 chars on the wire (`worker.py::_send_result`, a
+        # deliberate slice — this layer declining to put an unbounded string on
+        # a wire it owns), and the decline reason sat at the END of a longer
+        # message. It was truncated away, so the pod said WHAT was wrong and
+        # not WHY, which is the half nobody can reconstruct afterwards.
+        #
+        # Leading with it is structural: it survives ANY cap, at any layer,
+        # including caps nobody has told us about yet. The explanation that
+        # follows is the part a reader can afford to lose, because it is the
+        # same every time — the reason is not.
         super().__init__(
-            f"{self.tree} is a PROJECTED snapshot tree: {len(self.stubs)} of "
-            f"its tensor containers are tensorfs pointer stubs, not weights — "
-            f"{shown}{more}. The eager `from_pretrained` bridge reads with the "
-            f"stock safetensors reader and would report `header too large`, "
-            f"which describes a corrupt checkpoint and this checkpoint is not "
+            f"ENGINE DECLINED: {declined or 'unknown'} "
+            f"| PROJECTED TREE, {len(self.stubs)} pointer stub(s), NOT weights: "
+            f"{shown}{more} "
+            f"| tree={self.tree} "
+            f"| The eager `from_pretrained` bridge reads with the stock "
+            f"safetensors reader and would report `header too large`, which "
+            f"describes a corrupt checkpoint — and this checkpoint is NOT "
             f"corrupt: its bytes are in the CAS. The streaming engine "
-            f"(pgw#1380) is the reader for this tree and it declined to bind, "
-            f"which means `resolve_projection` could not recover the tree's "
-            f"manifest pin. THE ENGINE DECLINED BECAUSE: {declined or 'unknown'}. "
+            f"(pgw#1380) is the reader for this tree and declined to bind. "
             f"Refusing rather than serving a lie about the weights."
         )
 

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -39,6 +39,7 @@ import pytest
 from gen_worker._vendor.tensorfs.project import stub_bytes
 from gen_worker.serving.context import (
     DeployBinding,
+    _projection_declined_because,
     LoadContext,
     ProjectedTreeNotStreamable,
     _projection_artifacts,
@@ -284,3 +285,46 @@ def test_collected_entries_puts_model_index_json_FIRST(tmp_path: Path) -> None:
     assert got[1:] == sorted(got[1:]), f"the tail must stay sorted: {got}"
     assert "model_index.json" in projection.collected_refusal(tmp_path, got)[:400], (
         "and it must survive into the truncated (shown) window of the message")
+
+
+def test_the_decline_REASON_survives_the_wire_truncation(tmp_path: Path) -> None:
+    """The clause this refusal exists to deliver must survive the 512-char cap.
+
+    # pgw#1513 follow-up, from the FIRST FIELD FIRING of this refusal.
+
+    It worked — a pod reported `ProjectedTreeNotStreamable` naming four stubs
+    with bytes-on-disk against bytes-named — and then lost the one clause the
+    whole mechanism exists for. `JobResult.safe_message` is sliced to 512 chars
+    in `worker.py::_send_result` (deliberate: that layer declines to put an
+    unbounded string on a wire it owns), and `THE ENGINE DECLINED BECAUSE: …`
+    sat at the END of a longer message. It was truncated away, so the pod said
+    WHAT was wrong and never WHY — and WHY is the half nobody can reconstruct
+    from the logs afterwards.
+
+    Leading with the reason is structural: it survives any cap at any layer,
+    including caps nobody has told us about. This test asserts that property
+    against the real limit and the real field shape, so a later edit that
+    "tidies" the message ordering fails here instead of on a rental.
+    """
+    #: The exact slice `_send_result` applies.
+    WIRE_CAP = 512
+
+    tree = Path("/tensorhub-endpoint-cache/cas/snapshots/sha256:" + "b7" * 32)
+    stubs = [
+        (f"component_{i}/diffusion_pytorch_model.safetensors", 128, 3_400_000_000)
+        for i in range(4)
+    ]
+    declined = _projection_declined_because(tmp_path / "snapshots" / "absent")
+
+    message = str(ProjectedTreeNotStreamable(tree, stubs, declined))
+    truncated = message[:WIRE_CAP]
+
+    assert message.startswith("ENGINE DECLINED:"), (
+        "the reason must LEAD — anything after the first 512 characters is not "
+        f"guaranteed to reach a reader: {message[:80]!r}")
+    assert declined[:120] in truncated, (
+        "the decline reason must survive the wire cap intact; this is the "
+        f"clause the refusal exists to deliver. Truncated form: {truncated!r}")
+    assert "pointer stub(s), NOT weights" in truncated, (
+        "the stub count should also fit inside the cap — it is what identifies "
+        "the shape on sight")


### PR DESCRIPTION
**The refusal fired in the field and worked** — a pod reported `ProjectedTreeNotStreamable` naming four pointer stubs with bytes-on-disk vs bytes-named, on the ideal A/B (same volume that failed under the previous pin, only the pin changed). **And it lost the one clause it exists to deliver.**

`JobResult.safe_message` is sliced to 512 chars in `worker.py::_send_result` — deliberate, and correct: that layer declines to put an unbounded string on a wire it owns. `THE ENGINE DECLINED BECAUSE: …` sat at the end of a 1,181-char message and was truncated away. The pod said WHAT was wrong and never WHY.

**Fix: the reason LEADS.** I am not raising the cap — the slice has a stated rationale and overriding another layer's wire policy to fit my prose is the wrong direction. Ordering is structural: it survives any cap at any layer, including ones nobody has told us about. What gets truncated instead is the boilerplate explanation, which is identical every time; the reason is not.

Measured at the real limit with the real field shape: at the 512-char cut the reader now gets the **complete** decline reason plus the stub count.

Red/green: fixed → reason survives intact; RED (landed trailing ordering restored) → `AssertionError: the reason must LEAD`. The red arm reproduces the exact field loss. 8 tests green, ruff clean.

This unblocks the benchmark lane's $0.05 re-run, which captures the last unknown: **why `engine_for` declines on pods while binding locally.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)