### PR TITLE
pgw#1530: a lane's dtype is the TREE's precision — pgw#1512 read the contract as a component roster, and no shipped contract is spelled that way

### DIFF
--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -137,7 +137,10 @@ class TraceLoadContext:
            deleted, and at trace it would silently re-key a graph.
         """
 
-        from ..serving.checkpoint_dtype import checkpoint_dtype
+        from ..serving.checkpoint_dtype import (
+            _config_dtype,
+            _tensor_dtype as _header_dtype,
+        )
 
         directory = Path(str(tree))
         name = str(subfolder).strip("/") if subfolder else ""
@@ -159,57 +162,43 @@ class TraceLoadContext:
             if relative is not None and str(relative) not in (".", ""):
                 name = str(relative).strip("/")
 
-        governed = (not name) or name in self._lane_components()
-        if governed:
-            declared = _lane_torch_dtype(self.lane, checkpoint_dir=self.checkpoint_dir)
-            if declared is not None:
-                return declared
-        own = checkpoint_dtype(directory)
+        # 1. THE COMPONENT'S OWN BYTES, when it has any. A serving tree has
+        #    been CONVERTED through the lane contract by the store, so its
+        #    safetensors headers are the precision the pod actually runs —
+        #    read through the stub-aware reader, which knows a 128-byte
+        #    projection stub from a real file.
+        own = _header_dtype(directory)
         if own is not None:
             return own
 
-        if governed:
-            raise TraceSurfaceUnavailable(
-                f"nothing declares a load dtype for component "
-                f"{name or '<root>'!r} of {tree}, and the lane contract "
-                f"COVERS it: this is the component whose precision becomes "
-                f"graph identity (pgw#1458), so the derive cannot pick one. "
-                f"State a dtype on the lane contract, or a torch_dtype in "
-                f"the component's config."
-            )
-        # NOT a default, and the distinction is the whole ruling: this is the
-        # ABSENCE of a conversion. The serving loader casts nothing and reports
-        # a container that disagrees with the lane rather than repairing it, so
-        # a component nobody has said anything about keeps whatever its own
-        # config builds — exactly what a pod would serve. Refusing here instead
-        # would make every endpoint underivable: measured on the real trees,
-        # sd15's and sdxl's `[derive] checkpoint_configs` declare no dtype in
-        # any component config, none in `model_index.json`, and carry no
-        # safetensors to read a header from.
+        # 2. OTHERWISE THE LANE. pgw#1530: this is the half pgw#1512 got
+        #    wrong. A contract's `tensors` list enumerates the DENOISER's own
+        #    parameter names — every shipped contract does, `conv_in.weight`
+        #    for sd15, `transformer_blocks.…` for h3, never a `unet.`/
+        #    `transformer.` prefix — but its `dtype` states the precision of
+        #    the TREE the store converts to that contract. Treating the
+        #    tensor list as a component roster made the governed set match
+        #    nothing on every endpoint in the fleet, so the lane's dtype was
+        #    never applied anywhere and a config-only derive silently traced
+        #    fp32 graphs under a bf16 lane.
+        declared = _lane_torch_dtype(self.lane, checkpoint_dir=self.checkpoint_dir)
+        if declared is not None:
+            return declared
+
+        # 3. THE COMPONENT'S CONFIG, LAST and only when nothing above spoke.
+        #    On a converted tree a component config is the PUBLISHER's, not
+        #    the store's: sd15's `text_encoder/config.json` still says
+        #    `float32` in a tree whose bytes are bf16. Preferring it is what
+        #    put an fp32 encoder beside a bf16 denoiser and produced
+        #    `Input type (float) and bias type (c10::BFloat16)` on payload 0.
+        config = _config_dtype(directory)
+        if config is not None:
+            return config
+
+        # Nothing anywhere can say. No cast — the absence of a conversion,
+        # which is what the streaming loader does with bytes it was given no
+        # contract for.
         return None
-
-    def _lane_components(self) -> frozenset[str]:
-        """Component names the lane contract's tensor patterns cover.
-
-        Derived from the contract rather than declared a second time: a
-        pattern's first path segment IS the component that owns the tensor.
-        A lane with no readable patterns governs nothing, which sends every
-        component to its own container — the honest answer for a derived lane
-        that has no contract to speak with.
-        """
-
-        cached = getattr(self, "_lane_component_cache", None)
-        if cached is not None:
-            return cached  # type: ignore[no-any-return]
-        names: set[str] = set()
-        for entry in getattr(self.lane, "tensors", ()) or ():
-            pattern = str(getattr(entry, "pattern", "") or "")
-            head = pattern.split(".", 1)[0].strip()
-            if head and "{" not in head:
-                names.add(head)
-        resolved = frozenset(names)
-        self._lane_component_cache = resolved
-        return resolved
 
     def compile(self, target: Any) -> Any:
         """torch.compile-style marking, trace half (pgw#1370/#1372 contract).

--- a/tests/release_fixtures/sd15_shaped_endpoint.py
+++ b/tests/release_fixtures/sd15_shaped_endpoint.py
@@ -1,0 +1,57 @@
+"""sd15's shape exactly: a bf16 lane whose patterns are UNET-INTERNAL.
+
+pgw#1528. The real library contract `sd15.diffusers-bf16@1` states its tensors
+as `conv_in.weight`, `down_blocks.…`, `mid_block.…` — the DENOISER's own
+parameter names, with no `unet.` prefix. Every fixture written before this one
+used component-prefixed patterns (`unet.conv_out.weight`), which is a spelling
+the shipped contracts do not use.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+from gen_worker.models import SDXL
+from gen_worker.models.model_types import SD15_DIFFUSERS_BF16
+
+#: THE REAL SHIPPED CONTRACT, imported — not a path outside the repo and not a
+#: hand-written stand-in. pgw#1530 happened because a fixture invented a
+#: pattern spelling the fleet does not use, so this fixture takes the object.
+SD15_BF16 = SD15_DIFFUSERS_BF16
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class Sd15Shaped(Model[SDXL], lanes=(SD15_BF16,)):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In, model: Sd15Shaped) -> Out:
+    ctx.raise_if_cancelled()
+    with torch.inference_mode():
+        model.pipe(
+            prompt=payload.prompt,
+            num_inference_steps=2,
+            guidance_scale=7.5,
+            width=64,
+            height=64,
+            callback_on_step_end=ctx.step_callback(2),
+            output_type="latent",
+        )
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_release_derive_component_dtype.py
+++ b/tests/test_release_derive_component_dtype.py
@@ -1,23 +1,32 @@
-"""pgw#1512: the lane's dtype governs the lane's component, and nothing else.
+"""What precision each component loads at, and WHERE that fact comes from.
 
-Paul's ruling, 2026-08-19. The trace used to read one dtype off the lane and
-hand it to `from_pretrained`, casting EVERY component of the tree to it. The
-serving loader does the opposite and says so:
+pgw#1530 corrects pgw#1512. That issue read a lane contract's `tensors` list
+as a roster of the COMPONENTS the contract describes — first path segment of
+each pattern — and applied the lane's dtype only to those.
 
-    "No `torch_dtype=` (the lane contract IS the dtype)"   serving/context.py
-    "bytes land verbatim in the container's own dtype ... any conversion is
-     the STORE's contract-negotiation job, NEVER load time. A container that
-     disagrees with the active lane is reported, not silently repaired."
-                                          serving/streaming/engine.py
+**No shipped contract is spelled that way.** Every one states the DENOISER's
+own parameter names: sd15 and sd2 say `conv_in.weight` / `down_blocks.…`,
+minimax-h3 says `transformer_blocks.…`, flux says `context_embedder.…` — never
+a `unet.` or `transformer.` prefix. So the derived roster matched no component
+on any endpoint in the fleet, the lane's dtype was never applied anywhere, and
+two things followed:
 
-So the trace performed exactly the conversion serve refuses, and a DiT lane's
-bf16 landed on the VAE beside it — a bf16 bias meeting an fp32 activation in a
-decode block that is fine on a pod (h3's `MiniMaxH3VideoDecodeStep`).
+  * a config-only derive traced sd15's UNet at **float32 under a bfloat16
+    lane** — silently, and precision IS graph identity (pgw#1458), so a bf16
+    mint refuses those keys by name;
+  * a tree whose UNet declares bf16 while its text encoder's config still says
+    float32 (the publisher's config in a store-converted tree) put an fp32
+    activation into a bf16 denoiser: `Input type (float) and bias type
+    (c10::BFloat16)` on payload 0.
 
-Precision is now per component: the lane governs the components its CONTRACT
-DESCRIBES, everything else takes its own declared dtype, and a component the
-lane covers with nothing anywhere to state its precision REFUSES rather than
-defaulting (pgw#1448 — and at trace a default silently re-keys a graph).
+The rule is now about WHERE the answer comes from, in order of how directly
+the source knows: the component's own BYTES, then the LANE, then the
+component's config — with the config last precisely because it is the one
+source a conversion does not rewrite.
+
+These tests use the REAL library contracts on purpose. pgw#1512's fixture
+invented `unet.conv_out.weight`, and that invention is what let every check
+pass while the fleet's actual spelling did the opposite.
 """
 
 from __future__ import annotations
@@ -30,42 +39,41 @@ import pytest
 
 pytest.importorskip("torch")
 pytest.importorskip("diffusers")
-pytest.importorskip("transformers")
-import gen_worker._vendor.torchcg  # noqa: E402,F401
 import torch  # noqa: E402
 
-from gen_worker.release.trace_context import (  # noqa: E402
-    TraceLoadContext,
-    TraceSurfaceUnavailable,
-)
+from gen_worker._vendor import tensorfs as _vendored_tensorfs  # noqa: E402
+from gen_worker.release.trace_context import TraceLoadContext  # noqa: E402
+
+#: The shipped contracts, from the VENDORED tensorfs that ships in this wheel
+#: — not a path outside the repo. An earlier draft read
+#: `~/cozy/tensorfs/spec/...` and `~/cozy/serverless-endpoints/sd15/...`, which
+#: made every assertion here SKIP in CI: the tests that prove this fix would
+#: not have run in the gate that is supposed to catch its regression.
+CONTRACTS = Path(_vendored_tensorfs.__file__).resolve().parent / "_contracts"
 
 FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
 
 
-def _contract(*patterns: str, dtype: str = "bfloat16") -> Any:
-    """A real tensorfs contract covering exactly `patterns`."""
-
+def _contract(name: str) -> Any:
     from gen_worker._vendor.tensorfs.contract import Contract
 
-    return Contract.from_document(
-        json.dumps(
-            {
-                "format": "tensorfs-contract-v1",
-                "name": "probe.lane",
-                "version": 1,
-                "description": "pgw#1512 probe",
-                "dtype": dtype,
-                "tensors": [
-                    {"role": p, "pattern": f"{p}.weight", "rank": 4}
-                    for p in patterns
-                ],
-            }
-        )
-    )
+    return Contract.from_document((CONTRACTS / name).read_text())
+
+
+def _ctx(tree: Path, lane: Any) -> TraceLoadContext:
+    return TraceLoadContext(lane=lane, checkpoint_dir=tree)
 
 
 @pytest.fixture(scope="module")
-def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+def sd15_shaped_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """sd15's shape, built in-repo: a config-only pipeline tree whose TEXT
+    ENCODER config declares float32 while nothing else declares anything.
+
+    That is the real sd15 fixture's shape — `text_encoder/config.json` says
+    `float32` because it is the PUBLISHER's config, and a store conversion
+    rewrites bytes, not configs.
+    """
+
     import sys
 
     sys.path.insert(0, str(FIXTURES))
@@ -73,130 +81,156 @@ def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
         import tiny_tree
     finally:
         sys.path.remove(str(FIXTURES))
-    return tiny_tree.save_config_only(tmp_path_factory.mktemp("dtype-config-only"))
+
+    tree = tiny_tree.save_config_only(tmp_path_factory.mktemp("sd15-shaped"))
+    config = json.loads((tree / "text_encoder" / "config.json").read_text())
+    config["torch_dtype"] = "float32"
+    (tree / "text_encoder" / "config.json").write_text(json.dumps(config))
+    return tree
 
 
-def _ctx(tree: Path, lane: Any) -> TraceLoadContext:
-    return TraceLoadContext(lane=lane, checkpoint_dir=tree)
+def test_EVERY_shipped_contract_names_the_DENOISERS_OWN_parameters() -> None:
+    """The fact that falsified pgw#1512, pinned so it cannot be re-assumed.
 
-
-def test_the_lane_governs_the_component_its_CONTRACT_NAMES_and_no_other(
-    tree: Path,
-) -> None:
-    """The ruling in one assertion.
-
-    A contract covering `unet` says bf16 about the UNET and nothing else.
-    The three components beside it show all three outcomes at once:
-
-      * `vae` — uncovered, declares nothing: NOT cast, which is what a pod
-        does with bytes it was given no contract for;
-      * `text_encoder` — uncovered, but its own transformers config declares
-        `dtype: float32`, so passthrough honours the packager. Under the old
-        global cast this component was forced to the DENOISER's bf16 despite
-        saying float32 about itself — the fabrication in one line.
+    If a contract ever DID lead with a component name this would go red, and
+    whoever wrote it would find this test explaining why that matters.
     """
 
-    ctx = _ctx(tree, _contract("unet.conv_out"))
+    # True COMPONENT names as `model_index.json` spells them. `encoder` and
+    # `decoder` are deliberately absent: they are the VAE's own submodules,
+    # and sdxl's contract leads with them — which is itself the point of the
+    # next assertion.
+    component_words = {"unet", "vae", "transformer", "text_encoder", "tokenizer"}
+    offenders = []
+    for path in sorted(CONTRACTS.glob("*.json")):
+        heads = {
+            t["pattern"].split(".", 1)[0]
+            for t in json.loads(path.read_text()).get("tensors", [])
+        }
+        if heads & component_words:
+            offenders.append(path.name)
+    assert offenders == []
 
-    assert ctx.component_dtype(tree, "unet") is torch.bfloat16
-    assert ctx.component_dtype(tree, "vae") is None
-    assert ctx.component_dtype(tree, "text_encoder") is torch.float32
 
+def test_a_contract_can_cover_SEVERAL_components_which_settles_the_question() -> None:
+    """sdxl's contract enumerates the UNet, the VAE **and** the text encoder.
 
-def test_a_component_directory_passed_WITHOUT_a_subfolder_is_still_that_component(
-    tree: Path,
-) -> None:
-    """diffusers hands the directory over, not tree+subfolder.
+    `down_blocks`/`conv_in` (denoiser), `encoder`/`decoder`/`quant_conv`
+    (VAE), `text_model`/`text_projection` (text encoder) — all at one
+    `dtype: bfloat16`, none of them component-prefixed.
 
-    `AutoencoderKL.from_pretrained(<tree>/vae)` carries no subfolder, so an
-    absent subfolder must not read as "the root" — that mistake made every
-    component look lane-governed and refused a contractless endpoint's derive.
+    So "a denoiser contract says nothing about the VAE beside it" — pgw#1512's
+    premise, and mine — is not merely unprovable, it is contradicted by a
+    shipped contract. A lane's dtype is the precision of the TREE the store
+    converts, which is why it is the right answer for every component that has
+    no bytes of its own to speak with.
     """
 
-    ctx = _ctx(tree, _contract("unet.conv_out"))
+    heads = {
+        t["pattern"].split(".", 1)[0]
+        for t in json.loads(
+            (CONTRACTS / "sdxl.diffusers-bf16.v1.json").read_text()
+        )["tensors"]
+    }
+    assert {"down_blocks", "conv_in"} & heads, "the denoiser's own parameters"
+    assert {"encoder", "decoder", "quant_conv"} & heads, "the VAE's"
+    assert {"text_model", "text_projection"} & heads, "the text encoder's"
 
-    assert ctx.component_dtype(tree / "unet", None) is torch.bfloat16
-    assert ctx.component_dtype(tree / "vae", None) is None
+
+def test_sd15s_UNET_traces_at_the_LANES_dtype_not_at_float32(sd15_shaped_tree: Path) -> None:
+    """The regression, at the seam. Was float32 under a bfloat16 lane."""
+
+    ctx = _ctx(sd15_shaped_tree, _contract("sd15.diffusers-bf16.v1.json"))
+    assert ctx.component_dtype(sd15_shaped_tree, "unet") is torch.bfloat16
 
 
-def test_a_components_OWN_declared_dtype_wins_over_no_coverage(
-    tree: Path, tmp_path: Path
+def test_the_WHOLE_sd15_pipeline_agrees_so_no_activation_crosses_a_boundary(
+    sd15_shaped_tree: Path,
 ) -> None:
-    """Passthrough: what the packager said about THIS component."""
+    """Uniformity is the point: a mixed pipeline is what raised.
 
-    declared = tmp_path / "declared"
-    (declared / "vae").mkdir(parents=True)
-    config = json.loads((tree / "vae" / "config.json").read_text())
-    config["torch_dtype"] = "float16"
-    (declared / "vae" / "config.json").write_text(json.dumps(config))
-
-    ctx = _ctx(declared, _contract("unet.conv_out"))
-    assert ctx.component_dtype(declared, "vae") is torch.float16
-
-
-def test_the_lane_covering_a_component_nothing_can_speak_for_REFUSES(
-    tree: Path,
-) -> None:
-    """No silent fp32 where precision IS identity (pgw#1448 / pgw#1458).
-
-    The contract covers `unet` but declares no dtype, the tree declares none,
-    and a config-only tree has no headers — so nothing can answer for the one
-    component whose precision becomes the graph key.
+    `text_encoder/config.json` in this tree says float32. Under the corrected
+    order the lane answers first, so the encoder and the denoiser agree and
+    `prompt_embeds` can reach the UNet.
     """
 
-    from gen_worker._vendor.tensorfs.contract import Contract
+    ctx = _ctx(sd15_shaped_tree, _contract("sd15.diffusers-bf16.v1.json"))
+    seen = {
+        name: ctx.component_dtype(sd15_shaped_tree, name)
+        for name in ("unet", "vae", "text_encoder")
+    }
+    assert set(seen.values()) == {torch.bfloat16}, seen
 
-    dtypeless = Contract.from_document(
-        json.dumps(
-            {
-                "format": "tensorfs-contract-v1",
-                "name": "probe.dtypeless",
-                "version": 1,
-                "description": "covers unet, states no dtype",
-                "tensors": [
-                    {"role": "unet.conv_out", "pattern": "unet.conv_out.weight",
-                     "rank": 4}
-                ],
-            }
-        )
+
+def test_a_components_own_BYTES_outrank_the_lane(tmp_path: Path) -> None:
+    """A converted tree's headers are what the pod actually runs.
+
+    Built with real safetensors so the stub-aware reader is the thing under
+    test, not a stand-in.
+    """
+
+    safetensors = pytest.importorskip("safetensors.torch")
+
+    tree = tmp_path / "tree"
+    (tree / "vae").mkdir(parents=True)
+    (tree / "vae" / "config.json").write_text(json.dumps({"_class_name": "AutoencoderKL"}))
+    safetensors.save_file(
+        {"decoder.conv_out.weight": torch.zeros(2, 2, dtype=torch.float16)},
+        str(tree / "vae" / "diffusion_pytorch_model.safetensors"),
     )
-    ctx = _ctx(tree, dtypeless)
 
-    with pytest.raises(TraceSurfaceUnavailable) as refusal:
-        ctx.component_dtype(tree, "unet")
-    message = str(refusal.value)
-    assert "graph identity" in message
-    assert "'unet'" in message
+    ctx = _ctx(tree, _contract("sd15.diffusers-bf16.v1.json"))
+    # The lane says bfloat16; these bytes say float16, and the bytes win.
+    assert ctx.component_dtype(tree, "vae") is torch.float16
 
 
-def test_an_UNCOVERED_component_that_nothing_declares_is_NOT_a_refusal(
-    tree: Path,
+def test_a_stale_component_CONFIG_does_not_outrank_the_lane(
+    sd15_shaped_tree: Path,
 ) -> None:
-    """The absence of a conversion is not a default, and this is the line.
+    """The precedence inversion that produced the crash.
 
-    Measured on the real trees: sd15's and sdxl's `[derive]
-    checkpoint_configs` declare no dtype in any component config, none in
-    `model_index.json`, and ship no safetensors. Refusing here would make
-    every endpoint in the fleet underivable, so an uncovered component simply
-    is not cast — exactly what the streaming loader does with bytes it was
-    given no contract for.
+    sd15's `text_encoder/config.json` says float32 in a tree the store
+    converts to bf16 — a conversion rewrites bytes, not configs.
     """
 
-    ctx = _ctx(tree, _contract("unet.conv_out"))
-    assert ctx.component_dtype(tree, "scheduler") is None
+    declared = json.loads(
+        (sd15_shaped_tree / "text_encoder" / "config.json").read_text()
+    )
+    assert declared.get("torch_dtype") == "float32", "premise: the config says fp32"
+
+    ctx = _ctx(sd15_shaped_tree, _contract("sd15.diffusers-bf16.v1.json"))
+    assert ctx.component_dtype(sd15_shaped_tree, "text_encoder") is torch.bfloat16
 
 
-def test_a_lane_with_no_readable_patterns_governs_NOTHING(tree: Path) -> None:
-    """A derived lane has no contract, so it speaks for no component."""
+def test_the_config_is_still_read_when_NOTHING_else_can_speak(tmp_path: Path) -> None:
+    """Last, but not discarded — a derived lane has no dtype to offer."""
+
+    tree = tmp_path / "tree"
+    (tree / "thing").mkdir(parents=True)
+    (tree / "thing" / "config.json").write_text(json.dumps({"torch_dtype": "float16"}))
+
+    ctx = _ctx(tree, None)  # no lane, no bytes
+    assert ctx.component_dtype(tree, "thing") is torch.float16
+
+
+def test_nothing_anywhere_means_NO_CAST_rather_than_a_default(tmp_path: Path) -> None:
+    """The absence of a conversion is not a default precision (pgw#1448)."""
+
+    tree = tmp_path / "tree"
+    (tree / "thing").mkdir(parents=True)
+    (tree / "thing" / "config.json").write_text(json.dumps({"_class_name": "X"}))
 
     ctx = _ctx(tree, None)
-    assert ctx._lane_components() == frozenset()
+    assert ctx.component_dtype(tree, "thing") is None
 
 
-def test_the_governed_set_comes_from_the_patterns_not_a_second_list(
-    tree: Path,
+def test_a_component_directory_passed_WITHOUT_a_subfolder_still_resolves(
+    sd15_shaped_tree: Path,
 ) -> None:
-    """Derived, so it cannot go stale against the contract it describes."""
+    """diffusers hands the directory over: `from_pretrained(<tree>/vae)`."""
 
-    ctx = _ctx(tree, _contract("unet.conv_out", "vae.decoder.conv_out"))
-    assert ctx._lane_components() == frozenset({"unet", "vae"})
+    ctx = _ctx(sd15_shaped_tree, _contract("sd15.diffusers-bf16.v1.json"))
+    assert ctx.component_dtype(sd15_shaped_tree / "unet", None) is torch.bfloat16
+    assert (
+        ctx.component_dtype(sd15_shaped_tree / "text_encoder", None) is torch.bfloat16
+    )


### PR DESCRIPTION
## The reconciliation I owe, first

pgw#1512's verification **never ran sd15's real lock** — I said so at the time (*"a real sd15 endpoint derive could NOT be run here and was not claimed"*) and then generalised from the in-repo fixture anyway: *"for a single-precision endpoint the lane dtype and each component's own dtype coincide."* That generalisation is what failed, and the fixture is why it looked safe: `lane_contracts.py` invents `unet.conv_out.weight`, a **component-prefixed** spelling. Measured across every contract tensorfs ships: **not one uses it.**

## Root cause, measured

`_lane_components()` took the first path segment of each contract pattern as the component the contract describes. The shipped contracts state the **denoiser's own parameter names** — sd15/sd2 `conv_in.weight`, `down_blocks.…`; minimax-h3 `transformer_blocks.…`; flux `context_embedder.…`. So the derived roster matched **no subfolder on any endpoint in the fleet**, and the lane's dtype has not been applied anywhere since pgw#1512 landed.

Two manifestations of one cause:

- **config-only tree** — nothing declares anything, so sd15's UNet traced at **float32 under a bfloat16 lane**, silently. Precision is graph identity (pgw#1458), so those keys are refused by name by any bf16 mint. Measured: `target unet | input dtypes: ['float32', 'int64']`.
- **a store-converted tree** — the UNet's bytes say bf16 while `text_encoder/config.json` still says float32, because a conversion rewrites **bytes, not configs**. That put an fp32 activation into a bf16 denoiser. Reproduced verbatim on payload 0: `RuntimeError: Input type (float) and bias type (c10::BFloat16)`.

## The premise is contradicted outright, not merely unproven

pgw#1512 argued *"a denoiser contract says nothing about the VAE beside it."* **`sdxl.diffusers-bf16` enumerates the UNet (`down_blocks`, `conv_in`), the VAE (`encoder`, `decoder`, `quant_conv`) and the text encoder (`text_model`, `text_projection`) under one `dtype: bfloat16`.** A lane's dtype is the precision of the **tree** the store converts to it. There is a test asserting exactly this, so the claim can't be re-made from memory.

## The fix is an order, by how directly each source knows

1. the component's own **bytes** — a converted tree's safetensors headers, read through the stub-aware reader that knows a 128-byte projection stub from a real file;
2. otherwise **the lane** — the precision the store converted the tree to;
3. the component's **config** last, and only when nothing above spoke, because it is the one source a conversion does not rewrite;
4. nothing anywhere → **no cast**. The absence of a conversion is not a default precision (pgw#1448).

`_lane_components()` is **deleted** rather than repaired — it encoded the wrong model, and a corrected version would still be a roster the contracts do not provide.

## Verified by execution, on the real trees and real contracts

| check | result |
|---|---|
| sd15 UNet dtype | float32 → **bfloat16** |
| sd15 pipeline | unet / vae / text_encoder **all bf16** — no activation crosses a boundary |
| mixed-tree reproduction | **EXIT 1** with the reported `RuntimeError` at master → **EXIT 0** here |
| sdxl | unet / vae / text_encoder / text_encoder_2 all bf16 |
| byte-compare | `b6d23f8e01acc8528be773f70a57bcd0cacf4fec4e703d0a6b4e56b16b309f5c` **unchanged** |

78 passed across derive / surface / floor / eager-bridge suites · mypy clean (636 files) · ruff clean · `lint_unreached_surface` 97 = base.

## ⚠️ Two things this lane cannot settle and is not claiming

- **H3 must re-run.** Its lock is green at `bf6666e9` with *no* lane cast, which on this evidence means it is very likely tracing **fp32 graphs under a bf16 lane** — the same silent defect as sd15, without the crash. This change gives it bf16; whether that revives wall 7 can only be answered on H3's tree, which this box does not have. **Do not treat H3 as covered by these greens.**
- **pgw#1512's ruling rested on my analysis, and its premise was false.** Paul ruled per-component passthrough on my reading of the serving loader's doctrine; that doctrine is real, but I mapped *"the container's own dtype"* onto a config-only tree's **publisher** configs rather than onto converted **bytes**. This restores the lane as the default while keeping real bytes authoritative — the smallest correction consistent with the evidence, but it is a partial reversal and should be seen as one.