### PR TITLE
pgw#1525: `compile`'s re-derive branch was UNREACHABLE — both spellings of a missing program are a miss

### DIFF
--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -241,22 +241,65 @@ def _ensure_program(spec: Spec, store: Any, rederive: Any, scratch: Path) -> Pat
     re-deriving locally — never by fetching, because there is nothing portable
     to fetch. A malformed key is a typed refusal from the store rather than a
     miss, so a wiring bug can never spend a pointless two-minute derive.
+
+    A MISS ARRIVES TWO WAYS, AND THIS ASKED FOR ONLY ONE (pgw#1525).
+    ``LocalGraphStore.fetch_program`` returns ``None`` for a miss;
+    ``WorkerGraphStore.fetch_program`` — which is what ``_store`` actually
+    builds — RAISES ``ProgramBlobUnreachable``, and its own message calls the
+    condition "ORDINARY". This function only tested for ``None``, so on the one
+    state it exists for — a box that has never derived this endpoint — the
+    raise escaped past ``rederive()`` and the re-derive branch was unreachable.
+    Measured: `compile` on a wiped store answered ``failed=14 (of 14)`` in
+    6.04 s having never logged "re-deriving", and told the user to run
+    `compile`.
+
+    Both spellings are now the same miss, and the answer to a miss is to derive.
+    That includes the ``rotten`` arm of the same refusal: a serialized program
+    is a DERIVED, DISPOSABLE, machine-scoped artifact, so bytes that fail their
+    own scrub deserve exactly what absent bytes deserve — regeneration, not a
+    report. The refusal survives where it is load-bearing: a malformed graph key
+    is not a miss, so it is re-raised rather than paying for a derive that
+    cannot possibly satisfy it, and a program still missing AFTER the derive is
+    the typed ``CompileError`` below.
     """
+    from .._vendor.torchcg import is_graph_hash
+    from ..serving.mint_store import ProgramBlobUnreachable
+
+    # Checked HERE, by the predicate, rather than recognised from the refusal's
+    # wording. A malformed key is a wiring bug and no derive can satisfy it, so
+    # it must not be swallowed as a miss; matching on message text to tell the
+    # two apart would put this function one prose edit from silently paying for
+    # a two-minute derive on every specialization.
+    if not is_graph_hash(spec.graph):
+        raise CompileError(
+            f"{spec.graph!r} is not a cg-graph-v1 identity — the lock names a "
+            f"graph no store can be asked for. `gen-worker lock` rewrites it."
+        )
+
     destination = scratch / f"{spec.short}.pt2"
     destination.parent.mkdir(parents=True, exist_ok=True)
-    found = store.fetch_program(spec.graph, destination)
-    if found is not None:
-        return Path(found)
+
+    def _look() -> Optional[Path]:
+        try:
+            found = store.fetch_program(spec.graph, destination)
+        except ProgramBlobUnreachable as exc:
+            logger.debug("%s: no usable local program (%s)", spec.short, exc)
+            return None
+        return Path(found) if found is not None else None
+
+    program = _look()
+    if program is not None:
+        return program
     rederive()
-    found = store.fetch_program(spec.graph, destination)
-    if found is None:
+    program = _look()
+    if program is None:
         raise CompileError(
             f"no exported program for graph {spec.short} even after re-deriving "
             f"from this source tree: the committed lock and this checkout "
             f"disagree about what this endpoint traces to. "
             f"`gen-worker lock --check` names the drift."
         )
-    return Path(found)
+    return program
 
 
 def _build(

--- a/tests/test_compile_program_miss.py
+++ b/tests/test_compile_program_miss.py
@@ -1,0 +1,131 @@
+"""`compile` answers a missing exported program by DERIVING it, not by failing.
+
+Lineage: pgw#1525. `cli/compile.py`'s module docstring calls the re-derive
+load-bearing — *"when this machine's graph CAS does not hold the program for a
+specialization, `compile` RE-DERIVES it locally"* — and on the one state that
+sentence is about, a box that has never derived this endpoint, the branch was
+unreachable.
+
+Two implementations of one `GraphStore` protocol disagree about what a miss IS:
+`torchcg.store.LocalGraphStore.fetch_program` returns `None`;
+`serving.mint_store.WorkerGraphStore.fetch_program` — which is what `_store()`
+actually builds — RAISES `ProgramBlobUnreachable`, its own message calling the
+condition "ORDINARY". `_ensure_program` tested only for `None`, so the raise
+escaped past `rederive()`.
+
+MEASURED on a wiped store, canonical master, the real verb with no flags:
+`failed=14 (of 14)`, exit 1, **6.04 s**, having never logged "re-deriving" —
+and the error told the user to run `compile`, which is what they had just run.
+A verb whose job is a half-hour of compilation returning in six seconds is what
+a dead branch looks like.
+
+These tests drive `_ensure_program` against BOTH spellings of a miss, because a
+fix written against one store is how this happened in the first place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker.cli.compile import CompileError, Spec, _ensure_program
+from gen_worker.serving.mint_store import ProgramBlobUnreachable
+
+GRAPH = "cg-graph-v1-" + "a" * 56
+
+
+def spec() -> Spec:
+    return Spec(contract="sd15.diffusers-bf16@1", graph=GRAPH, target="unet", ingress=None)
+
+
+class _Store:
+    """A store whose miss spelling and post-derive answer are both dialled in."""
+
+    def __init__(self, *, raises: bool, lands: bool) -> None:
+        self.raises = raises
+        self.lands = lands
+        self.derived = False
+        self.looks = 0
+
+    def fetch_program(self, graph: str, destination: Path) -> Path | None:
+        self.looks += 1
+        if self.derived and self.lands:
+            Path(destination).write_bytes(b"an exported program")
+            return Path(destination)
+        if self.raises:
+            raise ProgramBlobUnreachable(
+                f"this box holds no serialized program for graph {graph}. That "
+                f"is ORDINARY on a pod that has not derived this endpoint yet"
+            )
+        return None
+
+
+@pytest.mark.parametrize(
+    "raises", [True, False], ids=["miss raises (WorkerGraphStore)", "miss is None (LocalGraphStore)"]
+)
+def test_a_missing_program_triggers_the_derive_in_both_store_dialects(
+    tmp_path: Path, raises: bool
+) -> None:
+    store = _Store(raises=raises, lands=True)
+
+    def rederive() -> None:
+        store.derived = True
+
+    program = _ensure_program(spec(), store, rederive, tmp_path)
+
+    assert store.derived, (
+        "the re-derive never ran — this is the pgw#1525 dead branch, and it is "
+        "invisible in a green test suite because the verb still exits cleanly"
+    )
+    assert program.exists()
+    assert store.looks == 2, "look, derive, look — never a third round trip"
+
+
+@pytest.mark.parametrize("raises", [True, False], ids=["raises", "None"])
+def test_a_program_still_absent_after_the_derive_is_the_typed_refusal(
+    tmp_path: Path, raises: bool
+) -> None:
+    """Degrading the miss must not swallow a genuine lock/checkout disagreement."""
+    store = _Store(raises=raises, lands=False)
+
+    def rederive() -> None:
+        store.derived = True
+
+    with pytest.raises(CompileError) as caught:
+        _ensure_program(spec(), store, rederive, tmp_path)
+
+    assert store.derived, "it must still have TRIED to derive before refusing"
+    assert "lock --check" in str(caught.value), "the refusal names the remedy"
+
+
+def test_a_present_program_is_returned_without_paying_for_a_derive(
+    tmp_path: Path,
+) -> None:
+    """The cache hit is the common path and must not have gotten slower."""
+    store = _Store(raises=False, lands=True)
+    store.derived = True  # already on this box
+
+    def rederive() -> None:  # pragma: no cover - must not run
+        raise AssertionError("a present program must never trigger a derive")
+
+    assert _ensure_program(spec(), store, rederive, tmp_path).exists()
+    assert store.looks == 1
+
+
+def test_a_malformed_graph_key_refuses_before_paying_for_a_derive() -> None:
+    """A wiring bug is not a miss, and no derive can satisfy it.
+
+    Checked by `is_graph_hash` UP FRONT rather than by recognising the store's
+    refusal wording — matching on message text would leave this one prose edit
+    away from silently paying a two-minute derive per specialization.
+    """
+    bad = Spec(contract="c", graph="not-a-graph-identity", target="unet", ingress=None)
+
+    def rederive() -> None:  # pragma: no cover - must not run
+        raise AssertionError("a malformed key must never trigger a derive")
+
+    with pytest.raises(CompileError) as caught:
+        _ensure_program(bad, _Store(raises=True, lands=True), rederive, Path("/tmp"))
+
+    assert "cg-graph-v1" in str(caught.value)


### PR DESCRIPTION
`cli/compile.py`'s module docstring calls the re-derive load-bearing: *"when this machine's graph CAS does not hold the program for a specialization, `compile` RE-DERIVES it locally (~2 min CPU)."* **On the one state that sentence is about — a box that has never derived this endpoint — the branch could not execute.**

### Root cause: a miss rendered as an exception (tcg#69's defect class, one layer up)

Two implementations of one `GraphStore` protocol disagree about what a miss IS:

| store | `fetch_program` on a miss |
|---|---|
| `torchcg.store.LocalGraphStore` | returns `None` |
| `serving.mint_store.WorkerGraphStore` | **raises `ProgramBlobUnreachable`** — its own message calling the condition *"ORDINARY"* |

`_store()` builds the second; `_ensure_program` tested only for `None`, so the raise escaped past `rederive()`.

**Measured** on a wiped graph-cas, canonical master, the real verb with no flags:

```
gen-worker compile: failed=14 (of 14)      exit 1, 6.04 s
```

— having never logged `re-deriving`, and every failure telling the user the remedy was to run `compile`. A verb whose job is a half-hour of compilation returning in **six seconds** is what a dead branch looks like.

### Why nobody saw it

pgw#1491's acceptance ran `compile` against a **full** store and recorded `present=14 of 14`. Every specialization short-circuits at `store.has_artifact()` **before `_ensure_program` is called**; the other arm (`--vram-budget 1.0` → `below_floor=14`) returns before the loop. **`compile`'s build path has never been executed by anything.** An acceptance run on a warm box cannot certify a verb whose whole job is the cold box.

### The fix

Both spellings of a miss are a miss, and the answer to a miss is to derive. The `rotten` arm of the same refusal is deliberately included — a serialized program is a derived, disposable, machine-scoped artifact, so bytes failing their own scrub deserve what absent bytes deserve. Two refusals survive because they are load-bearing: a **malformed graph key** is checked by `is_graph_hash` up front (by the predicate, never by matching the refusal's wording — that would leave this one prose edit from paying a two-minute derive per specialization), and a program still missing **after** the derive stays the typed `CompileError`.

### Necessary, not sufficient — and the tracker says so

With this in, the same run gets further and hits three more defects, all filed under pgw#1525:
1. the re-derive passes the endpoint **source** dir as `checkpoint_dir`, and `compile` has none of `lock`'s `--checkpoint` flags because it declares itself WEIGHTLESS — both cannot be true for a model-bearing endpoint (**needs a Paul-level ruling; filed, not chosen**);
2. the mint child hard-codes `/usr/local/cuda`;
3. worst — a completed `built=14 (of 14)` writes **every artifact to `torchcg/v1/graphs`**, the band pgw#1373 retired, so adoption sees **0 artifacts / 14 holes after 26 minutes of real GPU work.**

### What it does buy, measured tonight on a 4070

With this fix the mint runs end to end: **derive 127.2 s + build 1561.1 s = 28.1 min** for sd15's 14 specializations — va#3's *"paid once ever"* column, previously ABSENT.

### Red arm

4 mutations, each applied 5x, **all CAUGHT 5/5**: the pre-fix `raise` · a swallowed miss that never derives · a malformed key treated as a miss · a present program made to pay for a derive. 6 tests, parametrized over **both** store dialects, because a fix written against one store is how this happened.

`ruff check src/gen_worker` clean · `mypy` clean on both changed files.