### PR TITLE
pgw#1537: an unreadable endpoint module name refuses in one sentence, not a traceback

### DIFF
--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -405,12 +405,32 @@ def endpoint_module(endpoint_dir: Path) -> str:
     ``main =`` — because ``_adoption_source`` reads it the same way. Two
     spellings of "which document is this endpoint's" is exactly the drift that
     would make ``compile`` publish under a name ``up`` never asks for.
+
+    An import failure here is a TYPED refusal, not a traceback (pgw#1537).
+    pgw#1533 made this the first thing `compile` needs that can fail on the
+    author's own code — `declared_floor_gb` calls `load_endpoint` too, but
+    swallows everything, because an unreadable floor is genuinely "no floor
+    stated". An unreadable MODULE NAME is not "no name": nothing can be
+    published under a name that could not be read, so the run cannot deliver a
+    servable endpoint and must say why in one sentence.
     """
     from ..discovery.discover import prime_sys_path
     from ..serving.loader import load_endpoint
 
-    prime_sys_path(endpoint_dir)
-    return str(load_endpoint(endpoint_dir).module_name)
+    try:
+        prime_sys_path(endpoint_dir)
+        return str(load_endpoint(endpoint_dir).module_name)
+    except Exception as exc:  # noqa: BLE001 — author code; any failure is theirs
+        raise CompileError(
+            f"cannot read {endpoint_dir}'s module name "
+            f"({type(exc).__name__}: {exc}).\n"
+            f"  `compile` publishes this endpoint's graph-set document under "
+            f"that name and boot-time adoption looks it up by the same one, so "
+            f"a document published under a guess would be invisible to `up`.\n"
+            f"  Fix the import (this is the endpoint's own `main =` module), or "
+            f"pass the name explicitly if you are compiling for a tree you "
+            f"cannot import here."
+        ) from exc
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_compile_servability.py
+++ b/tests/test_compile_servability.py
@@ -409,3 +409,26 @@ def test_a_relocated_root_says_so_rather_than_relocating_silently(
     assert composed.path == str(tmp_path / "cache" / "cuda-root")
     assert any("is neither present nor this process's to create" in note
                for note in composed.notes)
+
+
+def test_an_unreadable_module_name_is_a_typed_refusal_not_a_traceback(
+    tmp_path: Path,
+) -> None:
+    """pgw#1537: `compile` reads the endpoint's module name and can now fail on
+    the author's own import.
+
+    `declared_floor_gb` calls `load_endpoint` too and swallows everything,
+    because an unreadable floor genuinely IS "no floor stated". An unreadable
+    module NAME is not "no name" — nothing can be published under a name that
+    could not be read — so it refuses, in one sentence, with the cause.
+    """
+    empty = tmp_path / "not-an-endpoint"
+    empty.mkdir()
+
+    with pytest.raises(compile_cli.CompileError) as refusal:
+        compile_cli.endpoint_module(empty)
+
+    message = str(refusal.value)
+    assert "cannot read" in message
+    assert "graph-set document" in message, "it says WHY the name is needed"
+    assert str(empty) in message, "and which endpoint it was asked about"


### PR DESCRIPTION
**My own regression from pgw#1533**, found by reviewing what that change made reachable rather than by anything failing.

`compile` now reads the endpoint's module name so it can publish the graph-set document under the name adoption looks it up by. That made `load_endpoint` the first thing the verb needs that can fail on the **author's** code — on a path where `run_compile` catches only `CompileError`. A broken endpoint got a bare `EndpointLoadError` traceback.

## Not fixed by swallowing it, and the distinction is the point

The neighbouring caller does swallow: `declared_floor_gb` catches everything, correctly, because an unreadable floor genuinely **is** "no floor stated" and proceeding is right.

An unreadable module **name** is not "no name". Nothing can be published under a name that could not be read, and a document published under a guess is invisible to `up` — so it refuses, naming the cause, why the name is needed, and what to do about it.

## Red arm

Removing the refusal turns `test_an_unreadable_module_name_is_a_typed_refusal_not_a_traceback` red (verified by mutation).