### PR TITLE
pgw#1528: the precision vocabulary grew a SEVENTH class and two fences were left to rot

### DIFF
--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -296,3 +296,39 @@ CI-SKIPPED tests/test_bridge_placement.py|hf-internal-testing/tiny-stable-diffus
 # the fix engages `model_offload` pre-placement, 0.51 GiB resident, and serves),
 # plus the red arm in a detached master worktree where 4 of the 6 cases fail.
 CI-SKIPPED tests/test_vram_fit.py|hf-internal-testing/tiny-stable-diffusion-pipe is not in the local hf cache (<path>)
+
+# pgw#1528 — the two keys the guard reported UNCLASSIFIED on master (run
+# 32325673668, `5443fbcb`), which is what kept the whole `tests` job red for
+# every PR in the repo overnight. Neither is new behaviour: pgw#1525 RENAMED
+# both modules (`test_partial_stream_rung_pgw1497.py` -> `test_partial_stream_rung.py`,
+# and `test_arena_residency.py` arrived with pgw#1507), and the census key is
+# `<file>|<reason>` — so a rename retires the old key and mints a new one that
+# nobody has classified. Read that as the general rule: RENAMING A TEST MODULE
+# THAT TAKES A CLASSIFIED SKIP IS A CENSUS EDIT, in the same landing.
+#
+# 3 rows, the pgw#1497 GPU window's own findings (`@CUDA`, three sites in
+# section 5). `ubuntu-latest` has no CUDA device and there is no GPU lane
+# anywhere (pgw#953), so this is UNVERIFIED in CI and always will be. WHERE IT
+# IS MEASURED: by hand on the rig box's RTX 4070 during the pgw#1497 window —
+# these three rows exist BECAUSE the card found two defects the cardless rows
+# could not. Sections 1-4 of the same file (the rung's ladder position, who may
+# select it, what it refuses, and whether its price was measured) need no card
+# and run on every runner, so the rung's CONTRACT is covered in CI; only the
+# cross-device placement behaviour is not.
+CI-SKIPPED tests/test_partial_stream_rung.py|cross-device placement needs a card
+
+# 1 row, and it is LOCAL-ONLY rather than CI-SKIPPED because the artifact it
+# needs is not something a runner could ever be given: the row reads the
+# AUTHORING BOX's own sd1.5 HF snapshot by absolute path
+# (`~/.cache/huggingface/hub/models--stable-diffusion-v1-5--...`) and walks
+# every UNet parameter's (path, offset, len) triple against it. Multi-GB
+# weights never transit CI, nor this box's uplink (workspace weights-locality
+# rule), so a fixture is the only thing CI could hold — and a fixture is
+# exactly what this row refuses to be: the whole point is that the triples
+# cover a REAL component exactly, since the cold-load arm would otherwise fill
+# some weights and leave others as whatever the arena last held.
+# WHAT IS UNVERIFIED WHILE IT SKIPS: only the real-snapshot coverage claim. The
+# layout arithmetic and triple resolution — every byte the arena maps — are
+# decidable without weights and run on every runner from real safetensors this
+# file builds itself.
+LOCAL-ONLY tests/test_arena_residency.py|sd# snapshot not on this box

--- a/tests/convert/test_flavor_token_deleted_pgw1319.py
+++ b/tests/convert/test_flavor_token_deleted_pgw1319.py
@@ -281,10 +281,32 @@ def test_the_produced_struct_has_no_flavor_field() -> None:
 
 def test_the_classifier_is_deleted_and_the_vocabulary_survives() -> None:
     """The vocabulary is what a DECLARATION is checked against, so it stays —
-    one home, in this repo, which te imports rather than re-listing."""
+    one home, in this repo, which te imports rather than re-listing.
+
+    SEVEN classes since pgw#1498 (`4d2bce0c`), which added `gguf`: ONE class
+    for every ggml block encoding, because the qtype is a property of the
+    artifact's bytes (it travels in the tensor-layout contract) while the CLASS
+    is what the hub's ladder ranks, and every qtype ranks the same way against
+    fp8 and base. The exact-set form is deliberate — the vocabulary is a
+    cross-repo contract (tensorhub `precision.Class*`, which te imports rather
+    than re-lists), so a member added or removed here must be a decision
+    somebody took, not a drift somebody absorbed.
+    """
     assert not hasattr(ladder, "classify_flavor_token")
     assert ladder.PRECISION_CLASSES == frozenset({
-        "base", "fp8", "nvfp4", "nvfp4-w4a4", "svdq-fp4", "svdq-int4"})
+        "base", "fp8", "gguf", "nvfp4", "nvfp4-w4a4", "svdq-fp4", "svdq-int4"})
+
+
+@pytest.mark.parametrize(
+    "dead", ["svdq-fp4-r128", "fp8-w8a8", "q4_k_m", "q8_0", "bnb-nf4", "int4"])
+def test_a_dead_spelling_can_never_re_enter_the_vocabulary(dead: str) -> None:
+    """The positive half of the fence above, stated as the thing that must not
+    come back. Each of these was once a real spelling somewhere — `-r128` and
+    `fp8-w8a8` are TOKENS (the axis A18 deleted), the two ggml qtypes are what
+    pgw#1498 refused to make classes of, and `bnb-nf4` is the rung pgw#1206 D
+    deleted. A class is refused at publish (`convert.publish`) precisely
+    because it is not a member here, so membership is the whole gate."""
+    assert dead not in ladder.PRECISION_CLASSES
 
 
 def test_the_publish_leg_names_the_artifact_not_a_flavor(

--- a/tests/convert/test_precision_class_stamp_pgw1300.py
+++ b/tests/convert/test_precision_class_stamp_pgw1300.py
@@ -55,6 +55,11 @@ EXPECTED: dict[str, dict[str, Any] | None] = {
     "svdq-fp4": {"precision_class": "svdq-fp4"},
     "nvfp4": {"precision_class": "nvfp4"},
     "nvfp4-w4a4": {"precision_class": "nvfp4-w4a4"},
+    # pgw#1498 (`4d2bce0c`) added the SEVENTH class. It stamps like any other:
+    # the hub reads `placement.precision_class` verbatim, so a gguf row reaches
+    # the catalog carrying its class even though `precision.StoredPrecisionOf`
+    # does not RANK it yet (the hub half is OWED and named in `ladder.py`).
+    "gguf": {"precision_class": "gguf"},
 }
 
 #: The keys th#2055 stopped reading. Any of them at the wire is the regression.
@@ -114,7 +119,7 @@ def test_the_declared_block_is_precision_class_and_nothing_else(
         "unread JSON at best and a resurrected purchase veto at worst")
 
 
-@pytest.mark.parametrize("cls", ["svdq-fp4", "svdq-int4", "nvfp4-w4a4", "fp8"])
+@pytest.mark.parametrize("cls", ["svdq-fp4", "svdq-int4", "nvfp4-w4a4", "fp8", "gguf"])
 def test_no_admission_key_survives_at_the_wire(
     fake_hub: Any, tmp_path: Path, cls: str
 ) -> None:
@@ -146,17 +151,39 @@ def test_the_ladder_module_no_longer_exports_a_placement() -> None:
     `default_placement` and `placement_to_metadata` are gone, and with them the
     reason `models/svdq.py` kept nunchaku's kernel windows alive — pgw#1298's
     two deliberate survivors, whose only consumers were this stamp and a
-    tensorhub peer pin th#2055 deleted."""
+    tensorhub peer pin th#2055 deleted.
+
+    The export list is asserted WHOLE rather than by absence, so a class added
+    to the vocabulary without being exported (or the reverse) is caught here —
+    that is the half that went stale when pgw#1498 landed `CLASS_GGUF`.
+    """
     from gen_worker.models import svdq
 
     assert set(ladder.__all__) == {
-        "CLASS_BASE", "CLASS_FP8", "CLASS_NVFP4", "CLASS_NVFP4_W4A4",
-        "CLASS_SVDQ_FP4", "CLASS_SVDQ_INT4", "PRECISION_CLASSES",
+        "CLASS_BASE", "CLASS_FP8", "CLASS_GGUF", "CLASS_NVFP4",
+        "CLASS_NVFP4_W4A4", "CLASS_SVDQ_FP4", "CLASS_SVDQ_INT4",
+        "PRECISION_CLASSES",
     }
     leftovers = [n for n in vars(ladder) if "PLACEMENT" in n.upper()]
     assert leftovers == [], f"placement survived the cut: {leftovers}"
     assert not hasattr(svdq, "SVDQ_FP4_SMS")
     assert not hasattr(svdq, "SVDQ_INT4_SMS")
+
+
+def test_every_exported_class_constant_is_in_the_vocabulary_and_back() -> None:
+    """The self-consistency half, which no transcribed literal can state: the
+    `CLASS_*` names `__all__` exports and the members of `PRECISION_CLASSES`
+    are the SAME set. pgw#1498 added `CLASS_GGUF` to both and to the exports;
+    a future class added to only one of the three would publish a value the
+    publish gate refuses, or export a name nothing checks against."""
+    exported_classes = {
+        getattr(ladder, name) for name in ladder.__all__
+        if name.startswith("CLASS_")
+    }
+    assert exported_classes == set(ladder.PRECISION_CLASSES)
+    assert {n for n in vars(ladder) if n.startswith("CLASS_")} == {
+        n for n in ladder.__all__ if n.startswith("CLASS_")
+    }
 
 
 def test_the_worker_no_longer_reports_a_nunchaku_admission_token(

--- a/tests/test_guard_attribution.py
+++ b/tests/test_guard_attribution.py
@@ -132,15 +132,56 @@ def test_the_attribution_helper_selftest_passes():
     assert done.returncode == 0, done.stdout + done.stderr
 
 
+#: The `scripts/lint_*.py` that are NOT `fast gates` diff-local guards, and so
+#: are not expected to carry the attribution seam. Transcribed, not derived —
+#: deriving it from the same `_lint_side` probe the rows below use would make
+#: the exemption self-granting, which is the whole defect this literal closes.
+#:
+#: `lint_skip_census.py` is the pgw#966 census guard. It runs in the `tests`
+#: job, not `fast gates`, and its finding is never a file in a diff — it is a
+#: skip key, which has no side to fall on.
+NOT_DIFF_LOCAL = frozenset({"lint_skip_census.py"})
+
+
+def test_the_set_of_guards_exempt_from_attribution_is_exactly_the_named_one():
+    """pgw#1528. This row replaces a `pytest.skip` and the replacement is the
+    point: the parametrized rows below used to SKIP when a script had no
+    `_lint_side` — so a guard that silently LOST the seam produced a skip, not
+    a failure. That is the exact shape pgw#966's census exists to catch (a row
+    that stops measuring and reports nothing), reached from inside the guard
+    that was supposed to prevent it. A skip is also not free: it minted an
+    unclassified census key that failed the `tests` job for every PR in the
+    repo until somebody disposed of it.
+
+    Stated as a set instead, an unconverted NEW guard is red HERE, naming
+    itself, and a conversion that regresses is red rather than quiet.
+    """
+    unconverted = {p.name for p in SCRIPTS.glob("lint_*.py")
+                   if "_lint_side" not in p.read_text()}
+    assert unconverted == NOT_DIFF_LOCAL, (
+        "a `fast gates` guard lost (or never got) the attribution seam: "
+        f"{sorted(unconverted - NOT_DIFF_LOCAL)}; or an exempt one was "
+        f"converted and this literal is stale: {sorted(NOT_DIFF_LOCAL - unconverted)}"
+    )
+
+
 @pytest.mark.parametrize("script", sorted(
-    p.name for p in SCRIPTS.glob("lint_*.py")
+    p.name for p in SCRIPTS.glob("lint_*.py") if p.name not in NOT_DIFF_LOCAL
 ))
 def test_every_fast_gates_guard_can_attribute(script):
     """A guard that stopped importing the attribution seam is a guard that
-    silently went back to being unattributable. Structural, not a promise."""
+    silently went back to being unattributable. Structural, not a promise.
+
+    The parametrization EXCLUDES the exempt set rather than skipping over it,
+    so every row here executes and the exemption is a decision recorded in one
+    place (`NOT_DIFF_LOCAL`, fenced as a set above) instead of a condition
+    evaluated per row.
+    """
     source = (SCRIPTS / script).read_text()
-    if "_lint_side" not in source:
-        pytest.skip(f"{script} is not a `fast gates` diff-local guard")
+    assert "_lint_side" in source, (
+        f"{script} carries no attribution seam at all — add it, or name it in "
+        "NOT_DIFF_LOCAL with the reason it has no side to report"
+    )
     assert "_lint_side.report" in source or "_lint_side.verdict" in source, (
         f"{script} imports the attribution seam but never calls it — the import "
         f"is the only thing left of the conversion"


### PR DESCRIPTION
Makes pgw's non-required `tests` job green on master again. It has been red all night on a baseline every lane attributed and none owned — one attribution cycle per lane per PR.

## 1. The svdq pair — root-caused to `4d2bce0c`, not to the tcg re-vendors

`4d2bce0c` (pgw#1498, *"the GGUF lane is REACHABLE"*) added `CLASS_GGUF = "gguf"` to `PRECISION_CLASSES` **and** to `ladder.__all__`, and did not adapt the two fences that assert those collections WHOLE.

```
test_the_classifier_is_deleted_and_the_vocabulary_survives  ->  Extra items in the left set: 'gguf'
test_the_ladder_module_no_longer_exports_a_placement        ->  Extra items in the left set: 'CLASS_GGUF'
```

Attribution: `git log -S CLASS_GGUF -- src/gen_worker/models/ladder.py` returns exactly one commit. The tracker filing's hypothesis (`svdq-int4` vs `svdq-fp4` drift) and the tcg#67/tcg#69 re-vendors are both **non-causes** — neither svdq class moved.

**Which side is ruled:** the vocabulary's. pgw#1498 declares `gguf` deliberately — ONE class for every ggml qtype, because the qtype is a property of the artifact's bytes (it travels in the tensor-layout contract) while the CLASS is what the hub's ladder ranks. Verified hub-side: `precision.stampedPrecisionClass` (`internal/orchestrator/precision/stored_th1803.go`) reads `placement.precision_class` verbatim with no allow-list, so a gguf row reaches the catalog carrying its class. The hub half — `StoredPrecisionOf` does not RANK it yet — is already OWED and named in `ladder.py`'s own docstring, and is not a reason to un-declare the class here. So the assertions move; the module does not.

### Adapted, and fenced positively

Per DEFECT-TAXONOMY: an assertion whose subject died gets INVERTED in the same landing, never left to rot.

- Both exact-set fences now name seven classes, and state why the exact-set form is deliberate — the vocabulary is a cross-repo contract te imports rather than re-lists.
- **`test_a_dead_spelling_can_never_re_enter_the_vocabulary`** — six spellings each real somewhere once (`svdq-fp4-r128`, `fp8-w8a8` = TOKENS, the axis A18 deleted; `q4_k_m`/`q8_0` = what pgw#1498 refused to make classes of; `bnb-nf4` = the rung pgw#1206 D deleted; `int4`) may never become members.
- **`test_every_exported_class_constant_is_in_the_vocabulary_and_back`** — the self-consistency half no transcribed literal can state: `__all__`'s `CLASS_*` names and `PRECISION_CLASSES` are the SAME set. **This is the guard that would have caught the half-landing at the time.**
- `gguf` joins the wire fences (`EXPECTED`, `test_no_admission_key_survives_at_the_wire`).

### Red arms — source restored each time

| mutation | caught |
|---|---|
| a class in `PRECISION_CLASSES`, not exported | 4 red, incl. the new consistency row |
| a class exported, not in `PRECISION_CLASSES` (the exact pgw#1498 half-landing shape) | 4 red, incl. the new consistency row |

## 2. pgw#966 skip census — the undisposed keys

Master run [32325673668](https://github.com/cozy-creator/python-gen-worker/actions/runs/32325673668) reported `UNCLASSIFIED: 2`, which failed the guard step for **every PR in the repo**. Neither is new behaviour: the census key is `<file>|<normalized reason>`, so pgw#1525's module RENAMES (`test_partial_stream_rung_pgw1497.py` -> `test_partial_stream_rung.py`) retired the classified keys and minted unclassified ones. **That general rule is now written into the file** — renaming a test module that takes a classified skip is a census edit, in the same landing.

| disposition | key | rows | why |
|---|---|---|---|
| `CI-SKIPPED` | `tests/test_partial_stream_rung.py\|cross-device placement needs a card` | 3 | the pgw#1497 GPU window's own findings (`@CUDA`, section 5). No CUDA on `ubuntu-latest`, no GPU lane anywhere (pgw#953) — UNVERIFIED in CI and always will be; measured by hand on the rig box's RTX 4070. Sections 1-4 of the same file need no card and cover the rung's contract on every runner. |
| `LOCAL-ONLY` | `tests/test_arena_residency.py\|sd# snapshot not on this box` | 1 | reads the AUTHORING BOX's own sd1.5 HF snapshot by absolute path. A runner could never be given it (weights-locality rule), and a fixture is exactly what the row exists to refuse — the point is that the triples cover a REAL component exactly. The layout arithmetic and triple resolution it guards run on every runner from safetensors the file builds itself. |

Each names where the property IS measured and what is unverified while it skips, per the file's own format.

**Verified by replay, not by assertion:** master's own 18 observed keys, rebuilt from that run's log, through `lint_skip_census.py --ci` against this file — `CI-SKIPPED: 13, LOCAL-ONLY: 3, STAGED: 2`, **0 unclassified, exit 0**.

## Evidence

- `pytest tests/convert/test_precision_class_stamp_pgw1300.py tests/convert/test_flavor_token_deleted_pgw1319.py` — **47 passed, 3 skipped**, exit 0 (was `2 failed, 36 passed` on the base tree at `6a6fd144`).
- `lint_flavor_deletion.py`, `lint_fence_symbols.py` — exit 0.
- mypy: **0 errors in the changed files** (the 73 reported are pre-existing `src/` errors from torch stubs being absent on this box).

Acceptance for this lane is the **`tests` job green**, not just `fast gates`.

Closes pgw#1528.