### PR TITLE
pgw#1543: REPAIR AT THE DECLINE — ensure_pinned was never on the path that refuses

### DIFF
--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -127,6 +127,35 @@ class _MaterializedLocal:
     path: Path
     identity: _ResidencyIdentity
 
+# pgw#1543: THE SERVING PATH NEEDS THE STORE, and had no way to reach it.
+#
+# `ensure_pinned` had exactly two callers — `announce_resident` (boot) and
+# `_materialize_local` (materialization) — and `ctx.load`, the per-request path
+# that ACTUALLY REFUSES, called neither. A pod whose tree was already
+# materialized and whose announce already ran serves every later request
+# through `ctx.load`, which finds the pin missing and refuses forever, while
+# the repair sits two modules away with no reference to reach it by. Three
+# commits of observability were watching a door the failure does not use.
+#
+# The resolver already takes the store by `bind_store`; this is the same idea
+# for the serving path, which holds a `DeployBinding` (ref + dir) and nothing
+# else. Module-level because a `ServingContext` is built per host from a
+# binding that deliberately carries no store, and threading one through every
+# construction site to fix an outage is the wrong trade today.
+_ACTIVE_STORE: "Optional[ModelStore]" = None
+
+
+def bind_active_store(store: "ModelStore") -> None:
+    """Publish the process's store for paths that hold no reference to it."""
+    global _ACTIVE_STORE
+    _ACTIVE_STORE = store
+
+
+def active_store() -> "Optional[ModelStore]":
+    """The bound store, or None in a process that never made one (a fixture)."""
+    return _ACTIVE_STORE
+
+
 class ModelStore:
     """The worker's model seam: ensure-local with retries, the residency map,
     and disk retention (#370). All tier transitions flow through
@@ -689,6 +718,31 @@ class ModelStore:
         """
         with self._identity_lock:
             return self._snapshots.get(ref)
+
+    def banked_snapshot_for_tree(self, tree_name: str) -> Optional[pb.Snapshot]:
+        """The banked snapshot whose DIGEST names ``tree_name``, if any.
+
+        pgw#1543. `banked_snapshot` is keyed by ref, and the serving path holds
+        `DeployBinding.checkpoint_ref` — which is the resolver's `pick.ref`,
+        not necessarily the exact string the store banked under. A repair that
+        depended on those two spellings matching would SILENTLY NO-OP on any
+        mismatch: `banked_snapshot` misses, `ensure_pinned` returns False, the
+        pod refuses exactly as before, and every stubbed test still passes.
+        That failure mode is invisible, so the lookup does not rely on the ref
+        at all — the tree's directory name IS its digest, and that is a fact
+        about disk rather than about vocabulary.
+        """
+        want = str(tree_name)
+        with self._identity_lock:
+            banked = list(self._snapshots.values())
+        for snapshot in banked:
+            digest = str(getattr(snapshot, "digest", "") or "").strip()
+            if not digest or not snapshot.files:
+                continue
+            bare = digest.split(":", 1)[-1]
+            if want in (snapshot_dir_key(digest), snapshot_dir_key(bare)):
+                return snapshot
+        return None
 
     def bank_snapshot(self, ref: WireRef, snapshot: pb.Snapshot) -> None:
         """Make hub metadata available without starting a download."""

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -50,6 +50,7 @@ from ..request_context import _PublisherMixin
 if TYPE_CHECKING:
     from ..models.defaults_decode import CarriesDefaults
     from ..models.model_types import ModelType
+    from ..models.refs import WireRef
 
 P = TypeVar("P")
 D = TypeVar("D", bound=GenerationDefaults)
@@ -386,6 +387,7 @@ class LoadContext(Generic[MT_co]):
         engine: Optional[LoaderEngine] = None,
         compile_sink: Optional[Callable[[Any], Any]] = None,
         device: str = "",
+        io: str = "buffered",
         weight_budget_bytes: int = 0,
     ) -> None:
         self._binding = binding
@@ -398,6 +400,10 @@ class LoadContext(Generic[MT_co]):
         #: means none was handed down — a bare `LoadContext(...)` places
         #: nothing, exactly as before.
         self._device = str(device or "")
+        #: pgw#1543: the host's IO mode, kept so a repair-at-decline re-asks
+        #: `engine_for` with the SAME arguments the host used. Retrying with a
+        #: guessed mode would make the retry a different question.
+        self._io = str(io or "buffered")
         #: The offload rung `_placed` engaged for this load, or "" for "the
         #: ladder was never consulted" (pgw#1486). Read by `compile()`, which
         #: may not arm a compiled graph over hook-managed weights.
@@ -432,6 +438,54 @@ class LoadContext(Generic[MT_co]):
                 "(eager-permanent); there is no active lane to read"
             )
         return self._lane
+
+    def _repair_pin_and_rebind(self) -> bool:
+        """Re-pin this tree's manifest and re-ask for an engine. True if bound.
+
+        pgw#1543. Idempotent and moves NO BYTES — `ensure_pinned` rewrites the
+        manifest pin from the banked snapshot, and the objects are already on
+        disk (guaranteed by the `collected` check above). A pod that has been
+        refusing every request becomes a serving pod on its next one.
+
+        Never raises: a repair that fails must leave the ORIGINAL refusal
+        intact rather than replace a precise diagnosis with a repair traceback.
+        The outcome is recorded either way (pgw#1542) and rides the refusal.
+        """
+        try:
+            from ..models.store import active_store
+            from .streaming import engine_for
+
+            store = active_store()
+            if store is None:
+                return False
+            ref = cast("WireRef", self.checkpoint_ref)
+            # The snapshot is looked up BY TREE first, not by ref. The serving
+            # path holds the resolver's `pick.ref`, which need not be the exact
+            # string the store banked under, and a ref-only lookup would make
+            # this repair a SILENT NO-OP on any spelling mismatch — refusing
+            # exactly as before while every stubbed test passes. The tree's
+            # directory name is its digest, which is a fact about disk.
+            snapshot = store.banked_snapshot_for_tree(self.checkpoint_dir.name)
+            if not store.ensure_pinned(ref, self.checkpoint_dir, snapshot):
+                return False
+            engine = engine_for(
+                self.checkpoint_dir,
+                device=self._device or "cuda",
+                io=self._io or "buffered",
+            )
+            if engine is None:
+                # Re-pinned and STILL no engine: a different fault, and the
+                # refusal below is the honest answer. Not logging this as a
+                # success is the whole point of re-asking rather than assuming.
+                return False
+            self._engine = engine
+            return True
+        except Exception:  # noqa: BLE001 — a repair must never mask the refusal
+            logger.warning(
+                "pgw#1543: repair-at-decline raised for %s; falling through to "
+                "the refusal", self.checkpoint_dir, exc_info=True,
+            )
+            return False
 
     def load(self, pipeline_cls: Type[P]) -> P:
         """Build ``pipeline_cls`` with this checkpoint's weights resident —
@@ -508,6 +562,33 @@ class LoadContext(Generic[MT_co]):
             )
         stubbed = _projection_artifacts(self.checkpoint_dir)
         if stubbed:
+            # pgw#1543: REPAIR AT THE DECLINE, because this is the only place
+            # the failure actually happens.
+            #
+            # `ensure_pinned` existed since pgw#1526 and had two callers —
+            # `announce_resident` (boot) and `_materialize_local`
+            # (materialization). NEITHER is on this path. A pod whose tree was
+            # already materialized, or whose announce ran before the repair
+            # existed, reaches here on EVERY request and refuses, forever,
+            # while a working repair sits two modules away. That is a ~19 h
+            # fleet-wide serve outage explained without a single log line: the
+            # fix was never on the failing path.
+            #
+            # Ordering is load-bearing: `collected` is checked ABOVE and never
+            # reaches here, because a tree whose objects were GC'd has nothing
+            # to re-pin (se#790 measured 5.6 GB / 134 GB gone) and writing a
+            # pin over absent bytes would convert an honest refusal into a
+            # corrupt serve. Only the stubbed-but-INTACT case is repairable —
+            # exactly "the objects are present and only the pin is gone".
+            if self._repair_pin_and_rebind():
+                engine = self._engine
+                assert engine is not None  # set by the repair above
+                rebound: P = engine.build(
+                    pipeline_cls,
+                    checkpoint_dir=self.checkpoint_dir,
+                    lane=self._lane,
+                )
+                return self._placed(rebound)
             raise ProjectedTreeNotStreamable(
                 self.checkpoint_dir,
                 stubbed,

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -146,6 +146,7 @@ class EndpointHost:
 
             engine = engine_for(binding.checkpoint_dir, device=device, io=io)
         self._engine = engine
+        self._io = str(io or "buffered")
         #: pgw#1452: the SAME decision reaches the eager bridge. Handing it
         #: only to `engine_for` meant a tree with no chunk store behind it
         #: was built by `from_pretrained` and left wherever that put it —
@@ -191,6 +192,7 @@ class EndpointHost:
             engine=self._engine,
             compile_sink=compile_sink,
             device=self._device,
+            io=self._io,
         )
 
     # -- boot ---------------------------------------------------------------

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -55,7 +55,7 @@ from .models.cache_paths import tensorhub_cache_dir, tensorhub_cas_dir
 from .models.cozy_snapshot import snapshot_dir_key
 from .models.disk_gc import tree_bytes
 from .models.projection import SNAPSHOTS_DIR
-from .models.store import ModelStore
+from .models.store import ModelStore, bind_active_store
 from .boot_materialize import (
     REASON_MODEL_UNAVAILABLE,
     CheckpointConfig,
@@ -661,6 +661,8 @@ class Worker:
         # it; the resolver hands it to `ctx.load`. Two answers to that question
         # is how a pod ends up holding a checkpoint it cannot find.
         self.resolver.bind_store(self.store)
+        # pgw#1543: and the SERVING path too, which holds only a binding.
+        bind_active_store(self.store)
         # NOTE: the disk rescan is NOT here. `Worker` is constructed with no
         # running event loop (`entrypoint.py`), and `ModelStore`'s event path
         # closes its coroutine when it can find neither a running loop nor a

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -31,8 +31,9 @@ So the bridge refuses instead, naming the stub and its two sizes.
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -705,3 +706,246 @@ def test_the_registry_is_BOUNDED_so_a_long_lived_pod_cannot_grow_it() -> None:
     # The most RECENT survive — a live refusal is about a recent repair.
     assert proj.pin_outcome(f"bounded-probe-{proj._PIN_OUTCOMES_CAP * 3 - 1}") == (
         "not needed: already pinned")
+
+
+class _PipelineCls:
+    """Stands in for a real pipeline class: it HAS `from_pretrained`.
+
+    `ctx.load` refuses a class without one BEFORE it reaches the projection
+    checks, so a bare `object` never gets far enough to exercise the repair.
+    Every real pipeline (`StableDiffusionPipeline`, `FluxPipeline`, …) has it.
+    """
+
+    @classmethod
+    def from_pretrained(cls, *a: Any, **k: Any) -> Any:  # pragma: no cover
+        raise AssertionError(
+            "the eager bridge must never run for an unpinned projected tree")
+
+
+def _unpinned_projected_tree(tmp_path: Path) -> Path:
+    """A tree that is STUBBED and UNPINNED — the fleet's exact failing state."""
+    from gen_worker._vendor.tensorfs.project import stub_bytes
+
+    base = tmp_path / "cas"
+    (base / "refs").mkdir(parents=True)
+    (base / "objects").mkdir(parents=True)
+    tree = base / "snapshots" / ("sha256:" + "7c" * 32)
+    (tree / "unet").mkdir(parents=True)
+    (tree / "unet" / "diffusion_pytorch_model.safetensors").write_bytes(
+        stub_bytes("d" * 64, 3_438_167_536)
+    )
+    return tree
+
+
+def test_the_repair_RUNS_ON_THE_REAL_PATH_with_a_MISMATCHED_ref_spelling(
+    tmp_path: Path,
+) -> None:
+    """pgw#1543, on a REAL `ModelStore` — no stubbed store, no stubbed pin.
+
+    Two things are proven here, and the second is the one a mock would miss.
+
+    1. The repair reaches the path that actually refuses. `ensure_pinned`
+       shipped in pgw#1526 with two callers — `announce_resident` (boot) and
+       `_materialize_local` (materialization) — and NEITHER is on `ctx.load`.
+       A pod whose tree was materialized already, or whose announce ran before
+       the repair existed, hits the engine decline on every request and refuses
+       forever while a working repair sits two modules away. That is a ~19h
+       fleet-wide serve outage that needs no log line to explain.
+
+    2. The repair does not depend on REF SPELLING. The store banks snapshots by
+       ref; the serving path holds `DeployBinding.checkpoint_ref`, which is the
+       resolver's `pick.ref` and need not be the same string. A ref-keyed
+       lookup would SILENTLY NO-OP on a mismatch — miss, return False, refuse
+       exactly as before — and every stubbed test would still pass. So this
+       banks under one spelling and serves under a deliberately DIFFERENT one,
+       and still requires the pin to be written.
+    """
+    from gen_worker.models import projection
+    from gen_worker.models import store as store_mod
+    from gen_worker.models.refs import WireRef
+    from gen_worker.models.store import ModelStore
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+
+    digest = "sha256:" + "7c" * 32
+    base = tmp_path / "cas"
+    (base / "refs").mkdir(parents=True)
+    (base / "objects").mkdir(parents=True)
+    tree = base / "snapshots" / digest
+    (tree / "unet").mkdir(parents=True)
+    # Under 64 MiB on purpose: a real manifest for a larger file carries chunk
+    # entries, and `_manifest` rightly refuses to build one without them. The
+    # pin mechanism under test is identical either way, and the field's
+    # multi-GB shapes are asserted by the stub-signature tests above.
+    (tree / "unet" / "x.safetensors").write_bytes(stub_bytes("a" * 64, 4096))
+
+    assert projection.stub_at_any(tree) is True
+    assert projection.resolve_projection(tree) is None, "fixture must be UNPINNED"
+
+    async def noop(_msg: Any) -> None:
+        return None
+
+    store = ModelStore(noop, cache_dir=base)
+    snap = pb.Snapshot(digest=digest)
+    snap.files.add(path="unet/x.safetensors", size_bytes=4096,
+                   digest="sha256:" + "a" * 64)
+    # Banked under the STORE's spelling ...
+    store.bank_snapshot(WireRef("acme/sd15@1"), snap)
+    store_mod.bind_active_store(store)
+    try:
+        ctx: Any = LoadContext(
+            # ... and served under a DIFFERENT one. A ref-keyed repair no-ops here.
+            binding=DeployBinding(
+                checkpoint_ref="acme/sd15", checkpoint_dir=tree),
+            engine=None,          # the engine DECLINED — the failing state
+            device="cuda",
+        )
+        # The load cannot COMPLETE here — this fixture has no `model_index.json`
+        # and no real weights, so once the repair lets the engine bind, the
+        # skeleton builder rightly objects. That is fine and is not what is
+        # under test: the claim is that the PIN GETS WRITTEN on this path.
+        with contextlib.suppress(Exception):
+            ctx.load(_Pipeline)
+    finally:
+        store_mod.bind_active_store(cast(Any, None))
+
+    assert projection.resolve_projection(tree) is not None, (
+        "THE PIN MUST ACTUALLY BE WRITTEN on the real path — this is the whole "
+        "fix, and a repair that resolves to nothing here is the silent no-op "
+        "that a ref-keyed lookup would have produced")
+    assert projection.pin_outcome(tree.name) == "REPAIRED, pin rewritten", (
+        "and pgw#1542's instrument must record it, so a post-mortem reader can "
+        f"tell a repaired pod from an unattempted one: {projection.pin_outcome(tree.name)!r}")
+
+
+def test_a_REFUSING_pod_REPAIRS_AT_THE_DECLINE_and_serves(tmp_path: Path) -> None:
+    """The conversion the fleet needs: would-have-refused now returns a pipeline.
+
+    The companion to the test above. That one proves the pin is really written
+    on the real path; this one proves that once the engine can bind, the
+    request SERVES instead of refusing — a currently-refusing pod becoming a
+    serving pod on its next request, with no bytes moved.
+    """
+    from gen_worker.models import store as store_mod
+    import gen_worker.serving.streaming as streaming_mod
+
+    tree = _unpinned_projected_tree(tmp_path)
+    built = object()
+    repaired: list[Path] = []
+
+    class _Engine:
+        def build(self, cls: Any, *, checkpoint_dir: Path, lane: Any) -> Any:
+            return built
+
+    class _Store:
+        def banked_snapshot_for_tree(self, tree_name: str) -> Any:
+            return object()
+
+        def ensure_pinned(self, ref: str, path: Path, snap: Any) -> bool:
+            repaired.append(Path(path))
+            return True
+
+    store_mod.bind_active_store(cast(Any, _Store()))
+    orig = streaming_mod.engine_for
+    streaming_mod.engine_for = lambda *a, **k: _Engine()  # type: ignore[assignment]
+    try:
+        ctx: Any = LoadContext(
+            binding=DeployBinding(checkpoint_ref="ep/sd15@1", checkpoint_dir=tree),
+            engine=None,
+            device="cuda",
+        )
+        out = ctx.load(_Pipeline)
+    finally:
+        streaming_mod.engine_for = orig  # type: ignore[assignment]
+        store_mod.bind_active_store(cast(Any, None))
+
+    assert out is built, "a repaired pod must SERVE, not refuse"
+    assert repaired == [tree], "the repair must target the refusing tree"
+
+
+def test_a_repair_that_FAILS_leaves_the_original_refusal_intact(
+    tmp_path: Path,
+) -> None:
+    """A failed repair must not replace a precise diagnosis with a traceback.
+
+    The refusal is the most valuable artifact this path produces — it is the
+    one channel that survives the pod. A repair attempt that raises, or that
+    re-pins and still gets no engine, must fall through to it unchanged.
+    """
+    from gen_worker.models import store as store_mod
+    from gen_worker.serving.context import (
+        DeployBinding, LoadContext, ProjectedTreeNotStreamable,
+    )
+
+    tree = _unpinned_projected_tree(tmp_path)
+
+    class _ExplodingStore:
+        def banked_snapshot_for_tree(self, tree_name: str) -> Any:
+            return object()
+
+        def ensure_pinned(self, ref: str, path: Path, snap: Any) -> bool:
+            raise RuntimeError("pin write blew up")
+
+    store_mod.bind_active_store(cast(Any, _ExplodingStore()))
+    try:
+        ctx: Any = LoadContext(
+            binding=DeployBinding(checkpoint_ref="ep/sd15@1", checkpoint_dir=tree),
+            engine=None,
+            device="cuda",
+        )
+        with pytest.raises(ProjectedTreeNotStreamable) as caught:
+            ctx.load(_PipelineCls)
+    finally:
+        store_mod.bind_active_store(cast(Any, None))
+
+    assert "ENGINE DECLINED" in str(caught.value), (
+        "the original refusal must survive a failed repair")
+
+
+def test_repair_is_NOT_attempted_when_the_objects_were_COLLECTED(
+    tmp_path: Path,
+) -> None:
+    """The GC'd case must NEVER be re-pinned — that would serve a lie.
+
+    se#790 measured the worse state on a real tree: the manifest pin is a
+    tree's only GC root, so a tree outliving its pin and then meeting a GC pass
+    has its objects DELETED (5.6 GB there, 134 GB on H3), leaving stubs plus
+    dangling symlinks. Writing a pin over absent bytes would convert an honest
+    refusal into a corrupt serve, so `collected` is checked FIRST and the
+    repair must not run.
+    """
+    from gen_worker.models import store as store_mod
+    from gen_worker.models import projection as proj_mod
+    from gen_worker.serving.context import (
+        DeployBinding, LoadContext, ProjectedTreeNotStreamable,
+    )
+
+    tree = _unpinned_projected_tree(tmp_path)
+    attempted: list[Path] = []
+
+    class _Store:
+        def banked_snapshot_for_tree(self, tree_name: str) -> Any:
+            return object()
+
+        def ensure_pinned(self, ref: str, path: Path, snap: Any) -> bool:
+            attempted.append(Path(path))
+            return True
+
+    store_mod.bind_active_store(cast(Any, _Store()))
+    orig = proj_mod.collected_entries
+    proj_mod.collected_entries = (  # type: ignore[assignment]
+        lambda root: ["unet/diffusion_pytorch_model.safetensors"])
+    try:
+        ctx: Any = LoadContext(
+            binding=DeployBinding(checkpoint_ref="ep/sd15@1", checkpoint_dir=tree),
+            engine=None,
+            device="cuda",
+        )
+        with pytest.raises(ProjectedTreeNotStreamable):
+            ctx.load(_PipelineCls)
+    finally:
+        proj_mod.collected_entries = orig  # type: ignore[assignment]
+        store_mod.bind_active_store(cast(Any, None))
+
+    assert attempted == [], (
+        "a tree whose objects were COLLECTED must never be re-pinned — the "
+        "bytes are gone and a pin over them is a corrupt serve")


### PR DESCRIPTION
pgw#1543: REPAIR AT THE DECLINE — the repair was never on the path that refuses

THE OUTAGE, EXPLAINED WITHOUT A SINGLE LOG LINE

`ensure_pinned` shipped in pgw#1526 and has had exactly TWO callers ever since:
`announce_resident` (the boot readiness answer) and `_materialize_local`
(materialization). **Neither is on `ctx.load`.** A pod whose tree was already
materialized — or that hit `_materialize_local`'s cached short-circuit, which
pgw#1526 itself measured as skipping `ensure_snapshot` entirely — or whose
announce ran before the repair existed, reaches the engine decline on EVERY
request and refuses, forever, while a working repair sits two modules away with
no reference to reach it by.

That is the ~19h fleet-wide serve outage. Three commits of observability
(pgw#1536, #1541, #1542) were all watching a door the failure does not use. The
census and the outcome field were right to land — they are how the next one gets
diagnosed in minutes — but they were never going to fix this, and #1542's own
instrument says so out loud: the field pods' refusal reads
`repair attempted: not attempted`, which was TRUE and was the finding.

THE FIX

On the stubbed-but-intact branch of the refusal, re-pin and re-ask for an
engine before refusing. Idempotent, moves no bytes, and converts a
currently-refusing pod into a serving pod on its next request.

* ORDERING IS LOAD-BEARING. `collected` is checked ABOVE and never reaches the
  repair: a tree whose objects were GC'd has nothing to re-pin (se#790 measured
  5.6 GB there, 134 GB on H3), and writing a pin over absent bytes would turn an
  honest refusal into a CORRUPT SERVE. Only "the objects are present and only
  the pin is gone" is repairable. Asserted.
* A FAILED REPAIR NEVER REPLACES THE REFUSAL. The refusal is the most valuable
  artifact this path produces — the one channel that survives a pod — so a
  repair that raises, or that re-pins and still gets no engine, falls through to
  it unchanged. Asserted.
* THE REPAIR DOES NOT DEPEND ON REF SPELLING, and this one nearly shipped
  broken. The store banks snapshots by ref; the serving path holds
  `DeployBinding.checkpoint_ref` (the resolver's `pick.ref`), which need not be
  the same string. A ref-keyed lookup would SILENTLY NO-OP on a mismatch —
  miss, return False, refuse exactly as before — with every stubbed test still
  green. So `banked_snapshot_for_tree` keys on the TREE'S DIRECTORY NAME, which
  is its digest and a fact about disk rather than about vocabulary. The red arm
  restores the ref-keyed lookup and the real-store test fails on it.

TESTED ON A REAL `ModelStore`, NOT A MOCK — real bank, real `ensure_pinned`,
real pin write, real `resolve_projection`, and deliberately MISMATCHED ref
spellings between bank and serve. Red/green, $0, no GPU:

  pin IS written on the real path,   | pass | FAIL "…the silent no-op that a
   mismatched ref spelling           |      |  ref-keyed lookup would produce"
  refusing pod repairs and SERVES    | pass | FAIL raises ProjectedTree…
  failed repair keeps the refusal    | pass | —
  COLLECTED objects: no repair       | pass | —

71 neighbours green; ruff clean; whole-tree mypy clean (643 files).

Also plumbs the host's `io` into `LoadContext` so the retry re-asks `engine_for`
with the SAME arguments the host used — retrying with a guessed mode would make
the retry a different question.

**This is the fleet fix, not another instrument.** Follows #1107 (`6a6fd144`) and #1108 (`a3389c45`), which made the outage legible; this is what ends it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)