### PR TITLE
pgw#1544: NOBODY ASKED FOR THE ENGINE — and the refusal blamed the store for it

### DIFF
--- a/changelog.d/pgw1544-ask-for-the-engine.md
+++ b/changelog.d/pgw1544-ask-for-the-engine.md
@@ -1,0 +1,13 @@
+- **pgw#1544: `ctx.load` asks for the streaming engine itself, and the refusal
+  stops asserting a cause it never measured.** `engine_for` had two production
+  call sites — `EndpointHost` (the local CLI and the daemon) and pgw#1543's
+  repair. The serverless worker builds `ServeLoop` with no `engine=`, so on a
+  POD nothing ever asked: every projected checkpoint fell to the eager bridge
+  and refused on every request. The refusal then blamed the store, because
+  `_projection_declined_because` returned "the manifest pin is MISSING" as the
+  else of two structural checks without ever looking — so a pod whose pin was
+  present and perfectly resolvable produced `pin ... is MISSING | repair
+  attempted: not needed: already pinned`, one string contradicting itself. The
+  engine is now asked at the one place that always has the tree, the pin is
+  measured ONCE and handed to both the decision and the sentence, and
+  "already pinned" no longer reads as "cannot serve".

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -235,6 +235,9 @@ class ModelStore:
         # : a cached snapshot is re-verified on first use per process
         # so pod-churn corruption can never be trusted forever.
         self._verified: set[str] = set()
+        #: pgw#1544: the snapshot census is one statement about the whole
+        #: store, so the per-ref residency answer emits it at most once.
+        self._censused = False
         # Last digest-carrying snapshot seen per ref: companion-slot
         # setups may arrive snapshot-less; without memory of the hub's desired
         # state / RunJob snapshot they cannot materialize tensorhub refs. Stale
@@ -1229,6 +1232,20 @@ class ModelStore:
             )
         return snapshot
 
+    def _census_snapshot_pins_once(self) -> None:
+        """The census, at most once per process, and never failing its caller.
+
+        pgw#1544. `announce_resident` runs per ref per reconcile; the census is
+        a statement about the whole store, so N refs must not mean N rows.
+        """
+        if self._censused:
+            return
+        self._censused = True
+        try:
+            self._census_snapshot_pins()
+        except Exception:  # noqa: BLE001 — a census never fails a residency answer
+            logger.debug("snapshot census raised", exc_info=True)
+
     def _census_snapshot_pins(self) -> None:
         """One line per snapshot tree on disk: is it pinned, and is it stubbed.
 
@@ -1472,6 +1489,23 @@ class ModelStore:
         # first). Without this the eviction of a tree we just refused is
         # dropped, and the hub keeps the residency this pod has disowned.
         self.bind_loop()
+        # pgw#1544: THE CENSUS'S SECOND CALL SITE, and it is here because this
+        # is a window whose rows demonstrably REACH THE HUB.
+        #
+        # `rescan_disk` (the only caller pgw#1536 gave it) runs inside `arun`
+        # BEFORE the transport task exists, and on the fleet's pods NOTHING
+        # emitted in that window landed: the four verification pods of
+        # 2026-08-19/20 produced `weight_fetch` and `snapshot_pull` rows and
+        # NOT ONE row of any boot-window kind — no `snapshot_census`, no
+        # `process_role`, no `boot_stages` — while pods from a day earlier have
+        # all three. So the census's absence was never a missing call site, and
+        # a second boot-window caller would have produced a second row nobody
+        # can read. This runs on the reconcile, after HelloAck, in the same
+        # window that delivered `snapshot_pull` — and BEFORE this pod
+        # materializes anything, so it still answers pgw#1536's
+        # predate-vs-built-this-boot question. Once per process; the hub folds
+        # a duplicate payload onto one row by `payload_digest` anyway.
+        self._census_snapshot_pins_once()
         if snapshot is None:
             snapshot = self._snapshots.get(ref)
         if snapshot is None or not snapshot.digest:

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -315,12 +315,58 @@ def _projection_pin_outcome(tree: Path) -> str:
         return "unknown"
 
 
-def _projection_declined_because(tree: Path) -> str:
+def _serving_device() -> str:
+    """The device to stream onto when nobody handed one down (pgw#1544).
+
+    ``ServeLoop`` builds its load contexts with no ``device=``, and the literal
+    ``"cuda"`` is an enumeration of what a pod usually is rather than a
+    measurement of this machine — pgw#1452's whole point. So the same probe the
+    host uses answers here.
+    """
+    try:
+        from .placement import serving_device
+
+        return serving_device()
+    except Exception:  # noqa: BLE001 — an unprobeable host is not a refusal
+        return "cuda"
+
+
+def _projection_pinned(tree: Path) -> bool:
+    """Does this tree's manifest pin RESOLVE. The one measurement (pgw#1544).
+
+    Both the repair's precondition and the refusal's decline reason are derived
+    from this single call, passed down. Two independent lookups of one fact is
+    how a refusal came to contradict itself in the same sentence.
+    """
+    from ..models import projection
+
+    try:
+        return projection.resolve_projection(tree) is not None
+    except Exception:  # noqa: BLE001 — a probe never fails a load
+        return False
+
+
+def _projection_declined_because(
+    tree: Path, *, pinned: Optional[bool] = None
+) -> str:
     """WHICH of `resolve_projection`'s three silent Nones fired, in words.
 
     pgw#1513. Without this the reader gets a beautiful message about stubs and
     still does not know why the streaming engine passed on a tree it should
     have taken — the same two-day hunt, one layer up.
+
+    **pgw#1544: the last branch used to ASSERT the pin was missing without ever
+    looking.** It was the else of two structural checks, so any tree in the
+    right place with a CAS behind it got the sentence "the manifest pin ... is
+    MISSING" whether or not it was. On the fleet's pods the pin was PRESENT, so
+    the refusal read `pin ... is MISSING | repair attempted: not needed:
+    already pinned` — one string contradicting itself, on every request, for
+    21 hours, sending three lanes to look at the store while the defect was in
+    the wiring. A refusal that names an unmeasured cause is worse than one that
+    names none.
+
+    ``pinned`` is the caller's own measurement, handed in so that the sentence
+    and the decision it explains can never key on two different lookups.
     """
     from ..models.projection import SNAPSHOTS_DIR
 
@@ -339,6 +385,16 @@ def _projection_declined_because(tree: Path) -> str:
         return (
             f"the store root {base} has no {'/'.join(missing)} directory, so "
             f"there is no CAS behind this tree"
+        )
+    if pinned is None:
+        pinned = _projection_pinned(root)
+    if pinned:
+        return (
+            f"the manifest pin `snapshot:{root.name}` RESOLVES at {base} and "
+            f"this tree is STREAMABLE — the store is not the problem. No "
+            f"streaming engine was bound for this load, so the eager bridge "
+            f"was handed a projected tree. That is a WIRING defect on the path "
+            f"that built this load context, not a missing pin (pgw#1544)"
         )
     return (
         f"the manifest pin `snapshot:{root.name}` is MISSING from the store at "
@@ -439,53 +495,79 @@ class LoadContext(Generic[MT_co]):
             )
         return self._lane
 
-    def _repair_pin_and_rebind(self) -> bool:
-        """Re-pin this tree's manifest and re-ask for an engine. True if bound.
+    def _bind_streaming_engine(self, *, pinned: bool) -> Tuple[bool, bool]:
+        """ASK for this projected tree's engine, repairing the pin if it is
+        gone. Returns ``(bound, pinned_after)``.
 
-        pgw#1543. Idempotent and moves NO BYTES — `ensure_pinned` rewrites the
-        manifest pin from the banked snapshot, and the objects are already on
-        disk (guaranteed by the `collected` check above). A pod that has been
-        refusing every request becomes a serving pod on its next one.
+        pgw#1543 put the REPAIR here. pgw#1544 puts the ASK here, which is the
+        half that was missing and the reason the fleet stayed down.
 
-        Never raises: a repair that fails must leave the ORIGINAL refusal
-        intact rather than replace a precise diagnosis with a repair traceback.
-        The outcome is recorded either way (pgw#1542) and rides the refusal.
+        **A projected tree reaching this method means no engine was bound for
+        this load, and until now that was read as "the engine declined".** It
+        is not. ``engine_for`` has two production call sites: ``EndpointHost``
+        (the local CLI and the daemon) and this one. The serverless worker
+        builds its ``LoadContext`` in ``ServeLoop._backend_factory`` with
+        ``engine=self._engine``, and ``worker.py`` constructs ``ServeLoop``
+        with no ``engine=`` at all — so on a POD nothing ever asked. Every
+        projected tree fell to the eager bridge and refused, on every request,
+        with a message blaming the store.
+
+        So the engine is asked HERE, at the one place that always has the tree,
+        rather than at each of the N paths that build a context — the same
+        defect class pgw#1543 fixed one layer up, and the reason this fix does
+        not simply add an ``engine=`` to ``ServeLoop``: the next path to build
+        a context would omit it again.
+
+        ``pinned`` is the caller's measurement, not a second lookup. When it is
+        True the pin is already good and the repair is not merely unnecessary,
+        it is **not a precondition** — pgw#1543 returned False here because
+        `ensure_pinned` answers "did I repair", and "already pinned" is False.
+        A correctly-pinned tree therefore never re-asked for an engine and
+        refused anyway. That single conflation is the outage's second half.
+
+        Never raises: a failure must leave the ORIGINAL refusal intact rather
+        than replace a precise diagnosis with a repair traceback. The outcome
+        is recorded either way (pgw#1542) and rides the refusal.
         """
         try:
             from ..models.store import active_store
-            from .streaming import engine_for
+            from . import streaming
 
-            store = active_store()
-            if store is None:
-                return False
-            ref = cast("WireRef", self.checkpoint_ref)
-            # The snapshot is looked up BY TREE first, not by ref. The serving
-            # path holds the resolver's `pick.ref`, which need not be the exact
-            # string the store banked under, and a ref-only lookup would make
-            # this repair a SILENT NO-OP on any spelling mismatch — refusing
-            # exactly as before while every stubbed test passes. The tree's
-            # directory name is its digest, which is a fact about disk.
-            snapshot = store.banked_snapshot_for_tree(self.checkpoint_dir.name)
-            if not store.ensure_pinned(ref, self.checkpoint_dir, snapshot):
-                return False
-            engine = engine_for(
+            if not pinned:
+                store = active_store()
+                if store is None:
+                    return False, pinned
+                ref = cast("WireRef", self.checkpoint_ref)
+                # The snapshot is looked up BY TREE first, not by ref. The
+                # serving path holds the resolver's `pick.ref`, which need not
+                # be the exact string the store banked under, and a ref-only
+                # lookup would make this repair a SILENT NO-OP on any spelling
+                # mismatch — refusing exactly as before while every stubbed
+                # test passes. The tree's directory name is its digest, which
+                # is a fact about disk.
+                snapshot = store.banked_snapshot_for_tree(
+                    self.checkpoint_dir.name)
+                if not store.ensure_pinned(ref, self.checkpoint_dir, snapshot):
+                    return False, pinned
+                pinned = True
+            engine = streaming.engine_for(
                 self.checkpoint_dir,
-                device=self._device or "cuda",
+                device=self._device or _serving_device(),
                 io=self._io or "buffered",
             )
             if engine is None:
-                # Re-pinned and STILL no engine: a different fault, and the
+                # Pinned and STILL no engine: a different fault, and the
                 # refusal below is the honest answer. Not logging this as a
-                # success is the whole point of re-asking rather than assuming.
-                return False
+                # success is the whole point of asking rather than assuming.
+                return False, pinned
             self._engine = engine
-            return True
-        except Exception:  # noqa: BLE001 — a repair must never mask the refusal
+            return True, pinned
+        except Exception:  # noqa: BLE001 — this must never mask the refusal
             logger.warning(
-                "pgw#1543: repair-at-decline raised for %s; falling through to "
-                "the refusal", self.checkpoint_dir, exc_info=True,
+                "pgw#1544: binding the streaming engine raised for %s; falling "
+                "through to the refusal", self.checkpoint_dir, exc_info=True,
             )
-            return False
+            return False, pinned
 
     def load(self, pipeline_cls: Type[P]) -> P:
         """Build ``pipeline_cls`` with this checkpoint's weights resident —
@@ -563,7 +645,8 @@ class LoadContext(Generic[MT_co]):
         stubbed = _projection_artifacts(self.checkpoint_dir)
         if stubbed:
             # pgw#1543: REPAIR AT THE DECLINE, because this is the only place
-            # the failure actually happens.
+            # the failure actually happens. pgw#1544: and ASK FOR THE ENGINE
+            # here too, because on a pod nobody else ever does.
             #
             # `ensure_pinned` existed since pgw#1526 and had two callers —
             # `announce_resident` (boot) and `_materialize_local`
@@ -580,19 +663,33 @@ class LoadContext(Generic[MT_co]):
             # pin over absent bytes would convert an honest refusal into a
             # corrupt serve. Only the stubbed-but-INTACT case is repairable —
             # exactly "the objects are present and only the pin is gone".
-            if self._repair_pin_and_rebind():
+            #
+            # pgw#1544: ONE LOOKUP OF "IS THIS TREE PINNED", derived from here
+            # and handed to both the decision and the sentence that explains
+            # it. The pod's refusal read `pin ... is MISSING | repair
+            # attempted: not needed: already pinned` because the repair MEASURED
+            # the pin and the message ASSUMED it — and the message was wrong.
+            pinned = _projection_pinned(self.checkpoint_dir)
+            bound, pinned = self._bind_streaming_engine(pinned=pinned)
+            if bound:
                 engine = self._engine
-                assert engine is not None  # set by the repair above
+                assert engine is not None  # set by the bind above
+                # Returned RAW, exactly as the primary streaming arm above
+                # returns it. `_placed` is the EAGER bridge's placement — the
+                # streaming engine already streamed these weights onto the
+                # device it was handed, and running the fit ladder over a
+                # pipeline that is already resident is how pgw#1486's OOM
+                # happens. One placement story for one engine.
                 rebound: P = engine.build(
                     pipeline_cls,
                     checkpoint_dir=self.checkpoint_dir,
                     lane=self._lane,
                 )
-                return self._placed(rebound)
+                return rebound
             raise ProjectedTreeNotStreamable(
                 self.checkpoint_dir,
                 stubbed,
-                _projection_declined_because(self.checkpoint_dir),
+                _projection_declined_because(self.checkpoint_dir, pinned=pinned),
             )
         # pgw#1473: a VARIANT-ONLY tree (`*.fp16.safetensors`, which is what
         # every fp16 mirror ships) is invisible to `from_pretrained` unless it

--- a/tests/test_projected_tree_reading.py
+++ b/tests/test_projected_tree_reading.py
@@ -949,3 +949,292 @@ def test_repair_is_NOT_attempted_when_the_objects_were_COLLECTED(
     assert attempted == [], (
         "a tree whose objects were COLLECTED must never be re-pinned — the "
         "bytes are gone and a pin over them is a corrupt serve")
+
+
+# ── pgw#1544: the refusal contradicted itself, and nobody was asking ──────────
+#
+# THE FIELD ARTIFACT, one string, from `request_state.error_message_safe` on the
+# standing stack (pod 6r92qnflyt9blk, release b98aad88…, pin e3527cab):
+#
+#   ENGINE DECLINED: the manifest pin `snapshot:sha256:5bd90786…` is MISSING
+#   from the store at /tmp/tensorhub-cache/cas … | repair attempted: not
+#   needed: already pinned | PROJECTED TREE, 4 pointer stub(s) …
+#
+# The pin is MISSING and the repair says already pinned, in one sentence. It was
+# read as two lookups of one fact disagreeing. It is not: there was only ever
+# ONE lookup. `_projection_declined_because`'s last branch was the else of two
+# STRUCTURAL checks and asserted the pin was missing without ever looking, so
+# the repair MEASURED and the message ASSUMED — and on the fleet the message was
+# the one that was wrong. The pin was there the whole time.
+#
+# Which raises the question the contradiction was hiding: if the tree is pinned
+# and streamable, why was the eager bridge holding it at all? Because on a POD
+# nobody asks for an engine. `engine_for` has two production call sites:
+# `EndpointHost` — which only `serving/__main__.py` (the local CLI) and
+# `cli/daemon.py` construct — and pgw#1543's repair. The serverless worker
+# builds `ServeLoop` (`worker.py:582`) with NO `engine=`, and
+# `ServeLoop._backend_factory` hands `engine=self._engine` to every
+# `LoadContext`. So every projected tree on every pod fell to the eager bridge
+# and refused, on every request, blaming the store.
+#
+# That is why every local red/green passed while every pod failed: the tests
+# went through `EndpointHost`, which asks, and the fleet went through
+# `ServeLoop`, which does not.
+
+
+def _pinned_projected_tree(tmp_path: Path) -> Path:
+    """sd15's real shape, through the REAL store: 4 pointer stubs, PINNED.
+
+    Built by `ModelStore.ensure_local` over a real CAS and a real HTTP origin,
+    so the pin is the one production writes rather than one a fixture staged.
+    """
+    import asyncio
+
+    from gen_worker import activity
+    from gen_worker.models.refs import WireRef
+    from test_weight_position import (  # type: ignore[import-not-found]
+        OBJECT_BYTES,
+        _Origin,
+        _Wire,
+        _pb_snapshot,
+        _store,
+    )
+
+    members = [
+        "unet/diffusion_pytorch_model.fp16.safetensors",
+        "vae/diffusion_pytorch_model.fp16.safetensors",
+        "text_encoder/model.fp16.safetensors",
+        # The member the field refusal named, at its field size.
+        "safety_checker/model.fp16.safetensors",
+    ]
+    origin = _Origin()
+    try:
+        files = [(p, bytes([i + 1]) * OBJECT_BYTES) for i, p in enumerate(members)]
+        snapshot = _pb_snapshot([(p, b, origin.put(b)) for p, b in files])
+
+        async def stage() -> Path:
+            wire = _Wire()
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            store = _store(wire, tmp_path / "tensorhub-cache" / "cas")
+            return await store.ensure_local(WireRef("tensorhub/sd15-base@prod"),
+                                            snapshot)
+
+        return asyncio.run(stage())
+    finally:
+        origin.close()
+
+
+def test_a_PINNED_projected_tree_REACHES_THE_STREAMING_ENGINE_on_the_serve_path(
+    tmp_path: Path,
+) -> None:
+    """pgw#1544's reproduction, and the fleet fix: the pod's own state.
+
+    A real store, a real pinned projected tree in sd15's shape, and a
+    `LoadContext` built EXACTLY as `ServeLoop._backend_factory` builds one on a
+    pod — `engine=None`, no `device=`, no `io=`. Before this fix that
+    combination refused every request with a message blaming a pin that was
+    sitting right there.
+
+    The load cannot COMPLETE over a fixture tree with no `model_index.json` —
+    the skeleton builder rightly objects, and that objection is the proof: it
+    comes from INSIDE the streaming engine, which is a place the pod's requests
+    never reached.
+    """
+    from gen_worker.models import projection
+    from gen_worker.serving.streaming.skeleton import SkeletonError
+
+    tree = _pinned_projected_tree(tmp_path)
+    stubs = _projection_artifacts(tree)
+    assert len(stubs) == 4, f"fixture must be sd15-shaped: {stubs}"
+    assert any(p == "safety_checker/model.fp16.safetensors" for p, _, _ in stubs)
+    assert projection.resolve_projection(tree) is not None, (
+        "fixture must be PINNED — the pod's actual state, and the one the "
+        "refusal claimed was impossible")
+
+    _Pipeline.called.clear()
+    ctx: LoadContext[Any] = LoadContext(
+        binding=DeployBinding(
+            checkpoint_ref="tensorhub/sd15-base@prod", checkpoint_dir=tree),
+        engine=None,  # ServeLoop hands this to every load on every pod
+    )
+
+    with pytest.raises(SkeletonError):
+        ctx.load(_Pipeline)
+
+    assert _Pipeline.called == [], (
+        "the eager bridge must never see a projected tree — reaching "
+        "from_pretrained is the `header too large` lie pgw#1513 killed")
+    assert ctx._engine is not None, (
+        "THE ENGINE MUST BE ASKED FOR. Nothing on the serverless worker path "
+        "calls `engine_for`: `worker.py` builds ServeLoop with no engine= and "
+        "ServeLoop hands that None down. A projected tree with a good pin then "
+        "refused forever while the engine that reads it was never constructed")
+
+
+def test_the_PRODUCTION_dispatcher_hands_its_loads_NO_ENGINE(
+    tmp_path: Path,
+) -> None:
+    """The premise of the test above, asserted on the real object.
+
+    `worker.py:582` constructs `ServeLoop` with no `engine=`. This builds one
+    the same way and reads what its own factory manufactures. If a future
+    change starts binding an engine here, this test says so — rather than
+    leaving the test above passing for a reason that has quietly changed.
+    """
+    import sys
+
+    from gen_worker.serving.loader import load_endpoint_module
+    from gen_worker.serving.residency import ResidencyManager
+    from gen_worker.serving.serve_loop import ServeLoop
+
+    fixtures = Path(__file__).resolve().parent / "release_fixtures"
+
+    class _Sizer:
+        def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
+            return 1 << 20
+
+        def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+            return 0
+
+    class _Resolver:
+        def resolve(self, model_cls: type, checkpoint_ref: str) -> Any:
+            raise AssertionError("not reached")
+
+        def default_pick(self, model_cls: type, slot_name: str) -> str:
+            return "tensorhub/sd15-base@prod"
+
+    sys.path.insert(0, str(fixtures))
+    try:
+        loaded = load_endpoint_module("sd15_shaped_endpoint")
+    finally:
+        sys.path.remove(str(fixtures))
+
+    loop = ServeLoop(
+        loaded,
+        residency=ResidencyManager(1 << 30, _Sizer()),
+        resolver=_Resolver(),
+        lane_contract="sd15.diffusers-bf16@1",
+    )
+    model_cls = next(iter(loaded.models))
+    binding = DeployBinding(
+        checkpoint_ref="tensorhub/sd15-base@prod",
+        checkpoint_dir=tmp_path / "tree",
+    )
+    key = (model_cls, "tensorhub/sd15-base@prod", "sd15.diffusers-bf16@1")
+    backend = loop._backend_factory(model_cls, binding, key)()
+
+    assert backend.load_context._engine is None, (
+        "the pod's dispatcher binds NO streaming engine — which is why "
+        "`ctx.load` must ask for one itself")
+
+
+def test_the_decline_reason_is_MEASURED_and_never_ASSERTED(tmp_path: Path) -> None:
+    """The self-contradiction, killed at its source.
+
+    `_projection_declined_because` returned "the manifest pin ... is MISSING"
+    as the ELSE of two structural checks — a sentence about the store that
+    nothing in the function had looked at. Both states are driven here on real
+    trees: the claim must follow the disk, in both directions.
+    """
+    from gen_worker.models import projection
+
+    pinned = _pinned_projected_tree(tmp_path / "good")
+    assert projection.resolve_projection(pinned) is not None
+    said = _projection_declined_because(pinned)
+    assert "is MISSING" not in said, (
+        "a PINNED tree must never be told its pin is missing — that sentence "
+        f"sent three lanes to the store while the defect was in the wiring: {said}")
+    assert "RESOLVES" in said and "WIRING" in said
+
+    unpinned = _unpinned_projected_tree(tmp_path / "bad")
+    assert projection.resolve_projection(unpinned) is None
+    still = _projection_declined_because(unpinned)
+    assert "is MISSING" in still, (
+        f"and the genuine missing-pin diagnosis must survive intact: {still}")
+
+
+def test_the_refusal_and_the_repair_OUTCOME_can_never_contradict_each_other(
+    tmp_path: Path,
+) -> None:
+    """The field artifact, as an invariant.
+
+    "the pin is MISSING" and "not needed: already pinned" must never appear in
+    one refusal again, whatever else changes. Driven over a real pinned tree
+    with the repair's own outcome recorded against it — the exact pairing the
+    pod produced.
+    """
+    from gen_worker.models import projection
+
+    tree = _pinned_projected_tree(tmp_path)
+    projection.record_pin_outcome(tree.name, "not needed: already pinned")
+
+    message = str(ProjectedTreeNotStreamable(
+        tree,
+        _projection_artifacts(tree),
+        _projection_declined_because(tree),
+    ))
+    assert "not needed: already pinned" in message
+    assert "is MISSING" not in message, (
+        "ONE STRING MUST NOT CONTRADICT ITSELF. The pod said the pin was "
+        f"missing and the repair said it was already pinned: {message}")
+
+
+def test_the_boot_census_FIRES_ON_THE_RECONCILE_where_rows_reach_the_hub(
+    tmp_path: Path,
+) -> None:
+    """pgw#1544: the census had a caller and still produced zero rows.
+
+    `rescan_disk` runs inside `arun` BEFORE the transport task is created, and
+    on the field pods NOTHING emitted in that window survived: the four
+    verification pods of 2026-08-19/20 each produced exactly `weight_fetch` and
+    `snapshot_pull` rows and not one row of any boot-window kind —
+    `snapshot_census`, `process_role` and `boot_stages` are all absent, while
+    pods from a day earlier carry all three. So a second boot-window caller
+    would have bought a second unreadable row.
+
+    `announce_resident` runs on the reconcile, after HelloAck, in the same
+    window that delivered `snapshot_pull` — and before this pod materializes
+    anything, so it still answers the predate-vs-built-this-boot question.
+    Driven through the REAL store with a REAL bound activity sink: the check is
+    that a ROW is EMITTED, not that a symbol exists.
+    """
+    import asyncio
+
+    from gen_worker import activity
+    from gen_worker.models.refs import WireRef
+    from gen_worker.models.store import ModelStore
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+    from test_weight_position import _Wire  # type: ignore[import-not-found]
+
+    base = tmp_path / "cas"
+    (base / "refs").mkdir(parents=True)
+    (base / "objects").mkdir(parents=True)
+    tree = base / "snapshots" / ("sha256:" + "e5" * 32)
+    (tree / "unet").mkdir(parents=True)
+    (tree / "unet" / "x.safetensors").write_bytes(stub_bytes("a" * 64, 3_400_000_000))
+
+    wire = _Wire()
+
+    async def reconcile() -> None:
+        activity.bind_sink(wire.send, asyncio.get_running_loop())
+        store = ModelStore(wire.send, cache_dir=base)
+        snapshot = pb.Snapshot(digest="sha256:" + "e5" * 32)
+        # Twice on purpose: a pod reconciles every configured ref, and the
+        # census is one statement about the whole store.
+        for _ in range(2):
+            await store.announce_resident(WireRef("tensorhub/sd15-base@prod"),
+                                          snapshot)
+        # The activity sink ships on the loop; let those tasks run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    asyncio.run(reconcile())
+
+    rows = [u for u in wire.updates if u.kind == activity.KIND_SNAPSHOT_CENSUS]
+    assert len(rows) == 1, (
+        "the residency answer must emit the census EXACTLY ONCE per process — "
+        f"a per-ref row is N rows for one fact: {[u.detail for u in rows]}")
+    row = rows[0]
+    assert "of=1" in row.detail and "unservable=1" in row.detail, (
+        f"the row must carry the census, not just exist: {row.detail}")
+    assert row.phase == "unpinned_projected"


### PR DESCRIPTION
## The contradiction was not two lookups disagreeing — there is only one lookup

The field artifact (pod `6r92qnflyt9blk`, release `b98aad88…`, pin `e3527cab`):

```
ENGINE DECLINED: the manifest pin `snapshot:sha256:5bd90786…` is MISSING from the
store at /tmp/tensorhub-cache/cas … | repair attempted: not needed: already pinned
| PROJECTED TREE, 4 pointer stub(s) …
```

`_projection_declined_because`'s last branch was the **else of two structural checks** and
asserted the pin was missing **without ever looking**. The repair measured; the message
assumed; the message was wrong. The pin was present the whole time.

**Reproduced on a box before any fix**, on a REAL `ModelStore` (real CAS, real HTTP origin,
real `ensure_local`, sd15's real projected layout — 4 pointer stubs incl.
`safety_checker/model.fp16.safetensors`), byte-for-byte in shape, over a tree whose pin
resolves and whose `engine_for` returns a working engine. It is the red arm:
`pytest tests/test_projected_tree_reading.py -k PINNED_projected_tree_REACHES`.

## The outage: `engine_for` is never called on the serverless worker path

`engine_for` has two production call sites — `EndpointHost` (constructed only by
`serving/__main__.py`, the local CLI, and `cli/daemon.py`) and pgw#1543's repair. The pod
builds `ServeLoop` (`worker.py:582`) with **no `engine=`**, and `_backend_factory` hands
`engine=self._engine` to every `LoadContext`. Nothing on a pod ever asked. Every projected
tree fell to the eager bridge and refused, on every request, blaming the store.

That is why every local red/green passed while every pod failed: the tests go through
`EndpointHost`, which asks; the fleet goes through `ServeLoop`, which does not. pgw#1543's
own defect class, one layer up.

pgw#1543's repair could not save it either: `ensure_pinned` answers *"did I REPAIR"*, so a
correctly-pinned tree returns False, and `_repair_pin_and_rebind` read that as fatal and
refused **without re-asking for an engine**.

## The fix

* **`ctx.load` asks for the engine** on the projected branch — the one place that always has
  the tree. Adding `engine=` to `ServeLoop` would leave the next context-building path to
  omit it again.
* **One lookup** of *is this tree pinned*, taken at the decline and handed to both the
  decision and the sentence. They can no longer disagree.
* **The decline reason is measured.** A pinned tree is told its pin RESOLVES and that no
  engine was bound — a wiring defect, not a store defect. The genuine missing-pin diagnosis
  is unchanged and still red-armed.
* Both pgw#1543 invariants held and asserted: `collected` trees never repair; a failed repair
  never replaces the refusal.
* The streamed rebind returns the engine's build raw, as the primary streaming arm does —
  `_placed` is the eager bridge's placement, and running pgw#1486's fit ladder over
  already-resident weights is that issue's OOM.

## The census had a caller — and the absence is bigger than the census

`rescan_disk()` **is** on the boot path, unconditionally (`worker.py:1315`, inside `arun`).
But it runs before the transport task exists, and **nothing emitted in that window survived
on any field pod**: the four verification pods of 2026-08-19/20 each produced exactly
`weight_fetch` and `snapshot_pull` and not one row of any boot-window kind — no
`snapshot_census`, no `process_role`, no `boot_stages` — while pods from a day earlier carry
all three. A second boot-window caller buys a second unreadable row.

So the census also fires from `announce_resident`: on the reconcile, after HelloAck, in the
window that demonstrably delivers, and before this pod materializes anything — so it still
answers pgw#1536's predate-vs-built-this-boot question. Once per process, asserted by
**emission** on a real bound sink.

Why the pre-transport window loses every row is **owed and not fixed here** (tracker
pgw#1544 carries the candidates).

## Evidence

| | clean `origin/master` (e3527cab) | this branch |
|---|---|---|
| pinned projected tree reaches the streaming engine | **FAIL** — the field's contradictory refusal | pass |
| decline reason is measured, both directions | **FAIL** | pass |
| refusal and repair outcome cannot contradict | **FAIL** | pass |
| census emits on the reconcile, exactly once | **FAIL** (0 rows) | pass |
| the pod's dispatcher hands its loads no engine | pass (the premise) | pass |

26/26 in the file, 114 neighbours green, ruff clean, whole-src mypy clean (353 files). $0, no
GPU, no pods. `test_serve_loop_envelope.py::…fake_tensors` fails identically on clean
`e3527cab` on this box (it expects a machine with no GPU) — pre-existing, not this lane's.
