### PR TITLE
pgw#1526: `artifacts_dir` moves to the box cache; the cwd-relative `.compiled-graphs` default dies

### DIFF
--- a/changelog.d/pgw1526.md
+++ b/changelog.d/pgw1526.md
@@ -1,0 +1,34 @@
+- **The cwd-relative `.compiled-graphs` default is DELETED.** `artifacts_dir` now defaults to the
+  box cache (`~/.cache/cozy/compiled-graphs`), stated ONCE in `cli/workspace.py` beside
+  `graph_cas_root()`. Explicit `--artifacts-dir` still wins; there is no fallback and no alias,
+  because a default that depends on where you happened to `cd` is not a default.
+- **Why it mattered.** `BootSpec.artifacts_dir` was `Path(".compiled-graphs")` — relative to
+  whatever cwd the daemon started in — and `compile` wrote its mint scratch to
+  `<endpoint>/.compiled-graphs`, so running `up` or `compile` inside an endpoint deposited a
+  MACHINE-SCOPED AOTInductor store into a source tree, untracked, unignored and indistinguishable
+  from endpoint content. Measured while it stood (cl#88): sd15 0.3.2's source tarball went
+  **75,164 → 59,408,521 bytes (790x)** on 172 MB of local compile output, and the first build died
+  in 35 s on an S3 `PutObject` fault over a residential uplink. Nothing anywhere read the shipped
+  copy — artifacts are keyed (env × sm) per pgw#1471, so a laptop's is a keyed miss on a pod.
+- It is **pgw#1513 in a different path**: one machine-scoped store whose address was decided by an
+  accident of cwd instead of stated once by the layer that owns it.
+- **The sweep found two more of the same shape**, both fixed here: `serving/self_mint.py` (the
+  serve-coordinated half of the same work ledger `gen-worker compile` drives) and
+  `serving/host.py`'s adopt fallback. A background mint writing where the explicit verb does not
+  look is a hole that refills forever and reads as a cache miss every boot. `--output-dir`
+  deliberately stays cwd-relative: media from a local `run` belongs where you ran it.
+- `COZY_ARTIFACTS` / Settings field `artifacts_root`, alongside `COZY_WEIGHTS_CAS` and
+  `COZY_GRAPH_CAS` — a config field rather than a direct env read (§1.18).
+- `up -d` hands its detached child the **resolved absolute** path. The child re-execs with a
+  different cwd, so a relative value would build under one address and look up another — an endless
+  cache miss rather than an error.
+- `publish`'s `.compiled-graphs` exclusion **stays**: it is a floor, and a floor that only holds for
+  the default is not a floor.
+- **Acceptance asserted at the store/path level, deliberately.** The peer pgw#1532 lane reports
+  adoption enumerating zero records over a full store (`adopted=0, holes=0`) for a cause of its own,
+  so an adoption-based assertion would go green or red for their reason instead of this one. New
+  `tests/test_store_addresses.py` pins every resolution site plus a structural scan that the
+  retired default cannot come back; the compile-side arm is FOLDED into
+  `tests/test_compile_servability.py`, the module that already owns driving the real `compile`
+  through its no-GPU builder seam (4.34b fold-first). **Red-verified against `origin/master`'s own
+  tree: 11 of 12 fail there**, and the scan names the exact three sites this diff fixed.

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -582,7 +582,18 @@ def compile_all(
         store = _store(cas_root)
     build = builder if builder is not None else _default_builder(cas_root, sm)
     module = module or endpoint_module(endpoint_dir)
-    artifacts_dir = Path(endpoint_dir) / ".compiled-graphs"
+    # pgw#1526: the BOX cache, not `<endpoint>/.compiled-graphs`. This is mint
+    # SCRATCH plus the pre-publish destination — machine-scoped by nature, and
+    # nothing downstream reads it from the source tree: the artifact's only
+    # durable address is the CAS entry `publish_compiled` writes below, keyed
+    # (graph x env). Writing it into the endpoint made it look like endpoint
+    # content and shipped 172 MB of it in a source tarball (cl#88).
+    #
+    # Box-wide is safe to SHARE because the leaf is `spec.short` — the graph
+    # identity, content-addressed over the exported program — so two endpoints
+    # collide only when they trace to the same graph, in which case the CAS
+    # deduplicates them anyway.
+    artifacts_dir = workspace.artifacts_root()
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
     rederive_ran = [False]

--- a/src/gen_worker/cli/daemon.py
+++ b/src/gen_worker/cli/daemon.py
@@ -50,6 +50,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import msgspec
 
 from . import endpoint_state, sockaddr
+from .workspace import artifacts_root
 from .endpoint_state import EndpointHandle
 from .protocol import PROTOCOL_VERSION, gen_worker_version
 
@@ -79,7 +80,15 @@ class BootSpec:
     lane: str = ""
     sm: str = ""
     graph_store: Optional[Path] = None
-    artifacts_dir: Path = Path(".compiled-graphs")
+    #: pgw#1526: the BOX cache, stated once in `cli/workspace.py` beside
+    #: `graph_cas_root()`. It was `Path(".compiled-graphs")` — relative to
+    #: whatever cwd the daemon happened to start in, which put a
+    #: machine-scoped artifact store inside an endpoint source tree.
+    #: A `default_factory` and not a module-level constant: the address is
+    #: config (`COZY_ARTIFACTS`), so it must be read when a BootSpec is
+    #: built, not frozen at import — a process that installs Settings after
+    #: import would otherwise silently keep the pre-config answer.
+    artifacts_dir: Path = field(default_factory=artifacts_root)
     output_dir: Path = Path("outputs")
     #: Background pre-warm posture: "auto" mints the adopt session's holes in
     #: the background, "off" never compiles. `gen-worker compile` is the

--- a/src/gen_worker/cli/publish.py
+++ b/src/gen_worker/cli/publish.py
@@ -75,11 +75,14 @@ _EXCLUDE_DIRS = frozenset({
     # Build/tool detritus.
     ".venv", "venv", "__pycache__", ".git", ".mypy_cache", ".pytest_cache",
     ".tox", ".ruff_cache", "node_modules",
-    # A LOCAL RUN'S OUTPUT. Both are cwd-relative defaults (pgw#1526): the
-    # daemon writes artifacts to `.compiled-graphs` and media to `outputs`,
-    # so anyone who runs `up`/`compile` inside an endpoint leaves them in the
-    # source tree. Measured via cozy-local's twin of this set (cl#88): 172 MB
-    # of artifacts took one tarball 75 KB -> 59 MB.
+    # A LOCAL RUN'S OUTPUT. `outputs` is still a cwd-relative default (media
+    # from `run`). `.compiled-graphs` is NO LONGER ONE — pgw#1526 moved the
+    # artifacts default to the box cache (`cli/workspace.artifacts_root`), so
+    # the only way it appears in a source tree now is an explicit
+    # `--artifacts-dir .compiled-graphs`. It stays in this set anyway: this is
+    # a FLOOR, and a floor that only holds for the default is not a floor.
+    # Measured via cozy-local's twin of this set (cl#88): 172 MB of artifacts
+    # took one tarball 75 KB -> 59 MB.
     ".compiled-graphs", "outputs",
     # CREDENTIAL DIRECTORIES. Not bloat — a secret-leak vector. `publish`
     # uploads a whole tree when the endpoint is not a git work tree, and an

--- a/src/gen_worker/cli/up.py
+++ b/src/gen_worker/cli/up.py
@@ -66,7 +66,13 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
     up.add_argument("--graph-store", default="", metavar="DIR",
                     help="compiled-graph CAS to adopt from. Default: the box "
                          "graph CAS when it exists; absent = serve eager.")
-    up.add_argument("--artifacts-dir", default=".compiled-graphs")
+    # pgw#1526: NO default here. Unset means "ask `cli/workspace.py`", which
+    # is the one place that answers it; a default spelled here would be a
+    # second answer that can drift from the daemon's.
+    up.add_argument("--artifacts-dir", default="", metavar="DIR",
+                    help="where compiled artifacts are built and adopted "
+                         "from. Default: the box cache "
+                         "(~/.cache/cozy/compiled-graphs).")
     up.add_argument("--output-dir", default="outputs",
                     help="where saved images/media land")
     up.add_argument("--compile", dest="compile_policy", default="auto",
@@ -100,6 +106,21 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
 # --------------------------------------------------------------------------
 # up
 # --------------------------------------------------------------------------
+
+
+def _artifacts_dir(args: argparse.Namespace) -> Path:
+    """STATED wins; otherwise the box cache (pgw#1526).
+
+    Resolved HERE and passed to the detached child as an absolute path, not
+    re-defaulted there: `up -d` re-execs with a different cwd, so a relative
+    or re-derived answer would put the child's artifacts somewhere the parent
+    never looks — a build under one address and a lookup under another, which
+    reads as an endless cache miss rather than as an error.
+    """
+    from . import workspace
+
+    stated = str(getattr(args, "artifacts_dir", "") or "").strip()
+    return Path(stated).resolve() if stated else workspace.artifacts_root()
 
 
 def _spec(args: argparse.Namespace) -> BootSpec:
@@ -146,7 +167,7 @@ def _spec(args: argparse.Namespace) -> BootSpec:
         lane=args.lane,
         sm=sm,
         graph_store=graph_store,
-        artifacts_dir=Path(args.artifacts_dir),
+        artifacts_dir=_artifacts_dir(args),
         output_dir=Path(args.output_dir),
         compile_policy=args.compile_policy,
         idle_timeout_s=float(args.idle_timeout or 0.0),
@@ -256,7 +277,7 @@ def _child_argv(args: argparse.Namespace) -> List[str]:
             argv += [flag, str(value)]
     argv += [
         "--defaults", args.defaults,
-        "--artifacts-dir", str(args.artifacts_dir),
+        "--artifacts-dir", str(_artifacts_dir(args)),
         "--output-dir", str(Path(args.output_dir).resolve()),
         "--compile", args.compile_policy,
         "--idle-timeout", str(args.idle_timeout),

--- a/src/gen_worker/cli/workspace.py
+++ b/src/gen_worker/cli/workspace.py
@@ -23,6 +23,11 @@ Weights and graphs are split because their lifetimes differ by orders of
 magnitude: a weight tree is worth 6 GB and survives every code change, a graph
 blob is invalidated by a torch bump. One CAS would make a GC policy that is
 right for one of them wrong for the other.
+
+Plus one working address on the same footing (pgw#1526): the **artifacts root**,
+where `compile` builds and `up` adopts. It is here for the reason everything
+else is here — it is MACHINE-scoped, so letting it fall out of whatever cwd the
+daemon started in put an AOTInductor store inside a source tree.
 """
 
 from __future__ import annotations
@@ -40,6 +45,27 @@ DEFAULT_WEIGHTS_CAS = Path.home() / ".cache" / "tensorhub" / "cas"
 #: Exported programs (from `lock`) and compiled artifacts (from `compile`).
 #: Config key `COZY_GRAPH_CAS` (Settings field `graph_cas_root`).
 DEFAULT_GRAPH_CAS = Path.home() / ".cache" / "cozy" / "graph-cas"
+
+#: Where `compile` builds artifacts and `up` adopts them from — the scratch and
+#: staging half of the graph store, beside the CAS it publishes into.
+#: Config key `COZY_ARTIFACTS` (Settings field `artifacts_root`).
+#:
+#: pgw#1526: this used to default to `Path(".compiled-graphs")` — RELATIVE TO
+#: CWD — so running `up` or `compile` from inside an endpoint deposited a
+#: MACHINE-SCOPED AOTInductor store into a source tree, untracked, unignored
+#: and indistinguishable from endpoint content. Measured cost while it stood
+#: (cl#88): sd15 0.3.2's source tarball went 75,164 -> 59,408,521 bytes (790x)
+#: on 172 MB of local compile output, and the first build died in 35 s on an S3
+#: PutObject fault over a residential uplink. Nothing anywhere read the shipped
+#: copy: artifacts are keyed (env x sm) per pgw#1471, so a laptop's would be a
+#: keyed miss on a pod regardless.
+#:
+#: It is pgw#1513 in a different path — one store whose address was decided by
+#: an accident of cwd rather than stated once by the layer that owns it. A
+#: default that depends on where you happened to `cd` is not a default, so
+#: there is no fallback and no alias: explicit `--artifacts-dir` still wins,
+#: and nothing else resolves it.
+DEFAULT_ARTIFACTS = Path.home() / ".cache" / "cozy" / "compiled-graphs"
 
 
 class WorkspaceError(RuntimeError):
@@ -67,6 +93,17 @@ def weights_cas_root() -> Path:
 
 def graph_cas_root() -> Path:
     return Path(_settings().graph_cas_root or DEFAULT_GRAPH_CAS)
+
+
+def artifacts_root() -> Path:
+    """Where compiled artifacts are built and adopted from (pgw#1526).
+
+    ONE answer, here, for the same reason `graph_cas_root` is here: `compile`
+    WRITES artifacts and `up` ADOPTS them, so two spellings would silently
+    split the pool — build under one address, look up another, and every hit
+    reads as a miss.
+    """
+    return Path(_settings().artifacts_root or DEFAULT_ARTIFACTS)
 
 
 def host_sm() -> str:
@@ -222,10 +259,12 @@ def local_cas(root: Path) -> Any:
 
 
 __all__ = [
+    "DEFAULT_ARTIFACTS",
     "DEFAULT_GRAPH_CAS",
     "DEFAULT_WEIGHTS_CAS",
     "CheckpointRef",
     "WorkspaceError",
+    "artifacts_root",
     "graph_cas_root",
     "host_sm",
     "local_cas",

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -43,6 +43,7 @@ _ENV_TO_FIELD: Dict[str, str] = {
     # TENSORHUB_CACHE_DIR does.
     "COZY_WEIGHTS_CAS": "weights_cas_root",
     "COZY_GRAPH_CAS": "graph_cas_root",
+    "COZY_ARTIFACTS": "artifacts_root",
     "COZY_ENDPOINT_STATE": "endpoint_state_root",
     "COZY_HOME": "cozy_home",
     "BAKED_PROGRAM_CAS_ROOT": "baked_program_cas_root",

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -64,6 +64,10 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     # CLI installs Settings at process entry like every other entry point.
     weights_cas_root: str = ""
     graph_cas_root: str = ""
+    # pgw#1526: where `compile` builds artifacts and `up` adopts them.
+    # Empty = the box default in `cli/workspace.py`. The cwd-relative
+    # `.compiled-graphs` default is DELETED, not deprecated.
+    artifacts_root: str = ""
     # pgw#1491/cl#85: `~/.cozy` — the USER-GLOBAL root cozy-local also
     # resolves, holding the shared credential store both tools read. A Settings
     # field rather than a direct env read (§1.18) because it IS configuration:

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -148,7 +148,10 @@ def _parser() -> argparse.ArgumentParser:
              "triton, nvidia-*). Default: the endpoint's own uv.lock, which "
              "is the SAME file `gen-worker lock` read for the document being "
              "adopted. Absent, the document's own stamp is used.")
-    parser.add_argument("--artifacts-dir", default=".compiled-graphs")
+    # pgw#1526: resolved from `cli/workspace.py`, never from cwd.
+    parser.add_argument("--artifacts-dir", default="", metavar="DIR",
+                        help="where compiled artifacts are built and "
+                             "adopted from (default: the box cache).")
     parser.add_argument("--mint", action="store_true",
                         help="after boot, fill this (lane x sm)'s holes "
                              "(pgw#1371) and WAIT for the mint before "
@@ -240,10 +243,18 @@ def _adoption_source(
     return store, store.get_graphs(module_name)
 
 
+def _artifacts_dir(args: argparse.Namespace) -> Path:
+    """STATED wins; otherwise the box cache (pgw#1526), one spelling."""
+    from ..cli.workspace import artifacts_root
+
+    stated = str(getattr(args, "artifacts_dir", "") or "").strip()
+    return Path(stated).resolve() if stated else artifacts_root()
+
+
 def _mint_cas(args: argparse.Namespace) -> Path:
     """Where the mint's compile child admits artifacts, one spelling."""
     return Path(
-        args.mint_cas or args.graph_store or (Path(args.artifacts_dir) / "cas"))
+        args.mint_cas or args.graph_store or (_artifacts_dir(args) / "cas"))
 
 
 def _toolchain() -> Mapping[str, str]:
@@ -379,7 +390,7 @@ def main(argv: list[str] | None = None) -> int:
     # `lint_raw_aoti_load` fence exists to stop.
     host.setup(
         store=store, document=document, sm=args.sm,
-        artifacts_dir=Path(args.artifacts_dir),
+        artifacts_dir=_artifacts_dir(args),
         stack=stack,
     )
     if host.adoption is not None:
@@ -404,7 +415,7 @@ def main(argv: list[str] | None = None) -> int:
 
         box = SelfMint(
             store=store,
-            artifacts_dir=Path(args.artifacts_dir),
+            artifacts_dir=_artifacts_dir(args),
             cas_dir=_mint_cas(args),
             target_arch=args.sm,
             toolchain=dict(_toolchain()),

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -49,6 +49,21 @@ from .placement import serving_device, warn_if_degraded
 logger = logging.getLogger(__name__)
 
 
+def _artifacts_root() -> Path:
+    """The box artifacts cache — pgw#1526's ONE address.
+
+    Imported inside the function, not at module scope: this module is inside
+    the adopt-only serve closure (pgw#1328) and must not acquire the CLI
+    package merely to learn a path. The answer still comes from
+    `cli/workspace.py` and is not restated here — a second spelling of a store
+    address is how a build and a lookup end up at different directories.
+    """
+    from ..cli.workspace import artifacts_root
+
+    return artifacts_root()
+
+
+
 class ServeDispatchError(RuntimeError):
     """A request names a function this endpoint does not serve."""
 
@@ -257,8 +272,9 @@ class EndpointHost:
                     lane_contract,
                     sm,
                     loader=loader,
-                    artifacts_dir=artifacts_dir
-                    or Path(".compiled-graphs"),
+                    # pgw#1526: the box cache, never cwd. `compile` writes
+                    # there and this is the reader that arms what it wrote.
+                    artifacts_dir=artifacts_dir or _artifacts_root(),
                     stack=stack_rows,
                 )
             except EnvironmentMismatch as exc:

--- a/src/gen_worker/serving/self_mint.py
+++ b/src/gen_worker/serving/self_mint.py
@@ -70,6 +70,21 @@ from .mint import (
 
 logger = logging.getLogger(__name__)
 
+
+def _artifacts_root() -> Path:
+    """The box artifacts cache — pgw#1526's ONE address.
+
+    Imported inside the function, not at module scope: this module is inside
+    the adopt-only serve closure (pgw#1328) and must not acquire the CLI
+    package merely to learn a path. The answer still comes from
+    `cli/workspace.py` and is not restated here — a second spelling of a store
+    address is how a build and a lookup end up at different directories.
+    """
+    from ..cli.workspace import artifacts_root
+
+    return artifacts_root()
+
+
 #: The counted observable. ``compile:`` prefixes into
 #: :data:`gen_worker.progress.STALL_WINDOW_S`'s 600s window, which is the
 #: right order of magnitude for one inductor compile of one graph specialization.
@@ -151,7 +166,12 @@ class SelfMint:
     """
 
     store: Any = None
-    artifacts_dir: Path = Path(".compiled-graphs")
+    #: pgw#1526: the box cache, from `cli/workspace.py`. This is the
+    #: SERVE-coordinated half of the same work ledger `gen-worker compile`
+    #: drives, so the two must resolve the same address — a background
+    #: mint writing where the explicit verb does not look is a hole that
+    #: refills forever and reads as a cache miss every boot.
+    artifacts_dir: Path = field(default_factory=_artifacts_root)
     cas_dir: Optional[Path] = None
     target_arch: str = ""
     toolchain: Mapping[str, str] = field(default_factory=dict)

--- a/tests/test_compile_servability.py
+++ b/tests/test_compile_servability.py
@@ -180,6 +180,49 @@ def test_a_built_graph_lands_where_boot_time_adoption_reads_it(
     assert "SERVABLE" in compile_cli.summarize(report)[0]
 
 
+def test_a_build_lands_in_the_box_cache_and_never_in_the_endpoint_tree(
+    endpoint: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """# pgw#1526: `compile` wrote its scratch to `<endpoint>/.compiled-graphs`.
+
+    Machine-scoped bytes inside a source tree, untracked and unignored and
+    indistinguishable from endpoint content — which is how 172 MB of local
+    compile output took an sd15 source tarball from 75,164 to 59,408,521 bytes
+    (cl#88) and killed the first build on an S3 fault over a residential link.
+
+    Asserted at the PATH level rather than through adoption: the peer #1532
+    lane reports adoption enumerating zero records over a full store for a
+    cause of its own, so an adoption-based assertion here would go green or red
+    for their reason instead of this one.
+    """
+    box = tmp_path / "box-artifacts"
+    monkeypatch.setattr(compile_cli.workspace, "artifacts_root", lambda: box)
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+
+    destinations: List[Path] = []
+
+    def build(spec: compile_cli.Spec, program: Path, destination: Path) -> Path:
+        destinations.append(destination)
+        destination.mkdir(parents=True, exist_ok=True)
+        tcg_artifacts.aoti_package(
+            destination / "model.pt2", graph_specialization=spec.graph)
+        return destination
+
+    report = _run(endpoint, cas, store=store, builder=build)
+
+    assert [outcome.state for outcome in report.outcomes] == [
+        compile_cli.BUILT, compile_cli.BUILT]
+    assert destinations, "the builder was never reached"
+    for destination in destinations:
+        assert box in destination.parents, destination
+        assert endpoint not in destination.parents, destination
+    # The endpoint tree is UNTOUCHED — the property a `.gitignore` or an
+    # upload-exclusion can only paper over.
+    assert not (endpoint / ".compiled-graphs").exists()
+
+
 def test_a_second_run_over_a_full_store_reports_present_and_stays_servable(
     endpoint: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_compile_servability.py
+++ b/tests/test_compile_servability.py
@@ -29,6 +29,7 @@ from gen_worker._vendor.torchcg import CallIngress, CallInput
 from gen_worker._vendor.torchcg.document import GraphRecord, GraphSetDocument, LaneGraphs
 from gen_worker._vendor.torchcg.graph_identity import EnvIdentity
 from gen_worker._vendor.torchcg.store import LocalGraphStore, PublishOutcome
+from gen_worker.cli import workspace
 from gen_worker.cli import compile as compile_cli
 from gen_worker.cli import endpoint_lock as el
 
@@ -181,7 +182,7 @@ def test_a_built_graph_lands_where_boot_time_adoption_reads_it(
 
 
 def test_a_build_lands_in_the_box_cache_and_never_in_the_endpoint_tree(
-    endpoint: Path, tmp_path: Path, monkeypatch
+    endpoint: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """# pgw#1526: `compile` wrote its scratch to `<endpoint>/.compiled-graphs`.
 
@@ -196,7 +197,10 @@ def test_a_build_lands_in_the_box_cache_and_never_in_the_endpoint_tree(
     for their reason instead of this one.
     """
     box = tmp_path / "box-artifacts"
-    monkeypatch.setattr(compile_cli.workspace, "artifacts_root", lambda: box)
+    # Patched on `cli.workspace` itself, which is where the answer lives —
+    # `compile` looks the attribute up at call time, so this is the real seam
+    # rather than a re-export the module never promised.
+    monkeypatch.setattr(workspace, "artifacts_root", lambda: box)
     cas = tmp_path / "graph-cas"
     store = LocalGraphStore(LocalCAS(cas))
     _seed_programs(store, tmp_path)

--- a/tests/test_store_addresses.py
+++ b/tests/test_store_addresses.py
@@ -1,0 +1,208 @@
+"""Where the box's machine-scoped stores live, and who is allowed to answer.
+
+# pgw#1526: `artifacts_dir` defaulted to `Path(".compiled-graphs")` — relative
+# to whatever cwd the daemon started in — so running `up` or `compile` inside an
+# endpoint deposited a machine-scoped AOTInductor store into a source tree.
+# pgw#1513 in a different path: one store whose address was decided by an
+# accident of cwd instead of stated once by the layer that owns it.
+
+ASSERTED AT THE STORE/PATH LEVEL, DELIBERATELY, and the reason is recorded
+because it changes what a green run here proves. The peer #1532 lane reports
+adoption currently enumerating ZERO records over a full store
+(`adopted=0, holes=0`) for a cause one layer down that is theirs and unfixed. An
+adoption-based acceptance of THIS move would therefore read empty for their
+reason rather than mine — a pass and a failure that look identical. So these
+assert what this diff actually changed: the location is answered by
+`cli/workspace.py`, `compile` builds there, the serve side adopts from the same
+address, and the cwd-relative default is gone from the tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+
+import pytest
+
+from gen_worker import config
+from gen_worker.cli import daemon, up, workspace
+
+SRC = Path(workspace.__file__).resolve().parents[1]
+
+#: The retired spelling. A default anywhere in `src/` is the defect; the
+#: `publish` exclusion set names it on purpose (a floor, not a default).
+RETIRED = ".compiled-graphs"
+
+
+@pytest.fixture()
+def zero_config(monkeypatch):
+    """No Settings installed — the state a bare `gen-worker` invocation is in."""
+    monkeypatch.setattr(config, "current_or", lambda fallback: fallback)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# one home answers it
+# ---------------------------------------------------------------------------
+
+def test_the_box_cache_is_the_default_and_workspace_states_it(zero_config):
+    root = workspace.artifacts_root()
+    assert root == workspace.DEFAULT_ARTIFACTS
+    assert root.is_absolute(), root
+    assert root == Path.home() / ".cache" / "cozy" / "compiled-graphs"
+
+
+def test_the_address_does_not_depend_on_where_you_cd(zero_config, tmp_path,
+                                                     monkeypatch):
+    """The whole defect, stated as a test.
+
+    Two cwds, one answer. Under the old default these differed, and the
+    difference was invisible: each run wrote a real store, just not the same
+    one — and one of them was inside somebody's source tree.
+    """
+    monkeypatch.chdir(tmp_path)
+    from_a = workspace.artifacts_root()
+    other = tmp_path / "some" / "endpoint"
+    other.mkdir(parents=True)
+    monkeypatch.chdir(other)
+    from_b = workspace.artifacts_root()
+
+    assert from_a == from_b
+    assert tmp_path not in from_a.parents
+
+
+def test_config_overrides_it_through_the_pipeline_not_an_env_read(monkeypatch):
+    """`COZY_ARTIFACTS` is a Settings field, like the other two store roots.
+
+    Through the real loader map, not by patching the function: a module reading
+    `os.environ` itself would be a second loader that can disagree with the
+    first (§1.18), and that is the failure this field exists to avoid.
+    """
+    from gen_worker.config import loader
+
+    assert loader._ENV_TO_FIELD["COZY_ARTIFACTS"] == "artifacts_root"
+    stated = Path("/srv/artifacts")
+    monkeypatch.setattr(
+        config, "current_or",
+        lambda fallback: config.Settings(artifacts_root=str(stated)))
+    assert workspace.artifacts_root() == stated
+
+
+# ---------------------------------------------------------------------------
+# every consumer resolves to that one answer
+# ---------------------------------------------------------------------------
+
+def test_a_bootspec_with_no_artifacts_dir_lands_in_the_box_cache(zero_config):
+    assert daemon.BootSpec(endpoint_dir=Path("/tmp/ep")).artifacts_dir == \
+        workspace.artifacts_root()
+
+
+def test_the_bootspec_default_is_read_when_the_spec_is_built_not_at_import(
+    monkeypatch,
+):
+    """A `default_factory`, not a module constant.
+
+    The CLI installs Settings at process entry, which happens AFTER this module
+    is imported. A default frozen at import would keep the pre-config answer
+    forever and no test that never installs Settings could see it.
+    """
+    stated = Path("/srv/late-config")
+    monkeypatch.setattr(
+        config, "current_or",
+        lambda fallback: config.Settings(artifacts_root=str(stated)))
+    assert daemon.BootSpec(endpoint_dir=Path("/tmp/ep")).artifacts_dir == stated
+
+
+def test_up_honors_an_explicit_artifacts_dir_and_resolves_it(tmp_path):
+    """`--artifacts-dir` still wins. The default died; the flag did not."""
+    args = argparse.Namespace(artifacts_dir=str(tmp_path / "mine"))
+    assert up._artifacts_dir(args) == (tmp_path / "mine").resolve()
+
+
+def test_up_falls_back_to_the_box_cache_when_unstated(zero_config):
+    assert up._artifacts_dir(argparse.Namespace(artifacts_dir="")) == \
+        workspace.artifacts_root()
+
+
+def test_the_detached_child_is_handed_an_absolute_path(zero_config, tmp_path):
+    """`up -d` re-execs with a different cwd.
+
+    A relative value — or one the child re-defaults for itself — would put the
+    child's artifacts somewhere the parent never looks. That is a build under
+    one address and a lookup under another, which reads as an endless cache
+    miss rather than as an error, so it is asserted rather than assumed.
+    """
+    args = argparse.Namespace(artifacts_dir="relative-dir")
+    resolved = up._artifacts_dir(args)
+    assert resolved.is_absolute(), resolved
+
+
+def test_compile_and_the_serve_side_mint_resolve_the_same_address(zero_config):
+    """`compile` WRITES and the background mint WRITES; they share a ledger.
+
+    Two spellings would make each skip work the other did not do.
+    """
+    from gen_worker.serving.self_mint import SelfMint
+
+    assert SelfMint().artifacts_dir == workspace.artifacts_root()
+
+
+def test_the_standalone_serve_entry_resolves_the_same_address(zero_config,
+                                                              tmp_path):
+    from gen_worker.serving import __main__ as serve_main
+
+    assert serve_main._artifacts_dir(argparse.Namespace(artifacts_dir="")) == \
+        workspace.artifacts_root()
+    assert serve_main._artifacts_dir(
+        argparse.Namespace(artifacts_dir=str(tmp_path))) == tmp_path.resolve()
+
+
+# ---------------------------------------------------------------------------
+# the cwd-relative default is DEAD — no fallback, no alias
+# ---------------------------------------------------------------------------
+
+def test_no_cwd_relative_compiled_graphs_default_survives_in_src():
+    """Structural, because a reintroduced default is silent.
+
+    Nothing goes red when a store writes to the wrong directory: it writes a
+    real store there. Only a scan notices, which is why this is a scan and not
+    a promise.
+    """
+    offenders: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        if "_vendor" in path.parts or "pb" in path.parts:
+            continue
+        rel = path.relative_to(SRC.parent)
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            # A bare string CONSTANT is fine (`publish`'s exclusion set names
+            # the directory to refuse it). What must not come back is the
+            # spelling used as a PATH: `Path(".compiled-graphs")`.
+            if not (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "Path"):
+                continue
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and arg.value == RETIRED:
+                    offenders.append(f"{rel}:{node.lineno}")
+    assert not offenders, (
+        "pgw#1526: a cwd-relative `.compiled-graphs` path is back at "
+        f"{offenders}. The address is answered ONCE by "
+        "`cli/workspace.artifacts_root()`; a default that depends on where you "
+        "happened to `cd` is not a default."
+    )
+
+
+def test_publish_still_refuses_the_directory_as_a_floor():
+    """The exclusion is a FLOOR and outlives the default it was written for.
+
+    `--artifacts-dir .compiled-graphs` is still legal, so a tree can still
+    contain one — and it still must never be uploaded.
+    """
+    from gen_worker.cli.publish import _EXCLUDE_DIRS
+
+    assert RETIRED in _EXCLUDE_DIRS


### PR DESCRIPTION
**Coordinator ruling, implemented.** `artifacts_dir` moves under the box cache beside the graph CAS; the location is stated ONCE in `cli/workspace.py` beside `graph_cas_root()`; explicit `--artifacts-dir` still honored; the cwd-relative default dies with no fallback and no alias.

## The defect

`BootSpec.artifacts_dir` was `Path(".compiled-graphs")` — **relative to whatever cwd the daemon started in** — and `compile` wrote its mint scratch to `<endpoint>/.compiled-graphs`. Running `up` or `compile` inside an endpoint deposited a machine-scoped AOTInductor store into a source tree: untracked, unignored, indistinguishable from endpoint content.

Measured while it stood (cl#88): sd15 0.3.2's source tarball went **75,164 → 59,408,521 bytes (790x)** on 172 MB of local compile output, and the first build died in 35 s on an S3 `PutObject` fault over a residential uplink. Nothing anywhere read the shipped copy — artifacts are keyed (env × sm) per pgw#1471, so a laptop's is a keyed miss on a pod regardless.

It is **pgw#1513 in a different path**: one machine-scoped store whose address was decided by an accident of cwd instead of stated once by the layer that owns it.

## The sweep found two more of the same shape

Both fixed here, and neither was in the issue's checklist:

* `serving/self_mint.py` — the **serve-coordinated half of the same work ledger** `gen-worker compile` drives. Two spellings would make each skip work the other did not do: a background mint writing where the explicit verb does not look is a hole that refills forever and reads as a cache miss every boot.
* `serving/host.py`'s adopt fallback — the reader that arms what `compile` wrote.

`--output-dir` deliberately stays cwd-relative: media from a local `run` belongs where you ran it.

## Details worth reviewing

* **`default_factory`, not a module constant.** The address is config (`COZY_ARTIFACTS` / Settings field `artifacts_root`, beside `COZY_WEIGHTS_CAS` and `COZY_GRAPH_CAS` — a field rather than a direct env read, §1.18). Frozen at import it would keep the pre-Settings answer forever, and the CLI installs Settings at process entry.
* **`up -d` hands its child the RESOLVED absolute path.** The child re-execs with a different cwd; a relative value builds under one address and looks up another, which reads as an endless cache miss rather than an error.
* **`publish`'s `.compiled-graphs` exclusion stays.** `--artifacts-dir .compiled-graphs` is still legal, so a tree can still contain one — and a floor that only holds for the default is not a floor.
* The serving-side helpers import `cli.workspace` **lazily inside the function** so the adopt-only serve closure (pgw#1328) does not acquire the CLI package at import time. `lint_serve_role_closure` green.

## Acceptance — at the store/path level, deliberately

Carrying the coordination note: the peer **pgw#1532** lane reports adoption enumerating **zero** records over a full store (`adopted=0, holes=0`) for a cause one layer down that is theirs and unfixed. An adoption-based acceptance of this move would go green or red for *their* reason instead of this one, and the two would look identical. So the assertions are at the level this diff actually changed.

* `tests/test_store_addresses.py` (new, domain-named) pins every resolution site — workspace, the real config-loader route, `BootSpec`, `up` stated and unstated, the detached child's absolute path, `SelfMint`, the standalone serve entry — plus a structural AST scan that the retired default cannot come back. Structural because **nothing goes red when a store writes to the wrong directory: it writes a real store there.**
* The compile-side arm is **FOLDED** into `tests/test_compile_servability.py`, the module that already owns driving the real `compile` through its declared no-GPU builder seam (4.34b fold-first). It asserts the destination is under the box cache, is *not* under the endpoint, and that the endpoint tree is untouched.

**Red-verified from `origin/master`'s own tree**, not from a reverted fix: run against a pristine base worktree the new module fails **11 of 12**, and the scan names the exact three sites this diff fixes (`cli/daemon.py:82`, `serving/host.py:261`, `serving/self_mint.py:154`). The one that passes there is the publish floor, which landed earlier under pgw#1529.

All 29 repo guards run locally, exit codes read, 29/29 exit 0. Ruff clean. No local mint or compile was executed.