### PR TITLE
pgw#1539: the endpoint source root is the sys.path ENTRY, not the main package — a sibling author module was uncovered

### DIFF
--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -1256,12 +1256,25 @@ def _resolve_lane(torchcg: ModuleType, cls: type, lane: Any) -> Any:
 
 
 def endpoint_source_root(module: ModuleType) -> Optional[Path]:
-    """The directory the AUTHOR's code lives in, or None if it cannot be told.
+    """The SOURCE ROOT the author's modules live under, or None if unknowable.
 
-    The top-level package of the endpoint's main module: `minimax_h3.main` ->
-    `<repo>/src/minimax_h3`, a bare fixture module -> the directory holding it.
-    None when the module has no file (namespace/frozen), and None is treated as
-    "cannot prove endpoint-owned", which keeps the conservative default.
+    The sys.path entry that holds the endpoint's code — `minimax_h3.main` ->
+    `<repo>/src`, a bare fixture module -> the directory holding it. None when
+    the module has no file (namespace/frozen), and None is treated as "cannot
+    prove endpoint-owned", which keeps the conservative default.
+
+    **pgw#1533: this used to return the top-level PACKAGE directory**
+    (`<repo>/src/minimax_h3`), which silently uncovered every author module
+    that is not inside that one package. h3's fps refusal raises in
+    `src/cozy_rife.py` — a SIBLING top-level module at the same source root —
+    so `deepest_endpoint_frame` could not prove it was the author's and the
+    whole derive died on a product bug that pgw#1527 exists to skip. A shared
+    helper module beside the main package is the common case, not an exotic
+    one, so the roster was wrong for most endpoints rather than a few.
+
+    Widening the root is safe only because :func:`deepest_endpoint_frame`
+    SUBTRACTS: the SDK and any third-party install root are excluded from it
+    explicitly, so a wider root can add author files and never adds a library.
     """
 
     import sys
@@ -1272,9 +1285,28 @@ def endpoint_source_root(module: ModuleType) -> Optional[Path]:
     if not path:
         return None
     try:
-        return Path(path).resolve().parent
+        here = Path(path).resolve()
     except OSError:
         return None
+    # A PACKAGE's `__init__.py` sits one level below the source root; a bare
+    # module sits directly in it.
+    if here.name == "__init__.py":
+        return here.parent.parent
+    return here.parent
+
+
+def _third_party_root(where: Path) -> bool:
+    """Is this path inside an installed-dependency tree?
+
+    Named by the install layout rather than by a list of libraries, so torch,
+    diffusers and anything else an endpoint pulls in are covered without being
+    enumerated.
+    """
+
+    return any(
+        part in ("site-packages", "dist-packages", "__pypackages__")
+        for part in where.parts
+    )
 
 
 def _sdk_root() -> Path:
@@ -1317,8 +1349,24 @@ def deepest_endpoint_frame(
         where = Path(deepest.filename).resolve()
     except OSError:
         return None
-    sdk = _sdk_root()
-    if where.is_relative_to(sdk):
+    # THE SUBTRACTION, and it is what makes a wide source root safe (pgw#1533).
+    # The root is now the sys.path entry holding the author's modules, so a
+    # sibling helper beside the main package is covered — but a root can only
+    # ADD author files if everything that is not the author's is removed from
+    # it first, and removed by construction rather than by a list:
+    #
+    #   * the SDK, even if it somehow sits under the same root;
+    #   * any installed-dependency tree (site-packages / dist-packages), which
+    #     is where torch, diffusers and everything else an endpoint pulls in
+    #     actually live.
+    #
+    # The degenerate case is the safe one: an endpoint pip-INSTALLED into
+    # site-packages has a source root that is entirely subtracted, so nothing
+    # is claimed and every failure stays fatal. "Unsure" still resolves to
+    # fatal, which is the property pgw#1527 was built on.
+    if where.is_relative_to(_sdk_root()):
+        return None
+    if _third_party_root(where):
         return None
     if not where.is_relative_to(endpoint_root):
         return None

--- a/tests/release_fixtures/sibling_helper.py
+++ b/tests/release_fixtures/sibling_helper.py
@@ -1,0 +1,17 @@
+"""A SIBLING top-level module beside the endpoint's package (pgw#1533).
+
+h3's shape: `minimax_h3.main` is the endpoint, and its fps refusal raises in
+`src/cozy_rife.py` — a top-level module at the same source root, not inside
+the `minimax_h3` package. A shared helper beside the main package is the
+common case, and it was uncovered.
+"""
+
+from __future__ import annotations
+
+
+def refuse_unservable(fps: int) -> int:
+    """The author's own refusal, raised from a SIBLING module."""
+
+    if fps == 60:
+        raise ValueError(f"fps={fps} is not servable by this checkpoint")
+    return fps

--- a/tests/test_release_derive_unservable_payload.py
+++ b/tests/test_release_derive_unservable_payload.py
@@ -29,6 +29,7 @@ pytest.importorskip("transformers")
 import gen_worker._vendor.torchcg  # noqa: E402,F401
 
 from gen_worker.release.derive import (  # noqa: E402
+    _third_party_root,
     deepest_endpoint_frame,
     endpoint_source_root,
 )
@@ -200,3 +201,108 @@ def test_the_endpoint_root_is_the_TOP_LEVEL_package_directory() -> None:
         sys.path.remove(str(FIXTURES))
 
     assert endpoint_source_root(ep) == FIXTURES
+
+
+# ---------------------------------------------------------------------------
+# pgw#1533: the source root is the sys.path ENTRY, not the main package.
+
+
+def test_a_SIBLING_top_level_module_is_endpoint_owned(tmp_path: Path) -> None:
+    """h3's actual shape, and the hole that killed its run.
+
+    `endpoint_source_root` used to return the main module's top-level PACKAGE
+    directory, so a helper module BESIDE that package — `src/cozy_rife.py`
+    next to `src/minimax_h3/` — was not provably the author's, and a product
+    bug raised there took the whole derive down.
+    """
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import sibling_helper
+        import tiny_endpoint
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+    root = endpoint_source_root(tiny_endpoint)
+    exc = _raise_from(lambda: sibling_helper.refuse_unservable(60))
+    frame = deepest_endpoint_frame(exc, root)
+
+    assert frame is not None, "a sibling author module must be endpoint-owned"
+    assert Path(frame.filename).name == "sibling_helper.py"
+    assert frame.name == "refuse_unservable"
+
+
+def test_a_PACKAGE_endpoints_root_is_the_directory_ABOVE_the_package() -> None:
+    """That is what makes a sibling reachable at all."""
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import modular_tiny_endpoint  # a module inside no package
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+    assert endpoint_source_root(modular_tiny_endpoint) == FIXTURES
+
+
+def test_the_SUBTRACTION_keeps_an_SDK_frame_fatal_even_under_a_WIDE_root() -> None:
+    """The original concern, tested at its worst case.
+
+    A wider root can only be safe if everything that is not the author's is
+    removed from it. This hands the matcher a root so wide it contains the
+    SDK — the filesystem ROOT — and the SDK frame is still refused.
+    """
+
+    import gen_worker
+    from gen_worker.release.derive import _auto_payloads
+
+    class NotAStruct:
+        pass
+
+    exc = _raise_from(lambda: _auto_payloads("@entrypoint x", NotAStruct))
+    sdk = Path(gen_worker.__file__).resolve().parent
+    assert deepest_endpoint_frame(exc, Path(sdk.anchor)) is None
+    assert deepest_endpoint_frame(exc, sdk) is None
+    assert deepest_endpoint_frame(exc, sdk.parent) is None
+
+
+def test_the_SUBTRACTION_keeps_a_THIRD_PARTY_frame_fatal_under_a_wide_root() -> None:
+    """torch/diffusers live in site-packages, and a wide root would swallow it.
+
+    Named by install LAYOUT rather than by a list of libraries, so it holds for
+    whatever an endpoint pulls in next. The raise site is real diffusers PYTHON
+    code — a C extension reports `<string>` and would make this pass without
+    testing anything.
+    """
+
+    import traceback
+
+    from diffusers import AutoencoderKL
+
+    exc = _raise_from(lambda: AutoencoderKL.load_config("/nonexistent-tree"))
+    deepest = Path(traceback.extract_tb(exc.__traceback__)[-1].filename).resolve()
+    # Pin the PREMISE: this really is a third-party python frame.
+    assert _third_party_root(deepest), deepest
+
+    # A root wide enough to contain it — the filesystem root — and it is still
+    # refused, because the install tree is subtracted.
+    assert deepest_endpoint_frame(exc, Path(deepest.anchor)) is None
+
+
+def test_an_endpoint_INSTALLED_into_site_packages_claims_nothing() -> None:
+    """The degenerate case resolves the SAFE way.
+
+    If the author's code were itself installed into site-packages, the whole
+    source root is subtracted and nothing is claimed — every failure stays
+    fatal, which is the property this design rests on.
+    """
+
+    import traceback
+
+    from diffusers import AutoencoderKL
+
+    exc = _raise_from(lambda: AutoencoderKL.load_config("/nonexistent-tree"))
+    installed = Path(traceback.extract_tb(exc.__traceback__)[-1].filename).resolve()
+    assert _third_party_root(installed)
+
+    # Treat that very tree as the "endpoint source root".
+    assert deepest_endpoint_frame(exc, installed.parent) is None


### PR DESCRIPTION
pgw#1527's `endpoint_source_root()` returned the top-level **package** directory of the endpoint's main module (`<repo>/src/minimax_h3`). Any author module not inside that one package was therefore not provably the author's, `deepest_endpoint_frame()` returned `None`, and *"cannot prove endpoint-owned"* resolved to **fatal** — the right default applied to the wrong roster.

It killed H3's matchscope run: its fps refusal raises in `src/cozy_rife.py`, a **sibling** top-level module at the same source root. A product bug that pgw#1527 exists to skip took the whole derive down instead, at payload 7.

**A shared helper module beside the main package is the common case**, so the roster was wrong for most endpoints rather than an exotic few. The fix is one line of meaning: the root is the sys.path **entry** holding the author's modules — for a package endpoint, the directory *above* the package; for a bare module, the directory holding it.

## Widening the root is only safe because of the subtraction

That's the half answering pgw#1527's original concern. A wider root may add author files and must never add a library, so what is not the author's is removed **by construction, not by a list**:

- the **SDK**, even if it somehow sits under the same root;
- any **installed-dependency tree** — `site-packages` / `dist-packages` / `__pypackages__` — which is where torch, diffusers and everything else an endpoint pulls in actually live. Named by install *layout*, so it holds for whatever gets pulled in next.

The degenerate case resolves the safe way: an endpoint pip-**installed** into site-packages has a source root that is entirely subtracted, claims nothing, and every failure stays fatal. **"Unsure" still means fatal.**

## Red/green by execution, on H3's exact layout

`src/pkgep/main.py` plus a sibling `src/sibling_mod.py`:

| arm | source root | result |
|---|---|---|
| master | `…/src/pkgep` | sibling **not** claimed → **FATAL**, whole derive dies |
| fixed | `…/src` | sibling claimed → skipped as unservable |

## The tests that matter are the ones trying to break it

An SDK frame handed **the filesystem root** as its endpoint root is still refused; a real diffusers frame under a root wide enough to contain site-packages is still refused. Both **pin their own premise first** (the deepest frame really is in the SDK / really is third-party) — because msgspec's C extension reports `<string>`, and an earlier draft of these **skipped** on that, proving nothing while reading green. No skips remain in this file.

## Gates

Byte-compare `b6d23f8e01acc8528be773f70a57bcd0cacf4fec4e703d0a6b4e56b16b309f5c` unchanged · 43 passed across the derive suites · mypy clean (643 files) · ruff clean · `lint_unreached_surface` 97 = base.