### PR TITLE
pgw#1521: every diff-local guard in `fast gates` says which side it failed on

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,7 +188,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # pgw#1477 — FIRST, ahead of uv itself, and stdlib-only so it can be.
+      # pgw#1521 — SECOND, before any guard, and stdlib-only so it can be.
+      # `fast gates` is this repo's only required context and it bundles ~25
+      # unrelated guards, so at the merge button "somebody else's master-red"
+      # and "a guard is refusing MY OWN new file" are indistinguishable — and
+      # an `--admin` granted for the first silently buys the second. Measured
+      # four times in one night (pgw#1521); pgw has no post-merge CI, so a
+      # guard can stop being enforced and nothing detects it.
+      #
+      # Nothing new is computed: every one of those guards already names the
+      # file it refuses. This step resolves the base ONCE — a PR checkout is
+      # shallow at the merge commit, so resolving it costs a fetch — and every
+      # guard below reads the answer through `scripts/_lint_side.py` and prints
+      # the side on the failing line itself.
+      #
+      # A base it cannot resolve prints as UNKNOWN, never as "not yours".
+      - name: pgw#1521 - name the files THIS diff touches
+        run: |
+          python3 scripts/_lint_side.py --selftest
+          python3 scripts/_lint_side.py --emit "$RUNNER_TEMP/pgw1521-diff-files.txt"
+          echo "PGW1521_DIFF_FILES=$RUNNER_TEMP/pgw1521-diff-files.txt" >> "$GITHUB_ENV"
+
+      # pgw#1477 — FIRST OF THE GUARDS, ahead of uv itself, and stdlib-only so
+      # it can be. (Only pgw#1521's attribution step precedes it, because every
+      # guard from here down — this one included — reads its answer.)
       # `uv sync --locked` (two steps down, and the first step of every other
       # job in every other workflow) dies on a stale lock with a message that
       # names neither file and no rev — so a torchcg re-vendor that moved

--- a/changelog.d/pgw1521.md
+++ b/changelog.d/pgw1521.md
@@ -1,0 +1,27 @@
+- **Every diff-local guard in `fast gates` now prints WHICH SIDE it failed on.** `fast gates` is
+  this repo's only required context and it bundles ~25 unrelated guards, so at the merge button
+  *"red because of somebody else's problem on master"* and *"red because a guard is refusing MY OWN
+  new file"* were indistinguishable — and an `--admin` granted for the first silently bought the
+  second. Four instances in one night (pgw#1521), and pgw has **no post-merge CI**, so a guard can
+  stop being enforced and nothing anywhere detects it.
+- Each finding is now prefixed `[YOUR DIFF]`, `[PRE-EXISTING]` or `[SIDE UNKNOWN]`, and each guard
+  closes with the one line the merge button needs — either *"AT LEAST ONE OF THESE IS YOURS"* or
+  *"None of this is in your diff: a TARGETED `--admin` is defensible, and it does not fix the
+  base"*. Nothing new is computed: every one of these guards already named the file it refuses.
+- `scripts/_lint_side.py` states the base ONCE (the `_lint_scope.py` shape). `fast gates` resolves
+  it in one step before any guard runs — a PR checkout is shallow at the merge commit, so resolving
+  it costs a fetch — and locally it falls back to `merge-base origin/master HEAD` plus uncommitted
+  and untracked files.
+- **UNKNOWN is printed as UNKNOWN and never as "not yours."** An unresolvable base and a resolved
+  base with an empty diff are different states and read differently. Ambiguity rounds toward YOURS:
+  a finding naming several files is yours if ANY of them is in the diff, because calling master's
+  red yours costs a minute of reading while calling your red master's buys a bypass of your own
+  violation.
+- 29 guards converted, plus the pgw#849 unreached-surface ratchet, whose hand-written *"IT MAY NOT
+  BE YOUR CHANGE"* paragraph is the prose this replaces with a computed answer.
+- **Red-verified by execution on both sides** — the same planted violation reads `[YOUR DIFF]` when
+  the file is in the diff and `[PRE-EXISTING]` when it is not, driven through the real guard
+  scripts as subprocesses (`tests/test_guard_attribution.py`), plus a 15-case `--selftest`.
+- Also, per the DESIGN-RULINGS 4.34b **fold-first** addendum: pgw#1362's refusal now lists FOLDING
+  into the existing domain module first and renaming as the fallback — renaming satisfies the
+  letter of 4.34b while still growing the corpus the rule exists to shrink.

--- a/scripts/_lint_side.py
+++ b/scripts/_lint_side.py
@@ -1,0 +1,355 @@
+"""pgw#1521: which SIDE a guard finding falls on — THIS DIFF, or the base.
+
+`fast gates` is this repo's only required context and it bundles ~25 unrelated
+guards, so at the merge button these two are indistinguishable:
+
+* *"`fast gates` is red because of somebody else's problem on master"* — the
+  legitimate reason to reach for `--admin`; and
+* *"`fast gates` is red because a guard is refusing MY OWN new file"* — which is
+  the guard doing the single job it exists for.
+
+A bypass granted for the first silently includes the second. **Nothing new needs
+computing to tell them apart**: every one of these guards already names the file
+it is refusing, and the set of files this diff touches is known to CI. This
+module joins the two and prints the answer on the failing line itself.
+
+ONE HOME for that fact, the `_lint_scope.py` shape: a guard that resolves its own
+base makes a change of CI trigger a hunt through every scanner.
+
+WHERE THE DIFF COMES FROM, in order:
+
+1. ``$PGW1521_DIFF_FILES`` — a file this module wrote earlier in the job
+   (``--emit``). CI resolves the base ONCE, before the guards run, because on a
+   shallow PR checkout resolving it costs a fetch.
+2. Otherwise, locally: ``git diff --name-only <merge-base origin/master HEAD>``
+   plus uncommitted and untracked files, because a guard refusing a file you have
+   not committed yet is very definitely refusing YOURS.
+3. Otherwise **UNKNOWN**, which is printed as UNKNOWN and never as "not yours".
+   An unattributed finding is the state this module exists to end, not a pass.
+
+WHICH WAY IT ROUNDS. A finding naming several files is attributed to the diff if
+ANY of them is in it. The two errors are not symmetric: calling master's red
+YOURS costs a minute of reading, calling YOUR red master's buys an `--admin` past
+your own violation. So ambiguity resolves toward YOURS, always.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Set, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+
+#: Set by the `fast gates` emit step to the file `--emit` wrote.
+DIFF_FILES_ENV = "PGW1521_DIFF_FILES"
+
+#: Written as the first line of that file. `UNKNOWN` means the base could not be
+#: resolved — distinct from a resolved base with an empty diff.
+_BASE_PREFIX = "# base "
+_UNKNOWN = "UNKNOWN"
+
+#: Repo-relative paths as the guards spell them in their findings. Anchored on a
+#: known top-level directory (or one of the two root files the guards name) so
+#: prose that mentions `config.py` is not mistaken for a path — an unanchored
+#: match would round toward PRE-EXISTING, which is the unsafe direction.
+_PATH_RE = re.compile(
+    r"\b((?:(?:src|tests|tests_v2|scripts|examples|docs|proto|benchmarks|\.github)"
+    r"/[A-Za-z0-9_./+-]*[A-Za-z0-9_]|uv\.lock|pyproject\.toml))"
+)
+
+YOURS = "YOUR DIFF"
+BASE = "PRE-EXISTING"
+UNKNOWN = "SIDE UNKNOWN"
+
+_cache: Optional[Tuple[Optional[Set[str]], str]] = None
+
+
+# ---------------------------------------------------------------------------
+# resolving the diff
+# ---------------------------------------------------------------------------
+
+def _git(*args: str, cwd: Path = REPO) -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ("git", *args), cwd=cwd, capture_output=True, text=True, timeout=120
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout if out.returncode == 0 else None
+
+
+def _event_base() -> Optional[str]:
+    """The base sha GitHub already put in the event payload, if any."""
+    event = os.environ.get("GITHUB_EVENT_NAME", "")
+    path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not path or not Path(path).is_file():
+        return None
+    try:
+        payload = json.loads(Path(path).read_text())
+    except (OSError, ValueError):
+        return None
+    if event == "pull_request":
+        return (payload.get("pull_request") or {}).get("base", {}).get("sha")
+    if event == "merge_group":
+        return (payload.get("merge_group") or {}).get("base_sha")
+    return None
+
+
+def _have(sha: str) -> bool:
+    return _git("cat-file", "-e", f"{sha}^{{commit}}") is not None
+
+
+def resolve_base() -> Optional[str]:
+    """The commit this diff is measured against, or None when unresolvable."""
+    sha = _event_base()
+    if sha:
+        if not _have(sha):
+            # A PR checkout is shallow at the merge commit; the base is one fetch
+            # away and the diff needs only its tree.
+            _git("fetch", "--no-tags", "--depth=1", "origin", sha)
+        return sha if _have(sha) else None
+    for ref in ("origin/master", "master"):
+        if _git("rev-parse", "--verify", "--quiet", ref):
+            merge_base = _git("merge-base", ref, "HEAD")
+            if merge_base and merge_base.strip():
+                return merge_base.strip()
+    return None
+
+
+def _diff_against(base: str) -> Set[str]:
+    """Every path this working tree changes relative to `base`."""
+    paths: Set[str] = set()
+    for out in (
+        _git("diff", "--name-only", base, "HEAD"),
+        _git("diff", "--name-only", "HEAD"),
+        _git("ls-files", "--others", "--exclude-standard"),
+    ):
+        for line in (out or "").splitlines():
+            if line.strip():
+                paths.add(line.strip())
+    return paths
+
+
+def _read_emitted(path: Path) -> Tuple[Optional[Set[str]], str]:
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as exc:
+        return None, f"cannot read {DIFF_FILES_ENV}={path} ({exc})"
+    base = _UNKNOWN
+    paths: Set[str] = set()
+    for line in lines:
+        if line.startswith(_BASE_PREFIX):
+            base = line[len(_BASE_PREFIX):].strip() or _UNKNOWN
+        elif line.strip() and not line.startswith("#"):
+            paths.add(line.strip())
+    if base == _UNKNOWN:
+        return None, "CI could not resolve this run's base commit"
+    return paths, base
+
+
+def diff_files() -> Tuple[Optional[Set[str]], str]:
+    """``(paths, base)``; `paths` is None when the side cannot be known.
+
+    `base` is a short description for the rollup line — a sha, or why not.
+    """
+    global _cache
+    if _cache is None:
+        emitted = os.environ.get(DIFF_FILES_ENV)
+        if emitted:
+            _cache = _read_emitted(Path(emitted))
+        else:
+            base = resolve_base()
+            if base is None:
+                _cache = (None, "no base commit resolvable from here")
+            else:
+                _cache = (_diff_against(base), base[:12])
+    return _cache
+
+
+def reset_cache() -> None:
+    """For the selftest; the diff does not move inside one guard run."""
+    global _cache
+    _cache = None
+
+
+# ---------------------------------------------------------------------------
+# attributing findings
+# ---------------------------------------------------------------------------
+
+def paths_in(text: str) -> List[str]:
+    """The repo-relative paths a finding names."""
+    return [m.rstrip(".,:;") for m in _PATH_RE.findall(text)]
+
+
+def side_of(text: str) -> str:
+    """`YOURS` / `BASE` / `UNKNOWN` for one finding."""
+    paths, _ = diff_files()
+    if paths is None:
+        return UNKNOWN
+    named = paths_in(text)
+    if not named:
+        return UNKNOWN
+    return YOURS if any(p in paths for p in named) else BASE
+
+
+def annotate(problems: Iterable[str]) -> List[str]:
+    """Each finding prefixed with the side it falls on."""
+    return [f"[{side_of(p)}] {p}" for p in problems]
+
+
+def verdict(problems: Sequence[str], guard: str) -> str:
+    """The one line the merge button needs."""
+    sides = [side_of(p) for p in problems]
+    _, base = diff_files()
+    yours = sides.count(YOURS)
+    theirs = sides.count(BASE)
+    unknown = sides.count(UNKNOWN)
+    head = (
+        f"pgw#1521 attribution — {guard}: {len(problems)} finding(s), "
+        f"{yours} in files THIS DIFF touches, {theirs} pre-existing on the base"
+    )
+    if unknown:
+        head += f", {unknown} unattributed"
+    if yours:
+        return (
+            f"{head} (base {base}). "
+            f"AT LEAST ONE OF THESE IS YOURS — an `--admin` here bypasses your "
+            f"own violation, not somebody else's master-red."
+        )
+    if unknown or theirs == 0:
+        return (
+            f"{head} (base {base}). "
+            f"UNKNOWN is not 'not yours' — attribute before bypassing."
+        )
+    return (
+        f"{head} (base {base}). "
+        f"None of this is in your diff: a TARGETED `--admin` is defensible, "
+        f"and it does not fix the base — say both on the PR."
+    )
+
+
+def report(problems: Sequence[str], guard: str, stream=sys.stderr) -> None:
+    """Print findings with their side, then the verdict. Callers exit 1."""
+    for line in annotate(problems):
+        print(line, file=stream)
+    print(verdict(problems, guard), file=stream)
+
+
+# ---------------------------------------------------------------------------
+# emit — CI resolves the base once, ahead of the guards
+# ---------------------------------------------------------------------------
+
+def emit(target: Path) -> int:
+    base = resolve_base()
+    if base is None:
+        target.write_text(f"{_BASE_PREFIX}{_UNKNOWN}\n")
+        print(
+            "pgw#1521: no base commit resolvable — guard findings will print "
+            "as unattributed rather than as somebody else's problem",
+            file=sys.stderr,
+        )
+        return 0
+    paths = sorted(_diff_against(base))
+    target.write_text(f"{_BASE_PREFIX}{base}\n" + "".join(f"{p}\n" for p in paths))
+    print(f"pgw#1521: {len(paths)} file(s) in this diff against {base[:12]}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# selftest — a mechanism that has never been seen work is not known to work
+# ---------------------------------------------------------------------------
+
+def _selftest() -> int:
+    import tempfile
+
+    failures = 0
+
+    def expect(label: str, got: object, want: object) -> None:
+        nonlocal failures
+        if got != want:
+            failures += 1
+            print(f"SELFTEST FAIL — {label}: got {got!r}, want {want!r}",
+                  file=sys.stderr)
+
+    expect("a path is found in a finding",
+           paths_in("tests/test_a_pgw1.py: a NEW test module"),
+           ["tests/test_a_pgw1.py"])
+    expect("a line:col suffix does not swallow the path",
+           paths_in("src/gen_worker/cli/compile.py:294: reads config"),
+           ["src/gen_worker/cli/compile.py"])
+    expect("several paths in one finding are all found",
+           paths_in("src/gen_worker/a.py and tests/b.py disagree"),
+           ["src/gen_worker/a.py", "tests/b.py"])
+    expect("prose that names no file yields nothing",
+           paths_in("the baseline lists 124 modules; the mark is 120"), [])
+
+    with tempfile.TemporaryDirectory() as raw:
+        emitted = Path(raw) / "diff.txt"
+
+        # a resolved base with the file in it -> YOURS
+        emitted.write_text("# base deadbeef\ntests/test_a_pgw1.py\n")
+        os.environ[DIFF_FILES_ENV] = str(emitted)
+        reset_cache()
+        expect("a file in the diff is YOURS",
+               side_of("tests/test_a_pgw1.py: refused"), YOURS)
+        expect("a file NOT in the diff is the base's",
+               side_of("tests/test_b_pgw2.py: refused"), BASE)
+        expect("ANY named path in the diff makes the finding yours",
+               side_of("tests/test_b_pgw2.py mismatches tests/test_a_pgw1.py"),
+               YOURS)
+        expect("a finding naming no file is unattributed",
+               side_of("the high-water mark is wrong"), UNKNOWN)
+        v = verdict(["tests/test_a_pgw1.py: refused"], "g")
+        expect("a finding in the diff says so in the verdict",
+               "AT LEAST ONE OF THESE IS YOURS" in v, True)
+        v = verdict(["tests/test_b_pgw2.py: refused"], "g")
+        expect("a base-only red offers the targeted bypass",
+               "TARGETED" in v, True)
+
+        # a resolved base with an EMPTY diff is not the same as UNKNOWN
+        emitted.write_text("# base deadbeef\n")
+        reset_cache()
+        expect("an empty diff still attributes to the base",
+               side_of("tests/test_a_pgw1.py: refused"), BASE)
+
+        # an unresolvable base is UNKNOWN, and never reads as 'not yours'
+        emitted.write_text(f"{_BASE_PREFIX}{_UNKNOWN}\n")
+        reset_cache()
+        expect("an unresolved base is UNKNOWN, not BASE",
+               side_of("tests/test_a_pgw1.py: refused"), UNKNOWN)
+        expect("and the verdict refuses to call it somebody else's",
+               "UNKNOWN is not 'not yours'" in
+               verdict(["tests/test_a_pgw1.py: refused"], "g"), True)
+
+        del os.environ[DIFF_FILES_ENV]
+        reset_cache()
+
+    if failures:
+        print(f"{failures} selftest case(s) failed", file=sys.stderr)
+        return 1
+    print("_lint_side selftest OK")
+    return 0
+
+
+def main(argv: List[str]) -> int:
+    if "--selftest" in argv:
+        return _selftest()
+    if "--emit" in argv:
+        return emit(Path(argv[argv.index("--emit") + 1]))
+    paths, base = diff_files()
+    if paths is None:
+        print(f"pgw#1521: side UNKNOWN — {base}", file=sys.stderr)
+        return 0
+    print(f"pgw#1521: {len(paths)} file(s) in this diff against {base}")
+    for path in sorted(paths):
+        print(f"  {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/lint_ambient_census.py
+++ b/scripts/lint_ambient_census.py
@@ -30,6 +30,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC_ROOT = REPO / "src" / "gen_worker"
 CENSUS = REPO / "scripts" / "ambient_inputs_census.txt"
 
@@ -220,7 +222,7 @@ def check(census_path: Path = CENSUS) -> List[str]:
 def main() -> int:
     problems = check()
     if problems:
-        print("\n".join(problems), file=sys.stderr)
+        _lint_side.report(problems, "pgw#1049 ambient-input census")
         return 1
     rows, _ = load_census()
     print(f"ambient-input census: {len(rows)} row(s), structural claims hold")

--- a/scripts/lint_arm_state_feeders.py
+++ b/scripts/lint_arm_state_feeders.py
@@ -37,6 +37,8 @@ from pathlib import Path
 from typing import Mapping, Optional, Sequence
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 
 ARM_MODULE = "aot_serve.py"
 ARM_SEAM = "arm_compiled_graph"
@@ -586,7 +588,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         + check_allowlist(sites, allowed)
     )
     if problems:
-        print("\n".join(problems), file=sys.stderr)
+        _lint_side.report(problems, "pgw#1152 arm-state feeders")
         return 1
     print(
         f"arm-state fence: {red_proofs} red proofs passed; "

--- a/scripts/lint_compiled_graph_key_layout_fence.py
+++ b/scripts/lint_compiled_graph_key_layout_fence.py
@@ -53,6 +53,7 @@ from typing import Dict, List, Optional, Sequence, Set, Tuple
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
 
 REPO = Path(__file__).resolve().parents[1]
 SRC = REPO / "src" / "gen_worker"
@@ -303,8 +304,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if failures:
         print(f"\n§1.33 point 5 fence BROKEN ({len(failures)} violation(s)):")
-        for line in failures:
-            print(f"  - {line}")
+        _lint_side.report(failures, "pgw#1143 compiled graph-key layout fence",
+                          stream=sys.stdout)
         print(
             "\nConversion is UPSTREAM of compute. If a compiled graph-key axis needs to "
             "know the layout, the conversion is happening too late — move it "

--- a/scripts/lint_config_reads.py
+++ b/scripts/lint_config_reads.py
@@ -44,6 +44,8 @@ from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC_ROOT = REPO / "src" / "gen_worker"
 CONFIG_PKG = SRC_ROOT / "config"
 ALLOWLIST = REPO / "scripts" / "config_reads_allowlist.txt"
@@ -599,8 +601,7 @@ def main() -> int:
 
     if errors:
         print("config-read guard (§1.18) failed:\n", file=sys.stderr)
-        for err in errors:
-            print(f"  {err}", file=sys.stderr)
+        _lint_side.report(errors, "pgw#931 config reads")
         print(
             f"\n{len(errors)} problem(s). See scripts/lint_config_reads.py.",
             file=sys.stderr)

--- a/scripts/lint_credential_identity.py
+++ b/scripts/lint_credential_identity.py
@@ -48,6 +48,8 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC_ROOT = REPO / "src" / "gen_worker"
 ALLOWLIST = REPO / "scripts" / "credential_identity_allowlist.txt"
 
@@ -225,7 +227,7 @@ def main() -> int:
     allowed, errors = load_allowlist()
     problems = errors + check(sites, allowed)
     if problems:
-        print("\n".join(problems), file=sys.stderr)
+        _lint_side.report(problems, "pgw#1122 worker-credential reads")
         return 1
     print(f"credential-identity fence: {len(sites)} classified read(s); "
           f"the resolver is {sorted(RESOLVER_FILES)}")

--- a/scripts/lint_fence_symbols.py
+++ b/scripts/lint_fence_symbols.py
@@ -41,6 +41,9 @@ from typing import Dict, Set, Tuple
 
 HERE = pathlib.Path(__file__).resolve().parent
 ROOT = HERE.parent
+
+sys.path.insert(0, str(HERE))
+import _lint_side  # noqa: E402
 SRC = ROOT / "src" / "gen_worker"
 
 #: The guards. This script is IN this list on purpose — see the module
@@ -141,9 +144,10 @@ def main() -> int:
     if dead:
         print("lint_fence_symbols: A FENCE NAMES A SYMBOL THAT NO LONGER "
               "EXISTS.\n", file=sys.stderr)
-        for rel in sorted(dead):
-            for name in sorted(dead[rel]):
-                print(f"  {rel}: {name!r}", file=sys.stderr)
+        _lint_side.report(
+            [f"{rel}: {name!r} is named by this fence and no longer exists"
+             for rel in sorted(dead) for name in sorted(dead[rel])],
+            "pgw#1176 fence symbols")
         print(
             "\nThat fence still runs and still exits 0 — and guards NOTHING "
             "for this symbol.\nA green fence is not evidence after a rename. "

--- a/scripts/lint_flavor_deletion.py
+++ b/scripts/lint_flavor_deletion.py
@@ -40,6 +40,8 @@ from pathlib import Path
 from typing import Iterator, List, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 DEFAULT_ROOTS = (REPO / "src" / "gen_worker",)
 
 #: Names §1.32(d) / pgw#1148 / th#1803 deleted. Binding or reading one in `src/`
@@ -230,8 +232,7 @@ def main(argv: List[str]) -> int:
               "precision class is DECLARED by the producer (`precision_class`, "
               "checked against models.ladder.PRECISION_CLASSES); it is never "
               "inferred from a label.\n", file=sys.stderr)
-        for f in findings:
-            print(f, file=sys.stderr)
+        _lint_side.report(findings, "A18 flavor-token residue")
         print(f"\n{len(findings)} finding(s)", file=sys.stderr)
         return 1
     print("lint_flavor_deletion: the flavor axis is deleted; the A18 residue is "

--- a/scripts/lint_http_timeouts.py
+++ b/scripts/lint_http_timeouts.py
@@ -25,6 +25,9 @@ import sys
 from pathlib import Path
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SANCTIONED = SRC_ROOT / "net.py"
 
 # huggingface_hub submodules with no network entry points.
@@ -81,16 +84,18 @@ def check_file(path: Path) -> list[tuple[int, str]]:
 
 
 def main() -> int:
-    bad = 0
+    problems: list[str] = []
     for path in sorted(SRC_ROOT.rglob("*.py")):
         if path == SANCTIONED:
             continue
         for lineno, msg in check_file(path):
-            print(f"{path.relative_to(SRC_ROOT.parents[1])}:{lineno}: {msg}")
-            bad += 1
-    if bad:
-        print(f"\nlint_http_timeouts: {bad} violation(s). Every HTTP call needs an explicit "
-              "timeout; huggingface_hub goes through gen_worker.net.hf().", file=sys.stderr)
+            problems.append(
+                f"{path.relative_to(SRC_ROOT.parents[1])}:{lineno}: {msg}")
+    if problems:
+        _lint_side.report(problems, "gw#467 HTTP timeouts")
+        print(f"\nlint_http_timeouts: {len(problems)} violation(s). Every HTTP call "
+              "needs an explicit timeout; huggingface_hub goes through "
+              "gen_worker.net.hf().", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/lint_incident_test_names.py
+++ b/scripts/lint_incident_test_names.py
@@ -61,6 +61,10 @@ from pathlib import Path
 from typing import List, Sequence, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
+
 BASELINE_PATH = REPO / "scripts" / "incident_named_tests.txt"
 ROOTS: Tuple[str, ...] = ("tests", "tests_v2")
 
@@ -131,11 +135,13 @@ def check(repo: Path = REPO, baseline_path: Path = BASELINE_PATH,
         problems.append(
             f"{rel}: a NEW test module named for an ISSUE. The file name says "
             f"WHEN this was written, not WHAT it exercises (DESIGN-RULINGS "
-            f"4.34b). Put these tests in the domain module for their subject "
-            f"— e.g. {_EXAMPLES} — or add a new domain module named for its "
-            f"subject, and keep the lineage as a one-line comment on the test: "
-            f"`# pgw#1234: <one clause>`. The full story belongs in the tracker "
-            f"issue, which is where anyone looking for it will actually go."
+            f"4.34b). FOLD the cases into the existing domain module that owns "
+            f"their subject — e.g. {_EXAMPLES} — and keep the lineage as a "
+            f"one-line comment on the test: `# pgw#1234: <one clause>`. Only if "
+            f"the subject is genuinely new, add a domain module named for it: "
+            f"renaming satisfies the letter of 4.34b while still growing the "
+            f"corpus the rule exists to shrink. The full story belongs in the "
+            f"tracker issue, which is where anyone looking for it will go."
         )
 
     for rel in stale:
@@ -233,8 +239,7 @@ def main(argv: List[str]) -> int:
             f"({len(load_baseline())} grandfathered, and that list only shrinks)"
         )
         return 0
-    for problem in problems:
-        print(problem, file=sys.stderr)
+    _lint_side.report(problems, "pgw#1362 incident-named tests")
     print(f"{len(problems)} incident-naming problem(s)", file=sys.stderr)
     return 1
 

--- a/scripts/lint_layout_declarations.py
+++ b/scripts/lint_layout_declarations.py
@@ -39,6 +39,8 @@ from pathlib import Path
 from typing import Iterator, List, Set, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 
 #: `src/` only, deliberately. The subject is a declaration that gets
 #: PUBLISHED — an endpoint's `Slot(layouts=...)` reaching a release manifest.
@@ -260,8 +262,7 @@ def main(argv: List[str]) -> int:
     if problems:
         print("pgw#1143 / A19: Slot layout declarations that are missing or "
               "that the AST sweep cannot read:\n", file=sys.stderr)
-        for problem in problems:
-            print(f"  {problem}", file=sys.stderr)
+        _lint_side.report(problems, "pgw#1143 Slot layout declarations")
         print(
             "\nWrite the declaration literally — a dict literal of string "
             "literals mapping to tuple literals of handles. The demand is "

--- a/scripts/lint_lock_pin_agreement.py
+++ b/scripts/lint_lock_pin_agreement.py
@@ -33,6 +33,9 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
+
 #: uv writes a git source as `<repo>?rev=<rev>#<resolved>` (lock `source.git`),
 #: and as `<repo>?rev=<rev>` in the `[package.metadata]` tables. One pattern
 #: reads both.
@@ -206,8 +209,7 @@ def main(argv: list[str]) -> int:
         "  BEFORE any gate runs — three red checks, none of them the cause.\n",
         file=sys.stderr,
     )
-    for failure in failures:
-        print(f"  - {failure}", file=sys.stderr)
+    _lint_side.report(failures, "pgw#1477 uv.lock/pyproject pin agreement")
     print("", file=sys.stderr)
     return 1
 

--- a/scripts/lint_materialization_hatch.py
+++ b/scripts/lint_materialization_hatch.py
@@ -71,6 +71,7 @@ SELF = Path(__file__).resolve()
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
 
 DEFAULT_ROOTS = (
     REPO / "src", REPO / "tests", REPO / "tests_v2", REPO / "scripts",
@@ -394,8 +395,7 @@ def main(argv: List[str]) -> int:
             "is the retired name (tensorfs#107).\n",
             file=sys.stderr,
         )
-        for f in findings:
-            print(f, file=sys.stderr)
+        _lint_side.report(findings, "pgw#1308 materialization hatch")
         print(f"\n{len(findings)} undeclared materialization(s)", file=sys.stderr)
         return 1
     print(

--- a/scripts/lint_mypy_ratchet.py
+++ b/scripts/lint_mypy_ratchet.py
@@ -33,6 +33,8 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 
 #: flag name -> (high-water EXACT-module count, errors it was hiding at adoption).
 #: Measured 2026-08-12 on 28018a0a: 413 --strict errors in 101 of 266 src modules,
@@ -245,8 +247,7 @@ def main(argv: List[str]) -> int:
     if problems:
         print("pgw#1202: the mypy strictness ratchet turned the wrong way:\n",
               file=sys.stderr)
-        for problem in problems:
-            print(f"  - {problem}\n", file=sys.stderr)
+        _lint_side.report(problems, "pgw#1202 mypy strictness ratchet")
         return 1
     total = sum(limit for limit, _ in HIGH_WATER.values())
     print(f"pgw#1202: strict = true; {total} module-exemptions remaining "

--- a/scripts/lint_no_installed_set_keying.py
+++ b/scripts/lint_no_installed_set_keying.py
@@ -35,6 +35,8 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC = REPO / "src" / "gen_worker"
 VENDOR = SRC / "_vendor"
 
@@ -137,8 +139,7 @@ def main() -> int:
     if violations:
         print(f"lint_no_installed_set_keying: {len(violations)} violation(s)",
               file=sys.stderr)
-        for row in violations:
-            print(f"  - {row}", file=sys.stderr)
+        _lint_side.report(violations, "pgw#1489 installed-set keying")
         return 1
     print(f"lint_no_installed_set_keying: clean ({scanned} files)")
     return 0

--- a/scripts/lint_phase_enum_emitters.py
+++ b/scripts/lint_phase_enum_emitters.py
@@ -51,6 +51,8 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC = REPO / "src" / "gen_worker"
 VENDOR = SRC / "_vendor"
 CENSUS = REPO / "scripts" / "phase_enum_census.txt"
@@ -187,8 +189,8 @@ def main(argv: list[str]) -> int:
         violations.append(
             f"{key} is in {CENSUS.name} but no longer exists. Remove the line.")
 
-    for line in violations:
-        print(line, file=sys.stderr)
+    if violations:
+        _lint_side.report(violations, "pgw#1480 phase vocabulary")
     if violations:
         print(f"\n{len(violations)} phase-vocabulary violation(s).", file=sys.stderr)
         return 1

--- a/scripts/lint_pickle_readers.py
+++ b/scripts/lint_pickle_readers.py
@@ -40,6 +40,8 @@ from pathlib import Path
 from typing import Iterator, List, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 
 DEFAULT_ROOTS = (
     REPO / "src", REPO / "tests", REPO / "tests_v2", REPO / "scripts",
@@ -162,8 +164,7 @@ def main(argv: List[str]) -> int:
               "as msgspec (`gen_worker/parallel/wire.py`) or mirror the source "
               "without the pickle. `weights_only=True` is not an exemption.\n",
               file=sys.stderr)
-        for f in findings:
-            print(f, file=sys.stderr)
+        _lint_side.report(findings, "HARDCUT E5 pickle deserializers")
         print(f"\n{len(findings)} pickle deserializer(s)", file=sys.stderr)
         return 1
     print("lint_pickle_readers: no pickle deserializer in the tree")

--- a/scripts/lint_post_connect_resolution.py
+++ b/scripts/lint_post_connect_resolution.py
@@ -53,6 +53,8 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC_ROOT = REPO / "src" / "gen_worker"
 ALLOWLIST = REPO / "scripts" / "post_connect_resolution_allowlist.txt"
 
@@ -152,8 +154,8 @@ def main() -> int:
             "second resolver and needs a ruling, not an allowlist line.\n",
             file=sys.stderr,
         )
-        for key in new:
-            print(f"  + {key}", file=sys.stderr)
+        _lint_side.report([f"+ {key}" for key in new],
+                          "pgw#891 post-connect resolution surface")
         return 1
 
     if stale:
@@ -162,8 +164,8 @@ def main() -> int:
         # ever comes back. Same defect class the gate exists to police.
         print("allowlist has entries with no matching call site — delete them:",
               file=sys.stderr)
-        for key in stale:
-            print(f"  - {key}", file=sys.stderr)
+        _lint_side.report([f"- {key}" for key in stale],
+                          "pgw#891 post-connect resolution surface")
         return 1
 
     connected = sum(1 for c in accepted.values() if c == "CONNECTED")

--- a/scripts/lint_raw_aoti_load.py
+++ b/scripts/lint_raw_aoti_load.py
@@ -52,6 +52,8 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC = REPO / "src" / "gen_worker"
 VENDOR = SRC / "_vendor"
 
@@ -113,8 +115,8 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    for line in violations:
-        print(line, file=sys.stderr)
+    if violations:
+        _lint_side.report(violations, "pgw#1460 raw AOTI package loads")
     if violations:
         print(
             f"\n{len(violations)} raw AOTI package load(s).", file=sys.stderr

--- a/scripts/lint_repo_ref_pins.py
+++ b/scripts/lint_repo_ref_pins.py
@@ -52,6 +52,8 @@ from pathlib import Path
 from typing import Iterator, List, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 
 DEFAULT_ROOTS = (
     REPO / "src", REPO / "tests", REPO / "tests_v2", REPO / "examples",
@@ -173,8 +175,7 @@ def main(argv: List[str]) -> int:
               "attach artifacts to it); a `:tag` ref is refused by "
               "gen_worker.models.refs.parse_model_ref on the pod, not here.\n",
               file=sys.stderr)
-        for f in findings:
-            print(f, file=sys.stderr)
+        _lint_side.report(findings, "th#1987 retired `:tag` pins")
         print(f"\n{len(findings)} retired tag pin(s)", file=sys.stderr)
         return 1
     print("lint_repo_ref_pins: no retired `:tag` repo-ref literal survives")

--- a/scripts/lint_retired_graph_class_spellings.py
+++ b/scripts/lint_retired_graph_class_spellings.py
@@ -71,6 +71,8 @@ from pathlib import Path
 from typing import Iterator
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 
 #: spelling -> what replaced it. The message names the successor, because a
 #: refusal that does not say what to write instead just costs a grep.
@@ -215,6 +217,7 @@ def main(argv: list[str]) -> int:
         REPO / "scripts",
         REPO / "docs",
     ]
+    problems: list[str] = []
     findings = 0
     for path in _walk(roots):
         try:
@@ -227,9 +230,12 @@ def main(argv: list[str]) -> int:
                 rel = rel.relative_to(REPO)
             except ValueError:
                 pass
-            print(f"{rel}:{lineno}: retired spelling {spelling!r} -> write {successor}")
+            problems.append(
+                f"{rel}:{lineno}: retired spelling {spelling!r} -> write {successor}")
             findings += 1
     if findings:
+        _lint_side.report(problems, "tcg#56 retired graph-class spellings",
+                          stream=sys.stdout)
         print(
             f"\nlint_retired_graph_class_spellings: {findings} finding(s). tcg#56 renamed the "
             "compiled-graph vocabulary: a target has ONE graph and MANY graph SPECIALIZATIONS.\n"

--- a/scripts/lint_retired_package_names.py
+++ b/scripts/lint_retired_package_names.py
@@ -58,6 +58,7 @@ from typing import Iterator, List, Tuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
 
 REPO = Path(__file__).resolve().parents[1]
 SELF = Path(__file__).resolve()
@@ -203,15 +204,16 @@ def main(argv: List[str]) -> int:
     if not findings:
         print(f"no retired package name survives ({len(RETIRED)} spellings swept)")
         return 0
+    problems = []
     for path, lineno, retired, replacement in findings:
         rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
-        print(
+        problems.append(
             f"{rel}:{lineno}: `{retired}` is retired — it is `{replacement}` now, "
             f"and the old PyPI project is permanently deleted. Respell it, or "
             f"classify the line with `{MARKER} <reason>` if it must name the "
-            f"dead project (a fence's own denylist, a historical rationale).",
-            file=sys.stderr,
+            f"dead project (a fence's own denylist, a historical rationale)."
         )
+    _lint_side.report(problems, "pgw#1297 retired package names")
     print(f"{len(findings)} retired package name(s) survive", file=sys.stderr)
     return 1
 

--- a/scripts/lint_retired_sdk_spellings.py
+++ b/scripts/lint_retired_sdk_spellings.py
@@ -53,6 +53,7 @@ from typing import Iterator, List, Tuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
 
 REPO = Path(__file__).resolve().parents[1]
 SELF = Path(__file__).resolve()
@@ -221,15 +222,16 @@ def main(argv: List[str]) -> int:
     if not findings:
         print(f"no retired SDK spelling survives ({len(RETIRED)} spellings swept)")
         return 0
+    problems = []
     for path, lineno, spelling, replacement in findings:
         rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
-        print(
+        problems.append(
             f"{rel}:{lineno}: `{spelling}` is retired (pgw#1346) — it is "
             f"`{replacement}` now, and there is no alias. Respell it, or "
             f"classify the line with `{MARKER} <reason>` if it must name the "
-            f"dead spelling (a fence's own denylist, a historical rationale).",
-            file=sys.stderr,
+            f"dead spelling (a fence's own denylist, a historical rationale)."
         )
+    _lint_side.report(problems, "pgw#1346 retired SDK spellings")
     print(f"{len(findings)} retired SDK spelling(s) survive", file=sys.stderr)
     return 1
 

--- a/scripts/lint_serve_role_closure.py
+++ b/scripts/lint_serve_role_closure.py
@@ -54,6 +54,8 @@ from pathlib import Path
 from typing import Dict, List, Sequence, Set, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC = REPO / "src" / "gen_worker"
 ROLE_FILE = SRC / "serve" / "role.py"
 
@@ -568,9 +570,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     problems = check(roots, banned)
     problems.extend(check_model_free(model_free, libraries, optional, within=roots))
     problems.extend(check_bearing_ledger(bearing, model_free, libraries))
-    for line in problems:
-        print(line, file=sys.stderr)
     if problems:
+        _lint_side.report(problems, "pgw#1328 adopt-only serve role")
         print(
             f"\n{len(problems)} adopt-only serve-role violation(s).",
             file=sys.stderr)

--- a/scripts/lint_serving_process_compiles.py
+++ b/scripts/lint_serving_process_compiles.py
@@ -56,6 +56,8 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 SRC = REPO / "src" / "gen_worker"
 
 #: Dotted attribute paths whose CALL is a graph export or an AOTI compile.
@@ -264,8 +266,8 @@ def main() -> int:
             f"exempt from the serving-process rule and asserted to obey it. "
             f"Decide which the module is.")
 
-    for line in violations:
-        print(line, file=sys.stderr)
+    if violations:
+        _lint_side.report(violations, "pgw#1215 serving-process compiles")
     if violations:
         print(
             f"\n{len(violations)} serving-process compile fence violation(s).",

--- a/scripts/lint_settings_writers.py
+++ b/scripts/lint_settings_writers.py
@@ -53,6 +53,7 @@ SRC_ROOT = REPO / "src" / "gen_worker"
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
 ALLOWLIST = REPO / "scripts" / "settings_writers_allowlist.txt"
 
 CLASSIFICATIONS = {"SCOPED", "PLUMBING", "SCRUB"}
@@ -282,7 +283,7 @@ def main() -> int:
     allowed, errors = load_allowlist()
     problems = errors + check(sites, allowed)
     if problems:
-        print("\n".join(problems), file=sys.stderr)
+        _lint_side.report(problems, "pgw#1049 torch-settings writers")
         return 1
     print(f"settings-writer fence: {len(sites)} classified site(s), "
           f"authority = {sorted(AUTHORITY_FILES)}")

--- a/scripts/lint_tcg_vocabulary.py
+++ b/scripts/lint_tcg_vocabulary.py
@@ -65,6 +65,7 @@ from typing import Iterator, List, Tuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
 
 REPO = Path(__file__).resolve().parents[1]
 DEFAULT_ROOT = REPO / "src" / "gen_worker"
@@ -182,8 +183,8 @@ def main(argv: List[str]) -> int:
             )
     if findings:
         print("pgw#1299: compiled-graph vocabulary respelled as a literal\n")
-        for row in findings:
-            print(f"  {row}")
+        _lint_side.report(findings, "pgw#1299 TCG metadata vocabulary",
+                          stream=sys.stdout)
         print(
             f"\n{len(findings)} finding(s). A TCG rename does not raise on these — "
             "it returns None and the arm reads as a cache miss.\n"

--- a/scripts/lint_test_fork_start_method.py
+++ b/scripts/lint_test_fork_start_method.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import List, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _lint_side  # noqa: E402
 DEFAULT_ROOTS = (REPO / "tests", REPO / "tests_v2")
 
 #: Attributes of `multiprocessing` (or a context) that start a process.
@@ -127,8 +129,7 @@ def main(argv: List[str]) -> int:
             "everything crossing the boundary picklable.\n",
             file=sys.stderr,
         )
-        for finding in findings:
-            print(finding, file=sys.stderr)
+        _lint_side.report(findings, "pgw#1316 test forks")
         return 1
     print("lint_test_fork_start_method: no test forks this interpreter")
     return 0

--- a/scripts/lint_unbounded_reads.py
+++ b/scripts/lint_unbounded_reads.py
@@ -61,6 +61,7 @@ SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
 
 # Calls whose result is a length taken from bytes the process did not compute.
 LENGTH_SOURCES = {"unpack", "unpack_from", "from_bytes"}
@@ -453,8 +454,8 @@ def main() -> int:
 
     if findings:
         print("unbounded-read guard: an external length sizes a read with no bound\n")
-        for f in findings:
-            print(f)
+        _lint_side.report(findings, "pgw#1013 unbounded reads",
+                          stream=sys.stdout)
         print(
             "\npgw#1013 / th#1662: the bounds census could not see these — it enumerated "
             "bounds that exist, not sites that need one."

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -70,6 +70,7 @@ SELF = Path(__file__).resolve()
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
 
 # The RATCHET. Every entry is a live hit, recorded rather than silently
 # tolerated: the guard fails on anything NEW, and equally on an entry that has
@@ -1383,8 +1384,16 @@ def main() -> int:
         rewrite_baseline(current)
         return 0
 
+    # pgw#1521: one headline per finding, each naming the file it is about, so
+    # the verdict at the bottom can say whether this red is THIS DIFF's or the
+    # base's. The prose below is unchanged — it is the reading, this is the
+    # attribution, and the merge button needs the second one first.
+    attributable: List[str] = []
+
     writerless = writerless_private_setters()
     for name, path, line in writerless:
+        attributable.append(
+            f"{path.relative_to(REPO)}:{line}: writer-less private setter {name}")
         print(f"WRITER-LESS SETTER: {path.relative_to(REPO)}:{line}: {name}\n"
               f"  Nothing in src/ calls it, so the PUBLIC reader it fills "
               f"answers `None` forever — a contract that fails as ABSENCE, "
@@ -1403,6 +1412,8 @@ def main() -> int:
     known, notes, reasons = baseline_rows()
     unexplained = gate_rows_without_reasons(known, reasons)
     for label in unexplained:
+        attributable.append(
+            f"{BASELINE.relative_to(REPO)}: gate row with no reason: {label}")
         print(f"GATE ROW WITH NO REASON: {label}\n"
               f"  This is a GATE — its leaf name is one of "
               f"{'/'.join(GATE_PREFIXES)}* — and it is on the ratchet, which "
@@ -1421,7 +1432,10 @@ def main() -> int:
               file=sys.stderr)
     new = sorted(current - known)
     stale = sorted(known - current)
+    homes = {f.label: f"{f.path.relative_to(REPO)}:{f.line}" for f in findings}
     for label in new:
+        attributable.append(
+            f"{homes.get(label, '')}: NEW unreached public surface: {label}")
         print(f"NEW unreached public surface: {label}\n"
               f"  Nothing in src/ reaches this. That is the program's dominant "
               f"defect class (pgw#849) and one of three things:\n"
@@ -1455,6 +1469,9 @@ def main() -> int:
                   f"your branch predates it. Rebase and the red goes with it. "
                   f"Nothing here needs investigating.", file=sys.stderr)
             continue
+        # No path to attribute a stale row to — the symbol is gone or newly
+        # wired — so it prints unattributed rather than as somebody else's.
+        attributable.append(f"stale ratchet row: {label}")
         note = notes.get(label, "")
         owed = f"\n  THE ROW SAID: {note}" if note else ""
         if label in DEFINED_LABELS:
@@ -1470,7 +1487,11 @@ def main() -> int:
                   f"nothing can. Delete its line from {BASELINE.name} in the "
                   f"same commit as the deletion. (Do not go looking for its new "
                   f"caller — there isn't one.)", file=sys.stderr)
-    return 1 if (new or stale or unexplained or writerless) else 0
+    if new or stale or unexplained or writerless:
+        print(_lint_side.verdict(attributable, "pgw#849 unreached surface"),
+              file=sys.stderr)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_guard_attribution.py
+++ b/tests/test_guard_attribution.py
@@ -51,7 +51,8 @@ def _emit(path: Path, base: str, files: tuple[str, ...]) -> Path:
     return path
 
 
-def _run(script: str, target: Path, diff_file: Path | None):
+def _run(script: str, target: Path,
+         diff_file: Path | None) -> "subprocess.CompletedProcess[str]":
     env = dict(os.environ)
     env.pop("PGW1521_DIFF_FILES", None)
     if diff_file is not None:

--- a/tests/test_guard_attribution.py
+++ b/tests/test_guard_attribution.py
@@ -1,0 +1,146 @@
+"""Every diff-local repo guard says WHICH SIDE its finding falls on.
+
+# pgw#1521: `fast gates` is the only required context and bundles ~25 guards, so
+# an `--admin` past somebody else's master-red silently bypasses a guard that is
+# refusing YOUR OWN file. Four instances in one night, and pgw has no post-merge
+# CI to catch the fifth.
+
+These run the REAL guard scripts as subprocesses against a real planted
+violation, with the real attribution file `fast gates` writes — the production
+path end to end, not a call into `_lint_side` with hand-made inputs. A guard
+whose findings stop naming a file fails here rather than in the field.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO / "scripts"
+
+#: The violation these tests plant. It names a retired package on purpose:
+#: the guard under test is the one that refuses it.
+VIOLATION = "import hashrepo\n"  # retired-name: the fixture IS the violation
+
+
+@pytest.fixture()
+def fixture_tree():
+    """A violation inside the repo, so the guard reports a repo-relative path.
+
+    Under `scripts/` deliberately: the guards spell findings relative to the
+    repo root, and attribution reads that spelling.
+    """
+    root = SCRIPTS / f"_pgw1521_fixture_{uuid.uuid4().hex[:8]}"
+    root.mkdir()
+    try:
+        yield root
+    finally:
+        for child in root.rglob("*"):
+            child.unlink()
+        root.rmdir()
+
+
+def _emit(path: Path, base: str, files: tuple[str, ...]) -> Path:
+    path.write_text(f"# base {base}\n" + "".join(f"{f}\n" for f in files))
+    return path
+
+
+def _run(script: str, target: Path, diff_file: Path | None):
+    env = dict(os.environ)
+    env.pop("PGW1521_DIFF_FILES", None)
+    if diff_file is not None:
+        env["PGW1521_DIFF_FILES"] = str(diff_file)
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / script), str(target)],
+        cwd=REPO, capture_output=True, text=True, env=env, timeout=300,
+    )
+
+
+def test_a_finding_in_this_diff_is_named_as_yours(fixture_tree, tmp_path):
+    (fixture_tree / "mod.py").write_text(VIOLATION)
+    rel = (fixture_tree / "mod.py").relative_to(REPO).as_posix()
+    diff = _emit(tmp_path / "diff.txt", "deadbeefcafe", (rel,))
+
+    done = _run("lint_retired_package_names.py", fixture_tree, diff)
+
+    assert done.returncode == 1, done.stdout + done.stderr
+    out = done.stdout + done.stderr
+    assert "[YOUR DIFF]" in out, out
+    # The verdict is the line the merge button needs, and it must refuse to
+    # read as somebody else's problem.
+    assert "AT LEAST ONE OF THESE IS YOURS" in out, out
+
+
+def test_a_finding_outside_this_diff_is_named_as_the_base(fixture_tree, tmp_path):
+    (fixture_tree / "mod.py").write_text(VIOLATION)
+    diff = _emit(tmp_path / "diff.txt", "deadbeefcafe",
+                 ("src/gen_worker/cli/daemon.py",))
+
+    done = _run("lint_retired_package_names.py", fixture_tree, diff)
+
+    assert done.returncode == 1, done.stdout + done.stderr
+    out = done.stdout + done.stderr
+    assert "[PRE-EXISTING]" in out, out
+    assert "TARGETED" in out, out
+
+
+def test_an_unresolvable_base_is_unknown_and_never_reads_as_not_yours(
+    fixture_tree, tmp_path
+):
+    """UNKNOWN is the one verdict that must not be mistaken for a pass.
+
+    A gate that cannot attribute must say so — reporting "not in your diff"
+    when the diff is unknown is the exact bypass pgw#1521 exists to stop.
+    """
+    (fixture_tree / "mod.py").write_text(VIOLATION)
+    diff = _emit(tmp_path / "diff.txt", "UNKNOWN", ())
+
+    done = _run("lint_retired_package_names.py", fixture_tree, diff)
+
+    assert done.returncode == 1, done.stdout + done.stderr
+    out = done.stdout + done.stderr
+    assert "[SIDE UNKNOWN]" in out, out
+    assert "UNKNOWN is not 'not yours'" in out, out
+    assert "PRE-EXISTING" not in out, out
+
+
+def test_a_resolved_base_with_an_empty_diff_is_not_unknown(fixture_tree, tmp_path):
+    """An empty diff is a fact; an unresolved base is not. They differ."""
+    (fixture_tree / "mod.py").write_text(VIOLATION)
+    diff = _emit(tmp_path / "diff.txt", "deadbeefcafe", ())
+
+    done = _run("lint_retired_package_names.py", fixture_tree, diff)
+
+    out = done.stdout + done.stderr
+    assert done.returncode == 1, out
+    assert "[PRE-EXISTING]" in out, out
+
+
+def test_the_attribution_helper_selftest_passes():
+    """The helper's own red arms — every one of them runs here too."""
+    done = subprocess.run(
+        [sys.executable, str(SCRIPTS / "_lint_side.py"), "--selftest"],
+        cwd=REPO, capture_output=True, text=True, timeout=120,
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+
+
+@pytest.mark.parametrize("script", sorted(
+    p.name for p in SCRIPTS.glob("lint_*.py")
+))
+def test_every_fast_gates_guard_can_attribute(script):
+    """A guard that stopped importing the attribution seam is a guard that
+    silently went back to being unattributable. Structural, not a promise."""
+    source = (SCRIPTS / script).read_text()
+    if "_lint_side" not in source:
+        pytest.skip(f"{script} is not a `fast gates` diff-local guard")
+    assert "_lint_side.report" in source or "_lint_side.verdict" in source, (
+        f"{script} imports the attribution seam but never calls it — the import "
+        f"is the only thing left of the conversion"
+    )


### PR DESCRIPTION
**Ruled option 2 (pgw#1521), implemented.** `fast gates` is this repo's only required context and it bundles ~25 unrelated guards, so at the merge button these two are indistinguishable:

* *"`fast gates` is red because of somebody else's problem on master"* — the legitimate reason to reach for `--admin`; and
* *"`fast gates` is red because a guard is refusing MY OWN new file"* — the guard doing the one job it exists for.

A bypass granted for the first silently includes the second. Four instances in one night, and **pgw has no post-merge CI**, so a guard can stop being enforced and nothing anywhere detects it.

## What it prints now

```
[YOUR DIFF] tests/test_widget_pgw9999.py: a NEW test module named for an ISSUE. …
pgw#1521 attribution — pgw#1362 incident-named tests: 1 finding(s), 1 in files THIS
DIFF touches, 0 pre-existing on the base (base 5443fbcb86e7). AT LEAST ONE OF THESE
IS YOURS — an `--admin` here bypasses your own violation, not somebody else's master-red.
```

and the other side, same planted violation, file not in the diff:

```
[PRE-EXISTING] tests/test_widget_pgw9999.py: a NEW test module named for an ISSUE. …
pgw#1521 attribution — pgw#1362 incident-named tests: 1 finding(s), 0 in files THIS
DIFF touches, 1 pre-existing on the base (base 5443fbcb86e7). None of this is in your
diff: a TARGETED `--admin` is defensible, and it does not fix the base — say both on the PR.
```

## Design

* **Nothing new is computed.** Every one of these guards already names the file it refuses; CI already knows the diff. This joins the two.
* **One home for the base** (`scripts/_lint_side.py`, the `_lint_scope.py` shape). `fast gates` resolves it in ONE step ahead of every guard — a PR checkout is shallow at the merge commit, so resolving it costs a fetch — and writes the file the guards read. Locally it falls back to `merge-base origin/master HEAD` plus uncommitted and untracked files.
* **UNKNOWN is printed as UNKNOWN, never as "not yours."** An unresolvable base and a resolved base with an *empty* diff are different states and read differently.
* **Ambiguity rounds toward YOURS.** A finding naming several files is yours if ANY is in the diff — calling master's red yours costs a minute of reading; calling your red master's buys a bypass of your own violation.
* 29 guards converted, plus the pgw#849 unreached-surface ratchet, whose hand-written *"IT MAY NOT BE YOUR CHANGE"* paragraph is the prose this replaces with a computed answer.

## Evidence

* **Red proven by EXECUTION on both sides**, not by reading the code — the transcript above is a real run of `scripts/lint_incident_test_names.py`, and the same two-sided proof was run on `lint_retired_package_names.py`.
* `tests/test_guard_attribution.py` (domain-named) drives the real guard scripts as subprocesses over a planted violation and pins all four states, including UNKNOWN; plus a structural check that a guard which imports the seam still calls it.
* 15-case `--selftest` in the helper, run in `fast gates` itself.
* Every guard run locally, **exit codes read**: 29/29 exit 0 on this branch.

## Also, the 4.34b fold-first one-liner

Per the DESIGN-RULINGS 2026-08-19 addendum, noted there for whoever next touched pgw#1362's guard: the refusal now lists **FOLDING** into the existing domain module FIRST, with renaming as the fallback. Renaming satisfies the letter of 4.34b while still growing the corpus the rule exists to shrink.