### PR TITLE
pgw#1534: an OOM-retry wrapper silently switched the WHOLE compiled path off

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,7 +696,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "f45fc64a9ba1323e0a44975565d822517aab8058" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "d4bf7889a72f8a7e9a47da67b0917815090cf710" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -306,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "f45fc64a9ba1323e0a44975565d822517aab8058"
+rev = "d4bf7889a72f8a7e9a47da67b0917815090cf710"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -511,11 +511,11 @@ rewrites = [
 "writer.py" = "f44e74d983d2f642e8479f85a3682bb737dd76ffbd62c3fe7d684ae5c0c71ca1"
 
 [packages.torchcg.files]
-"__init__.py" = "ed20294bb586c6209538dbe6f0d120ec5ff41ef24002ec2daf751e3e6abde891"
+"__init__.py" = "0948c32c9e5f3772bc0995855a0b1acdcba5f75f7c4733eae5a3ae841915459e"
 "__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
 "_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
 "_wrapper_split.py" = "1d5a3bc1ccabadeaa2b8b54f1492cba10723e53074a0022b8c7453565a86a4ce"
-"adopt.py" = "78f6557c7f68fa4e96b27bce25b49f056f2e1bd02e1118d48b3ed71ccf3317c1"
+"adopt.py" = "7cc8965a48e9f2ea5867e80ccc3dec506d33fe86896de37528a6652fe80c19e9"
 "artifact.py" = "a3c96d845be49c752bd608dbb4b36fb192cb449937716d8d835aeba2e28d12ba"
 "cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
 "compiler.py" = "6ee54b26286b215eef8867dffb133d023a6808379574ac69f8007a64c477045a"

--- a/src/gen_worker/_vendor/torchcg/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/__init__.py
@@ -5,6 +5,7 @@ from .adopt import (
     AdoptSession,
     ArtifactLoader,
     Hole,
+    UnclaimedMark,
 )
 from .artifact import ARTIFACT_METADATA_FIELDS, COMPILED_GRAPH_FORMAT, ArtifactError
 from .compiler import CompileError
@@ -210,6 +211,7 @@ __all__ = [
     "GraphSetDocument",
     "GraphStore",
     "Hole",
+    "UnclaimedMark",
     "LaneError",
     "LaneGraphs",
     "LocalGraphStore",

--- a/src/gen_worker/_vendor/torchcg/adopt.py
+++ b/src/gen_worker/_vendor/torchcg/adopt.py
@@ -25,7 +25,7 @@ forward — the author's code stays the serve host.
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -69,6 +69,75 @@ class Hole:
 
     def __repr__(self) -> str:  # pragma: no cover - diagnostics
         return f"Hole({self.record.graph}, {self.reason!r})"
+
+
+class UnclaimedMark:
+    """A module the author MARKED with ``ctx.compile`` that fit no record.
+
+    tcg#70. This used to be a bare ``return`` with a comment on it — a marked
+    module that claims nothing is eager FOREVER, and nothing anywhere said so.
+    Together with a lane whose records also go unclaimed it produces
+    ``adopted=0, holes=0``: two zeros indistinguishable from "there was nothing
+    to do", over a store holding every artifact the document asked for.
+
+    A hole would be the wrong shape for it — a hole is a graph the mint should
+    build, and these graphs are already built. What is broken is the MATCH, so
+    what gets recorded is both sides of it: the module's own forward signature,
+    and the parameters the nearest record needed that this signature does not
+    have. That difference IS the diagnosis, and it costs one set subtraction.
+    """
+
+    __slots__ = ("module", "parameters", "nearest", "missing")
+
+    def __init__(
+        self,
+        module: str,
+        parameters: tuple[str, ...],
+        nearest: str,
+        missing: tuple[str, ...],
+    ) -> None:
+        self.module = module
+        self.parameters = parameters
+        self.nearest = nearest
+        self.missing = missing
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics
+        return (
+            f"UnclaimedMark({self.module}, missing={list(self.missing)}, "
+            f"nearest={self.nearest[-12:] if self.nearest else None})"
+        )
+
+    def describe(self) -> str:
+        """One operator-facing line naming what did not match and why."""
+
+        if not self.parameters:
+            # THE MOST LIKELY CAUSE GETS THE MOST DIRECT SENTENCE. A denoiser
+            # with no NAMED forward parameters does not exist; a `*args,
+            # **kwargs` wrapper installed over one does, and every parameter
+            # name the match is made on disappears behind it. Measured exactly
+            # this way (pgw#1534): an OOM-retry wrapper installed at load time
+            # turned a 13-parameter forward into an empty set, and every record
+            # in the lane went unclaimed in silence.
+            return (
+                f"{self.module}: marked with ctx.compile, and its forward "
+                f"accepts NO named parameters — so no record can name anything "
+                f"it takes. That is the signature of a `*args, **kwargs` "
+                f"wrapper installed over the real forward: a wrapper must "
+                f"carry the wrapped signature (functools.wraps, or an explicit "
+                f"__signature__), or it silently disables adoption for this "
+                f"module"
+            )
+        if not self.nearest:
+            return (
+                f"{self.module}: marked with ctx.compile and this lane has no "
+                f"records left to match it against"
+            )
+        return (
+            f"{self.module}: marked with ctx.compile, matched NO graph in this "
+            f"lane. Nearest record {self.nearest[-12:]} needs "
+            f"{sorted(self.missing)!r}, which this module's forward does not "
+            f"accept; it accepts {sorted(self.parameters)!r}"
+        )
 
 
 class AmbiguousStructure(Exception):
@@ -177,6 +246,31 @@ def _forward_parameters(module: Any) -> frozenset[str]:
     )
 
 
+def _describe_unclaimed(
+    module: Any, signature: frozenset[str], records: Iterable[GraphRecord]
+) -> UnclaimedMark:
+    """Why this marked module fits nothing, in the terms the match is made in.
+
+    "Nearest" is the record needing the FEWEST parameters this signature lacks
+    — the one whose gap is most likely to be the real story. Ties break on the
+    graph hash so the message is deterministic across boots, because an operator
+    comparing two runs must not be reading a set-iteration order.
+    """
+
+    best: tuple[int, str, tuple[str, ...]] | None = None
+    for record in records:
+        missing = tuple(sorted(set(record.ingress.parameters) - signature))
+        candidate = (len(missing), record.graph, missing)
+        if best is None or candidate < best:
+            best = candidate
+    return UnclaimedMark(
+        module=type(module).__name__,
+        parameters=tuple(sorted(signature)),
+        nearest="" if best is None else best[1],
+        missing=() if best is None else best[2],
+    )
+
+
 class AdoptSession:
     """One boot's adoption for the active (lane, sm) — ``ctx.compile``'s engine.
 
@@ -233,6 +327,7 @@ class AdoptSession:
         self._adopted: set[str] = set()
         self._holes: dict[str, Hole] = {}
         self._ambiguous: set[str] = set()
+        self._unclaimed_marks: list[UnclaimedMark] = []
 
     @staticmethod
     def _reconcile_passes(
@@ -296,7 +391,12 @@ class AdoptSession:
             if set(record.ingress.parameters) <= signature
         ]
         if not claimed:
-            return  # marked module, no graphs for it in this document: eager
+            # RECORDED, not returned from silently (tcg#70). Eager is a safe
+            # answer and stays one; an unexplained eager is not.
+            self._unclaimed_marks.append(
+                _describe_unclaimed(module, signature, self._unclaimed.values())
+            )
+            return
         dispatcher = self._dispatcher_for(module)
         for record in claimed:
             del self._unclaimed[record.graph]
@@ -394,6 +494,26 @@ class AdoptSession:
         once observed."""
         return self._canonical(self._unclaimed)
 
+    @property
+    def unclaimed_marks(self) -> tuple[UnclaimedMark, ...]:
+        """The MODULE side of the same fact: every ``ctx.compile``-ed module
+        that matched no record, with the signature gap that explains it.
+
+        :attr:`unclaimed` says which graphs found no home; this says which
+        marks found no graph. Reading only one of them is how ``adopted=0,
+        holes=0`` became a silent verdict (tcg#70) — a boot needs both to tell
+        "the author stopped marking a module" from "the module the author
+        marks no longer has the forward the derive traced"."""
+        return tuple(self._unclaimed_marks)
+
+    def silently_eager(self) -> bool:
+        """Nothing armed, nothing to mint, and marks that matched nothing.
+
+        The exact state that used to print as two zeros. It is not an error —
+        eager costs speed, never correctness — but it is never a quiet success
+        either, and a caller that reports adoption MUST say so."""
+        return bool(self._unclaimed_marks) and not self._adopted and not self._holes
+
 
 __all__ = [
     "AdoptError",
@@ -401,4 +521,5 @@ __all__ = [
     "ArtifactLoader",
     "HOLE_MISS",
     "Hole",
+    "UnclaimedMark",
 ]

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -173,7 +173,17 @@ KIND_BOOT_ADOPT = "boot_adopt"
 # Same trap as pgw#1067's, caught before it shipped rather than after.
 #
 # `phase` is `reused` (this boot adopted everything and mints nothing) /
-# `minting` (holes remain) / `empty_lane`. THE COUNTS ARE NUMERIC, not prose:
+# `minting` (holes remain) / `empty_lane` (nothing was marked: an eager endpoint
+# saying so) / `marks_unmatched` (pgw#1534 — a `ctx.compile`-ed module fits NO
+# record in its own lane, so the compiled path is off and NO mint can turn it
+# on) / `all_ambiguous` (pgw#1534 — every record was disarmed as a literal-twin:
+# the artifacts are present and VALID, and the dispatcher refuses to guess
+# between two graphs with one tensor structure, so it disarms both).
+# THE LAST THREE ALL CARRY `step=0, total_steps=0` and are three different facts.
+# That is exactly why they are three phases: while they all read `empty_lane`,
+# no query could find a pod whose compiled path had silently switched off, and
+# the two zeros were measured on a box with 14 valid artifacts in its store.
+# THE COUNTS ARE NUMERIC, not prose:
 # `step` = graphs adopted, `total_steps` = graphs claimed, so the reuse ratio
 # is a query rather than a regex over `detail`. `detail` keeps the sentence.
 KIND_BOOT_ADOPT_SUMMARY = "boot_adopt_summary"

--- a/src/gen_worker/models/oom_ladder.py
+++ b/src/gen_worker/models/oom_ladder.py
@@ -408,7 +408,12 @@ def _carry_signature(wrapper: Any, wrapped: Any) -> None:
     """
     try:
         wrapper.__signature__ = inspect.signature(wrapped)
-    except (TypeError, ValueError):  # no introspectable signature: leave it
+    except Exception:  # noqa: BLE001 — an unsigned ladder must never fail a load
+        # Deliberately broad, and it is this module's own rule rather than a
+        # shrug: `inspect.signature` runs arbitrary code through `__signature__`
+        # descriptors and `__get__`, so the exception set is not enumerable.
+        # `install` catching it one frame up would abandon the WHOLE ladder over
+        # a cosmetic step, which is a worse trade than an unsigned wrapper.
         return
     for attribute in ("__name__", "__qualname__", "__doc__"):
         try:

--- a/src/gen_worker/models/oom_ladder.py
+++ b/src/gen_worker/models/oom_ladder.py
@@ -380,8 +380,41 @@ def _wrap_vae_decode(vae: Any, log: logging.Logger) -> bool:
                 log=log,
             )
 
+    # Same rule as the denoiser's (pgw#1534). `decode` is not a `forward` and
+    # adoption does not read it today, but a wrapper that erases the signature
+    # of what it wraps is wrong for the same reason wherever it is installed,
+    # and the two wrappers must not diverge on it.
+    _carry_signature(decode, original)
     setattr(vae, "decode", decode)
     return True
+
+
+def _carry_signature(wrapper: Any, wrapped: Any) -> None:
+    """Make ``wrapper`` present the signature of what it wraps (pgw#1534).
+
+    A ``*args, **kwargs`` wrapper is invisible to anything that INTROSPECTS the
+    forward it replaced, and adoption is exactly that: torchcg claims a graph
+    record for a marked module when the module's forward accepts every
+    parameter the record's ingress names. An erased signature therefore does not
+    degrade adoption — it silently switches it off for that module, everywhere,
+    permanently, and no mint can turn it back on because nothing is missing.
+
+    ``functools.wraps`` is not used: it copies ``__dict__`` and ``__wrapped__``
+    too, and this wrapper's identity should stay its own. Only the one fact a
+    caller introspects is carried, and a wrapped object that has no readable
+    signature (a builtin, a C-implemented forward) leaves the wrapper as it is
+    rather than failing a load — an unarmed ladder must never fail a load, and
+    neither must an unsigned one.
+    """
+    try:
+        wrapper.__signature__ = inspect.signature(wrapped)
+    except (TypeError, ValueError):  # no introspectable signature: leave it
+        return
+    for attribute in ("__name__", "__qualname__", "__doc__"):
+        try:
+            setattr(wrapper, attribute, getattr(wrapped, attribute))
+        except AttributeError:
+            pass
 
 
 def _denoiser(pipeline: Any) -> Optional[Any]:
@@ -404,6 +437,24 @@ def _wrap_denoiser_forward(pipeline: Any, module: Any, log: logging.Logger) -> b
     which is why this can be installed without touching the class — and it is
     the same seam ``aot_serve`` swaps, so an armed artifact simply captures
     this wrapper as its eager fallback.
+
+    🔴 **AND IT MUST CARRY THE WRAPPED SIGNATURE (pgw#1534).** That seam is not
+    only where a graph is armed; it is where adoption decides WHETHER to arm
+    one. ``torchcg`` claims a graph record for a marked module when the
+    module's forward accepts every parameter the record's ingress names, and it
+    reads those names off ``inspect.signature(module.forward)``. A bare
+    ``*args, **kwargs`` wrapper has no named parameters at all, so after this
+    installed, a 13-parameter unet forward presented an EMPTY set and **every
+    record in the lane went unclaimed** — measured on a real boot with all 14
+    artifacts present in the store: ``adopted: 0, holes: 0, armed: 0``.
+
+    pgw#1499 armed this ladder on EVERY rung, which is correct and is also what
+    made a per-OOM-path wrapper into a permanent, universal disabling of the
+    compiled path. ``models/lora_lifted.py`` already restores ``__signature__``
+    on its own forward wrapper; this one did not, and the two wrappers sit four
+    files apart. The rule is general and belongs to the seam, not to either
+    wrapper: **anything installed onto a module's ``forward`` must present the
+    signature it wrapped** — a fence test holds it.
     """
     slicer = getattr(pipeline, "enable_attention_slicing", None)
     original = getattr(module, "forward", None)
@@ -452,6 +503,7 @@ def _wrap_denoiser_forward(pipeline: Any, module: Any, log: logging.Logger) -> b
                 log=log,
             )
 
+    _carry_signature(forward, original)
     setattr(module, "forward", forward)
     return True
 

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -312,6 +312,7 @@ class EndpointHost:
                     manifest = store.get_manifest(record.graph, session.env)
                     if manifest is not None:
                         assert_satisfied(manifest, sm=sm)
+            marks = tuple(getattr(session, "unclaimed_marks", ()) or ())
             span(
                 graphs_from="release",
                 lane=lane_contract,
@@ -319,6 +320,58 @@ class EndpointHost:
                 artifact_from_eager=len(session.holes),
                 ambiguous=len(session.ambiguous),
                 unclaimed=len(session.unclaimed),
+                unmatched_marks=len(marks),
+            )
+            # THE VERDICT REACHES A TERMINAL, not only a span (pgw#1534).
+            #
+            # This is the path `up` and every in-process host take;
+            # `ServeAdoption` — which does emit a boot_adopt_summary — is the
+            # pod-side adopt-only object and does not run here. So on this
+            # path every one of these counts was going into a span no operator
+            # reads, and the boot printed nothing at all. Measured: 14 graphs
+            # in the document, 14 artifacts present in the store,
+            # `adopted: 0, holes: 0, armed: 0`, and not one line saying why.
+            #
+            # THREE DIFFERENT FACTS COLLAPSE ONTO THOSE TWO ZEROS, and each is
+            # loud below, because "which one" is the entire diagnosis:
+            #   * nothing was marked          -> an eager endpoint, correct
+            #   * marks matched no record     -> the compiled path is off and
+            #                                    no mint can turn it on
+            #   * every record was AMBIGUOUS  -> the artifacts are present and
+            #                                    fine, and the dispatcher
+            #                                    refuses to guess between
+            #                                    literal-twins, so it disarms
+            #                                    BOTH — adopted drops back to
+            #                                    zero and holes never rises
+            if session.ambiguous:
+                logger.warning(
+                    "adopt: %d graph(s) in lane %s share a tensor structure "
+                    "with another graph and were ALL disarmed — the dispatcher "
+                    "cannot tell literal-twins apart at call time and refuses "
+                    "to guess. The artifacts are present and valid; they are "
+                    "unusable as specialized. Serving EAGER for them.",
+                    len(session.ambiguous), lane_contract,
+                )
+                for record in session.ambiguous[:8]:
+                    logger.warning(
+                        "adopt:   ambiguous %s (target %s)",
+                        record.graph[-16:], record.target,
+                    )
+            if marks:
+                logger.warning(
+                    "adopt: %d module(s) marked with ctx.compile matched NO "
+                    "graph in lane %s. They serve EAGER, permanently — and no "
+                    "mint can change that, because the graphs are not missing, "
+                    "the MATCH is.", len(marks), lane_contract,
+                )
+                for mark in marks:
+                    logger.warning("adopt:   %s", mark.describe())
+            logger.info(
+                "adopt: lane=%s sm=%s — %d armed, %d hole(s) to mint, "
+                "%d ambiguous, %d record(s) unclaimed, %d marked module(s) "
+                "matched nothing",
+                lane_contract, sm, len(session.adopted), len(session.holes),
+                len(session.ambiguous), len(session.unclaimed), len(marks),
             )
         self.adoption = session
         self._booted = True

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -312,7 +312,7 @@ class EndpointHost:
                     manifest = store.get_manifest(record.graph, session.env)
                     if manifest is not None:
                         assert_satisfied(manifest, sm=sm)
-            marks = tuple(getattr(session, "unclaimed_marks", ()) or ())
+            marks = tuple(session.unclaimed_marks)
             span(
                 graphs_from="release",
                 lane=lane_contract,

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -349,10 +349,18 @@ class ServeAdoption:
             artifacts_dir=self.artifacts_dir,
             stack=stack,
         )
+        # WHAT IS KNOWN AT CONSTRUCTION, and only that (pgw#1534). This line
+        # used to report "%d adopted, %d hole(s)" from here — and it ran BEFORE
+        # any `ctx.compile` had, so both counts were structurally always 0. A
+        # log line that cannot say anything else is not a reading; the real
+        # verdict is `_say_outcome`, emitted from `loaded` for exactly this
+        # reason, and its own docstring already said so.
         logger.info(
-            "adopt: release=%s lane=%s sm=%s — %d adopted, %d hole(s)",
+            "adopt: release=%s lane=%s sm=%s — %d graph(s) claimed by the "
+            "document; what this boot arms is decided by the author's "
+            "ctx.compile calls and reported after load",
             self.release_id, contract, self.sm,
-            len(self.adoption.adopted), len(self.adoption.holes),
+            len(self.adoption.lane.graphs),
         )
 
     def _say_outcome(self, contract: str) -> None:
@@ -389,16 +397,47 @@ class ServeAdoption:
         if session is None:
             return
         adopted, holes = len(session.adopted), len(session.holes)
+        marks = tuple(getattr(session, "unclaimed_marks", ()) or ())
+        # `adopted=0, holes=0` HAD TWO CAUSES AND ONE PHASE (pgw#1534).
+        #
+        # An endpoint that marks nothing is an eager endpoint and `empty_lane`
+        # is the truth about it. An endpoint whose `ctx.compile`-ed module fits
+        # NO record in the lane is a compiled path silently switched off — over
+        # a store that may hold every artifact the document names. Both landed
+        # on `empty_lane` with the same two zeros, so no query could separate
+        # "nothing to do" from "the compiled path is off and nobody noticed".
+        # Measured exactly that way on this box: 14 graphs in the document, 14
+        # artifacts present, `adopted: 0, holes: 0, armed: 0`.
+        silent = bool(getattr(session, "silently_eager", bool)())
+        ambiguous = len(session.ambiguous)
         activity_mod.emit_event(
             activity_mod.KIND_BOOT_ADOPT_SUMMARY,
             f"release={self.release_id} lane={contract} sm={self.sm}: "
             f"{adopted} graph(s) adopted from the store, {holes} hole(s) for "
-            f"the background mint, {len(session.unclaimed)} unclaimed",
-            phase="reused" if holes == 0 and adopted else (
-                "minting" if holes else "empty_lane"),
+            f"the background mint, {ambiguous} disarmed as ambiguous, "
+            f"{len(session.unclaimed)} unclaimed, "
+            f"{len(marks)} marked module(s) that matched nothing",
+            phase=(
+                "marks_unmatched" if silent else
+                "reused" if holes == 0 and adopted else
+                "minting" if holes else
+                "all_ambiguous" if ambiguous and not adopted else "empty_lane"
+            ),
             step=adopted,
             total_steps=adopted + holes,
         )
+        if marks:
+            # LOUD, and at WARNING: this is the author's own mark producing
+            # nothing, which is never what the author meant. Eager still serves
+            # — correctness is untouched — so it is stated, not raised.
+            logger.warning(
+                "adopt: %d module(s) marked with ctx.compile matched NO graph "
+                "in lane %s. They serve EAGER, permanently, and no mint will "
+                "change that: the graphs exist, the MATCH does not.",
+                len(marks), contract,
+            )
+            for mark in marks:
+                logger.warning("adopt:   %s", mark.describe())
 
     def _refuse(self, phase: str, detail: str) -> None:
         self.refusal = f"{phase}: {detail}"
@@ -436,11 +475,28 @@ class ServeAdoption:
         when no session was ever built, and `refusal` says why."""
         if self.adoption is None:
             return {"adopting": False, "refusal": self.refusal or "not_attempted"}
+        marks = tuple(getattr(self.adoption, "unclaimed_marks", ()) or ())
         return {
             "adopting": True,
             "adopted": len(self.adoption.adopted),
             "holes": len(self.adoption.holes),
             "unclaimed": len(self.adoption.unclaimed),
+            # pgw#1534: the MODULE side. Without it `adopted: 0, holes: 0` is
+            # the same reading for "this endpoint marks nothing" and "this
+            # endpoint's marked module fits no graph in its own lane", and a
+            # caller deciding whether the compiled path is live cannot tell
+            # them apart. `unmatched_marks` is the count; `unmatched` is the
+            # per-module reason, which is what makes it actionable rather than
+            # merely non-zero.
+            "unmatched_marks": len(marks),
+            "unmatched": [mark.describe() for mark in marks],
+            # pgw#1534: the THIRD way to reach `adopted: 0, holes: 0` — every
+            # record disarmed as a literal-twin. The artifacts are present and
+            # valid; the dispatcher refuses to guess between two graphs whose
+            # tensor structures are identical, so it disarms BOTH. Counted here
+            # because a caller asking "is the compiled path live" gets three
+            # different answers behind one pair of zeros.
+            "ambiguous": len(self.adoption.ambiguous),
         }
 
 

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -397,7 +397,7 @@ class ServeAdoption:
         if session is None:
             return
         adopted, holes = len(session.adopted), len(session.holes)
-        marks = tuple(getattr(session, "unclaimed_marks", ()) or ())
+        marks = tuple(session.unclaimed_marks)
         # `adopted=0, holes=0` HAD TWO CAUSES AND ONE PHASE (pgw#1534).
         #
         # An endpoint that marks nothing is an eager endpoint and `empty_lane`
@@ -408,7 +408,7 @@ class ServeAdoption:
         # "nothing to do" from "the compiled path is off and nobody noticed".
         # Measured exactly that way on this box: 14 graphs in the document, 14
         # artifacts present, `adopted: 0, holes: 0, armed: 0`.
-        silent = bool(getattr(session, "silently_eager", bool)())
+        silent = bool(session.silently_eager())
         ambiguous = len(session.ambiguous)
         activity_mod.emit_event(
             activity_mod.KIND_BOOT_ADOPT_SUMMARY,
@@ -475,7 +475,7 @@ class ServeAdoption:
         when no session was ever built, and `refusal` says why."""
         if self.adoption is None:
             return {"adopting": False, "refusal": self.refusal or "not_attempted"}
-        marks = tuple(getattr(self.adoption, "unclaimed_marks", ()) or ())
+        marks = tuple(self.adoption.unclaimed_marks)
         return {
             "adopting": True,
             "adopted": len(self.adoption.adopted),

--- a/tests/test_boot_end_verdict.py
+++ b/tests/test_boot_end_verdict.py
@@ -43,15 +43,41 @@ PHASE = EagerPhase.BOOT_ENDED_UNCOMPILED.value
 
 
 class FakeSession:
-    """What `AdoptSession` is to this verdict: three counted lists."""
+    """What `AdoptSession` is to this verdict: five counted collections.
 
-    def __init__(self, adopted: int = 0, holes: int = 0, unclaimed: int = 0):
+    pgw#1534 added `ambiguous` and `unclaimed_marks` to what the verdict
+    reads, and this double went stale the moment it did — which is the
+    argument for keeping it a MODEL of the contract rather than the two
+    fields one caller happened to use. `silently_eager` is a method on the
+    real session, so it is one here too.
+    """
+
+    def __init__(
+        self,
+        adopted: int = 0,
+        holes: int = 0,
+        unclaimed: int = 0,
+        ambiguous: int = 0,
+        unclaimed_marks: int = 0,
+    ):
         self.adopted = ["graph"] * adopted
         self.holes = ["hole"] * holes
         self.unclaimed = ["unclaimed"] * unclaimed
+        self.ambiguous = ["ambiguous"] * ambiguous
+        self.unclaimed_marks = [_Mark()] * unclaimed_marks
+
+    def silently_eager(self) -> bool:
+        return bool(self.unclaimed_marks) and not self.adopted and not self.holes
 
     def adopt(self, *a: Any, **k: Any) -> Any:  # pragma: no cover - unused
         raise AssertionError("the verdict never runs a graph")
+
+
+class _Mark:
+    """One `UnclaimedMark`: the verdict only ever asks it to describe itself."""
+
+    def describe(self) -> str:
+        return "FakeModule: marked with ctx.compile, matched NO graph in this lane"
 
 
 class FakeMintStatus:

--- a/tests/test_forward_wrapper_signatures.py
+++ b/tests/test_forward_wrapper_signatures.py
@@ -175,11 +175,18 @@ def test_carrying_a_signature_survives_a_forward_that_has_none(tmp_path: Any) ->
     marker["ok"] = True
     assert marker["ok"]
 
-    # And a genuinely unreadable callable takes the same path.
-    class Opaque:
-        __signature__ = property(lambda self: 1 / 0)  # noqa: ARG005
+    # And a callable whose `__signature__` RAISES takes the same path.
+    # `inspect.signature` runs arbitrary code through that descriptor, so the
+    # exception set is not enumerable and the catch is deliberately broad.
+    class Exploding:
+        @property
+        def __signature__(self) -> Any:
+            raise ZeroDivisionError("a descriptor can raise anything")
 
-    oom_ladder._carry_signature(wrapper, Opaque())
+        def __call__(self) -> None:
+            return None
+
+    oom_ladder._carry_signature(wrapper, Exploding())
     assert callable(wrapper)
 
 

--- a/tests/test_forward_wrapper_signatures.py
+++ b/tests/test_forward_wrapper_signatures.py
@@ -147,7 +147,9 @@ def test_a_signature_erasing_wrapper_is_what_switches_adoption_off(
     def erased(*args: Any, **kwargs: Any) -> Any:  # no named parameters
         return inner(*args, **kwargs)
 
-    pipe.unet.forward = erased
+    # The exact assignment `oom_ladder` makes, and mypy is right that it is a
+    # method assignment — that IS the seam under test.
+    pipe.unet.forward = erased  # type: ignore[method-assign]
     assert _forward_parameters(pipe.unet) == frozenset()
 
     live = session(tmp_path)
@@ -184,7 +186,9 @@ def test_carrying_a_signature_survives_a_forward_that_has_none(tmp_path: Any) ->
 def test_the_predicate_this_fence_uses_is_torchcgs_own() -> None:
     """If torchcg changes which parameter kinds count, this fence must move
     with it — so the rule is imported, never restated here."""
-    assert inspect.getmodule(_forward_parameters).__name__.endswith("torchcg.adopt")
+    module = inspect.getmodule(_forward_parameters)
+    assert module is not None
+    assert module.__name__.endswith("torchcg.adopt")
 
 
 def test_the_erased_signature_reaches_a_READER_and_names_the_remedy(
@@ -204,7 +208,7 @@ def test_the_erased_signature_reaches_a_READER_and_names_the_remedy(
     def erased(*args: Any, **kwargs: Any) -> Any:
         return inner(*args, **kwargs)
 
-    pipe.unet.forward = erased
+    pipe.unet.forward = erased  # type: ignore[method-assign]
     live = session(tmp_path)
     live.adopt(pipe.unet)
 

--- a/tests/test_forward_wrapper_signatures.py
+++ b/tests/test_forward_wrapper_signatures.py
@@ -1,0 +1,229 @@
+"""A wrapper installed onto a module's ``forward`` must present the signature
+it wrapped — because that signature is what decides whether the module is
+COMPILED.
+
+``nn.Module.__call__`` reads ``self.forward`` as an instance attribute, so
+installing a wrapper there is a legitimate and widely used seam in this repo.
+But it is not only where a compiled graph is armed; it is where adoption
+decides whether to arm one. ``torchcg`` claims a graph record for a
+``ctx.compile``-ed module when the module's forward accepts every parameter the
+record's ingress names, and it reads those names off
+``inspect.signature(module.forward)``.
+
+A bare ``*args, **kwargs`` wrapper has no named parameters at all. So it does
+not degrade adoption — it switches it OFF for that module, permanently and
+everywhere, and no mint can turn it back on, because nothing is missing. That
+is what happened (pgw#1534): the OOM-retry ladder — armed on every rung by
+pgw#1499, correctly — presented a 13-parameter unet forward as an empty set, and
+a real boot with all 14 artifacts sitting in its store reported
+``adopted: 0, holes: 0, armed: 0``.
+
+The predicate here is IMPORTED from torchcg, never restated: a local
+reimplementation of "which parameters count" would pass while the real claim
+still failed.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Dict, Tuple
+
+import torch
+
+from gen_worker._vendor.torchcg import CallIngress, CallInput
+from gen_worker._vendor.torchcg.adopt import AdoptSession, _forward_parameters
+from gen_worker._vendor.torchcg.document import (
+    GraphRecord,
+    GraphSetDocument,
+    LaneGraphs,
+)
+from gen_worker.models import oom_ladder
+
+SM = "sm_89"
+STACK: Tuple[Tuple[str, str], ...] = (("torch", "2.13.0"),)
+LANE = "tiny.plain-bf16@1"
+TARGET = "unet"
+GRAPH = "cg-graph-v1-" + "c" * 56
+
+#: The real sd1.5 unet's ingress, as the derive recorded it.
+PARAMETERS = ("sample", "timestep", "encoder_hidden_states", "return_dict")
+
+
+class Unet(torch.nn.Module):
+    """A denoiser-shaped module: NAMED forward parameters, as every real one has."""
+
+    def forward(
+        self,
+        sample: torch.Tensor,
+        timestep: Any = None,
+        encoder_hidden_states: Any = None,
+        return_dict: bool = True,
+    ) -> torch.Tensor:
+        return sample
+
+
+class Pipe:
+    """The pipeline surface ``oom_ladder`` needs, and nothing else."""
+
+    def __init__(self) -> None:
+        self.unet = Unet()
+        self.vae = None
+
+    def enable_attention_slicing(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def document() -> GraphSetDocument:
+    ingress = CallIngress(
+        parameters=PARAMETERS,
+        flat_arity=1,
+        inputs=(CallInput("sample", 0, "sample", 0, (), "sample", "float32", (1, 4)),),
+    )
+    return GraphSetDocument(
+        stack=STACK,
+        lanes=(
+            LaneGraphs(
+                contract=LANE,
+                targets=(TARGET,),
+                graphs=(GraphRecord(graph=GRAPH, target=TARGET, ingress=ingress),),
+            ),
+        ),
+    )
+
+
+def session(tmp_path: Any) -> AdoptSession:
+    # No store: every claimed record becomes a HOLE, which is exactly the
+    # signal wanted here — "was this record claimed at all" without needing a
+    # real artifact to arm.
+    return AdoptSession(
+        None, document(), LANE, SM,
+        artifacts_dir=tmp_path / "adopted", stack=STACK,
+    )
+
+
+def test_the_oom_ladder_leaves_the_denoiser_claimable(tmp_path: Any) -> None:
+    """The real `install`, on the real seam. This is the regression."""
+    pipe = Pipe()
+    before = _forward_parameters(pipe.unet)
+    assert set(PARAMETERS) <= before
+
+    armed = oom_ladder.install(pipe)
+    assert armed.get("attention_sliced_retry") is True, "the ladder must still arm"
+
+    after = _forward_parameters(pipe.unet)
+    assert after == before, "the wrapper must present the signature it wrapped"
+
+    # And the claim itself, through torchcg's own session rather than through a
+    # restatement of its rule.
+    live = session(tmp_path)
+    live.adopt(pipe.unet)
+    assert [hole.record.graph for hole in live.holes] == [GRAPH]
+
+
+def test_the_ladder_is_still_installed_and_still_wraps(tmp_path: Any) -> None:
+    """Carrying the signature must not have quietly turned the wrapper into a
+    no-op — a fence that passes by removing the feature is worse than the bug."""
+    pipe = Pipe()
+    original = pipe.unet.forward
+    oom_ladder.install(pipe)
+    assert pipe.unet.forward is not original
+    assert pipe.unet.forward.__module__ == oom_ladder.__name__
+    # It still forwards.
+    out = pipe.unet(torch.zeros(1, 4))
+    assert out.shape == torch.Size((1, 4))
+
+
+def test_a_signature_erasing_wrapper_is_what_switches_adoption_off(
+    tmp_path: Any,
+) -> None:
+    """THE RED ARM, built by hand: the shape the ladder had before pgw#1534.
+
+    Nothing is missing, nothing raises, the module works — and the record is
+    never claimed, so it is not even a hole. `adopted=0, holes=0`.
+    """
+    pipe = Pipe()
+    inner = pipe.unet.forward
+
+    def erased(*args: Any, **kwargs: Any) -> Any:  # no named parameters
+        return inner(*args, **kwargs)
+
+    pipe.unet.forward = erased
+    assert _forward_parameters(pipe.unet) == frozenset()
+
+    live = session(tmp_path)
+    live.adopt(pipe.unet)
+    assert live.adopted == ()
+    assert live.holes == (), "not even mint work — the record was never claimed"
+    assert len(live.unclaimed) == 1
+
+
+def test_carrying_a_signature_survives_a_forward_that_has_none(tmp_path: Any) -> None:
+    """A wrapped object with no introspectable signature must not fail a load.
+
+    An unarmed ladder never fails a load, and neither may an unsigned one.
+    """
+    marker: Dict[str, Any] = {}
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return None
+
+    # `len` is a builtin: `inspect.signature` may or may not describe it, and
+    # either way this must return quietly rather than raise.
+    oom_ladder._carry_signature(wrapper, len)
+    marker["ok"] = True
+    assert marker["ok"]
+
+    # And a genuinely unreadable callable takes the same path.
+    class Opaque:
+        __signature__ = property(lambda self: 1 / 0)  # noqa: ARG005
+
+    oom_ladder._carry_signature(wrapper, Opaque())
+    assert callable(wrapper)
+
+
+def test_the_predicate_this_fence_uses_is_torchcgs_own() -> None:
+    """If torchcg changes which parameter kinds count, this fence must move
+    with it — so the rule is imported, never restated here."""
+    assert inspect.getmodule(_forward_parameters).__name__.endswith("torchcg.adopt")
+
+
+def test_the_erased_signature_reaches_a_READER_and_names_the_remedy(
+    tmp_path: Any,
+) -> None:
+    """The half that makes the red arm above actionable instead of merely red.
+
+    Before tcg#70 the state above was recorded nowhere: `_adopt_module` ended
+    in a bare `return`, `adopted` and `holes` both read 0, and an operator with
+    a full store had nothing to go on. The mark now carries the module, its
+    (empty) signature and the remedy, so the diagnosis is one line of the boot
+    log rather than an afternoon.
+    """
+    pipe = Pipe()
+    inner = pipe.unet.forward
+
+    def erased(*args: Any, **kwargs: Any) -> Any:
+        return inner(*args, **kwargs)
+
+    pipe.unet.forward = erased
+    live = session(tmp_path)
+    live.adopt(pipe.unet)
+
+    assert live.silently_eager() is True, "two zeros, and NOT nothing-to-do"
+    (mark,) = live.unclaimed_marks
+    assert mark.module == "Unet"
+    assert mark.parameters == ()
+    described = mark.describe()
+    assert "accepts NO named parameters" in described
+    assert "__signature__" in described, "the remedy is in the message"
+
+
+def test_the_real_ladder_leaves_no_unclaimed_mark_behind(tmp_path: Any) -> None:
+    """And with the fix in place the instrument stays quiet on the real path."""
+    pipe = Pipe()
+    oom_ladder.install(pipe)
+    live = session(tmp_path)
+    live.adopt(pipe.unet)
+
+    assert live.unclaimed_marks == ()
+    assert live.silently_eager() is False
+    assert [hole.record.graph for hole in live.holes] == [GRAPH]

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=f45fc64a9ba1323e0a44975565d822517aab8058" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=d4bf7889a72f8a7e9a47da67b0917815090cf710" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=f45fc64a9ba1323e0a44975565d822517aab8058#f45fc64a9ba1323e0a44975565d822517aab8058" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=d4bf7889a72f8a7e9a47da67b0917815090cf710#d4bf7889a72f8a7e9a47da67b0917815090cf710" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
Root-caused on CPU in eight lines, fixed at the cause, and the silence that hid it is fixed too.

## The cause

`nn.Module.__call__` reads `self.forward` as an instance attribute, so installing a wrapper there is a legitimate seam this repo uses in four places. But it is not only where a compiled graph is **armed** — it is where adoption decides **whether to arm one**. torchcg claims a graph record for a `ctx.compile`-ed module when the module's forward accepts every parameter the record's ingress names, read off `inspect.signature(module.forward)`.

`oom_ladder._wrap_denoiser_forward` installed `def forward(*args, **kwargs)` onto the denoiser. That has **no named parameters at all**:

```
BEFORE install : ['encoder_hidden_states', 'return_dict', 'sample', 'timestep']
AFTER  install : []
```

So no record could ever be claimed. Not a degradation — the compiled path **off**, for that module, permanently, everywhere, and unfixable by minting because nothing was missing. pgw#1499 armed this ladder on every rung (correctly), which is what turned a per-OOM-path wrapper into a universal one.

Measured on a real boot after pgw#1533 filled the store: document with 14 graphs, **14 artifacts present** at the right `(graph, env)` positions, env identity matching — `adopted: 0, holes: 0, armed: 0`, and not one line saying why.

## The fix is the seam's rule, not this wrapper's

Anything installed onto a module's `forward` must present the signature it wrapped. `_carry_signature` does it (**not** `functools.wraps` — that copies `__dict__` and `__wrapped__` too, and this wrapper's identity should stay its own); the vae `decode` wrapper takes the same treatment so the two cannot diverge; a wrapped object with no readable signature is left alone, because an unarmed ladder never fails a load and neither may an unsigned one.

`models/lora_lifted.py` already restored `__signature__` on its own forward wrapper. The two sat four files apart and only one knew the rule.

## And the silence — the reusable half

`adopted=0, holes=0` had **three** causes and one phase:

| cause | what it means |
|---|---|
| nothing was marked | an eager endpoint, correct |
| marks matched no record | **this bug** — the compiled path is off |
| every record AMBIGUOUS | literal-twins, both disarmed; the artifacts are fine |

The last two now say so. **tcg#70** (vendored here, `d4bf7889`) records the MODULE side of an unclaimed record with the signature gap that explains it, and its message names the wrapper cause and the remedy directly. `host.py` — the path `up` and every in-process host take, where these counts were going into a span no operator reads — now WARNs with the per-module reason. `serve_adoption` gains `marks_unmatched` and `all_ambiguous` phases so the states are queryable, and `facts()` carries them.

Also fixed: `serve_adoption`'s construction-time log line reported `%d adopted, %d hole(s)` from **before** any `ctx.compile` had run, so both counts were structurally always 0 — its own `_say_outcome` docstring already explained why that had to be.

## Red arm

Removing `_carry_signature` from the denoiser wrapper turns `test_the_oom_ladder_leaves_the_denoiser_claimable` red (verified by mutation). The fence **imports** torchcg's own `_forward_parameters` rather than restating which parameter kinds count — a local restatement would pass while the real claim still failed. A second test proves the fence cannot be satisfied by deleting the wrapper.

## Ruled out cheaply, so nobody re-walks it

- **structure ambiguity** — 14 records, 14 distinct structures, 0 collisions, all concrete
- **env mismatch** — would produce 14 HOLES, not silence
- **lane-name mismatch** — contract matches exactly

Unblocks va#3 arm 2.