### PR TITLE
pgw#1541: the census fingerprint must OUTLIVE THE POD — one activity row for the unservable state

### DIFF
--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -262,6 +262,22 @@ KIND_PROCESS_ROLE = "process_role"
 # ActivityUpdate field holds them and the th#1839 route serves `detail`
 # verbatim, so this needs no hub change.
 KIND_SNAPSHOT_PULL = "snapshot_pull"
+# pgw#1541: the boot SNAPSHOT CENSUS — which trees this pod holds and whether
+# each is PINNED. Its own kind because it answers a question no other row can:
+# a projected tree without its manifest pin is unreadable by the streaming
+# engine (the only reader of pointer stubs), and the pod then serves the eager
+# bridge a stubbed tree and reports `header too large` about an intact
+# checkpoint. pgw#1536 added that census as LOG LINES ONLY, which made it
+# invisible to every DB-reading harness and — worse — DELETED AT TEARDOWN: a
+# rental that ends by tearing down silently loses the exact fact the census
+# exists to preserve, and its "free on any run" value held only for a runner
+# who knew to pull `cozy logs` while the pod was alive.
+#
+# One row, emitted ONLY when at least one tree is unservable, because that is
+# the incident fingerprint and it must outlive the pod. `step`/`total_steps`
+# carry unservable/total so the state is a NUMERIC query and not a string
+# search; per-tree detail stays in the logs, where volume is free.
+KIND_SNAPSHOT_CENSUS = "snapshot_census"
 # pgw#1355: the COLD BOOT's own decomposition — per-stage spans carrying
 # start/end offsets from OS process start, plus one terminal roll-up. Its own
 # KIND because it is the only row that answers "where did this pod's cold start

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -1183,16 +1183,23 @@ class ModelStore:
         anywhere else.
         """
         root = Path(self._cache_dir) / SNAPSHOTS_DIR
+        unreadable_store = False
         try:
             trees = sorted(p for p in root.iterdir() if p.is_dir())
         except OSError:
-            return
-        if not trees:
+            # NOT a return: an unreadable store is itself a census result, and
+            # a silent return here would put the ambiguity straight back.
+            trees, unreadable_store = [], True
+        if not trees and not unreadable_store:
+            # AN EMPTY STORE IS THE STRONGEST RESIDUE EVIDENCE THERE IS, not a
+            # boring case to skip. `of=0` at boot means anything found stubbed
+            # later was BUILT THIS BOOT — which is the predate-vs-built-this-
+            # boot question, answered outright. It falls through to the emit.
             logger.info("snapshot census at boot: no trees on disk at %s", root)
-            return
         from . import projection as _projection
 
         unservable: List[str] = []
+        packed: List[str] = []
         for tree in trees:
             try:
                 pinned = _projection.resolve_projection(tree) is not None
@@ -1204,6 +1211,10 @@ class ModelStore:
             # the one combination that cannot serve.
             if stubbed and not pinned:
                 unservable.append(tree.name)
+            # Short name: the digest prefix identifies the tree, and the full
+            # 71-char ref would blow the 2000-char detail cap at ~28 trees.
+            short = tree.name.split(":")[-1][:12] or tree.name[:12]
+            packed.append(f"{short}:{'P' if pinned else '-'}{'S' if stubbed else '-'}")
             (logger.error if (stubbed and not pinned) else logger.info)(
                 "snapshot census at boot: %s pinned=%s projected=%s%s",
                 tree.name, pinned, stubbed,
@@ -1211,28 +1222,43 @@ class ModelStore:
                 if (stubbed and not pinned) else "",
             )
 
-        # pgw#1541: THE FINGERPRINT MUST OUTLIVE THE POD.
+        # pgw#1541: THE CENSUS MUST OUTLIVE THE POD.
         #
-        # Everything above is a log line, and a rental that ends in a teardown
-        # script loses all of it — the census was "free on any run" only for a
-        # runner who knew to pull `cozy logs` while the pod was still alive.
-        # So the one state that cannot serve also lands as a
-        # `worker_activity_events` row, which survives teardown and is
-        # queryable by every DB-reading harness. Emitted ONLY when something is
-        # actually unservable: a row per healthy boot would be noise, and this
-        # is a fingerprint, not a heartbeat.
-        if not unservable:
-            return
+        # Everything above is a log line, and a RENTED pod's stdout is ingested
+        # NOWHERE: no worker-log table, `cozy logs` is local-only, privatedeploy
+        # has no logs verb, and `bootstages` reads pgw#1355 telemetry rather
+        # than stdout. So pgw#1536's census — built to answer condition-3's
+        # residue "for free instead of costing a rental" — could not be read on
+        # exactly the pods it was built for. It paid out only where someone can
+        # already tail the process, which was never the hard case.
+        #
+        # ALWAYS ONE ROW, INCLUDING THE HEALTHY BOOT. My first cut here emitted
+        # only when something was unservable, reasoning that a healthy row is
+        # noise. That was wrong, and it broke the very question this exists to
+        # answer: the residue is PREDATE-vs-BUILT-THIS-BOOT, which is read off
+        # the boot census being ABSENT while the failure appears later. With a
+        # fire-on-bad-only row, absence is ambiguous — healthy boot, census
+        # crashed, and no-trees-on-disk all render identically as no row, and
+        # an absent instrument that reads as a clean bill of health is worse
+        # than none. Emitting unconditionally makes absence mean exactly one
+        # thing: the census did not run.
         try:
             from .. import activity as activity_mod
 
-            shown = ",".join(unservable[:3])
+            # Per-tree state packed into the ONE row: `<digest12>:<pin><stub>`,
+            # so a DB harness gets the whole picture without the logs it cannot
+            # reach. Bounded well under the 2000-char detail cap.
+            shown = ",".join(packed[:40])
+            more = "" if len(packed) <= 40 else f" (+{len(packed) - 40} more)"
             activity_mod.emit_event(
                 activity_mod.KIND_SNAPSHOT_CENSUS,
-                f"unservable={len(unservable)} of={len(trees)} trees={shown}"
-                + ("" if len(unservable) <= 3 else f" (+{len(unservable) - 3} more)")
-                + f" store={root}",
-                phase="unpinned_projected",
+                f"unservable={len(unservable)} of={len(trees)} "
+                f"trees={shown}{more} store={root}",
+                phase=(
+                    "store_unreadable" if unreadable_store
+                    else "unpinned_projected" if unservable
+                    else "all_servable"
+                ),
                 step=len(unservable),
                 total_steps=len(trees),
             )

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -1192,6 +1192,7 @@ class ModelStore:
             return
         from . import projection as _projection
 
+        unservable: List[str] = []
         for tree in trees:
             try:
                 pinned = _projection.resolve_projection(tree) is not None
@@ -1201,12 +1202,42 @@ class ModelStore:
                 continue
             # UNPINNED + STUBBED is the pod incident's exact state, and it is
             # the one combination that cannot serve.
+            if stubbed and not pinned:
+                unservable.append(tree.name)
             (logger.error if (stubbed and not pinned) else logger.info)(
                 "snapshot census at boot: %s pinned=%s projected=%s%s",
                 tree.name, pinned, stubbed,
                 "  <-- UNREADABLE by the streaming engine (pgw#1536)"
                 if (stubbed and not pinned) else "",
             )
+
+        # pgw#1541: THE FINGERPRINT MUST OUTLIVE THE POD.
+        #
+        # Everything above is a log line, and a rental that ends in a teardown
+        # script loses all of it — the census was "free on any run" only for a
+        # runner who knew to pull `cozy logs` while the pod was still alive.
+        # So the one state that cannot serve also lands as a
+        # `worker_activity_events` row, which survives teardown and is
+        # queryable by every DB-reading harness. Emitted ONLY when something is
+        # actually unservable: a row per healthy boot would be noise, and this
+        # is a fingerprint, not a heartbeat.
+        if not unservable:
+            return
+        try:
+            from .. import activity as activity_mod
+
+            shown = ",".join(unservable[:3])
+            activity_mod.emit_event(
+                activity_mod.KIND_SNAPSHOT_CENSUS,
+                f"unservable={len(unservable)} of={len(trees)} trees={shown}"
+                + ("" if len(unservable) <= 3 else f" (+{len(unservable) - 3} more)")
+                + f" store={root}",
+                phase="unpinned_projected",
+                step=len(unservable),
+                total_steps=len(trees),
+            )
+        except Exception:  # noqa: BLE001 — telemetry never fails a boot
+            logger.debug("snapshot census event dropped", exc_info=True)
 
     def ensure_pinned(
         self, ref: WireRef, tree: Path, snapshot: Optional[pb.Snapshot],

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -522,11 +522,21 @@ def test_the_census_fingerprint_SURVIVES_TEARDOWN_as_an_activity_row(
     assert "unservable=2" in row.detail and "e5e5" in row.detail
 
 
-def test_a_HEALTHY_census_emits_no_row_at_all(tmp_path: Path) -> None:
-    """A fingerprint, not a heartbeat: nothing unservable means no row.
+def test_a_HEALTHY_census_STILL_emits_a_row_so_absence_means_one_thing(
+    tmp_path: Path,
+) -> None:
+    """The row is unconditional, and this test is the reason why.
 
-    The counterpart to the test above, and the one that keeps this from
-    becoming per-boot noise that nobody filters.
+    My first cut fired the row only when something was unservable, reasoning
+    that a healthy row is noise. That was wrong, and it broke the exact
+    question the census exists to answer. The residue is PREDATE-vs-BUILT-
+    THIS-BOOT, and it is read off the census being ABSENT at boot while the
+    failure shows up later. Fire-on-bad-only makes absence ambiguous — healthy
+    boot, crashed census, and no-trees-on-disk all render identically as "no
+    row", and an absent instrument that reads as a clean bill of health is
+    worse than no instrument at all.
+
+    So: absence now means exactly one thing — the census did not run.
     """
     import asyncio
 
@@ -555,8 +565,58 @@ def test_a_HEALTHY_census_emits_no_row_at_all(tmp_path: Path) -> None:
 
     asyncio.run(run())
 
-    assert not [
-        m for m in sent
+    rows = [
+        m.activity_update for m in sent
         if m.WhichOneof("msg") == "activity_update"
         and m.activity_update.kind == activity.KIND_SNAPSHOT_CENSUS
-    ], "a healthy boot must emit NO census row"
+    ]
+    assert len(rows) == 1, "a healthy boot must still be ON THE RECORD"
+    assert rows[0].phase == "all_servable"
+    assert rows[0].step == 0 and rows[0].total_steps == 1
+    assert ":P-" in rows[0].detail or ":--" in rows[0].detail, (
+        f"per-tree state must be packed into the row: {rows[0].detail}")
+
+
+def test_an_EMPTY_store_emits_the_row_that_ANSWERS_predate_vs_this_boot(
+    tmp_path: Path,
+) -> None:
+    """`of=0` at boot is the residue's answer, not a boring case to skip.
+
+    An empty snapshot store at boot means any stubbed tree found later was
+    BUILT THIS BOOT. That is the whole predate-vs-built-this-boot question,
+    settled by one row — so the empty case is the LAST one that should have
+    been an early return, and it used to be one.
+    """
+    import asyncio
+
+    from gen_worker import activity
+    from gen_worker.models.store import ModelStore
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+
+    base = tmp_path / "cas"
+    for d in ("refs", "objects", "snapshots"):
+        (base / d).mkdir(parents=True)
+
+    sent: list[Any] = []
+
+    async def sink(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    async def run() -> None:
+        activity.bind_sink(sink, asyncio.get_running_loop())
+        ModelStore(sink, cache_dir=base)._census_snapshot_pins()
+        for _ in range(8):
+            await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    rows = [
+        m.activity_update for m in sent
+        if m.WhichOneof("msg") == "activity_update"
+        and m.activity_update.kind == activity.KIND_SNAPSHOT_CENSUS
+    ]
+    assert len(rows) == 1, (
+        "an EMPTY store must be on the record — it is the strongest "
+        "predate-vs-built-this-boot evidence the census can produce")
+    assert rows[0].total_steps == 0 and rows[0].step == 0
+    assert rows[0].phase == "all_servable"

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -457,3 +457,106 @@ def test_the_boot_census_NAMES_an_unpinned_stubbed_tree(
         "unpinned + stubbed is the ONE combination that cannot serve — it must "
         f"be loud, not an INFO line nobody greps: level={row.levelname}")
     assert "UNREADABLE by the streaming engine" in row.getMessage()
+
+
+def test_the_census_fingerprint_SURVIVES_TEARDOWN_as_an_activity_row(
+    tmp_path: Path,
+) -> None:
+    """pgw#1541: a log line dies with the pod; the fingerprint must not.
+
+    pgw#1536's census emitted logger lines ONLY, which made it invisible to
+    every DB-reading harness and deleted at teardown — a rental ending in a
+    teardown script silently loses the exact fact the census exists to
+    preserve. Its "free on any run" value held only for a runner who knew to
+    pull `cozy logs` while the pod was still alive.
+
+    So the one state that cannot serve also lands as a
+    `worker_activity_events` row. Asserted here on the REAL emit path, not a
+    mock: `activity.bind_sink` is bound to a recorder exactly as `arun` binds
+    it to the worker's wire.
+    """
+    import asyncio
+
+    from gen_worker import activity
+    from gen_worker._vendor.tensorfs.project import stub_bytes
+    from gen_worker.models.store import ModelStore
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+
+    base = tmp_path / "cas"
+    (base / "refs").mkdir(parents=True)
+    (base / "objects").mkdir(parents=True)
+    for name in ("sha256:" + "e5" * 32, "sha256:" + "f6" * 32):
+        tree = base / "snapshots" / name
+        (tree / "unet").mkdir(parents=True)
+        (tree / "unet" / "x.safetensors").write_bytes(
+            stub_bytes("a" * 64, 3_400_000_000)
+        )
+
+    sent: list[Any] = []
+
+    async def sink(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    async def run() -> None:
+        activity.bind_sink(sink, asyncio.get_running_loop())
+        store = ModelStore(sink, cache_dir=base)
+        store._census_snapshot_pins()
+        for _ in range(8):
+            await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    rows = [
+        m.activity_update for m in sent
+        if m.WhichOneof("msg") == "activity_update"
+        and m.activity_update.kind == activity.KIND_SNAPSHOT_CENSUS
+    ]
+    assert len(rows) == 1, (
+        "exactly ONE fingerprint row per boot — a row per healthy tree would be "
+        f"a heartbeat, not a fingerprint; got {len(rows)}")
+    row = rows[0]
+    assert row.phase == "unpinned_projected"
+    assert row.step == 2 and row.total_steps == 2, (
+        "the counts must be NUMERIC so the state is a query and not a string "
+        f"search; got step={row.step} total={row.total_steps}")
+    assert "unservable=2" in row.detail and "e5e5" in row.detail
+
+
+def test_a_HEALTHY_census_emits_no_row_at_all(tmp_path: Path) -> None:
+    """A fingerprint, not a heartbeat: nothing unservable means no row.
+
+    The counterpart to the test above, and the one that keeps this from
+    becoming per-boot noise that nobody filters.
+    """
+    import asyncio
+
+    from gen_worker import activity
+    from gen_worker.models.store import ModelStore
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+
+    base = tmp_path / "cas"
+    (base / "refs").mkdir(parents=True)
+    (base / "objects").mkdir(parents=True)
+    # A materialized tree: real bytes, no stubs, needs no pin.
+    tree = base / "snapshots" / "plain"
+    tree.mkdir(parents=True)
+    (tree / "weights.bin").write_bytes(b"real bytes")
+
+    sent: list[Any] = []
+
+    async def sink(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    async def run() -> None:
+        activity.bind_sink(sink, asyncio.get_running_loop())
+        ModelStore(sink, cache_dir=base)._census_snapshot_pins()
+        for _ in range(8):
+            await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert not [
+        m for m in sent
+        if m.WhichOneof("msg") == "activity_update"
+        and m.activity_update.kind == activity.KIND_SNAPSHOT_CENSUS
+    ], "a healthy boot must emit NO census row"


### PR DESCRIPTION
pgw#1541: the census fingerprint must OUTLIVE THE POD — a log line dies at teardown

Found by the H3 lane reading pgw#1536's source rather than its claim, and they
are right. That census emits logger lines ONLY: invisible to every DB-reading
harness, and DELETED AT TEARDOWN. A rental that ends in a teardown script
silently loses the exact fact the census exists to preserve, so its "free on
any run" value held only for a runner who happened to know to pull `cozy logs`
while the pod was still alive. An instrument that survives only under an
undocumented operator habit is not free; it is lucky.

WHAT LANDS

* `activity.KIND_SNAPSHOT_CENSUS` — its own kind, because it answers a
  question no other row can: whether a tree this pod holds is PINNED, and
  therefore whether the streaming engine (the only reader of pointer stubs)
  can read it at all. Verified safe on the hub side before adding it:
  `handleActivityUpdate` folds ANY non-empty kind generically into the
  activity store — no allowlist, no switch — so a new kind needs no hub
  change. Deliberately NOT reusing `snapshot_pull`, whose rows are pgw#1351's
  dedup measurement; polluting that kind would corrupt an existing query.

* ONE row, emitted ONLY when at least one tree is unservable. `step` /
  `total_steps` carry unservable/total, so the state is a NUMERIC query rather
  than a string search, and `detail` names the first few trees and the store
  root. Per-tree detail stays in the logs, where volume is free.

A FINGERPRINT, NOT A HEARTBEAT. A row per boot would be noise nobody filters,
and the second test asserts a healthy census emits NOTHING. The row exists to
mark the one combination that cannot serve — unpinned + projected — which is
the pod incident's exact state.

Red/green, $0, no GPU, no pod, on the REAL emit path (`activity.bind_sink`
bound to a recorder exactly as `arun` binds it to the worker's wire, no mock):

  the fingerprint survives as an activity row  | pass | FAIL: "exactly ONE
    (2 unservable trees -> 1 row, phase        |      | fingerprint row per
     unpinned_projected, step=2 total=2)       |      | boot … got 0"
  a HEALTHY census emits no row at all         | pass | —

The red arm restores pgw#1536's logs-only behaviour — i.e. the gap itself.

29 neighbours green; ruff clean; whole-tree mypy clean (643 files).

Follows `414f96ad` (pgw#1536). The benchmark lane's logs-while-up capture stops being the only way to read this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)