### PR TITLE
pgw#1526: the manifest pin is part of BEING MATERIALIZED — condition 3, the last blocker to a weight-bearing v2 serve

### DIFF
--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -1165,6 +1165,75 @@ class ModelStore:
             )
         return snapshot
 
+    def ensure_pinned(
+        self, ref: WireRef, tree: Path, snapshot: Optional[pb.Snapshot],
+    ) -> bool:
+        """Guarantee the tree's manifest pin exists. Returns True if repaired.
+
+        pgw#1526, and it is the LAST thing between the fleet and a weight-
+        bearing v2 serve. Measured on a pod, verbatim:
+
+            ENGINE DECLINED: the manifest pin `snapshot:sha256:5bd90786…` is
+            MISSING from the store at /tmp/tensorhub-cache/cas
+
+        A projected tree's manifest pin is the ONLY way a reader recovers its
+        manifest (`resolve_projection` reads `snapshot:<tree directory name>`),
+        and the streaming engine is the only legal reader of a tree made of
+        pointer stubs. No pin, no engine; no engine, the eager bridge gets a
+        stubbed tree and reports `header too large` about an intact checkpoint.
+
+        **Why the pin can be missing at all, which is the actual defect.**
+        `_pin_manifest` is called from exactly one place — `ensure_snapshot` —
+        but `_materialize_local` has CACHED SHORT-CIRCUITS that return a tree
+        already on disk WITHOUT going through it. So a tree that reaches
+        residency by any other route is unpinned, and `ensure_local` can never
+        repair it: it short-circuits on the same tree forever. That is a
+        materialization reporting success while leaving the tree unreadable by
+        the only component that can read it.
+
+        So the pin is established HERE, on the completion path every route
+        shares, rather than only on the download route. Cheap and idempotent:
+        the common case is one `read_ref`, and nothing is written when the pin
+        is already there. No bytes move — the manifest is rebuilt from the
+        snapshot the caller already holds.
+        """
+        if snapshot is None or not snapshot.files:
+            return False
+        path = Path(tree)
+        try:
+            from . import projection as _projection
+
+            if _projection.resolve_projection(path) is not None:
+                return False  # already pinned, the overwhelmingly common case
+            if not _projection.stub_at_any(path):
+                # A materialized tree holds its own bytes and needs no pin.
+                return False
+        except Exception:  # noqa: BLE001 — a probe must never fail a load
+            return False
+        try:
+            from .cozy_snapshot import _manifest, _pin_manifest
+            from .cache_paths import open_worker_cas
+
+            resolved = resolved_repo_from_snapshot(snapshot)
+            _pin_manifest(
+                open_worker_cas(self._cache_dir), path.name, _manifest(resolved.files),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "could not repair the manifest pin for %s at %s: %s: %s — the "
+                "streaming engine will decline this tree and the eager bridge "
+                "will misreport it as a corrupt checkpoint (pgw#1526)",
+                ref, path, type(exc).__name__, exc,
+            )
+            return False
+        logger.warning(
+            "REPAIRED the missing manifest pin `snapshot:%s` for %s at %s — the "
+            "tree was materialized by a path that does not pin, which leaves it "
+            "unreadable by the streaming engine. No bytes moved (pgw#1526)",
+            path.name, ref, path,
+        )
+        return True
+
     async def announce_resident(
         self, ref: WireRef, snapshot: Optional[pb.Snapshot] = None,
     ) -> bool:
@@ -1302,15 +1371,26 @@ class ModelStore:
         from . import projection as _projection
 
         if _projection.stub_at_any(tree) and _projection.resolve_projection(tree) is None:
-            logger.error(
-                "residency REFUSED for %s at %s: the tree is intact but its "
-                "manifest pin is missing, so the streaming engine cannot bind "
-                "and the eager bridge would read its pointer stubs as corrupt "
-                "weights. Re-materializing to re-pin (no bytes move) — "
-                "pgw#1513",
-                ref, tree,
-            )
-            return False
+            # pgw#1526: REPAIR IT HERE rather than bouncing to `ensure_local`.
+            #
+            # pgw#1513 refused and fell through, on the reasoning that
+            # `ensure_local` would re-materialize and re-pin. Measured on a
+            # pod: it does not. `_materialize_local`'s cached short-circuits
+            # return the tree already on disk WITHOUT calling
+            # `ensure_snapshot`, which is the only caller of `_pin_manifest` —
+            # so the bounce lands on the same unpinned tree, readiness is
+            # granted, and the dispatch declines. Refusing was right; refusing
+            # FOREVER was the bug.
+            if not self.ensure_pinned(ref, tree, snapshot):
+                logger.error(
+                    "residency REFUSED for %s at %s: the tree is intact but "
+                    "its manifest pin is missing AND could not be repaired, so "
+                    "the streaming engine cannot bind and the eager bridge "
+                    "would read its pointer stubs as corrupt weights "
+                    "(pgw#1526)",
+                    ref, tree,
+                )
+                return False
 
         identity = self._snapshot_identity(ref, snapshot)
         with self._identity_lock:
@@ -1387,6 +1467,13 @@ class ModelStore:
         acquired = False
 
         def complete(path: Path) -> _MaterializedLocal:
+            # pgw#1526: THE PIN IS PART OF BEING MATERIALIZED. Every route into
+            # this function returns a tree a caller will try to LOAD, and a
+            # projected tree without its manifest pin cannot be loaded by the
+            # only reader that can read it. `ensure_snapshot` pins; the cached
+            # short-circuits above do not, and they can never repair what they
+            # short-circuit on. So it is guaranteed here, where all routes meet.
+            self.ensure_pinned(ref, path, snapshot)
             # The bytes are pod-wide but each group keeps its own
             # ledger, so the group that asked must ALSO book the shared disk
             # entry — otherwise a group riding a sibling's materialization

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -328,3 +328,90 @@ def test_the_decline_REASON_survives_the_wire_truncation(tmp_path: Path) -> None
     assert "pointer stub(s), NOT weights" in truncated, (
         "the stub count should also fit inside the cap — it is what identifies "
         "the shape on sight")
+
+
+def test_a_missing_manifest_pin_is_REPAIRED_not_refused_forever(tmp_path: Path) -> None:
+    """The pod's condition 3, verbatim, and the loop it was stuck in.
+
+    # pgw#1526: measured on an L4, same volume, pin the only variable:
+    #   ENGINE DECLINED: the manifest pin `snapshot:sha256:5bd90786…` is
+    #   MISSING from the store at /tmp/tensorhub-cache/cas
+
+    `_pin_manifest` has exactly ONE caller, `ensure_snapshot`. But
+    `_materialize_local`'s cached short-circuits return a tree already on disk
+    without going through it, so a tree that reaches residency by any other
+    route is unpinned — and `ensure_local` can never repair it, because it
+    short-circuits on that same tree forever. pgw#1513 refused and bounced to
+    `ensure_local` expecting a re-pin; on a pod the bounce lands right back on
+    the unpinned tree. Refusing was right; refusing forever was the bug.
+
+    So: stage a real tree, DELETE its pin the way the pod's is missing, and
+    assert the store repairs it — without moving bytes — so the streaming
+    engine can bind and the checkpoint actually serves.
+    """
+    import asyncio
+
+    from gen_worker import activity
+    from gen_worker.models import projection
+    from test_weight_position import (  # type: ignore[import-not-found]
+        OBJECT_BYTES,
+        OBJECTS,
+        _Origin,
+        _Wire,
+        _pb_snapshot,
+        _store,
+    )
+    from gen_worker.models.refs import WireRef
+
+    ref = WireRef("acme/model-a")
+    origin = _Origin()
+    try:
+        files = [
+            (f"unet/shard-{i}.safetensors", bytes([i + 1]) * OBJECT_BYTES)
+            for i in range(OBJECTS)
+        ]
+        snapshot = _pb_snapshot([(p, b, origin.put(b)) for p, b in files])
+        cas = tmp_path / "cas"
+
+        async def stage() -> Path:
+            wire = _Wire()
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            store = _store(wire, cas)
+            return await store.ensure_local(ref, snapshot)
+
+        tree = asyncio.run(stage())
+        assert projection.resolve_projection(tree) is not None, "fixture never pinned"
+
+        # THE POD'S STATE: bytes fine, pin gone.
+        # Refs are stored under a hashed id, so the pin is found by the NAME it
+        # records rather than by its filename.
+        import json as _json
+
+        wanted = "snapshot:" + tree.name
+        pins = [
+            q for q in (cas / "refs").rglob("*")
+            if q.is_file() and _json.loads(q.read_bytes()).get("name") == wanted
+        ]
+        assert len(pins) == 1, f"expected exactly one pin for {wanted}, got {pins}"
+        pins[0].unlink()
+        assert projection.resolve_projection(tree) is None, "fixture is not in state 3"
+        before = sorted((p, p.stat().st_size) for p in tree.rglob("*") if p.is_file())
+
+        async def reboot() -> bool:
+            wire = _Wire()
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            store = _store(wire, cas)
+            store.rescan_disk()
+            return await store.announce_resident(ref, snapshot)
+
+        answered = asyncio.run(reboot())
+
+        assert projection.resolve_projection(tree) is not None, (
+            "the pin must be REPAIRED — bouncing to `ensure_local` lands on the "
+            "same unpinned tree forever, which is the loop the pod was in")
+        assert answered is True, (
+            "with the pin repaired the pod is genuinely resident and must say so")
+        after = sorted((p, p.stat().st_size) for p in tree.rglob("*") if p.is_file())
+        assert before == after, f"NO BYTES MAY MOVE; tree changed: {before} -> {after}"
+    finally:
+        origin.close()


### PR DESCRIPTION
pgw#1526: the manifest pin is part of BEING MATERIALIZED — the last thing between the fleet and a weight-bearing v2 serve

Condition 3, measured on a pod (L4, same volume, pin the only variable),
verbatim through the front-loaded message pgw#1513's follow-up landed:

  ENGINE DECLINED: the manifest pin `snapshot:sha256:5bd9078637d1e7d3…` is
  MISSING from the store at /tmp/tensorhub-cache/cas. The tree and its bytes
  are fine … | PROJECTED TREE, 4 pointer stub(s), NOT weights: …

ROOT CAUSE, and it is a one-caller fact anyone can check:
`_pin_manifest` has exactly ONE caller in the tree — `cozy_snapshot.
ensure_snapshot`. But `_materialize_local` has CACHED SHORT-CIRCUITS that
return a tree already on disk WITHOUT going through it (`if ref in
self._verified: return complete(cached)`, and the verify-then-return below
it). So a tree that reaches residency by any route other than a fresh
download is UNPINNED — and `ensure_local` can never repair it, because it
short-circuits on that same tree forever.

A projected tree's pin is the ONLY way a reader recovers its manifest
(`resolve_projection` reads `snapshot:<tree directory name>`), and the
streaming engine is the only legal reader of a tree made of pointer stubs.
No pin, no engine; no engine, the eager bridge gets the stubs and reports
`header too large` about an intact checkpoint. So an unpinned tree is a
materialization that reported SUCCESS while leaving the checkpoint unreadable
by the only component that can read it.

WHY pgw#1513 DID NOT ALREADY FIX THIS — my own defect, one layer up. That
change detected the missing pin and REFUSED, on the reasoning that
`ensure_local` would re-materialize and re-pin. On a pod it does not: the
bounce lands on the same unpinned tree, readiness is granted anyway, and the
dispatch declines. **Refusing was right; refusing FOREVER was the bug**, and
it is why the pod could report the condition perfectly and never escape it.

THE FIX — pin where all routes meet, not only on the download route:

  * `ModelStore.ensure_pinned(ref, tree, snapshot)` — create-or-repair,
    idempotent, and cheap: the common case is one `read_ref` and no write. It
    rebuilds the manifest from the snapshot the caller already holds, so NO
    BYTES MOVE. A materialized (non-projected) tree needs no pin and is left
    alone.
  * Called from `_materialize_local`'s `complete()` — the completion path
    EVERY route shares, including both short-circuits.
  * Called from `announce_resident` before refusing, so a warm pod repairs and
    serves instead of refusing forever. It still refuses if the repair itself
    fails, and says so.

Red/green, $0, no GPU, no pod — and the red arm is the pod's own loop:

  a missing pin is REPAIRED, not refused forever | pass | FAIL: "the pin must
    (stage a real tree, delete its pin as the pod's |      | be REPAIRED —
     is missing, reboot a second store on that CAS) |      | bouncing to
                                                    |      | `ensure_local`
                                                    |      | lands on the same
                                                    |      | unpinned tree
                                                    |      | forever"

The red arm restores exactly the landed pgw#1513 behaviour (refuse-and-bounce,
completion does not pin) and flips CONDITIONS, never cuts lines. The test also
asserts **no bytes moved** by comparing every file's size before and after, and
that the repaired pod then answers resident rather than merely not-crashing.

Neighbours green: test_projected_tree_reading, test_boot_materialize,
test_weight_position, test_model_residency — 40 passed. ruff clean; whole-tree
mypy clean (640 files).

Pins already on master: `ccdb490c` (the refusal), `c24636bb` (skeleton _resolve), `bf6666e9` (the reason survives the wire). This is the fix that reason pointed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)