### PR TITLE
pgw#1536: an instrument whose silence has several meanings is not an instrument — named exits, banked-snapshot fallback, boot pin census

### DIFF
--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -947,7 +947,17 @@ class ModelStore:
 
         Also sweeps abandoned writer-unique CAS temp artifacts: on
         pod-local disk those died with the pod, but a CAS root pointed at a
-        persistent volume keeps them until swept."""
+        persistent volume keeps them until swept.
+
+        pgw#1536: it also CENSUSES the snapshot trees on disk and whether each
+        is pinned. The pod incident turned on a tree existing without its
+        manifest pin, and nobody could say whether that tree predated the boot
+        or was built during it — because nothing ever looked. This is one
+        `read_ref` per tree, at boot, on a directory that is empty on a cold
+        pod, and it is the difference between "we would need a rental to know"
+        and reading it off the boot log of any run that happens anyway.
+        """
+        self._census_snapshot_pins()
         for ref, ent in self._index.entries().items():
             p = Path(str(ent.get("path") or ""))
             if p.exists():
@@ -1165,6 +1175,39 @@ class ModelStore:
             )
         return snapshot
 
+    def _census_snapshot_pins(self) -> None:
+        """One line per snapshot tree on disk: is it pinned, and is it stubbed.
+
+        pgw#1536. Deliberately at boot and deliberately cheap — the answer to
+        "did this tree predate the boot" is free here and costs a rental
+        anywhere else.
+        """
+        root = Path(self._cache_dir) / SNAPSHOTS_DIR
+        try:
+            trees = sorted(p for p in root.iterdir() if p.is_dir())
+        except OSError:
+            return
+        if not trees:
+            logger.info("snapshot census at boot: no trees on disk at %s", root)
+            return
+        from . import projection as _projection
+
+        for tree in trees:
+            try:
+                pinned = _projection.resolve_projection(tree) is not None
+                stubbed = _projection.stub_at_any(tree)
+            except Exception as exc:  # noqa: BLE001 — a census never fails a boot
+                logger.warning("snapshot census: %s unreadable: %s", tree.name, exc)
+                continue
+            # UNPINNED + STUBBED is the pod incident's exact state, and it is
+            # the one combination that cannot serve.
+            (logger.error if (stubbed and not pinned) else logger.info)(
+                "snapshot census at boot: %s pinned=%s projected=%s%s",
+                tree.name, pinned, stubbed,
+                "  <-- UNREADABLE by the streaming engine (pgw#1536)"
+                if (stubbed and not pinned) else "",
+            )
+
     def ensure_pinned(
         self, ref: WireRef, tree: Path, snapshot: Optional[pb.Snapshot],
     ) -> bool:
@@ -1197,18 +1240,47 @@ class ModelStore:
         is already there. No bytes move — the manifest is rebuilt from the
         snapshot the caller already holds.
         """
-        if snapshot is None or not snapshot.files:
-            return False
+        # pgw#1536: EVERY EXIT SAYS WHY.
+        #
+        # The first field run of this repair produced NO LOG LINE AT ALL, and
+        # that was uninformative in the worst way: "no repair attempt
+        # surfaced" could equally mean this was never called, or was called
+        # and declined at any of three silent returns. An instrument whose
+        # silence has several meanings is not an instrument. Cheap — one line
+        # per materialization, and only at DEBUG for the common already-pinned
+        # case.
         path = Path(tree)
+        if snapshot is None or not snapshot.files:
+            # The caller may hold a bare ref; the store may still know the
+            # snapshot. Not falling back here is how a repair that COULD have
+            # run silently did not.
+            snapshot = self.banked_snapshot(ref)
+        if snapshot is None or not snapshot.files:
+            logger.warning(
+                "pin check SKIPPED for %s at %s: no digest-carrying snapshot "
+                "is banked for this ref, so the manifest cannot be rebuilt. If "
+                "this tree is projected it is unreadable by the streaming "
+                "engine (pgw#1536)", ref, path,
+            )
+            return False
         try:
             from . import projection as _projection
 
             if _projection.resolve_projection(path) is not None:
+                logger.debug("pin OK for %s at %s", ref, path)
                 return False  # already pinned, the overwhelmingly common case
             if not _projection.stub_at_any(path):
                 # A materialized tree holds its own bytes and needs no pin.
+                logger.debug(
+                    "pin not required for %s at %s: tree is materialized, not "
+                    "projected", ref, path,
+                )
                 return False
-        except Exception:  # noqa: BLE001 — a probe must never fail a load
+        except Exception as exc:  # noqa: BLE001 — a probe must never fail a load
+            logger.warning(
+                "pin check FAILED to probe %s at %s: %s: %s (pgw#1536)",
+                ref, path, type(exc).__name__, exc,
+            )
             return False
         try:
             from .cozy_snapshot import _manifest, _pin_manifest

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -415,3 +415,45 @@ def test_a_missing_manifest_pin_is_REPAIRED_not_refused_forever(tmp_path: Path) 
         assert before == after, f"NO BYTES MAY MOVE; tree changed: {before} -> {after}"
     finally:
         origin.close()
+
+
+def test_the_boot_census_NAMES_an_unpinned_stubbed_tree(
+    tmp_path: Path, caplog: Any
+) -> None:
+    """pgw#1536: the one combination that cannot serve must be loud at boot.
+
+    The pod incident turned on a tree existing WITHOUT its manifest pin, and
+    nobody could say whether that tree predated the boot or was built during
+    it — because nothing ever looked. A census at boot answers that for free
+    on any run that happens anyway, instead of costing a rental.
+
+    UNPINNED + STUBBED is the state that cannot be served, so it is the one
+    that logs at ERROR rather than INFO.
+    """
+    import logging
+
+    from gen_worker._vendor.tensorfs.project import stub_bytes
+    from gen_worker.models.store import ModelStore
+
+    base = tmp_path / "cas"
+    (base / "refs").mkdir(parents=True)
+    (base / "objects").mkdir(parents=True)
+    tree = base / "snapshots" / ("sha256:" + "e5" * 32)
+    (tree / "unet").mkdir(parents=True)
+    (tree / "unet" / "x.safetensors").write_bytes(stub_bytes("a" * 64, 3_400_000_000))
+
+    async def noop(_msg: Any) -> None:
+        return None
+
+    store = ModelStore(noop, cache_dir=base)
+    with caplog.at_level(logging.INFO, logger="gen_worker.models.store"):
+        store._census_snapshot_pins()
+
+    census = [r for r in caplog.records if "snapshot census at boot" in r.message]
+    assert census, "the boot census must emit a line per tree"
+    row = census[0]
+    assert "pinned=False" in row.getMessage() and "projected=True" in row.getMessage()
+    assert row.levelno == logging.ERROR, (
+        "unpinned + stubbed is the ONE combination that cannot serve — it must "
+        f"be loud, not an INFO line nobody greps: level={row.levelname}")
+    assert "UNREADABLE by the streaming engine" in row.getMessage()


### PR DESCRIPTION
pgw#1536: an instrument whose silence has several meanings is not an instrument

Condition 3 reproduced BYTE-IDENTICALLY on the pin that was supposed to fix it
(pod vkg37aw530jft0, 0/12 served) — and **no repair attempt surfaced anywhere**.
That second fact should have located the bug and could not, because
`ensure_pinned` had THREE SILENT `return False` exits. "No repair attempt
surfaced" could equally mean never-called, or called-and-declined at any of
three points. That is my instrument defect, and it is fixed here.

FIRST, A HARD NEGATIVE THAT REDIRECTS THE SEARCH. pgw#1536 was filed asking
which THIRD ROUTE builds a tree without pinning it. There is none. Exhaustive
grep over `src/`, not sampling:

    project_snapshot(…)     ONE caller: cozy_snapshot._publish_snapshot:318
    _publish_snapshot(…)    ONE caller: cozy_snapshot.ensure_snapshot:424
    materialize_repository  ZERO callers anywhere in src/

`ensure_snapshot` pins at BOTH tree-returning paths (:380 convergence, :422
pre-publish). The fill path moves objects, never trees. `provision.py` and the
free `download.ensure_local` both delegate to `ensure_snapshot_async`. Store
roots agree (`base = cache_dir or tensorhub_cas_dir()` — the same
`/tmp/tensorhub-cache/cas` the reader asks), so it is not a two-store split.

**So the tree WAS built by the pinning route**, and the question becomes
written-then-removed, or never durably landed. Recorded because the wrong
hypothesis was about to cost hours.

WHAT THIS CHANGES

1. EVERY EXIT SAYS WHY — including one I had not considered, and which is the
   likeliest miss: `complete()` passes its LOCAL `snapshot`, which is `None`
   for a bare-ref materialization, so `ensure_pinned` returned False silently
   at the very site the fix was wired into. **It now falls back to
   `banked_snapshot(ref)`**, so a repair that COULD have run no longer
   silently does not. The remaining skip says
   `pin check SKIPPED … no digest-carrying snapshot is banked`.

2. A BOOT-TIME PIN CENSUS — one line per snapshot tree, `pinned=` /
   `projected=`, and the one combination that cannot serve (unpinned +
   stubbed) logs at ERROR with `<-- UNREADABLE by the streaming engine`. This
   answers "did the tree predate the boot" for FREE on any run that happens
   anyway, instead of costing a rental. On a cold pod the directory is empty
   and it is one line.

Red/green, $0, no GPU, no pod:

  the boot census NAMES an unpinned+stubbed tree | pass | (asserts ERROR level,
    and asserts it is ERROR, not an INFO nobody greps |  | not merely a message)

Neighbours green: test_projected_tree_reading, test_boot_materialize,
test_weight_position, test_model_residency — 42 passed. ruff clean; whole-tree
mypy clean (642 files).

The two facts the next run gains, which the last one could not produce: whether
a repair was ATTEMPTED and declined (and at which of the four now-named
points), and whether the tree was on disk BEFORE materialization ran. Together
they locate the residue.

Follows `9e0c01a3` (pgw#1526). The benchmark lane re-runs at this pin: it buys either outcome (a) directly if the `None`-fallback was the miss, or the four-point-named answer that locates the residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)