### PR TITLE
pgw#1529: publish must never upload a credential directory

### DIFF
--- a/src/gen_worker/cli/publish.py
+++ b/src/gen_worker/cli/publish.py
@@ -71,8 +71,24 @@ HTTP_TIMEOUT_S = 600.0
 
 #: Never uploaded, whatever git says: weights belong in repos, venvs and caches
 #: are machine-local, and a .env is a secret someone forgot to gitignore.
-_EXCLUDE_DIRS = frozenset({".venv", "venv", "__pycache__", ".git", ".mypy_cache",
-                           ".pytest_cache", ".compiled-graphs", "outputs"})
+_EXCLUDE_DIRS = frozenset({
+    # Build/tool detritus.
+    ".venv", "venv", "__pycache__", ".git", ".mypy_cache", ".pytest_cache",
+    ".tox", ".ruff_cache", "node_modules",
+    # A LOCAL RUN'S OUTPUT. Both are cwd-relative defaults (pgw#1526): the
+    # daemon writes artifacts to `.compiled-graphs` and media to `outputs`,
+    # so anyone who runs `up`/`compile` inside an endpoint leaves them in the
+    # source tree. Measured via cozy-local's twin of this set (cl#88): 172 MB
+    # of artifacts took one tarball 75 KB -> 59 MB.
+    ".compiled-graphs", "outputs",
+    # CREDENTIAL DIRECTORIES. Not bloat — a secret-leak vector. `publish`
+    # uploads a whole tree when the endpoint is not a git work tree, and an
+    # `.ssh/id_ed25519` sitting beside an endpoint would go to the hub with
+    # it. cozy-local's archiver has excluded these since it was written and
+    # asserts it in a test; this client did not, and the two clients publish
+    # the same trees.
+    ".aws", ".azure", ".gnupg", ".kube", ".secrets", ".ssh",
+})
 _EXCLUDE_SUFFIXES = (".safetensors", ".ckpt", ".bin", ".pt", ".pth", ".gguf",
                      ".onnx", ".so", ".pyc")
 _EXCLUDE_NAMES = frozenset({".env"})

--- a/tests/test_publish_source_exclusions.py
+++ b/tests/test_publish_source_exclusions.py
@@ -1,0 +1,92 @@
+"""What a source publish must never upload.
+
+Subject-named, not incident-named (pgw#1362 / 4.34b); lineage in comments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gen_worker.cli.publish import source_files
+
+
+def _tree(root: Path, files: dict[str, str]) -> None:
+    for name, body in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+
+def test_credential_directories_never_ship(tmp_path):
+    """# pgw#1529: a secret-leak vector, not bloat.
+
+    `publish` packages the WHOLE TREE when the endpoint is not a git work tree
+    (no commit to take a manifest from). A private key sitting beside an
+    endpoint would then go to the hub with it. cozy-local's archiver has
+    excluded these since it was written and asserts it; this client did not,
+    and both publish the same trees.
+    """
+    _tree(tmp_path, {
+        "endpoint.toml": "main = 'x.main'",
+        ".ssh/id_ed25519": "PRIVATE KEY",
+        ".aws/credentials": "[default]",
+        ".gnupg/secring.gpg": "secret",
+        ".kube/config": "token: x",
+        ".secrets/token": "s",
+        ".azure/accessTokens.json": "{}",
+    })
+    shipped = {p.relative_to(tmp_path).as_posix() for p in source_files(tmp_path)}
+
+    assert shipped == {"endpoint.toml"}, (
+        f"a credential file was about to be uploaded: {sorted(shipped)}"
+    )
+
+
+def test_a_local_runs_output_never_ships(tmp_path):
+    """# pgw#1529 / cl#88: cwd-relative defaults leave these in the tree.
+
+    Asserted as DIRECTORIES: the artifact store holds `<graph>.so.unpacked/`
+    trees whose bytes are mostly model.pt2 and metadata, so a `.so` suffix
+    filter would ship the bulk and look fixed.
+    """
+    _tree(tmp_path, {
+        "endpoint.toml": "main = 'x.main'",
+        ".compiled-graphs/env/g.so.unpacked/model.pt2": "aoti",
+        ".compiled-graphs/env/g.so.unpacked/metadata.json": "{}",
+        "outputs/run-0/image.webp": "image",
+    })
+    shipped = {p.relative_to(tmp_path).as_posix() for p in source_files(tmp_path)}
+
+    assert shipped == {"endpoint.toml"}, sorted(shipped)
+
+
+def test_tool_caches_never_ship(tmp_path):
+    _tree(tmp_path, {
+        "endpoint.toml": "main = 'x.main'",
+        ".tox/py312/x": "t",
+        ".ruff_cache/c": "r",
+        "node_modules/pkg/index.js": "js",
+        ".mypy_cache/3.12/x.json": "{}",
+    })
+    shipped = {p.relative_to(tmp_path).as_posix() for p in source_files(tmp_path)}
+
+    assert shipped == {"endpoint.toml"}, sorted(shipped)
+
+
+def test_the_endpoints_own_source_still_ships(tmp_path):
+    """The exclusions must not be so broad they eat the endpoint.
+
+    A guard that ships nothing is as broken as one that ships everything, and
+    the failure looks like success right up to the hub's build.
+    """
+    _tree(tmp_path, {
+        "endpoint.toml": "main = 'x.main'",
+        "pyproject.toml": "[project]",
+        "src/x/main.py": "print('ok')",
+        "README.md": "# x",
+    })
+    shipped = {p.relative_to(tmp_path).as_posix() for p in source_files(tmp_path)}
+
+    assert shipped == {
+        "endpoint.toml", "pyproject.toml", "src/x/main.py", "README.md",
+    }, sorted(shipped)


### PR DESCRIPTION
`gen-worker publish` packages the **whole tree** when the endpoint is not a git work tree — there is no commit to take a manifest from — so an `.ssh/id_ed25519` sitting beside an endpoint would go to the hub with it. This client excluded build detritus and a local run's output, and nothing else.

cozy-local's archiver has excluded `.aws` / `.azure` / `.gnupg` / `.kube` / `.secrets` / `.ssh` since it was written, and asserts it in a test. **The two clients publish the same trees**, so the weaker one set the real floor.

Found by diffing the two exclusion sets while closing cl#88. The divergence ran **both** ways — cozy-local was missing `.compiled-graphs`/`outputs` (fixed there, `4e7ec1f`), and this client was missing the credential directories. That direction is the one that mattered.

Also adds `.tox`, `.ruff_cache`, `node_modules` for parity. Those are bloat; the credential directories are not.

## Tests

Four, and the fourth keeps the other three honest:

- credential directories never ship;
- a local run's output never ships — asserted as **directories**, because the artifact store holds `<graph>.so.unpacked/` trees whose bytes are mostly `model.pt2` and metadata, so a `.so` suffix filter ships the bulk and *looks* fixed (measured on the cozy-local twin, cl#88: 172 MB, 75 KB → 59 MB);
- tool caches never ship;
- **the endpoint's own source still does.** A guard that ships nothing fails exactly like one that ships everything, and it looks like success right up to the hub's build.

## On parity

Achieved by bringing this set up to cozy-local's, not by inventing a shared list: the two live in different languages and repos, and a genuinely shared source would need a generated file neither repo owns.

The durable fix is **pgw#1526** — neither `.compiled-graphs` nor `outputs` should be written into a source tree at all; they are cwd-relative defaults. Both exclusion sets now say so in their comments, so whoever deletes those defaults can find both floors from either side.

Full `fast gates` sweep green with exit codes read (the one non-zero, `lint_skip_census.py` exit 2, is a usage error from omitting its required argument and is identical on master). `mypy` clean (353 files), `ruff` clean, 4 tests passing.