### PR TITLE
pgw#1533: `compile` succeeds only when the SERVING READER can find what it wrote

### DIFF
--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -18,6 +18,19 @@ than as process adoption.
 weightless trace and the mint runs against it, so ``compile`` legitimately runs
 before ``download``.
 
+**SERVABLE, OR IT FAILED (pgw#1532).** The success criterion is not "the builds
+returned". It is "the reader that arms graphs at boot can find what I wrote",
+and it is checked by asking THAT reader, through a store object this command did
+not publish through. Before this, ``compile`` reported ``built=14 (of 14)`` with
+rc=0 after 26 minutes of real inductor work and left the serving path with 14
+holes: ``Engine.compile`` banks bytes in torchcg's own engine cache, and
+NOTHING lands in the ``(cg-graph-v1, cg-env-v2)`` band adoption reads unless
+somebody calls ``publish_artifact`` — which the runtime mint did and this
+command did not. It also never called ``put_graphs``, so even a correctly placed
+artifact had no graph-set document to be found through. Both are now this
+command's job, and the read-back is what proves it: a count of builds that
+returned cannot go red on either failure, and did not.
+
 ## Address-free programs
 
 Paul ruled the exported-program blob ADDRESS-FREE: ``torch.export.save`` is
@@ -49,12 +62,18 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from . import endpoint_lock as el
 from . import work_ledger, workspace
 
 logger = logging.getLogger(__name__)
+
+#: Compile one specialization: (spec, program blob, destination) -> artifact.
+#: The production implementation is :func:`_build` (one child process per
+#: graph); an explicit one is the local seam — no GPU, no inductor — and
+#: nothing else.
+Builder = Callable[["Spec", Path, Path], Path]
 
 #: Outcome vocabulary. Closed: every specialization ends in exactly one of
 #: these and the summary counts them.
@@ -304,17 +323,24 @@ def _ensure_program(spec: Spec, store: Any, rederive: Any, scratch: Path) -> Pat
 
 def _build(
     spec: Spec, *, program: Path, cas_root: Path, sm: str, destination: Path,
-) -> None:
-    """Compile one specialization in its OWN process.
+) -> Path:
+    """Compile one specialization in its OWN process, and return its artifact.
 
     A child, not a thread: inductor keeps process-global mutable state, and a
     mint that dies must not take the driver with it. ``destination`` is
     deliberately NOT created here — torchcg refuses a destination that already
     exists unless every byte matches, so an empty directory made "for tidiness"
     reads as occupied by something that is not the artifact.
+
+    The child writes the artifact path it produced into ``result``, and this
+    function READS it (pgw#1532). The request already asked for that file and
+    nothing consumed it: the parent threw the child's only output away, so it
+    had nothing to publish and could only count exit statuses — which is
+    precisely how a green run left the serving path empty.
     """
     from ..compile_cache import toolchain_digest
 
+    result_path = destination.parent / f"{spec.short}.result.json"
     request = {
         "blob": str(program),
         "graph": spec.graph,
@@ -324,7 +350,7 @@ def _build(
         "toolchain": dict(toolchain_digest()),
         "cas": str(cas_root),
         "destination": str(destination),
-        "result": str(destination.parent / f"{spec.short}.result.json"),
+        "result": str(result_path),
     }
     request_path = destination.parent / f"{spec.short}.request.json"
     request_path.parent.mkdir(parents=True, exist_ok=True)
@@ -344,11 +370,141 @@ def _build(
         raise CompileError(
             f"mint child exited {completed.returncode} for graph {spec.short}"
         )
+    try:
+        artifact = Path(result_path.read_text(encoding="utf-8").strip())
+    except OSError as exc:
+        raise CompileError(
+            f"the mint child for graph {spec.short} exited 0 but wrote no "
+            f"artifact path to {result_path} ({exc}) — a zero exit is not an "
+            f"artifact, and there is nothing to publish"
+        ) from exc
+    if not artifact.exists():
+        raise CompileError(
+            f"the mint child for graph {spec.short} named {artifact} and it "
+            f"does not exist"
+        )
+    return artifact
+
+
+def _default_builder(cas_root: Path, sm: str) -> Builder:
+    """THE production builder: one child process per specialization."""
+
+    def build(spec: Spec, program: Path, destination: Path) -> Path:
+        return _build(
+            spec, program=program, cas_root=Path(cas_root), sm=sm,
+            destination=destination,
+        )
+
+    return build
+
+
+def endpoint_module(endpoint_dir: Path) -> str:
+    """The module name adoption looks this endpoint's document up BY.
+
+    Read through ``load_endpoint`` — the one reader of ``endpoint.toml``'s
+    ``main =`` — because ``_adoption_source`` reads it the same way. Two
+    spellings of "which document is this endpoint's" is exactly the drift that
+    would make ``compile`` publish under a name ``up`` never asks for.
+    """
+    from ..discovery.discover import prime_sys_path
+    from ..serving.loader import load_endpoint
+
+    prime_sys_path(endpoint_dir)
+    return str(load_endpoint(endpoint_dir).module_name)
+
+
+# --------------------------------------------------------------------------
+# The serving reader — the only witness that counts
+# --------------------------------------------------------------------------
+
+
+def serving_reader(cas_root: Path) -> Any:
+    """The store object BOOT-TIME ADOPTION builds, over this machine's CAS.
+
+    Constructed exactly the way ``cli/daemon._adoption_source`` constructs it,
+    and deliberately NOT the store this command publishes through. "My writer
+    returned without raising" and "the reader that arms graphs can find it" are
+    different claims, and pgw#1532 is what happens when only the first one is
+    ever checked: the write succeeded, into torchcg's engine cache, and the
+    reader saw nothing.
+    """
+    from .._vendor.tensorfs import LocalCAS
+    from .._vendor.torchcg.store import LocalGraphStore
+
+    return LocalGraphStore(LocalCAS(Path(cas_root)))
+
+
+def unservable(cas_root: Path, specs: Tuple[Spec, ...], env: Any, module: str) -> List[str]:
+    """What the serving reader still cannot find. Empty means servable.
+
+    Reports the DOCUMENT as its own row: an endpoint whose artifacts are all
+    present but whose graph-set document is missing adopts nothing, because
+    adoption enumerates lanes out of the document and never reaches the
+    artifacts. That was the second half of the same silent failure — nothing in
+    this CLI called ``put_graphs``, so ``get_graphs`` answered a clean miss and
+    ``up`` served eager over a full store.
+    """
+    reader = serving_reader(cas_root)
+    gaps: List[str] = []
+    try:
+        document = reader.get_graphs(module)
+    except Exception as exc:  # noqa: BLE001 — unreadable IS unservable
+        document = None
+        gaps.append(f"graph-set document {module!r}: unreadable ({exc})")
+    if document is None and not gaps:
+        gaps.append(f"graph-set document {module!r}: absent")
+    for spec in specs:
+        try:
+            present = reader.has_artifact(spec.graph, env)
+        except Exception as exc:  # noqa: BLE001
+            gaps.append(f"artifact {spec.short}: unreadable ({exc})")
+            continue
+        if not present:
+            gaps.append(f"artifact {spec.short}: absent at ({spec.short}, {env.value})")
+    return gaps
+
+
+def _publish_document(cas_root: Path, lock_path: Path, module: str) -> None:
+    """Publish the committed lock's graph-set document into this box's store.
+
+    The document is not derived here and must not be: the lock IS the authored
+    document, ``specializations()`` already reads its ``[derive].document``
+    block for the very specs being built, and adoption looks the same document
+    up by module name. Writing a second one would be a second answer to what
+    this endpoint compiles to.
+    """
+    from .._vendor.torchcg.document import GraphSetDocument
+
+    block = el.read_derive_block(lock_path)
+    if block is None:  # unreachable via compile_all, which refuses earlier
+        return
+    document = GraphSetDocument.decode(block.decoded()["graphs"])
+    serving_reader(cas_root).put_graphs(module, document)
+    logger.info(
+        "compile: published graph-set document %s (%d lane(s), %d graph(s)) — "
+        "adoption enumerates lanes out of this; artifacts alone adopt nothing",
+        module, len(document.lanes),
+        sum(len(lane.graphs) for lane in document.lanes),
+    )
 
 
 # --------------------------------------------------------------------------
 # The driver
 # --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Report:
+    """What one ``compile`` run did, and whether it left anything servable.
+
+    ``unservable`` is the verdict and ``outcomes`` is the narrative. They are
+    separate fields because they answer different questions and the whole of
+    pgw#1532 is that the narrative was mistaken for the verdict: fourteen
+    ``BUILT`` rows and rc=0 over a serving path that could arm nothing.
+    """
+
+    outcomes: List[Outcome]
+    unservable: List[str]
 
 
 def compile_all(
@@ -360,7 +516,10 @@ def compile_all(
     lockfile: Optional[Path],
     only: int = 0,
     vram_budget_gb: float = 0.0,
-) -> List[Outcome]:
+    module: str = "",
+    store: Any = None,
+    builder: Optional[Builder] = None,
+) -> Report:
     specs = specializations(lock_path)
     if only:
         specs = specs[:only]
@@ -369,7 +528,7 @@ def compile_all(
             "compile: this endpoint's lock claims no compiled specializations "
             "— nothing to build (it serves eager by declaration)"
         )
-        return []
+        return Report([], [])
 
     floor = declared_floor_gb(endpoint_dir)
     grant = grant_gb(vram_budget_gb)
@@ -381,10 +540,14 @@ def compile_all(
             "grant. NO-OP: %d specialization(s) left unbuilt on purpose.",
             grant, floor, len(specs),
         )
-        return [
-            Outcome(spec, BELOW_FLOOR, f"grant {grant:.1f} GiB < floor {floor:.1f} GiB")
-            for spec in specs
-        ]
+        return Report(
+            [
+                Outcome(spec, BELOW_FLOOR,
+                        f"grant {grant:.1f} GiB < floor {floor:.1f} GiB")
+                for spec in specs
+            ],
+            [],
+        )
     if floor is None:
         logger.info(
             "compile: compiled floor UNKNOWN for this endpoint (no declared "
@@ -392,8 +555,13 @@ def compile_all(
             "not a floor of zero"
         )
 
+    from ..serving.mint import publish_compiled
+
     env = _env_identity(endpoint_dir, sm, lockfile)
-    store = _store(cas_root)
+    if store is None:
+        store = _store(cas_root)
+    build = builder if builder is not None else _default_builder(cas_root, sm)
+    module = module or endpoint_module(endpoint_dir)
     artifacts_dir = Path(endpoint_dir) / ".compiled-graphs"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
@@ -435,12 +603,24 @@ def compile_all(
                     continue
                 logger.info("%s: building", label)
                 program = _ensure_program(spec, store, rederive, artifacts_dir)
-                _build(
-                    spec, program=program, cas_root=Path(cas_root), sm=sm,
-                    destination=destination,
-                )
+                artifact = build(spec, program, destination)
+                # PUBLISH, then ASK THE READER. Neither step existed before
+                # pgw#1532 and neither one alone is enough: the publish is what
+                # puts the bytes in the band adoption addresses, and the
+                # read-back is the only thing that can go red if it did not.
+                published = publish_compiled(store, spec.graph, env, artifact)
+                if not serving_reader(cas_root).has_artifact(spec.graph, env):
+                    raise CompileError(
+                        f"built {spec.short} and the publish reported "
+                        f"{published or 'nothing'}, and the store adoption "
+                        f"reads at boot still has no artifact at "
+                        f"({spec.short}, {env.value}). The build is not the "
+                        f"deliverable — an artifact the serving reader can "
+                        f"find is."
+                    )
+                logger.info("%s: built and servable (%s)", label, published or "published")
                 outcomes.append(
-                    Outcome(spec, BUILT, wall_s=time.monotonic() - started)
+                    Outcome(spec, BUILT, published, wall_s=time.monotonic() - started)
                 )
         except work_ledger.Busy:
             logger.info(
@@ -454,7 +634,15 @@ def compile_all(
                 Outcome(spec, FAILED, f"{type(exc).__name__}: {exc}",
                         wall_s=time.monotonic() - started)
             )
-    return outcomes
+
+    # The document is published for the WHOLE run, not per specialization: it
+    # names every lane the lock claims, so a partial run still leaves adoption
+    # able to enumerate and the mint able to fill the rest. Publishing it after
+    # the artifacts is the same durability order the runtime mint uses —
+    # nothing is announced before it exists.
+    _publish_document(cas_root, lock_path, module)
+    gaps = unservable(cas_root, specs, env, module)
+    return Report(outcomes, gaps)
 
 
 def _rederive_programs(
@@ -533,6 +721,51 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
     parser.set_defaults(_handler=run_compile)
 
 
+def summarize(report: Report) -> Tuple[str, int]:
+    """What the operator is told, and what the shell is told, from ONE fact.
+
+    Separated from :func:`run_compile` so the verdict is testable against real
+    reports rather than only through argparse and a live inductor. The whole of
+    pgw#1532 lives in the second element: for 26 minutes of real GPU work this
+    returned 0 beside ``built=14 (of 14)`` while the serving path held 14 holes,
+    because the exit code was computed from the outcome tally and the tally
+    counted builds that returned.
+    """
+    counts: Dict[str, int] = {}
+    for outcome in report.outcomes:
+        counts[outcome.state] = counts.get(outcome.state, 0) + 1
+    lines = [
+        "gen-worker compile: "
+        + ", ".join(f"{state}={counts[state]}" for state in sorted(counts))
+        + f" (of {len(report.outcomes)})\n"
+    ]
+    if report.unservable:
+        # NOT a warning. A run that leaves the serving path unable to arm what
+        # it was asked for has failed at the only thing it was for, and saying
+        # so quietly beside a green summary is the defect this fixed, not a
+        # style choice.
+        lines.append(
+            f"gen-worker compile: NOT SERVABLE — {len(report.unservable)} "
+            f"gap(s) in the store `gen-worker up` adopts from:\n"
+        )
+        lines.extend(f"  - {gap}\n" for gap in report.unservable)
+        lines.append(
+            "  A build that returned is not an artifact the serving path can "
+            "find; this command reports the second.\n"
+        )
+        return "".join(lines), 1
+    if counts.get(FAILED):
+        return "".join(lines), 1
+    if counts.get(BELOW_FLOOR) or not report.outcomes:
+        return "".join(lines), 0
+    lines.append(
+        f"gen-worker compile: SERVABLE — the graph-set document and all "
+        f"{len(report.outcomes)} artifact(s) are readable through the store "
+        f"boot-time adoption uses.\n"
+    )
+    return "".join(lines), 0
+
+
 def run_compile(args: argparse.Namespace) -> int:
     logging.basicConfig(
         level=logging.INFO, format="%(message)s", stream=sys.stderr, force=False,
@@ -549,7 +782,7 @@ def run_compile(args: argparse.Namespace) -> int:
     lock_path = Path(args.lock) if args.lock else endpoint_dir / el.LOCK_FILENAME
     cas_root = Path(args.graph_store) if args.graph_store else workspace.graph_cas_root()
     try:
-        outcomes = compile_all(
+        report = compile_all(
             endpoint_dir=endpoint_dir,
             lock_path=lock_path,
             cas_root=cas_root,
@@ -561,29 +794,29 @@ def run_compile(args: argparse.Namespace) -> int:
     except CompileError as exc:
         sys.stderr.write(f"gen-worker compile: {exc}\n")
         return 1
-    counts: Dict[str, int] = {}
-    for outcome in outcomes:
-        counts[outcome.state] = counts.get(outcome.state, 0) + 1
-    sys.stderr.write(
-        "gen-worker compile: "
-        + ", ".join(f"{state}={counts[state]}" for state in sorted(counts))
-        + f" (of {len(outcomes)})\n"
-    )
-    return 1 if counts.get(FAILED) else 0
+    summary, code = summarize(report)
+    sys.stderr.write(summary)
+    return code
 
 
 __all__ = [
     "BELOW_FLOOR",
     "BUILT",
     "CLAIMED",
+    "Builder",
     "CompileError",
     "FAILED",
     "FETCHED",
     "Outcome",
     "PRESENT",
+    "Report",
     "Spec",
     "add_subparser",
     "compile_all",
+    "endpoint_module",
     "run_compile",
+    "serving_reader",
     "specializations",
+    "summarize",
+    "unservable",
 ]

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -18,7 +18,7 @@ than as process adoption.
 weightless trace and the mint runs against it, so ``compile`` legitimately runs
 before ``download``.
 
-**SERVABLE, OR IT FAILED (pgw#1532).** The success criterion is not "the builds
+**SERVABLE, OR IT FAILED (pgw#1533).** The success criterion is not "the builds
 returned". It is "the reader that arms graphs at boot can find what I wrote",
 and it is checked by asking THAT reader, through a store object this command did
 not publish through. Before this, ``compile`` reported ``built=14 (of 14)`` with
@@ -333,7 +333,7 @@ def _build(
     reads as occupied by something that is not the artifact.
 
     The child writes the artifact path it produced into ``result``, and this
-    function READS it (pgw#1532). The request already asked for that file and
+    function READS it (pgw#1533). The request already asked for that file and
     nothing consumed it: the parent threw the child's only output away, so it
     had nothing to publish and could only count exit statuses — which is
     precisely how a green run left the serving path empty.
@@ -424,7 +424,7 @@ def serving_reader(cas_root: Path) -> Any:
     Constructed exactly the way ``cli/daemon._adoption_source`` constructs it,
     and deliberately NOT the store this command publishes through. "My writer
     returned without raising" and "the reader that arms graphs can find it" are
-    different claims, and pgw#1532 is what happens when only the first one is
+    different claims, and pgw#1533 is what happens when only the first one is
     ever checked: the write succeeded, into torchcg's engine cache, and the
     reader saw nothing.
     """
@@ -499,7 +499,7 @@ class Report:
 
     ``unservable`` is the verdict and ``outcomes`` is the narrative. They are
     separate fields because they answer different questions and the whole of
-    pgw#1532 is that the narrative was mistaken for the verdict: fourteen
+    pgw#1533 is that the narrative was mistaken for the verdict: fourteen
     ``BUILT`` rows and rc=0 over a serving path that could arm nothing.
     """
 
@@ -605,7 +605,7 @@ def compile_all(
                 program = _ensure_program(spec, store, rederive, artifacts_dir)
                 artifact = build(spec, program, destination)
                 # PUBLISH, then ASK THE READER. Neither step existed before
-                # pgw#1532 and neither one alone is enough: the publish is what
+                # pgw#1533 and neither one alone is enough: the publish is what
                 # puts the bytes in the band adoption addresses, and the
                 # read-back is the only thing that can go red if it did not.
                 published = publish_compiled(store, spec.graph, env, artifact)
@@ -726,7 +726,7 @@ def summarize(report: Report) -> Tuple[str, int]:
 
     Separated from :func:`run_compile` so the verdict is testable against real
     reports rather than only through argparse and a live inductor. The whole of
-    pgw#1532 lives in the second element: for 26 minutes of real GPU work this
+    pgw#1533 lives in the second element: for 26 minutes of real GPU work this
     returned 0 beside ``built=14 (of 14)`` while the serving path held 14 holes,
     because the exit code was computed from the outcome tally and the tally
     counted builds that returned.

--- a/src/gen_worker/cuda_root.py
+++ b/src/gen_worker/cuda_root.py
@@ -58,10 +58,12 @@ from typing import List, Optional
 CUDA_ROOT = Path("/usr/local/cuda")
 
 #: Where a CUDA root gets composed when ``/usr/local`` is not this process's to
-#: write. Beside the box's other cozy caches, and per-user by construction.
-USER_CUDA_ROOT = Path(
-    os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")
-) / "cozy" / "cuda-root"
+#: write. Spelled the same way ``cli/workspace.DEFAULT_GRAPH_CAS`` spells the
+#: box's graph CAS — one shape for "the box's cozy cache", and no environment
+#: read: §1.18 is right that "wherever XDG happens to point" is not a config
+#: value anyone can name, and the operator's own knob for this is CUDA_HOME,
+#: which wins outright and is never second-guessed.
+USER_CUDA_ROOT = Path.home() / ".cache" / "cozy" / "cuda-root"
 
 #: The header that proves the flattened-include problem is solved.
 CRT_HOST_DEFINES = Path("include/crt/host_defines.h")

--- a/src/gen_worker/cuda_root.py
+++ b/src/gen_worker/cuda_root.py
@@ -72,7 +72,7 @@ NV_TARGET = Path("include/nv/target")
 
 
 def default_root() -> Path:
-    """Where THIS process can actually compose a CUDA root (pgw#1532).
+    """Where THIS process can actually compose a CUDA root (pgw#1533).
 
     ``/usr/local/cuda`` is the answer on a pod, and it stayed the only answer
     for too long. On a developer box ``/usr/local`` is root-owned: the compose

--- a/src/gen_worker/cuda_root.py
+++ b/src/gen_worker/cuda_root.py
@@ -57,10 +57,40 @@ from typing import List, Optional
 
 CUDA_ROOT = Path("/usr/local/cuda")
 
+#: Where a CUDA root gets composed when ``/usr/local`` is not this process's to
+#: write. Beside the box's other cozy caches, and per-user by construction.
+USER_CUDA_ROOT = Path(
+    os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")
+) / "cozy" / "cuda-root"
+
 #: The header that proves the flattened-include problem is solved.
 CRT_HOST_DEFINES = Path("include/crt/host_defines.h")
 #: The CCCL header several cu13 headers include and no tree in the image ships.
 NV_TARGET = Path("include/nv/target")
+
+
+def default_root() -> Path:
+    """Where THIS process can actually compose a CUDA root (pgw#1532).
+
+    ``/usr/local/cuda`` is the answer on a pod, and it stayed the only answer
+    for too long. On a developer box ``/usr/local`` is root-owned: the compose
+    ran as the user, ``mkdir`` raised ``PermissionError`` minutes into a mint,
+    and every specialization failed for a reason that reads like a missing
+    toolkit while the toolkit was sitting in the venv's own ``nvidia-*``
+    wheels. Measured on this box: fourteen specializations, all
+    ``FileNotFoundError: '/usr/local/cuda/include'``.
+
+    An EXISTING ``/usr/local/cuda`` always wins — an image that composed one in
+    its Dockerfile, or ships a devel base, is not to be second-guessed. Then a
+    writable ``/usr/local``, which is the image case before the compose has
+    run. Only when neither holds does this fall to a per-user cache, and it says
+    so in the composition notes rather than silently relocating the toolkit.
+    """
+    if CUDA_ROOT.exists():
+        return CUDA_ROOT
+    if os.access(CUDA_ROOT.parent, os.W_OK):
+        return CUDA_ROOT
+    return USER_CUDA_ROOT
 
 
 @dataclass
@@ -70,10 +100,17 @@ class Composition:
     root: str = ""
     crt: str = ""
     nv: str = ""
+    #: WHERE the root was composed — the value a caller must export as
+    #: ``CUDA_HOME``. Distinct from ``root``, which names the donor wheel: a
+    #: caller that reads the module constant instead of this field points torch
+    #: at a directory nobody wrote.
+    path: str = ""
     notes: List[str] = field(default_factory=list)
 
     def lines(self) -> List[str]:
         out = [f"cuda_root: {self.root or 'none'}"]
+        if self.path:
+            out.append(f"cuda_home: {self.path}")
         if self.crt:
             out.append(f"cuda_crt: {self.crt}")
         if self.nv:
@@ -146,18 +183,26 @@ def _install_cuda_cccl(target: Path) -> str:
     return ""
 
 
-def compose(root_dir: Path = CUDA_ROOT) -> Composition:
+def compose(root_dir: Optional[Path] = None) -> Composition:
     """Assemble ``root_dir`` out of parts the image already ships.
 
-    Idempotent by the same test the synthesized step uses: a pre-existing
-    ``/usr/local/cuda`` is left alone. An image that already has a real CUDA
-    install (a devel base, a distro package) is not one this recipe should
-    second-guess.
+    Idempotent by the same test the synthesized step uses: a pre-existing root
+    is left alone. An image that already has a real CUDA install (a devel base,
+    a distro package) is not one this recipe should second-guess.
+
+    ``root_dir`` defaults to :func:`default_root`, which is what makes this
+    work off a pod at all.
     """
-    out = Composition()
+    root_dir = Path(root_dir) if root_dir is not None else default_root()
+    out = Composition(path=str(root_dir))
     if root_dir.exists():
         out.root = "preexisting"
         return out
+    if root_dir != CUDA_ROOT:
+        out.notes.append(
+            f"cuda_root: {CUDA_ROOT} is neither present nor this process's to "
+            f"create, so the root is composed at {root_dir} instead — export "
+            f"CUDA_HOME from `Composition.path`, never from the constant")
 
     wheel = wheel_cuda_root()
     if not wheel:
@@ -195,15 +240,17 @@ def compose(root_dir: Path = CUDA_ROOT) -> Composition:
     return out
 
 
-def missing_parts(root_dir: Path = CUDA_ROOT) -> List[str]:
+def missing_parts(root_dir: Optional[Path] = None) -> List[str]:
     """Which of the three measured facts this image still fails, if any.
 
     The one predicate ``aot_preconditions`` reads, so "is the CUDA root usable"
     has a single implementation and the gate cannot prove something the
-    composer never did.
+    composer never did — which is also why its default must be the composer's
+    default and not a second spelling of it.
     """
+    root_dir = Path(root_dir) if root_dir is not None else default_root()
     if not root_dir.is_dir():
-        return ["the root itself (/usr/local/cuda does not exist)"]
+        return [f"the root itself ({root_dir} does not exist)"]
     gaps = []
     if not (root_dir / "include" / "cuda_runtime.h").exists():
         gaps.append("include/cuda_runtime.h")
@@ -241,12 +288,14 @@ def main(argv: Optional[List[str]] = None) -> int:
         description=("Compose /usr/local/cuda for AOTInductor's host compile. "
                      "Run it in your Dockerfile when an endpoint in the image "
                      "declares an AOT export."))
-    parser.add_argument("--root", default=str(CUDA_ROOT),
-                        help="where to compose the root (default /usr/local/cuda)")
+    parser.add_argument("--root", default="",
+                        help="where to compose the root (default: "
+                             "/usr/local/cuda when it exists or /usr/local is "
+                             "writable, else a per-user cache root)")
     parser.add_argument("--check", action="store_true",
                         help="report what is missing and exit nonzero; compose nothing")
     args = parser.parse_args(argv)
-    root = Path(args.root)
+    root = Path(args.root) if args.root else default_root()
 
     if args.check:
         gaps = missing_parts(root)

--- a/src/gen_worker/serving/mint.py
+++ b/src/gen_worker/serving/mint.py
@@ -652,6 +652,58 @@ def driver_floor() -> Optional[str]:
         return None
 
 
+def artifact_manifest(env: Any, package: Path) -> Any:
+    """The COMPATIBILITY SET of these bytes, read off the artifact itself.
+
+    Paul, 2026-08-18: version constraints derived FROM THE ARTIFACT — its own
+    ELF ``DT_NEEDED`` entries plus the AOTI shim it was built against — never a
+    snapshot of the environment's package list. Each row is a same-major ``>=``
+    floor at the version present at mint; the sm and the driver floor ride their
+    own fields. An artifact whose kernels are all embedded Triton/SASS names no
+    libraries at all, and that is a correct answer, not a recording bug.
+
+    The mint always runs in the CURRENT env — by definition the newest the fleet
+    runs — so there is deliberately no staleness logic here and no opportunistic
+    re-mint.
+    """
+    from .._vendor.torchcg import RequirementsManifest
+
+    rows = dict(artifact_constraints(package))
+    name, floor = torch_shim_floor()
+    rows[name] = floor
+    return RequirementsManifest(
+        include_set=tuple(sorted(rows.items())),
+        sm_compiled=env.sm,
+        cuda_floor=driver_floor(),
+    )
+
+
+def publish_compiled(store: Any, graph: str, env: Any, artifact: Path) -> str:
+    """Put one freshly-compiled artifact WHERE THE SERVING PATH READS IT.
+
+    THE ONE PUBLISHER (pgw#1532). ``Engine.compile`` banks its output in
+    torchcg's own engine store — that is the engine's compile cache, keyed by
+    ``cg-key-v1`` and consulted by ``Engine.resolve`` so a re-compile is a
+    reuse. It is NOT the band adoption reads. ``holes()``, ``has_artifact`` and
+    every boot-time adopt address artifacts as ``(cg-graph-v1, cg-env-v2)`` in
+    the ``GraphStore``, and NOTHING lands there unless somebody calls
+    ``publish_artifact``.
+
+    The runtime mint called it; ``gen-worker compile`` did not — so the CLI
+    burned 26 minutes of real inductor work on this box, reported
+    ``built=14 (of 14)`` with rc=0, and left the serving reader looking at 14
+    holes. One compile path with two publishers was always going to drift; this
+    is the single one, and both callers go through it.
+
+    ``publish_artifact`` takes the package FILE, not the unpacked directory the
+    compiler returns (pgw#1471): an artifact position addresses ONE set of bytes
+    by digest and a directory has no digest.
+    """
+    package = artifact_package(Path(artifact))
+    outcome = store.publish_artifact(graph, env, package, artifact_manifest(env, package))
+    return str(getattr(outcome, "value", outcome) or "")
+
+
 def satisfied(
     manifest: Any, present: Mapping[str, str]
 ) -> Tuple[bool, Tuple[str, ...]]:
@@ -1057,15 +1109,7 @@ class BackgroundMint:
 
         published = ""
         if self.store is not None:
-            # pgw#1471: PUBLISH takes the package FILE, not the unpacked
-            # directory the compiler returns. `publish_artifact` requires a
-            # file because an artifact position addresses ONE set of bytes by
-            # digest, and a directory has no digest. `_manifest` reads the same
-            # package and unwraps to the ELF object inside it.
-            package = artifact_package(artifact)
-            outcome = self.store.publish_artifact(
-                record.graph, env, package, self._manifest(env, package))
-            published = str(getattr(outcome, "value", outcome) or "")
+            published = publish_compiled(self.store, record.graph, env, artifact)
 
         armed = False
         try:
@@ -1093,32 +1137,6 @@ class BackgroundMint:
         return MintedHole(
             graph=record.graph, target=record.target, artifact=artifact,
             published=published, armed=armed,
-        )
-
-    def _manifest(self, env: Any, artifact: Path) -> Any:
-        """The COMPATIBILITY SET of these bytes, read off the artifact itself.
-
-        Paul, 2026-08-18: version constraints derived FROM THE ARTIFACT — its
-        own ELF ``DT_NEEDED`` entries plus the AOTI shim it was built against
-        — never a snapshot of the environment's package list. Each row is a
-        same-major ``>=`` floor at the version present at mint; the sm and the
-        driver floor ride their own fields. An artifact whose kernels are all
-        embedded Triton/SASS names no libraries at all, and that is a correct
-        answer, not a recording bug.
-
-        The mint always runs in the CURRENT env — by definition the newest the
-        fleet runs — so there is deliberately no staleness logic here and no
-        opportunistic re-mint.
-        """
-        from .._vendor.torchcg import RequirementsManifest
-
-        rows = dict(artifact_constraints(artifact))
-        name, floor = torch_shim_floor()
-        rows[name] = floor
-        return RequirementsManifest(
-            include_set=tuple(sorted(rows.items())),
-            sm_compiled=env.sm,
-            cuda_floor=driver_floor(),
         )
 
     # -- the serving reserve, at the scheduler -------------------------------
@@ -1192,6 +1210,9 @@ __all__ = [
     "MissingProgram",
     "PROGRAM_GRAPH_FIELD",
     "artifact_constraints",
+    "artifact_manifest",
+    "artifact_package",
+    "publish_compiled",
     "assert_satisfied",
     "present_libraries",
     "driver_floor",

--- a/src/gen_worker/serving/mint.py
+++ b/src/gen_worker/serving/mint.py
@@ -681,7 +681,7 @@ def artifact_manifest(env: Any, package: Path) -> Any:
 def publish_compiled(store: Any, graph: str, env: Any, artifact: Path) -> str:
     """Put one freshly-compiled artifact WHERE THE SERVING PATH READS IT.
 
-    THE ONE PUBLISHER (pgw#1532). ``Engine.compile`` banks its output in
+    THE ONE PUBLISHER (pgw#1533). ``Engine.compile`` banks its output in
     torchcg's own engine store — that is the engine's compile cache, keyed by
     ``cg-key-v1`` and consulted by ``Engine.resolve`` so a re-compile is a
     reuse. It is NOT the band adoption reads. ``holes()``, ``has_artifact`` and

--- a/src/gen_worker/serving/mint_child.py
+++ b/src/gen_worker/serving/mint_child.py
@@ -130,7 +130,7 @@ def _ensure_cuda_home(target_arch: str) -> None:
     when nobody has said does this compose one, and `compose()` is itself
     idempotent -- a pre-existing root is left alone rather than rebuilt.
 
-    CUDA_HOME is set from WHERE THE COMPOSE ACTUALLY WROTE (pgw#1532), not from
+    CUDA_HOME is set from WHERE THE COMPOSE ACTUALLY WROTE (pgw#1533), not from
     the module constant. Reading the constant made this correct only on a pod:
     on a box whose `/usr/local` is root-owned the compose could not create
     `/usr/local/cuda`, and this pointed torch at it anyway. Fourteen
@@ -162,7 +162,7 @@ def _ensure_cuda_home(target_arch: str) -> None:
         )
     os.environ["CUDA_HOME"] = composed.path
     logger.info(
-        "mint: CUDA_HOME=%s (pgw#1464/pgw#1532) — AOTI resolves it at the link "
+        "mint: CUDA_HOME=%s (pgw#1464/pgw#1533) — AOTI resolves it at the link "
         "step, after the compile is already paid",
         composed.path,
     )

--- a/src/gen_worker/serving/mint_child.py
+++ b/src/gen_worker/serving/mint_child.py
@@ -130,6 +130,14 @@ def _ensure_cuda_home(target_arch: str) -> None:
     when nobody has said does this compose one, and `compose()` is itself
     idempotent -- a pre-existing root is left alone rather than rebuilt.
 
+    CUDA_HOME is set from WHERE THE COMPOSE ACTUALLY WROTE (pgw#1532), not from
+    the module constant. Reading the constant made this correct only on a pod:
+    on a box whose `/usr/local` is root-owned the compose could not create
+    `/usr/local/cuda`, and this pointed torch at it anyway. Fourteen
+    specializations died on `FileNotFoundError:
+    '/usr/local/cuda/include'` -- while the toolkit was in the venv's own
+    `nvidia-*` wheels the whole time, which is what `compose()` builds from.
+
     Only for `sm_*`: a CPU target needs no CUDA root, and composing one there
     would be work done to answer a question nobody asked.
     """
@@ -139,12 +147,24 @@ def _ensure_cuda_home(target_arch: str) -> None:
         return
     from .. import cuda_root
 
-    cuda_root.compose()
-    os.environ["CUDA_HOME"] = str(cuda_root.CUDA_ROOT)
+    composed = cuda_root.compose()
+    for line in composed.lines():
+        logger.info("mint: %s", line)
+    if cuda_root.missing_parts(Path(composed.path)):
+        # Stated, never fatal: an incomplete root is still worth pointing at
+        # (the gaps may be ones this compile does not need), and the refusal
+        # belongs to `aot_preconditions`, not here.
+        logger.warning(
+            "mint: the CUDA root at %s is incomplete (%s) — AOTI resolves it "
+            "at the LINK step, so a gap here surfaces after the compile is "
+            "already paid for",
+            composed.path, ", ".join(cuda_root.missing_parts(Path(composed.path))),
+        )
+    os.environ["CUDA_HOME"] = composed.path
     logger.info(
-        "mint: composed the CUDA root at %s and set CUDA_HOME (pgw#1464) — "
-        "AOTI resolves it at the link step, after the compile is already paid",
-        cuda_root.CUDA_ROOT,
+        "mint: CUDA_HOME=%s (pgw#1464/pgw#1532) — AOTI resolves it at the link "
+        "step, after the compile is already paid",
+        composed.path,
     )
 
 

--- a/tests/test_compile_servability.py
+++ b/tests/test_compile_servability.py
@@ -1,23 +1,17 @@
-"""pgw#1532: ``gen-worker compile`` succeeds only if the SERVING READER agrees.
+"""SERVABILITY: ``gen-worker compile`` succeeds only if the SERVING READER agrees.
 
-Measured on a 4070 the night this was filed: ``gen-worker compile`` ran fourteen
-real inductor/AOTI builds over 26 minutes, reported ``built=14 (of 14)``, exited
-0 — and boot-time adoption then saw **0 artifacts and 14 holes**. Two causes,
-both of them the same shape:
+The subject is one contract — *what this verb owes is not builds that returned,
+it is an endpoint the boot-time adopt path can arm* — and everything here is a
+precondition of it: that a built artifact lands in the band adoption addresses,
+that the graph-set document adoption enumerates through gets published, that the
+verdict and the exit code are computed from a reader rather than from a tally,
+and that the mint child can find a CUDA root on the box it is actually running
+on (no root, no artifact, so it belongs to the same claim).
 
-* ``Engine.compile`` banks its output in torchcg's own engine cache, keyed by
-  ``cg-key-v1``. NOTHING lands in the ``(cg-graph-v1, cg-env-v2)`` band adoption
-  reads unless somebody calls ``publish_artifact``. The runtime mint did. The
-  CLI did not.
-* Nothing in the CLI ever called ``put_graphs``, so even a correctly placed
-  artifact had no graph-set document to be enumerated through.
-
-Neither could be caught by anything ``compile`` measured, because it measured
-builds that returned. These tests drive the REAL ``compile_all`` — its work
-ledger, its store, its publish, its census — with only the inductor child
-replaced by a seam that emits a real torchcg artifact (``tests/tcg_artifacts``,
-no torch and no GPU). The red arms are the point: a build that publishes
-nowhere, and a run that never publishes its document, must both come out RED.
+Every test drives the REAL ``compile_all`` — its work ledger, its store, its
+publish, its census — with only the inductor child replaced by a seam emitting a
+real torchcg artifact (``tests/tcg_artifacts``: no torch, no GPU). The red arms
+are the point, because each of them was once GREEN.
 """
 
 from __future__ import annotations
@@ -162,6 +156,7 @@ def _run(endpoint: Path, cas: Path, **kwargs: Any) -> compile_cli.Report:
 def test_a_built_graph_lands_where_boot_time_adoption_reads_it(
     endpoint: Path, tmp_path: Path
 ) -> None:
+    # pgw#1533: `built=14 (of 14)`, rc 0, 26 min of real GPU work, 0 artifacts armed.
     cas = tmp_path / "graph-cas"
     store = LocalGraphStore(LocalCAS(cas))
     _seed_programs(store, tmp_path)
@@ -248,6 +243,7 @@ class PublishesNowhere:
 def test_a_compile_that_publishes_nowhere_fails_loudly(
     endpoint: Path, tmp_path: Path
 ) -> None:
+    # pgw#1533: the CLI never called `publish_artifact`; only the runtime mint did.
     cas = tmp_path / "graph-cas"
     real = LocalGraphStore(LocalCAS(cas))
     _seed_programs(real, tmp_path)
@@ -271,7 +267,8 @@ def test_a_compile_that_publishes_nowhere_fails_loudly(
 def test_an_unpublished_graph_set_document_is_a_gap_even_when_every_artifact_is_there(
     endpoint: Path, tmp_path: Path
 ) -> None:
-    """Findings #5 and #6 are independent, and either one alone serves eager.
+    """pgw#1533: the publish and the document are independent, and either gap alone
+    serves eager.
 
     Adoption enumerates lanes out of the document and never reaches the
     artifacts without one, so a store full of correctly addressed bytes and no
@@ -318,7 +315,7 @@ def test_an_artifact_under_the_wrong_env_is_absent_to_the_reader(
 
 
 def test_the_shell_learns_unservable_even_when_every_build_returned() -> None:
-    """The exact shape of the night this was filed: 14 BUILT, rc 0, 14 holes.
+    """pgw#1533: the exact shape of the night it was found — 14 BUILT, rc 0, 14 holes.
 
     Driven against a real ``Report`` rather than through argparse, because the
     thing under test is which fact the exit code is computed from.
@@ -353,7 +350,7 @@ def test_a_below_floor_no_op_is_not_an_unservable_run(
 
 
 # --------------------------------------------------------------------------
-# pgw#1532 finding #4 — the CUDA root the mint child points torch at
+# pgw#1533: the CUDA root the mint child points torch at — no root, no artifact
 # --------------------------------------------------------------------------
 
 

--- a/tests/test_compile_servable_pgw1532.py
+++ b/tests/test_compile_servable_pgw1532.py
@@ -1,0 +1,414 @@
+"""pgw#1532: ``gen-worker compile`` succeeds only if the SERVING READER agrees.
+
+Measured on a 4070 the night this was filed: ``gen-worker compile`` ran fourteen
+real inductor/AOTI builds over 26 minutes, reported ``built=14 (of 14)``, exited
+0 — and boot-time adoption then saw **0 artifacts and 14 holes**. Two causes,
+both of them the same shape:
+
+* ``Engine.compile`` banks its output in torchcg's own engine cache, keyed by
+  ``cg-key-v1``. NOTHING lands in the ``(cg-graph-v1, cg-env-v2)`` band adoption
+  reads unless somebody calls ``publish_artifact``. The runtime mint did. The
+  CLI did not.
+* Nothing in the CLI ever called ``put_graphs``, so even a correctly placed
+  artifact had no graph-set document to be enumerated through.
+
+Neither could be caught by anything ``compile`` measured, because it measured
+builds that returned. These tests drive the REAL ``compile_all`` — its work
+ledger, its store, its publish, its census — with only the inductor child
+replaced by a seam that emits a real torchcg artifact (``tests/tcg_artifacts``,
+no torch and no GPU). The red arms are the point: a build that publishes
+nowhere, and a run that never publishes its document, must both come out RED.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+
+import tcg_artifacts
+from gen_worker._vendor.tensorfs import LocalCAS
+from gen_worker._vendor.torchcg import CallIngress, CallInput
+from gen_worker._vendor.torchcg.document import GraphRecord, GraphSetDocument, LaneGraphs
+from gen_worker._vendor.torchcg.graph_identity import EnvIdentity
+from gen_worker._vendor.torchcg.store import LocalGraphStore, PublishOutcome
+from gen_worker.cli import compile as compile_cli
+from gen_worker.cli import endpoint_lock as el
+
+SM = "sm_89"
+STACK: Tuple[Tuple[str, str], ...] = (("torch", "2.13.0"), ("triton", "3.6.0"))
+ENV = EnvIdentity(stack=STACK, sm=SM)
+MODULE = "sd15.main"
+LANE = "sd15.diffusers-bf16@1"
+TARGET = "unet"
+
+#: Two graphs, because "all of them" and "some of them" are different verdicts
+#: and a one-graph fixture cannot tell them apart.
+GRAPHS = (
+    "cg-graph-v1-" + "a" * 56,
+    "cg-graph-v1-" + "b" * 56,
+)
+
+
+def _ingress() -> CallIngress:
+    return CallIngress(
+        parameters=("value",),
+        flat_arity=1,
+        inputs=(CallInput("value", 0, "value", 0, (), "value", "float32", (2,)),),
+    )
+
+
+def document() -> GraphSetDocument:
+    ingress = _ingress()
+    return GraphSetDocument(
+        stack=STACK,
+        lanes=(
+            LaneGraphs(
+                contract=LANE,
+                targets=(TARGET,),
+                graphs=tuple(
+                    GraphRecord(graph=graph, target=TARGET, ingress=ingress)
+                    for graph in GRAPHS
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture()
+def endpoint(tmp_path: Path) -> Path:
+    """An endpoint directory carrying the one thing ``compile`` reads: its lock.
+
+    The lock IS the authored graph-set document — ``specializations()`` reads
+    the specs out of it and ``_publish_document`` publishes the same bytes — so
+    a fixture that wrote the document twice would be testing agreement between
+    two things this design deliberately has only one of.
+    """
+    root = tmp_path / "endpoint"
+    root.mkdir()
+    # The compile stack is read from the endpoint's own uv.lock and NOWHERE
+    # else (pgw#1489), so the env half of every artifact key comes from here.
+    (root / "uv.lock").write_text(
+        "version = 1\n"
+        + "".join(
+            f'\n[[package]]\nname = "{name}"\nversion = "{version}"\n'
+            for name, version in STACK
+        )
+    )
+    raw = json.dumps(document().as_dict(), separators=(",", ":"), sort_keys=True)
+    payload = json.dumps({"graphs": json.loads(raw)}, separators=(",", ":"))
+    el.write_lock(
+        root / el.LOCK_FILENAME,
+        {},
+        el.DeriveBlock(
+            v=el.DERIVE_BLOCK_V,
+            interface_v=el.torchcg_format_versions()[0],
+            inputs_digest="0" * 64,
+            document_digest=hashlib.sha256(payload.encode("ascii")).hexdigest(),
+            document=payload,
+            trace_device="cuda",
+            endpoint="sd15.main:Sd15",
+        ),
+    )
+    return root
+
+
+def _seed_programs(store: LocalGraphStore, tmp_path: Path) -> None:
+    """This box's serialized programs, banked under their graph identities.
+
+    ``compile`` re-derives when they are absent; they are present here because
+    the subject is what happens AFTER a build, not the derive.
+    """
+    for graph in GRAPHS:
+        blob = tmp_path / f"{graph[-8:]}.pt2"
+        blob.write_bytes(b"exported-program-" + graph.encode("ascii"))
+        store.put_program(graph, blob)
+
+
+def _builder(built: List[str]) -> compile_cli.Builder:
+    """A compile that really produces an artifact, without inductor or a card."""
+
+    def build(spec: compile_cli.Spec, program: Path, destination: Path) -> Path:
+        assert program.is_file(), "the builder must be handed this box's program"
+        destination.mkdir(parents=True, exist_ok=True)
+        tcg_artifacts.aoti_package(
+            destination / "model.pt2", graph_specialization=spec.graph)
+        built.append(spec.graph)
+        return destination
+
+    return build
+
+
+def _run(endpoint: Path, cas: Path, **kwargs: Any) -> compile_cli.Report:
+    return compile_cli.compile_all(
+        endpoint_dir=endpoint,
+        lock_path=endpoint / el.LOCK_FILENAME,
+        cas_root=cas,
+        sm=SM,
+        lockfile=None,
+        module=MODULE,
+        **kwargs,
+    )
+
+
+# --------------------------------------------------------------------------
+# Green arm
+# --------------------------------------------------------------------------
+
+
+def test_a_built_graph_lands_where_boot_time_adoption_reads_it(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+    built: List[str] = []
+
+    report = _run(endpoint, cas, store=store, builder=_builder(built))
+
+    assert built == list(GRAPHS), "both specializations must have been built"
+    assert [outcome.state for outcome in report.outcomes] == [
+        compile_cli.BUILT, compile_cli.BUILT]
+    assert report.unservable == []
+
+    # The witness that matters: a store object this run did not publish
+    # through, built exactly the way `cli/daemon._adoption_source` builds it.
+    reader = compile_cli.serving_reader(cas)
+    assert reader.get_graphs(MODULE) == document()
+    for graph in GRAPHS:
+        assert reader.has_artifact(graph, ENV), f"{graph} is not where adoption looks"
+
+    assert compile_cli.summarize(report)[1] == 0
+    assert "SERVABLE" in compile_cli.summarize(report)[0]
+
+
+def test_a_second_run_over_a_full_store_reports_present_and_stays_servable(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """The warm path — the ONLY path pgw#1491's acceptance ever exercised.
+
+    It short-circuits at ``has_artifact`` before any build, which is exactly why
+    a green acceptance certified a verb whose build path had never run. It must
+    still be the census that decides, not the short-circuit.
+    """
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+    _run(endpoint, cas, store=store, builder=_builder([]))
+
+    second: List[str] = []
+    report = _run(endpoint, cas, store=store, builder=_builder(second))
+
+    assert second == [], "nothing should be rebuilt over a full store"
+    assert {outcome.state for outcome in report.outcomes} == {compile_cli.PRESENT}
+    assert report.unservable == []
+    assert compile_cli.summarize(report)[1] == 0
+
+
+# --------------------------------------------------------------------------
+# Red arms — each one is a compile that used to come out green
+# --------------------------------------------------------------------------
+
+
+class PublishesNowhere:
+    """A store that reports a successful publish, believes itself, and wrote
+    nothing where adoption reads.
+
+    THE DEFECT ITSELF, in a dozen lines. ``Engine.compile`` banked bytes into
+    torchcg's own engine cache and had every reason to call that a success —
+    it could resolve them right back. What it could not do was answer for the
+    ``(cg-graph-v1, cg-env-v2)`` band, and nothing asked it to.
+
+    So this double ALSO answers ``has_artifact`` from its own record of what it
+    published. That is the whole reason the read-back must go through a store
+    object the run did not publish through: a writer asked about its own write
+    is not a witness. Everything else is the real ``LocalGraphStore``.
+    """
+
+    def __init__(self, real: LocalGraphStore) -> None:
+        self._real = real
+        self.publishes = 0
+        self._believed: set[str] = set()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+    def publish_artifact(self, graph: str, env: Any, *args: Any, **kwargs: Any) -> Any:
+        self.publishes += 1
+        self._believed.add(graph)
+        return PublishOutcome.PUBLISHED
+
+    def has_artifact(self, graph: str, env: Any) -> bool:
+        return graph in self._believed or self._real.has_artifact(graph, env)
+
+
+def test_a_compile_that_publishes_nowhere_fails_loudly(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    cas = tmp_path / "graph-cas"
+    real = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(real, tmp_path)
+    store = PublishesNowhere(real)
+    built: List[str] = []
+
+    report = _run(endpoint, cas, store=store, builder=_builder(built))
+
+    # The build genuinely happened and the publish genuinely claimed success.
+    assert built == list(GRAPHS)
+    assert store.publishes == len(GRAPHS)
+    # And every one of them is a FAILURE, at the moment it happened.
+    assert {outcome.state for outcome in report.outcomes} == {compile_cli.FAILED}
+    assert all("serving reader" in outcome.detail for outcome in report.outcomes)
+    assert len(report.unservable) == len(GRAPHS)
+    summary, code = compile_cli.summarize(report)
+    assert code == 1
+    assert "NOT SERVABLE" in summary
+
+
+def test_an_unpublished_graph_set_document_is_a_gap_even_when_every_artifact_is_there(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """Findings #5 and #6 are independent, and either one alone serves eager.
+
+    Adoption enumerates lanes out of the document and never reaches the
+    artifacts without one, so a store full of correctly addressed bytes and no
+    document adopts exactly nothing. The census must say so rather than counting
+    the artifacts and calling it servable.
+    """
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+    _run(endpoint, cas, store=store, builder=_builder([]))
+
+    specs = compile_cli.specializations(endpoint / el.LOCK_FILENAME)
+    assert compile_cli.unservable(cas, specs, ENV, MODULE) == []
+    # Ask under a name nothing published: the artifacts are still all present,
+    # and that is not enough.
+    gaps = compile_cli.unservable(cas, specs, ENV, "some.other")
+    assert gaps == ["graph-set document 'some.other': absent"]
+
+
+def test_an_artifact_under_the_wrong_env_is_absent_to_the_reader(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """The env axis is real, and the census asks the reader on THIS card's axis.
+
+    A publish that lands under a different ``cg-env-v2`` is the same silent
+    failure wearing different clothes: the write succeeded, the position the
+    boot reads is empty.
+    """
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+    _run(endpoint, cas, store=store, builder=_builder([]))
+
+    specs = compile_cli.specializations(endpoint / el.LOCK_FILENAME)
+    other = EnvIdentity(stack=STACK, sm="sm_90")
+    gaps = compile_cli.unservable(cas, specs, other, MODULE)
+    assert len(gaps) == len(GRAPHS)
+    assert all("absent at" in gap for gap in gaps)
+
+
+# --------------------------------------------------------------------------
+# The exit code IS the verdict
+# --------------------------------------------------------------------------
+
+
+def test_the_shell_learns_unservable_even_when_every_build_returned() -> None:
+    """The exact shape of the night this was filed: 14 BUILT, rc 0, 14 holes.
+
+    Driven against a real ``Report`` rather than through argparse, because the
+    thing under test is which fact the exit code is computed from.
+    """
+    spec = compile_cli.Spec(contract=LANE, graph=GRAPHS[0], target=TARGET, ingress={})
+    green = compile_cli.Report([compile_cli.Outcome(spec, compile_cli.BUILT)], [])
+    assert compile_cli.summarize(green)[1] == 0
+
+    lying = compile_cli.Report(
+        [compile_cli.Outcome(spec, compile_cli.BUILT)],
+        ["artifact cg-graph-v1-aaa: absent at (cg-graph-v1-aaa, cg-env-v2-x)"],
+    )
+    summary, code = compile_cli.summarize(lying)
+    assert code == 1, "a build that returned is not an artifact anyone can serve"
+    assert "built=1" in summary and "NOT SERVABLE" in summary
+
+
+def test_a_below_floor_no_op_is_not_an_unservable_run(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """Refusing to build under a grant that could never arm is a SUCCESS.
+
+    It must not be swept into the new refusal: the store is legitimately empty
+    and nothing was promised.
+    """
+    spec = compile_cli.Spec(contract=LANE, graph=GRAPHS[0], target=TARGET, ingress={})
+    report = compile_cli.Report(
+        [compile_cli.Outcome(spec, compile_cli.BELOW_FLOOR, "grant 1.0 < floor 4.0")],
+        [],
+    )
+    assert compile_cli.summarize(report)[1] == 0
+
+
+# --------------------------------------------------------------------------
+# pgw#1532 finding #4 — the CUDA root the mint child points torch at
+# --------------------------------------------------------------------------
+
+
+def test_the_cuda_root_is_composed_where_this_process_can_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A box whose ``/usr/local`` is root-owned must not be told to write there.
+
+    Measured: fourteen specializations died on ``FileNotFoundError:
+    '/usr/local/cuda/include'`` while the toolkit sat in the venv's own
+    ``nvidia-*`` wheels — which is what ``compose()`` builds a root FROM.
+    """
+    from gen_worker import cuda_root
+
+    monkeypatch.setattr(cuda_root, "CUDA_ROOT", tmp_path / "usr" / "local" / "cuda")
+    monkeypatch.setattr(cuda_root, "USER_CUDA_ROOT", tmp_path / "cache" / "cuda-root")
+
+    # /usr/local absent and uncreatable by this process -> the user root.
+    assert cuda_root.default_root() == tmp_path / "cache" / "cuda-root"
+
+    # /usr/local writable -> the image answer, unchanged.
+    (tmp_path / "usr" / "local").mkdir(parents=True)
+    assert cuda_root.default_root() == tmp_path / "usr" / "local" / "cuda"
+
+    # An existing root always wins, writable or not.
+    (tmp_path / "usr" / "local" / "cuda").mkdir()
+    assert cuda_root.default_root() == tmp_path / "usr" / "local" / "cuda"
+
+
+def test_a_composition_names_where_it_wrote_not_where_the_constant_points(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CUDA_HOME`` comes from ``Composition.path``; reading the constant is
+    what made this correct only on a pod."""
+    from gen_worker import cuda_root
+
+    root = tmp_path / "composed"
+    root.mkdir()
+    composed = cuda_root.compose(root)
+    assert composed.path == str(root)
+    assert composed.root == "preexisting"
+    assert f"cuda_home: {root}" in composed.lines()
+
+
+def test_a_relocated_root_says_so_rather_than_relocating_silently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gen_worker import cuda_root
+
+    monkeypatch.setattr(cuda_root, "CUDA_ROOT", tmp_path / "usr" / "local" / "cuda")
+    monkeypatch.setattr(cuda_root, "USER_CUDA_ROOT", tmp_path / "cache" / "cuda-root")
+    monkeypatch.setattr(cuda_root, "wheel_cuda_root", lambda: "")
+
+    composed = cuda_root.compose()
+
+    assert composed.path == str(tmp_path / "cache" / "cuda-root")
+    assert any("is neither present nor this process's to create" in note
+               for note in composed.notes)


### PR DESCRIPTION
`gen-worker compile` reported `built=14 (of 14)`, exit 0, after 26 minutes of real inductor work on a 4070 — and boot-time adoption then saw **0 artifacts and 14 holes**. Every build was real. Nothing the verb measured could go red on either failure, because it measured builds that returned.

## Two causes, one shape — either alone serves eager

- `Engine.compile` banks its output in torchcg's **own engine cache** (`cg-key-v1`), which it can resolve straight back out of. That is not the band adoption reads. `holes()`, `has_artifact` and every boot-time adopt address artifacts as `(cg-graph-v1, cg-env-v2)` in the `GraphStore`, and **nothing lands there unless somebody calls `publish_artifact`**. `BackgroundMint._mint_one` did. This CLI did not — it threw the child's only output away (the request has always asked for a `result` file; no caller read it).
- Nothing in the CLI ever called `put_graphs`, so adoption had no graph-set document to enumerate lanes out of and would have served eager over a correctly-filled store anyway.

## The fix: one publisher, one witness

`serving/mint.publish_compiled` is the single place a freshly-compiled artifact is put where the serving path reads it; the runtime mint and `compile` both go through it (`_manifest` came out of `BackgroundMint` with it — a compatibility set read off the artifact's own ELF was never per-mint state).

The witness is `serving_reader(cas_root)`: a `LocalGraphStore` built exactly the way `cli/daemon._adoption_source` builds it, and deliberately **not** the store this command published through. *A writer asked about its own write is not a witness.* Every build is read back through it immediately, a read-back miss is a `FAILED` specialization at the moment it happens, and the run ends with a census (`unservable`) that names the document as its own row. **The exit code is computed from that census and nothing else.**

Also: the mint child hard-coded `/usr/local/cuda`. `_ensure_cuda_home` exported the module constant even when the compose could not create it — correct only on a pod. `default_root()` now answers where THIS process can write, `Composition` carries the path it used, and `CUDA_HOME` comes from that. A benchmark harness had been carrying this as a workaround.

## Measured, on the real verb, same box and card

| | before | after |
|---|---|---|
| wall | 1561 s (26.0 min) | **140 s** |
| verdict | `built=14 (of 14)`, rc 0 | `built=14 (of 14)`, rc 0, **`SERVABLE`** |
| `torchcg/v2/artifacts` | 0 | **14** |
| `torchcg/v2/manifests` | 0 | **14** |
| serving reader sees | 0 armed / 14 holes | 14 present / 0 holes |

No rebuild was paid and **no relocation machinery was written**: `Engine.compile` resolved each existing package as a REUSE and the new publish step carried it across, so the recovery *is* the fix running.

## Red arm — 7 mutations, 7 caught

no publish · no read-back · **read-back through my own writer** · no document · census ignores the document · census ignores the artifacts · exit code computed from the outcome tally. The `PublishesNowhere` double believes its own publish and answers `has_artifact` from its own record — it is the original defect exactly, and it is what makes mutation 3 fail.

## Not fixed here

- Adoption enumerates **zero records** over the now-full store (`adopted=0, holes=0, armed=0`), so va#3's arm 2 is still blocked. Filed as **pgw#1534** — the silent branch is `AdoptSession._adopt_module`'s `if not claimed: return`, and `adopted=0/holes=0` is itself an instrument that cannot go red.
- `WorkerGraphStore.fetch_program` still raises on a miss where the `GraphStore` protocol says `Path | None` (pgw#1525's finding #1); a fix for it is UNCOMMITTED in a peer worktree and preserved as a patch — see the tracker.

Id note: filed as pgw#1532, folded into **pgw#1533** (the #1525 close-out took #1533 for the same capstone concurrently and carries the measurement body). #1532 is a burned id.