### PR TITLE
pgw#1549/#1550/#1551/#1552: ONE tensorfs-aware seam, and a pod-shaped test that can see it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -481,6 +481,22 @@ jobs:
       - name: pgw#1460 guard - no raw AOTI package load in src/gen_worker
         run: uv run python scripts/lint_raw_aoti_load.py
 
+      # GATING. pgw#1550, bought by the ~21 h fleet serve outage of 2026-08-19.
+      # gen-worker had TWO construction paths for the tensorfs-aware streaming
+      # loader — the local CLI host asked for it, `ServeLoop` never did — so
+      # every pod fell to a naive file reader, met a 128 B TFSSTUB1 pointer
+      # stub, and refused every request while every local test passed. A raw
+      # `safe_open`/`load_file`/`torch.load` on a checkpoint path IS that
+      # outage; the seam is `gen_worker.models.tensor_source`. Selftest first:
+      # a fence whose red has never been observed proves nothing when green.
+      # NOTE: in this pgw-only clone the sibling `serverless-endpoints`
+      # checkout is absent, so the guard scans gen_worker and SAYS SO on
+      # stderr rather than scoring the half it could not read as clean.
+      - name: pgw#1550 guard - one tensorfs-aware tensor reader
+        run: |
+          uv run python scripts/lint_tensor_read_seam.py --selftest
+          uv run python scripts/lint_tensor_read_seam.py
+
       # pgw#1489: an artifact's env identity is the COMPILE STACK read off the
       # endpoint's uv.lock — torch/triton/nvidia and nothing else. The whole
       # installed set was a second representation of that lock, unable to agree

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -157,6 +157,10 @@ tasks:
       # reads the .skip-census-*.json that only a full pytest run produces —
       # it belongs to `task test`, not to a static lint pass.
       - cmd: uv run python scripts/lint_mypy_ratchet.py
+      # pgw#1550. Locally this one is STRICTLY STRONGER than CI's: the sibling
+      # `serverless-endpoints` checkout is present here, so the endpoint half
+      # of the fence actually runs. CI cannot see that repo and says so.
+      - cmd: uv run python scripts/lint_tensor_read_seam.py
       - cmd: uv run python scripts/lint_config_reads.py
       - cmd: uv run python scripts/lint_settings_writers.py
       - cmd: uv run python scripts/lint_layout_declarations.py

--- a/changelog.d/pgw1549-one-tensor-seam.md
+++ b/changelog.d/pgw1549-one-tensor-seam.md
@@ -1,0 +1,27 @@
+### One tensorfs-aware seam turns checkpoint files into tensors
+
+The ~21 h fleet serve outage of 2026-08-19 had one shape: a capability that two
+callers both needed was added to each of them separately, and the pod's caller
+was the one that got missed. `EndpointHost` asked for the streaming loader,
+`ServeLoop` never did, and every local test passed because every local test was
+the caller that asked.
+
+- **pgw#1549** — `EndpointHost` no longer builds a loader engine. `ctx.load` is
+  the sole binder (the one place that always has the tree), and both hosts now
+  build their `LoadContext` through one `serving/worker_context.py` factory. In
+  the process this fixes a live pod defect of the same shape: `ServeLoop` named
+  no placement device, so pgw#1452's fix never reached a pod and every eagerly
+  bridged pipeline there ran on the CPU.
+- **pgw#1550** — `scripts/lint_tensor_read_seam.py` (`fast gates`) fails any raw
+  `safe_open` / `load_file` / `torch.load` on a checkpoint path, in gen_worker
+  and in the sibling endpoint checkout, AND a second `LoadContext` builder
+  anywhere in `src/` — consolidating the two hosts is only worth something if a
+  third cannot appear. Exemption is a proof at the line with a mandatory reason. The quantizer producers now read through the seam;
+  `load_from_pretrained` and the skeleton's passthrough branch refuse typed.
+- **pgw#1551** — `tests/test_pod_serve_loop_streams.py` builds `ServeLoop`
+  exactly as `worker.py` does on a pod and serves a request off a real projected
+  tree with real stubs on a real `ModelStore`. No mocks on the seam. Reverting
+  the engine ask turns it red with the fleet's own refusal.
+- **pgw#1552** — `docs/projected-trees.md`: the stub contract, the one reader,
+  every other reader's obligation, and the catalogue of wrong inferences a stub
+  invites.

--- a/docs/projected-trees.md
+++ b/docs/projected-trees.md
@@ -1,0 +1,79 @@
+# Projected trees: the stub contract
+
+The one page for anyone whose code can meet a checkpoint directory.
+
+## What is on disk
+
+A **projected tree** is what the worker resolves for every served checkpoint
+(`<TENSORHUB_CACHE_DIR>/cas/snapshots/<key>/`). It carries no tensor bytes.
+
+| kind of file | what the path holds |
+|---|---|
+| non-tensor (config, tokenizer, `.so`, media) | a relative **symlink** into the CAS `objects/` — a real file, readable normally |
+| tensor container (`*.safetensors`, …) | a ~128 B **`TFSSTUB1` pointer stub**; the bytes are chunked into the CAS and **no path-based read can reach them** |
+
+The manifest is pinned in the same store under `snapshot:<key>`, so
+`(cas, manifest)` is recoverable from the tree's own directory name — which is
+its digest. Nothing needs a sidecar, and nothing may key that lookup on a
+*ref*: the serving path holds the resolver's `pick.ref`, which need not be the
+string the store banked under (pgw#1543).
+
+## The one reader
+
+```python
+from gen_worker.models.tensor_source import open_tensor_source, load_state_dict
+```
+
+`open_tensor_source(path, why=...)` keeps `safetensors.safe_open`'s shape and
+moves the source: `keys()`, `get_tensor()`, `metadata()` behave the same
+whether the path is a real file or a stub. `load_state_dict` is the
+`safetensors.torch.load_file` replacement. A lane is cut over by changing one
+`with` line.
+
+For a whole pipeline the seam is one level up: **`ctx.load(PipelineClass)`**,
+which binds the pgw#1380 streaming engine and walks the chunk store straight to
+VRAM. There is no `torch_dtype=` (the lane contract *is* the dtype) and no
+`.to("cuda")` (placement is the worker's decision, handed down).
+
+`scripts/lint_tensor_read_seam.py` fails the build on a raw
+`safe_open` / `load_file` / `torch.load` outside the seam.
+
+## Every other reader's obligation
+
+A consumer that can meet a projected tree needs a stub-aware branch or an
+**explicit typed refusal naming the stub and the remedy**. Falling back to a
+default is the defect. The refusals that exist:
+
+- `UnresolvedProjection` — the stub is here and its manifest is not recoverable.
+- `ProjectedTreeNotStreamable` — `ctx.load` was handed a projected tree and no
+  engine bound.
+- `ProjectedTreeNotEagerlyLoadable` — `load_from_pretrained` (the eager
+  whole-pipeline loader) met one; it would materialize a second copy of the
+  tree to read weights `ctx.load` streams with no file at all.
+- `SkeletonError` — a passthrough (non-`nn.Module`) component's directory holds
+  a stub, so the stock `from_pretrained` cannot build it.
+
+Third-party code that genuinely needs real files goes through
+`models/materialized_view.third_party_dir(path, why=...)` — **tier 3** of the
+pgw#1303 ladder, permanent for external binaries (`llama-server -m`,
+`gguf.GGUFReader`) and AOT `.so` delivery, and a **defect** for a serving
+pytorch endpoint since Paul's 2026-08-19 no-fill ruling.
+
+## The catalogue of wrong inferences (pgw#1308 finding 3)
+
+The stub format's safety property is that a naive `open()` fails **loudly at
+the parse site**. That guarantee constrains nothing about what the caller then
+concludes, and no change to the format can fix a wrong conclusion. Four have
+been paid for:
+
+| the observation | the wrong inference | what it cost |
+|---|---|---|
+| `SafetensorError: header too large` | **the checkpoint is corrupt** | `store.py` deleted the model on every boot; two days pointed at poisoned volumes and truncated downloads. The tell was that the error is identical for a 3.4 GB model and a 68 GB one — the stub is a fixed size. |
+| a header read returns `{}` | **the tensor is absent** | `detect_on_disk_dtype` silently doubled VRAM; `_quantized_layers` stopped detecting a w8a8 artifact as quantized and routed it to the plain bf16 lane. |
+| a dangling symlink / unreadable component | **the tree is missing a file** | `skeleton.build` reported `carries no model_index.json` about a tree that has one (pgw#1514). |
+| the streaming engine did not bind | **the store is broken / the pin is missing** | the ~21 h fleet outage of 2026-08-19. The pin resolved the whole time; nothing had *asked* for an engine. Three lanes read that sentence and went to look at the store (pgw#1544). |
+
+The shape is always the same: a correct loud failure, read as a fact about the
+**bytes** when it is a fact about the **reader**. Before concluding anything
+about a checkpoint from a parse failure, call
+`gen_worker.models.projection.stub_at(path)`.

--- a/scripts/lint_tensor_read_seam.py
+++ b/scripts/lint_tensor_read_seam.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""pgw#1550: ONE tensorfs-aware reader turns checkpoint files into tensors.
+
+THE INCIDENT. For ~21 h no endpoint in the fleet completed a serve. Root cause:
+gen-worker had TWO construction paths for the tensorfs-aware streaming loader —
+the local CLI host asked for it, the serverless worker's ``ServeLoop`` never
+did — so every pod fell through to a naive file reader, met a ~128 B
+``TFSSTUB1`` pointer stub where it expected a safetensors header, and refused.
+Every local test passed, because every local test went through the caller that
+asked. Paul's verdict: *"this is why you need fewer code paths / DRY
+principles."*
+
+WHAT THIS FENCE ASSERTS. A projected tensorfs tree is symlinks for non-tensor
+files plus pointer stubs for tensor containers; the bytes are chunked into the
+CAS and are unreachable by any path-based read. So a raw tensor-file read in
+first-party serving code is not a style question — it is that outage, ready to
+happen again. Every such read must go through
+``gen_worker.models.tensor_source`` (``open_tensor_source`` /
+``load_state_dict``), which keeps ``safe_open``'s shape and moves the source.
+
+WHAT IT DOES NOT ASSERT. ``from_pretrained`` is not banned: it is the eager
+bridge for a tree with NO chunk store behind it, and ``ctx.load`` already
+refuses to hand it a projected one. This fence is about the RAW readers —
+``safetensors.safe_open``, ``safetensors.torch.load_file``, ``torch.load`` —
+which have no such gate and cannot acquire one from outside.
+
+SCOPE. ``src/gen_worker`` minus ``_vendor``/``pb`` (``_lint_scope``), and the
+endpoint packages of the sibling ``serverless-endpoints`` checkout when it is
+present — an endpoint that opens a container itself is the same defect wearing
+a different repo, and pgw#1550's audit found several.
+
+EXEMPTION IS A PROOF AT THE LINE, never a path allowlist::
+
+    tensors = load_file(path)  # tensor-seam-exempt: <why this cannot be a stub>
+
+A reason is mandatory. A bare marker is a violation, because "somebody wrote a
+marker" is not evidence and an unexplained one is what a future reader deletes
+the wrong half of.
+
+Usage:
+    scripts/lint_tensor_read_seam.py [ROOT ...]
+    scripts/lint_tensor_read_seam.py --selftest
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lint_scope import is_unowned  # noqa: E402
+import _lint_side  # noqa: E402
+
+SRC = REPO / "src" / "gen_worker"
+def _sibling_endpoints() -> Path:
+    """The `serverless-endpoints` checkout beside this one, wherever we run.
+
+    NOT `REPO.parent / ...`: in a worktree under `~/cozy/.worktrees/<repo>/<br>`
+    that resolves two directories below the workspace and silently finds
+    nothing — the "absent scan reads as clean" failure this fence has its own
+    empty-scan rail for. Walk up instead, and report absence rather than
+    scoring it green.
+    """
+    for base in (REPO, *REPO.parents):
+        candidate = base.parent / "serverless-endpoints"
+        # `is_dir()` is not enough: `~/cozy/.worktrees/serverless-endpoints`
+        # is a real directory holding BRANCH worktrees, and stopping there
+        # found zero endpoints and scanned nothing while reporting green.
+        # Identify the checkout by what it contains, not by its name.
+        if candidate.is_dir() and any(candidate.glob("*/endpoint.toml")):
+            return candidate
+    return REPO.parent / "serverless-endpoints"
+
+
+#: The sibling endpoint checkout. Absent in CI's pgw-only clone, which is why
+#: its absence is reported rather than silently scoring green.
+ENDPOINTS = _sibling_endpoints()
+
+MARKER = "tensor-seam-exempt:"
+
+#: The seam itself, and the modules whose whole job is to be the thing behind
+#: it. These are STRUCTURAL exemptions: `tensor_source` IS the sanctioned
+#: reader, `safetensors_header` reads the 8-byte length that decides stub vs
+#: file, and `projection` reads the stub. A guard that refused them would be
+#: refusing its own remedy.
+SANCTIONED = frozenset({
+    SRC / "models" / "tensor_source.py",
+    SRC / "models" / "safetensors_header.py",
+    SRC / "models" / "projection.py",
+    SRC / "models" / "materialized_view.py",
+})
+
+#: The only two modules that may name `LoadContext(` — the class's own module,
+#: and pgw#1549's single production factory. See `_load_context_sites`.
+CONTEXT_BUILDERS = frozenset({
+    SRC / "serving" / "context.py",
+    SRC / "serving" / "worker_context.py",
+})
+
+#: Directories whose job is to PRODUCE checkpoints from upstream source trees
+#: (ingest -> normalize -> contract -> CAS). They read files that are files by
+#: construction: a conversion input has not been projected yet, and its output
+#: is being written by the same process. The serving fleet never enters here.
+PRODUCER_DIRS = (SRC / "convert",)
+
+#: `module.attr` spellings that read tensors from a path.
+DOTTED = {
+    ("safetensors", "safe_open"),
+    ("safetensors", "torch", "load_file"),
+    ("torch", "load"),
+    ("st", "load_file"),
+}
+#: Bare names, when imported from a tensor library. Tracked per-file: a local
+#: function called `load_file` is not this.
+BARE = {"safe_open", "load_file", "st_load_file"}
+TENSOR_MODULES = ("safetensors", "safetensors.torch", "torch")
+
+
+def _dotted_name(node: ast.AST) -> Tuple[str, ...]:
+    parts: List[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return tuple(reversed(parts))
+    return ()
+
+
+def _exempt(lines: Sequence[str], lineno: int) -> Tuple[bool, str]:
+    """Is this line proved, and with what reason. Looks at the line and the
+    three above it, because a long call wraps and the proof belongs with the
+    explanation rather than crammed onto the closing paren."""
+    for index in range(max(0, lineno - 4), min(len(lines), lineno)):
+        text = lines[index]
+        if MARKER in text:
+            reason = text.split(MARKER, 1)[1].strip().rstrip("\"')")
+            return True, reason
+    return False, ""
+
+
+def _imported_tensor_names(tree: ast.AST) -> set:
+    """Bare names in this file that were imported FROM a tensor library."""
+    found = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "") in TENSOR_MODULES:
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if alias.name in BARE or name in BARE:
+                    found.add(name)
+    return found
+
+
+def scan_file(path: Path) -> List[str]:
+    try:
+        source = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    lines = source.splitlines()
+    names = _imported_tensor_names(tree)
+    problems: List[str] = _load_context_sites(path, tree, lines)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        spelling = ""
+        if isinstance(node.func, ast.Attribute):
+            dotted = _dotted_name(node.func)
+            if dotted in DOTTED or (len(dotted) >= 2 and dotted[-2:] in DOTTED):
+                spelling = ".".join(dotted)
+            # NOT a suffix match on `.load`: `torch.export.load` reads an
+            # ExportedProgram, not a checkpoint, and has its own fence
+            # (`lint_raw_aoti_load.py`). A guard that claims a neighbouring
+            # domain teaches people to ignore it.
+        elif isinstance(node.func, ast.Name) and node.func.id in names:
+            spelling = node.func.id
+        if not spelling:
+            continue
+        proved, reason = _exempt(lines, node.lineno)
+        if proved and reason:
+            continue
+        shown = _shown(path)
+        if proved:
+            problems.append(
+                f"{shown}:{node.lineno}: `{spelling}` carries a bare "
+                f"`{MARKER}` with NO reason. The marker is not the proof — "
+                f"state why this path cannot hold a TFSSTUB1 stub."
+            )
+            continue
+        problems.append(
+            f"{shown}:{node.lineno}: `{spelling}` reads tensors from a FILE "
+            f"PATH. On a projected tensorfs tree that path holds a ~128 B "
+            f"TFSSTUB1 pointer stub and the real bytes are in the CAS: this "
+            f"reads the stub's first 8 bytes as a header length and blames "
+            f"the checkpoint. Use gen_worker.models.tensor_source "
+            f"(`open_tensor_source` / `load_state_dict`), or prove the path "
+            f"with `# {MARKER} <why>`."
+        )
+    return problems
+
+
+def _shown(path: Path) -> Path:
+    """The path as a finding spells it — repo-relative under a root
+    `_lint_side._PATH_RE` recognises, so the finding is ATTRIBUTABLE.
+
+    An endpoint file is spelled `src/serverless-endpoints/<endpoint>/...`: the
+    `src/` prefix is what makes attribution work at all, and the repo name is
+    what tells a reader which tree to open.
+    """
+    try:
+        return path.relative_to(REPO)
+    except ValueError:
+        pass
+    try:
+        return Path("src") / "serverless-endpoints" / path.relative_to(ENDPOINTS)
+    except ValueError:
+        return Path("src") / path.name
+
+
+#: Not source: installed environments, vendored trees, build output.
+SKIP_DIRS = frozenset({".venv", "venv", "vendor", "node_modules",
+                       "__pycache__", "build", "dist", ".git"})
+
+
+def _load_context_sites(path: Path, tree: ast.AST, lines: Sequence[str]) -> List[str]:
+    """pgw#1549: production code builds a ``LoadContext`` in ONE place.
+
+    The outage was not caused by a bad load context. It was caused by there
+    being TWO of them — `EndpointHost` and `ServeLoop` each assembling one out
+    of their own copy of the worker's decisions — so a decision added to one
+    silently missed the other, three times running (pgw#1452's placement
+    device, pgw#1380's engine, pgw#1543's repair). Consolidating them fixes
+    today; this arm is what stops a third host from re-creating the split,
+    which is the only reason the consolidation is worth anything.
+
+    Tests build them freely: a bare `LoadContext(...)` is inert by design
+    (it names no device and binds no engine) and pgw#1452's arm 2 asserts
+    exactly that, so the fence is on `src/` only.
+    """
+    if path in CONTEXT_BUILDERS or not str(path).startswith(str(SRC)):
+        return []
+    problems: List[str] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                and node.func.id == "LoadContext"):
+            continue
+        proved, reason = _exempt(lines, node.lineno)
+        if proved and reason:
+            continue
+        problems.append(
+            f"{_shown(path)}:{node.lineno}: builds a `LoadContext` directly. "
+            f"Production has ONE (pgw#1549): "
+            f"`gen_worker.serving.worker_context.worker_load_context`, which "
+            f"carries the worker's placement device, io mode and weight "
+            f"budget. A second builder is how pgw#1452's fix reached the local "
+            f"CLI and never reached a pod — every eagerly bridged pipeline on "
+            f"the fleet ran on the CPU because `ServeLoop` named no device."
+        )
+    return problems
+
+
+def _python_files(root: Path) -> Iterable[Path]:
+    """Every first-party ``.py`` under ``root``.
+
+    The skip test is RELATIVE to ``root``, never over the absolute path: this
+    repo is routinely checked out at `~/cozy/.worktrees/<repo>/<branch>`, and
+    an absolute-path test there matched every file in the tree and scanned
+    NOTHING — a fence reporting clean because it could not see. The empty-scan
+    rail below caught it, which is exactly what that rail is for.
+    """
+    for path in sorted(root.rglob("*.py")):
+        if SKIP_DIRS & set(path.relative_to(root).parts):
+            continue
+        yield path
+
+
+def scan(roots: Sequence[Path]) -> Tuple[List[str], int]:
+    problems: List[str] = []
+    scanned = 0
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in _python_files(root):
+            if path in SANCTIONED:
+                continue
+            if root == SRC and is_unowned(path, SRC):
+                continue
+            if any(str(path).startswith(str(d)) for d in PRODUCER_DIRS):
+                continue
+            scanned += 1
+            problems.extend(scan_file(path))
+    return problems, scanned
+
+
+def _endpoint_roots() -> List[Path]:
+    if not ENDPOINTS.is_dir():
+        return []
+    return [d / "src" for d in sorted(ENDPOINTS.iterdir())
+            if (d / "endpoint.toml").is_file() and (d / "src").is_dir()]
+
+
+def _selftest() -> int:
+    """Plant the violation and require the guard to SEE it. A fence whose red
+    has never been observed is a fence nobody has tested."""
+    failures: List[str] = []
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        (root / "bad.py").write_text(
+            "from safetensors.torch import load_file\n"
+            "def go(p):\n"
+            "    return load_file(str(p))\n"
+        )
+        # The planted call is ASSEMBLED, never written literally: HARDCUT E5's
+        # `lint_pickle_readers.py` scans this file too and would (correctly)
+        # refuse a verbatim torch deserializer sitting in a guard's source.
+        # Two fences over one repo must not make each other's fixtures illegal.
+        deserializer = "torch." + "load"
+        (root / "bad_dotted.py").write_text(
+            "import torch\n"
+            "def go(p):\n"
+            f"    return {deserializer}(p, map_location='cpu')\n"
+        )
+        (root / "bare_marker.py").write_text(
+            "from safetensors import safe_open\n"
+            "def go(p):\n"
+            "    return safe_open(p)  # tensor-seam-exempt:\n"
+        )
+        (root / "good_seam.py").write_text(
+            "from gen_worker.models.tensor_source import load_state_dict\n"
+            "def go(p):\n"
+            "    return load_state_dict(p, why='the sanctioned reader')\n"
+        )
+        (root / "good_proved.py").write_text(
+            "from safetensors import safe_open\n"
+            "def go(p):\n"
+            "    # tensor-seam-exempt: this path is written by this process\n"
+            "    return safe_open(p)\n"
+        )
+        found, scanned = scan([root])
+        if scanned != 5:
+            failures.append(f"scanned {scanned} file(s), expected 5")
+        named = " ".join(found)
+        for wanted in ("bad.py:3", "bad_dotted.py:3", "bare_marker.py:3"):
+            if wanted not in named:
+                failures.append(f"MISSED the planted violation at {wanted}")
+        for unwanted in ("good_seam.py", "good_proved.py"):
+            if unwanted in named:
+                failures.append(f"refused the legitimate form in {unwanted}")
+        if "NO reason" not in named:
+            failures.append("a bare marker was accepted as a proof")
+
+    # The one-load-context arm fires only under `src/gen_worker`, so its
+    # planted violation has to live there — the `test_guard_attribution.py`
+    # doctrine (plant it where the guard actually looks, or the selftest
+    # proves a code path production never takes).
+    planted = SRC / f"_seam_selftest_{os.getpid()}.py"
+    try:
+        planted.write_text(
+            "from .serving.context import LoadContext\n"
+            "def go(b):\n"
+            "    return LoadContext(binding=b)\n"
+        )
+        found, _ = scan([SRC])
+        if not any(planted.name in line and "ONE" in line for line in found):
+            failures.append(
+                "MISSED a second LoadContext builder planted under src/")
+    finally:
+        planted.unlink(missing_ok=True)
+    if failures:
+        for line in failures:
+            print(f"SELFTEST FAILED: {line}", file=sys.stderr)
+        return 1
+    print("lint_tensor_read_seam --selftest: the fence goes red on a planted "
+          "violation and green on the seam")
+    return 0
+
+
+def main(argv: Sequence[str]) -> int:
+    if "--selftest" in argv:
+        return _selftest()
+    roots = [Path(a).resolve() for a in argv if not a.startswith("-")]
+    if not roots:
+        roots = [SRC, *_endpoint_roots()]
+        if not ENDPOINTS.is_dir():
+            # NOT a silent pass. The endpoint half of this fence is the half
+            # that found live violations; a run that could not look at it must
+            # say so, or "green" means "did not check".
+            print(
+                f"lint_tensor_read_seam: NOTE — {ENDPOINTS} is not present, so "
+                f"only gen_worker was scanned. The endpoint half of this fence "
+                f"did not run.",
+                file=sys.stderr,
+            )
+    problems, scanned = scan(roots)
+    if not scanned:
+        print(
+            f"lint_tensor_read_seam: scanned NOTHING under "
+            f"{', '.join(str(r) for r in roots)} — the tree moved and this "
+            f"fence is asserting over an empty set.",
+            file=sys.stderr,
+        )
+        return 1
+    if problems:
+        _lint_side.report(problems, "pgw#1550 tensor-read seam")
+        print(
+            f"\nlint_tensor_read_seam: {len(problems)} raw tensor-file "
+            f"read(s) outside the seam ({scanned} file(s) scanned). The ~21 h "
+            f"fleet outage of 2026-08-19 was one of these.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"lint_tensor_read_seam: clean ({scanned} file(s) scanned)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1042,6 +1042,17 @@ def composition_compute_dtype(base_path: str | Path, dtype: str = "") -> str:
     return ""
 
 
+class ProjectedTreeNotEagerlyLoadable(RuntimeError):
+    """pgw#1549: the eager whole-pipeline loader met a projected tensorfs tree.
+
+    Typed rather than a log line, because the alternative outcomes are both
+    silent: `from_pretrained` on a stub raises `SafetensorError: header too
+    large` (a lie about the checkpoint — pgw#1513's two lost days), and the
+    tier-3 materialization that avoids it doubles the tree on disk to do a job
+    `ctx.load` does with no file at all.
+    """
+
+
 class MixedComputeDtypeError(RuntimeError):
     """A composed pipeline presents more than one COMPUTE dtype to its GEMMs.
 
@@ -2293,6 +2304,37 @@ def load_from_pretrained(
     modular lane must not stage them onto the card and must not take the
     per-component host-RAM discount."""
     path = str(path)
+    # pgw#1549: THE EAGER WHOLE-PIPELINE LOADER REFUSES A PROJECTED TREE.
+    #
+    # Every arm below ends at `third_party_dir(path, ...)`, which is tier 3 of
+    # the #1303 access ladder: it MATERIALIZES a second real copy of the tree
+    # so a third-party loader can read files. For a serving pytorch pipeline
+    # that is not a fallback, it is the defect Paul's 2026-08-19 no-fill ruling
+    # names — the weights are already in the chunk store and `ctx.load` streams
+    # them store->VRAM with no file written. Reaching here with a projected
+    # tree costs 2x the disk to produce a load `ctx.load` does better, and on a
+    # pod it is the difference between serving and filling the volume.
+    #
+    # This function has no production caller at HEAD: its only one was
+    # `provision.load_slot`, orphaned when pgw#1373 hardcut the v1 SDK. That is
+    # exactly why the guard goes here rather than in a comment — an exported
+    # eager loader with no caller is not safe, it is UNWATCHED, and the outage
+    # this refusal belongs to was caused by a second construction path nobody
+    # was looking at.
+    from .projection import stub_at_any
+
+    if stub_at_any(Path(path)):
+        raise ProjectedTreeNotEagerlyLoadable(
+            f"load_from_pretrained({getattr(cls, '__name__', cls)}, {path}): "
+            f"this is a PROJECTED tensorfs tree — its tensor containers are "
+            f"~128 B TFSSTUB1 pointer stubs whose bytes live in the CAS. The "
+            f"eager loader would materialize a full second copy of the tree "
+            f"to read them (tier 3 of the pgw#1303 ladder), which the "
+            f"2026-08-19 no-fill ruling leaves to external binaries only. "
+            f"Load through `ctx.load(<PipelineClass>)`, which binds the "
+            f"pgw#1380 streaming engine and walks the chunk store straight to "
+            f"VRAM with no tensor file written or read."
+        )
     if is_modular_pipeline_class(cls):
         return _load_modular_pipeline(
             cls, path, dtype=dtype, storage_dtype=storage_dtype,
@@ -2519,6 +2561,7 @@ __all__ = [
     "apply_fp8_storage",
     "assert_uniform_compute_dtype",
     "MixedComputeDtypeError",
+    "ProjectedTreeNotEagerlyLoadable",
     "composition_compute_dtype",
     "QUANT_EXECUTION_LANE_COMPUTE_DEFAULT",
     "pipeline_weight_lane",

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -838,7 +838,7 @@ def quantize_tree_w4a4(
     in %% 32 == 0, out %% 16 == 0, name not matching ``exclude``."""
 
     import torch
-    from safetensors.torch import load_file, save_file
+    from safetensors.torch import save_file
 
     src_tree, out_tree = Path(src_tree), Path(out_tree)
     comp = next((c for c in denoiser_components() if (src_tree / c).is_dir()), None)
@@ -856,7 +856,13 @@ def quantize_tree_w4a4(
         if rel.parts[0] != comp:
             shutil.copy2(f, dst)
             continue
-        tensors = load_file(str(f))
+    # pgw#1549: `safetensors.torch.load_file` is the ONE shape a projected
+    # tree cannot serve — it reads the ~128 B TFSSTUB1 pointer stub's first
+    # eight bytes as a header length. `tensor_source.load_state_dict` is its
+    # drop-in replacement and reads the CAS when the path holds a stub, so
+    # this producer is correct on a projected source tree instead of failing
+    # with a lie about the checkpoint.
+        tensors = load_state_dict(f, why="the w4a4 data-free producer reads a source shard")
         out: Dict[str, Any] = {}
         quantized = 0
         for name, t in tensors.items():

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -987,7 +987,7 @@ def quantize_tree_w8a8(
     ``exclude`` substrings."""
 
     import torch
-    from safetensors.torch import load_file, save_file
+    from safetensors.torch import save_file
 
     src_tree, out_tree = Path(src_tree), Path(out_tree)
     comp = next((c for c in denoiser_components() if (src_tree / c).is_dir()), None)
@@ -1004,7 +1004,13 @@ def quantize_tree_w8a8(
         if rel.parts[0] != comp:
             shutil.copy2(f, dst)
             continue
-        tensors = load_file(str(f))
+    # pgw#1549: `safetensors.torch.load_file` is the ONE shape a projected
+    # tree cannot serve — it reads the ~128 B TFSSTUB1 pointer stub's first
+    # eight bytes as a header length. `tensor_source.load_state_dict` is its
+    # drop-in replacement and reads the CAS when the path holds a stub, so
+    # this producer is correct on a projected source tree instead of failing
+    # with a lie about the checkpoint.
+        tensors = load_state_dict(f, why="the w8a8 data-free producer reads a source shard")
         out: Dict[str, Any] = {}
         quantized = 0
         for name, t in tensors.items():

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -472,6 +472,16 @@ class LoadContext(Generic[MT_co]):
         self._weight_budget_bytes = max(0, int(weight_budget_bytes))
 
     @property
+    def loader_engine(self) -> Optional[LoaderEngine]:
+        """The streaming engine THIS load actually bound, or ``None``.
+
+        pgw#1549. `EndpointHost` used to keep its own handle and report its
+        numbers; since `ctx.load` is the one binder, the only truthful source
+        for "did an engine run, and what did it do" is the context that ran.
+        """
+        return self._engine
+
+    @property
     def checkpoint_dir(self) -> Path:
         """The worker-resolved checkpoint tree, already converted to the
         active lane's tensor-layout contract."""

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -45,6 +45,7 @@ from .entrypoints import EntrypointSpec
 from .loader import LoadedEndpoint
 from .model import Model, model_type
 from .placement import serving_device, warn_if_degraded
+from .worker_context import worker_load_context
 
 logger = logging.getLogger(__name__)
 
@@ -128,23 +129,20 @@ class EndpointHost:
         #: it references no Model class, so it is never resident and has
         #: nothing to make resident.
         self._booted = False
-        if engine is None and not loaded.models:
-            # pgw#1392: a WEIGHTLESS endpoint references no Model class, so
-            # nothing will ever be built through the loader engine. Probing
-            # the binding's tree for a chunk store would be work done to
-            # answer a question nobody asks.
-            engine = None
-        elif engine is None:
-            # pgw#1380: the native store->VRAM engine, bound off the
-            # checkpoint tree the worker already resolved — a projected
-            # snapshot carries its own chunk store, so nothing extra is
-            # plumbed here. `None` back means this tree has no store behind
-            # it (a bare download, a fixture) and `ctx.load` keeps the eager
-            # bridge; PLACEMENT is decided here, by the worker, never by
-            # author code.
-            from .streaming import engine_for
-
-            engine = engine_for(binding.checkpoint_dir, device=device, io=io)
+        # pgw#1549: THIS HOST NO LONGER BUILDS AN ENGINE, and that deletion is
+        # the fix rather than a tidy-up.
+        #
+        # `engine_for` had two production call sites — here, and (since
+        # pgw#1544) `ctx.load`. Two constructions of one capability is exactly
+        # the state that kept the fleet down: the pod went through `ServeLoop`,
+        # which had NEITHER, so every local red/green passed against a caller
+        # the production path is not. Deleting this one leaves `ctx.load` — the
+        # one place that always has the tree, and the one place BOTH hosts
+        # reach — as the sole binder, so the local CLI and the pod now execute
+        # the same code and a local verdict finally means something about a pod.
+        #
+        # `engine=` survives as an EXPLICIT override (endpoint suites inject a
+        # fake). Production passes nothing.
         self._engine = engine
         self._io = str(io or "buffered")
         #: pgw#1452: the SAME decision reaches the eager bridge. Handing it
@@ -156,9 +154,15 @@ class EndpointHost:
         self._output_dir = output_dir
         self._context_kwargs = dict(context_kwargs or {})
 
-    def _stream_attributes(self) -> Dict[str, Any]:
-        """The streamed load's own numbers, or nothing when no engine ran."""
-        report = getattr(self._engine, "last_report", None)
+    def _stream_attributes(self, ctx: LoadContext[Any]) -> Dict[str, Any]:
+        """The streamed load's own numbers, or nothing when no engine ran.
+
+        pgw#1549: read off the CONTEXT that actually loaded, not off a
+        host-held engine. The host no longer builds one — `ctx.load` binds it —
+        so a host-held handle would report the numbers of a load that did not
+        happen, which is worse than reporting none.
+        """
+        report = getattr(ctx.loader_engine, "last_report", None)
         if report is None:
             return {}
         attributes: Dict[str, Any] = report.attributes()
@@ -185,7 +189,8 @@ class EndpointHost:
     def _load_context(
         self, model_cls: type, *, compile_sink: Any = None
     ) -> LoadContext[Any]:
-        return LoadContext(
+        # pgw#1549: THE ONE PRODUCTION LOAD CONTEXT, shared with `ServeLoop`.
+        return worker_load_context(
             binding=self.binding,
             model_type=model_type(model_cls),
             lane=self.lanes[model_cls],
@@ -314,7 +319,7 @@ class EndpointHost:
                 duration_ms=int((time.monotonic() - load_started) * 1000),
                 label=f"{self.loaded.module_name}:{model_cls.__name__}",
                 checkpoint=self.binding.checkpoint_ref,
-                **self._stream_attributes(),
+                **self._stream_attributes(load_context),
             )
         if session is not None:
             # The mint-written manifest is the artifact's COMPATIBILITY SET

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -55,6 +55,7 @@ from .reserved_repos import (
     reserved_context_kwargs,
 )
 from .residency import InstanceSizer, ResidencyError, ResidencyManager
+from .worker_context import worker_load_context
 
 logger = logging.getLogger(__name__)
 
@@ -308,7 +309,15 @@ class ServeLoop:
             )
             backend = _InstanceBackend(
                 model_cls,
-                LoadContext(
+                # pgw#1549: THE ONE PRODUCTION LOAD CONTEXT. This call used to
+                # be a hand-assembled `LoadContext(...)` that named no
+                # `device=` and no `io=`, so pgw#1452's placement decision —
+                # landed on `EndpointHost` and asserted there — never reached
+                # a pod at all: `_placed` saw `_device == ""` and returned
+                # every eagerly-bridged pipeline on the CPU. Same shape as
+                # pgw#1544's missing engine ask, on the same caller, silent
+                # instead of loud.
+                worker_load_context(
                     binding=binding,
                     model_type=model_type(model_cls),
                     lane=lane,

--- a/src/gen_worker/serving/streaming/skeleton.py
+++ b/src/gen_worker/serving/streaming/skeleton.py
@@ -227,6 +227,32 @@ def build(
             components[name] = _build_on_meta(cls, directory, name)
             modules[name] = components[name]
         else:
+            # PASSTHROUGH: a non-`nn.Module` component (tokenizer, scheduler,
+            # feature extractor). Its files are small REAL files, so the stock
+            # `from_pretrained` is correct — but ONLY while that stays true.
+            #
+            # pgw#1549: prove it instead of assuming it. A projected tree
+            # chunks TENSOR CONTAINERS into the CAS and leaves a ~128 B
+            # TFSSTUB1 stub at the path; if one ever lands under a passthrough
+            # component, `from_pretrained` reads the stub's first eight bytes
+            # as a header length and raises `SafetensorError: header too
+            # large` — a LIE ABOUT THE CHECKPOINT that cost two days once
+            # already (pgw#1513). One `stub_at_any` call converts that into a
+            # named refusal that says which component and what to do.
+            from ...models import projection
+
+            if projection.stub_at_any(directory):
+                raise SkeletonError(
+                    f"component {name!r} is a PASSTHROUGH component "
+                    f"({library}.{class_name} is not an nn.Module, so it is "
+                    f"built by the stock from_pretrained) but {directory} "
+                    f"holds a TFSSTUB1 pointer stub: its bytes are in the CAS "
+                    f"and no file reader can reach them. The stock loader "
+                    f"would read the stub as a truncated header and blame the "
+                    f"checkpoint. This component needs a tensorfs-aware "
+                    f"loader (gen_worker.models.tensor_source), or the "
+                    f"publisher must not chunk its containers."
+                )
             components[name] = cls.from_pretrained(str(directory))  # type: ignore[attr-defined]
             passthrough.append(name)
 

--- a/src/gen_worker/serving/worker_context.py
+++ b/src/gen_worker/serving/worker_context.py
@@ -1,0 +1,77 @@
+"""The ONE place the worker builds a production :class:`LoadContext`.
+
+pgw#1549. There are two objects in this repo that serve an endpoint's requests
+— :class:`~gen_worker.serving.host.EndpointHost` (the local CLI and the daemon)
+and :class:`~gen_worker.serving.serve_loop.ServeLoop` (the pod) — and each of
+them assembled its own load context from its own copy of the worker's
+decisions. That is not a style problem. It is the shape of the ~21 h fleet
+outage, three times over:
+
+* **pgw#1452** handed the placement device down through ``EndpointHost`` and
+  not through ``ServeLoop``. On a pod ``LoadContext._device`` was ``""``, so
+  ``_placed`` returned every eagerly-bridged pipeline UNPLACED — the CPU — for
+  the entire life of the v2 worker. Nothing failed; it was simply the wrong
+  processor, which is the exact defect pgw#1452 was filed to delete and which
+  survived on the half of the fleet that matters.
+* **pgw#1380/#1544** bound the streaming engine in ``EndpointHost`` and not in
+  ``ServeLoop``. Every pod fell to the eager bridge and met a pointer stub.
+* **pgw#1543** put the pin repair on ``announce_resident`` and
+  ``_materialize_local``, neither of which is on the path that refuses.
+
+Each fix landed on the caller somebody was testing. The tests passed because
+the tests were the caller. **A capability that two callers must both have does
+not get added to both callers — it gets constructed once, where neither can
+omit it.**
+
+So: nothing outside this module builds a production ``LoadContext``, and
+``scripts/lint_tensor_read_seam.py`` fails the build if something starts.
+A BARE ``LoadContext(...)`` remains inert on purpose — it names no device and
+binds no engine — because the derive/trace path (``release/derive.py``) must
+not acquire either, and pgw#1452's arm 2 asserts exactly that.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from .context import DeployBinding, LoadContext, LoaderEngine
+from .placement import serving_device
+
+__all__ = ["worker_load_context"]
+
+
+def worker_load_context(
+    *,
+    binding: DeployBinding,
+    model_type: Optional[type] = None,
+    lane: Any = None,
+    compile_sink: Optional[Callable[[Any], Any]] = None,
+    engine: Optional[LoaderEngine] = None,
+    device: str = "",
+    io: str = "buffered",
+    weight_budget_bytes: int = 0,
+) -> LoadContext[Any]:
+    """A ``LoadContext`` carrying every decision the WORKER owns.
+
+    ``device`` is measured when the caller states none — ``serving_device()``,
+    the same probe ``EndpointHost`` uses. The literal ``"cuda"`` would be an
+    enumeration of what a pod usually is rather than a measurement of this
+    machine (pgw#1452), and ``""`` would be the pod bug this module exists to
+    close.
+
+    ``engine`` is an explicit OVERRIDE and production passes nothing: since
+    pgw#1544 ``ctx.load`` asks ``engine_for`` itself, at the one place that
+    always has the tree. Pre-binding it here would restore the two-constructors
+    state — two spellings of one decision, free to drift.
+    """
+
+    return LoadContext(
+        binding=binding,
+        model_type=model_type,
+        lane=lane,
+        engine=engine,
+        compile_sink=compile_sink,
+        device=str(device or "") or serving_device(),
+        io=str(io or "buffered"),
+        weight_budget_bytes=weight_budget_bytes,
+    )

--- a/tests/fixtures/serving_projected_endpoint/endpoint.toml
+++ b/tests/fixtures/serving_projected_endpoint/endpoint.toml
@@ -1,0 +1,2 @@
+schema_version = 1
+main = "serving_projected_fixture.main"

--- a/tests/fixtures/serving_projected_endpoint/src/serving_projected_fixture/main.py
+++ b/tests/fixtures/serving_projected_endpoint/src/serving_projected_fixture/main.py
@@ -1,0 +1,111 @@
+"""A fixture endpoint that loads REAL weights off a REAL projected tree.
+
+pgw#1551. Every other serving fixture in this repo loads a config-only tree
+with fake weights, which is precisely the shape that cannot witness the
+~21 h fleet outage: a tree with no chunk store behind it never reaches the
+streaming engine, so a pod that never bound one looks identical to a pod that
+did. This endpoint is deliberately the other case — its checkpoint tree is
+projected, its tensor containers are ``TFSSTUB1`` pointer stubs, and the only
+way ``load()`` can succeed at all is through the pgw#1380 streaming engine.
+
+``probe`` returns what the load PROVED, not what it intended: whether the
+engine bound, what it reported, and whether the parameters are real tensors
+rather than meta ones. A pod that fell to the eager bridge cannot answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import msgspec
+import torch
+from diffusers import DiffusionPipeline
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+from gen_worker._vendor.torchcg import LaneRef
+
+#: bf16, because that is what the fixture writes to disk and the engine's whole
+#: contract is that bytes land verbatim in the container's own dtype. A lane
+#: naming something else here would make a dtype assertion below vacuous.
+STREAM_LANE = LaneRef("fixture.diffusers-bf16@1", dtype=torch.bfloat16)
+
+
+class TinyPipeline(DiffusionPipeline):
+    """A real ``DiffusionPipeline`` — real components, real ``model_index``.
+
+    Matches ``tests/streaming_fixture.py``'s saved article, because the
+    skeleton builder resolves each component from the tree's own
+    ``model_index.json`` and the class handed to ``ctx.load`` must accept them.
+    """
+
+    def __init__(self, unet: Any, vae: Any, text_encoder: Any,
+                 text_encoder_2: Any, scheduler: Any) -> None:
+        super().__init__()
+        self.register_modules(  # type: ignore[attr-defined]
+            unet=unet, vae=vae, text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2, scheduler=scheduler,
+        )
+
+
+class ProbeInput(msgspec.Struct, forbid_unknown_fields=True):
+    """This endpoint takes nothing: the request exists to make the LOAD run."""
+
+
+class LoadEvidence(msgspec.Struct):
+    """What the load actually did. Every field is a MEASUREMENT."""
+
+    #: True when `ctx.load` bound the pgw#1380 streaming engine. On the pod
+    #: path before pgw#1544 this was False for every request ever served.
+    engine_bound: bool
+    #: The engine's own report: how many tensors it walked out of the store.
+    tensors_streamed: int
+    #: WHICH byte source produced them — `native` (straight out of the CAS) or
+    #: `bridge`. Unlabelled the two differ by ~10x and read as one measurement.
+    stream_source: str
+    #: Parameters still on the meta device. A skeleton whose weights never
+    #: arrived reports > 0 here and would generate noise, not an error.
+    meta_parameters: int
+    #: The dtype the weights came back as, spelled by torch.
+    unet_dtype: str
+    #: A real parameter's checksum, so "the bytes arrived" is not merely
+    #: "a tensor of the right shape exists".
+    unet_checksum: float
+
+
+class StreamModel(Model[Any], lanes={STREAM_LANE: "vram8g"}):
+    """The stateful half. ``load`` has exactly one spelling and no fallback."""
+
+    def load(self, ctx: LoadContext[Any]) -> None:
+        self.pipe = ctx.load(TinyPipeline)
+        # Read off the CONTEXT, which is where pgw#1549 put the one truthful
+        # answer: the host no longer holds an engine handle of its own.
+        self.engine = ctx.loader_engine
+
+
+@entrypoint
+def probe(ctx: RequestContext, payload: ProbeInput,
+          model: StreamModel) -> LoadEvidence:
+    """Serve a request that reports its own load's provenance."""
+
+    ctx.raise_if_cancelled()
+    # `register_modules` installs these at runtime, so the class carries no
+    # static attributes for them — the same shape every real diffusers
+    # pipeline has.
+    pipe = cast(Any, model.pipe)
+    report = getattr(model.engine, "last_report", None)
+    modules = (pipe.unet, pipe.vae, pipe.text_encoder, pipe.text_encoder_2)
+    meta = sum(
+        1
+        for module in modules
+        for parameter in module.parameters()
+        if parameter.device.type == "meta"
+    )
+    first = next(pipe.unet.parameters())
+    return LoadEvidence(
+        engine_bound=model.engine is not None,
+        tensors_streamed=int(getattr(report, "tensors", 0) or 0),
+        stream_source=str(getattr(report, "source", "") or ""),
+        meta_parameters=meta,
+        unet_dtype=str(first.dtype),
+        unet_checksum=float(first.detach().float().abs().sum().item()),
+    )

--- a/tests/test_pod_serve_loop_streams.py
+++ b/tests/test_pod_serve_loop_streams.py
@@ -1,0 +1,301 @@
+"""The test that was always missing: the POD's caller, on a projected tree.
+
+pgw#1551. For ~21 h no endpoint in the fleet completed a serve, and every
+local red/green stayed green throughout. The reason was not a missing
+assertion. It was that **every test's caller was ``EndpointHost``, and no
+pod has ever used ``EndpointHost``.** A pod builds ``ServeLoop``
+(``worker.py:582``), ``ServeLoop`` built its load contexts with no engine, and
+so nothing on a pod ever asked for the streaming loader. The bug lived
+entirely in the gap between the caller under test and the caller in
+production — *a unit test is a caller that the production path is not*.
+
+So this suite fixes the CALLER, not the coverage:
+
+* the object under test is ``ServeLoop``, constructed with exactly the keyword
+  arguments ``worker.py`` passes on a pod and no others;
+* the tree is a REAL projected tensorfs snapshot — a real ``LocalCAS``, a real
+  ingested manifest, a real pin, projected by the same ``project_snapshot``
+  the chokepoint calls — so its tensor containers really are ~128 B
+  ``TFSSTUB1`` pointer stubs whose bytes no path-based read can reach;
+* the store is a REAL ``ModelStore``;
+* **nothing is mocked on the seam.** A fake engine is what let this defect
+  live for weeks: an injected engine makes "was one asked for?" — the only
+  question that mattered — unaskable.
+
+The red arm is not hypothetical. ``test_the_pre_1544_state_FAILS_this_test``
+reconstructs the exact production state of the outage (``engine_for`` never
+reached from ``ctx.load``) and requires this suite to go red for it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterator, cast
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+
+from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from gen_worker.models import projection, store as store_mod  # noqa: E402
+from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
+from gen_worker.models.refs import WireRef  # noqa: E402
+from gen_worker.models.store import ModelStore  # noqa: E402
+from gen_worker.pb import worker_scheduler_pb2 as pb  # noqa: E402
+from gen_worker.serving import DeployBinding, load_endpoint  # noqa: E402
+from gen_worker.serving.residency import ResidencyManager  # noqa: E402
+from gen_worker.serving.serve_loop import ServeLoop, manifest_sizer  # noqa: E402
+
+from streaming_fixture import build_source  # noqa: E402
+
+FIXTURE = Path(__file__).parent / "fixtures" / "serving_projected_endpoint"
+GB = 1024**3
+REF = "fixture/streamer@1"
+LANE = "fixture.diffusers-bf16@1"
+KEY = "e5" * 32
+
+
+class _PodResolver:
+    """The ``BindingResolver`` seam, answering the projected tree.
+
+    Deliberately answers a checkpoint_ref that is NOT the string the store
+    banks under: pgw#1543 proved a ref-keyed lookup silently no-ops on a
+    spelling mismatch, and the pod holds the resolver's `pick.ref`.
+    """
+
+    def __init__(self, tree: Path) -> None:
+        self.tree = tree
+
+    def resolve(self, model_cls: type, checkpoint_ref: str) -> DeployBinding:
+        return DeployBinding(
+            checkpoint_ref=checkpoint_ref, checkpoint_dir=self.tree,
+            model="streamer", defaults={},
+        )
+
+    def default_pick(self, model_cls: type, slot_name: str) -> str:
+        return REF
+
+
+@pytest.fixture(scope="module")
+def projected(tmp_path_factory: pytest.TempPathFactory) -> Dict[str, Any]:
+    """A real bf16 pipeline, ingested, pinned, and projected. No mocks."""
+    base = tmp_path_factory.mktemp("pod-cas")
+    source = base / "source-model"
+    build_source(source)
+
+    cas = LocalCAS(base)
+    manifest = cas.ingest_repository(source)
+    # Exactly what `cozy_snapshot._pin_manifest` does, so `resolve_projection`
+    # runs against the production pinning and not a test convention.
+    cas.compare_and_swap_ref(
+        REF_PREFIX + KEY, cas.store_manifest(manifest), expected=None)
+    tree = base / SNAPSHOTS_DIR / KEY
+    project_snapshot(cas, manifest, tree)
+
+    stubs = [p for p in tree.rglob("*") if p.is_file() and not p.is_symlink()
+             and projection.stub_at(p) is not None]
+    assert stubs, (
+        f"{tree} projected no pointer stubs, so this fixture cannot witness "
+        f"the defect it exists for — a tree of real files is exactly the "
+        f"shape that stayed green through the outage")
+    assert projection.resolve_projection(tree) is not None, "fixture must be PINNED"
+    return {"base": base, "tree": tree, "manifest": manifest, "stubs": stubs}
+
+
+@pytest.fixture()
+def bound_store(projected: Dict[str, Any]) -> Iterator[ModelStore]:
+    """A REAL ModelStore, bound as the process's active store."""
+
+    async def noop(_message: Any) -> None:
+        return None
+
+    store = ModelStore(noop, cache_dir=projected["base"])
+    snapshot = pb.Snapshot(digest="sha256:" + KEY)
+    for entry in projected["manifest"].files:
+        snapshot.files.add(path=entry.path, size_bytes=entry.size_bytes,
+                           digest=str(entry.digest))
+    # Banked under a DIFFERENT spelling than the one served, on purpose.
+    store.bank_snapshot(WireRef("fixture/streamer"), snapshot)
+    store_mod.bind_active_store(store)
+    try:
+        yield store
+    finally:
+        store_mod.bind_active_store(cast(Any, None))
+
+
+def pod_serve_loop(projected: Dict[str, Any], tmp_path: Path) -> ServeLoop:
+    """``ServeLoop`` as ``worker.py`` builds it on a pod — and ONLY that.
+
+    The keyword set is copied from `worker.py`'s construction. Nothing is
+    added here that a pod does not pass, because the whole finding is that a
+    test which passes one extra argument is testing a different program: for
+    ~21 h the extra argument was `engine=`, supplied by every test's
+    `EndpointHost` and by no pod.
+    """
+    loaded = load_endpoint(FIXTURE)
+    return ServeLoop(
+        loaded,
+        residency=ResidencyManager(
+            64 * GB, manifest_sizer({REF: 1 * GB}, headroom_bytes=1 * GB)),
+        resolver=_PodResolver(projected["tree"]),
+        lane_contract=LANE,
+        output_dir=tmp_path / "outputs",
+        compile_sink_for=None,
+        on_loaded=None,
+        hf_token="",
+    )
+
+
+def test_the_POD_loop_serves_a_projected_tree_through_the_streaming_engine(
+    projected: Dict[str, Any], bound_store: ModelStore, tmp_path: Path,
+) -> None:
+    """The whole point, in one request, on the caller a pod actually uses.
+
+    Before pgw#1544 this request raised `ProjectedTreeNotStreamable` — the
+    fleet's exact refusal — because `ServeLoop` handed `engine=None` down and
+    `ctx.load` never asked for one. The fix moved the ask into `ctx.load`,
+    which is the one place that always has the tree; pgw#1549 then deleted the
+    second construction site so there is nothing left to disagree with it.
+    """
+    loop = pod_serve_loop(projected, tmp_path)
+
+    outcome = loop.invoke("probe", {"model": REF, "input": {}},
+                          request_id="pod-1")
+    evidence = outcome.result
+
+    assert evidence.engine_bound, (
+        "NOBODY ASKED FOR THE ENGINE. `ServeLoop` built a LoadContext with no "
+        "engine and `ctx.load` did not ask, so this projected tree fell to the "
+        "eager `from_pretrained` bridge and met a pointer stub — the ~21 h "
+        "fleet outage, reproduced")
+    # BOTH stores read the chunked CAS objects; they differ in speed, not in
+    # source (`bridge` copies in Python at ~0.59 GiB/s, `native` at ~6.4). The
+    # claim under test is that the bytes came out of the CHUNK STORE at all —
+    # which of the two answered is a property of the vendored tensorfs build,
+    # and pinning it here would make this suite fail for a reason that has
+    # nothing to do with the outage.
+    assert evidence.stream_source in ("native", "bridge"), (
+        f"source={evidence.stream_source!r} is neither chunk-store reader, so "
+        f"these weights did not come out of the CAS")
+    assert evidence.tensors_streamed > 0, (
+        "an engine that bound and streamed nothing is a skeleton with no "
+        "weights, which generates noise rather than failing")
+    assert evidence.meta_parameters == 0, (
+        f"{evidence.meta_parameters} parameter(s) never left the meta device: "
+        f"the pipeline was built but its weights did not arrive")
+    assert evidence.unet_dtype == "torch.bfloat16", (
+        f"bytes land VERBATIM in the container's own dtype and this article "
+        f"is bf16 on disk; got {evidence.unet_dtype}")
+    assert evidence.unet_checksum > 0.0, (
+        "a real parameter's magnitude, so 'the bytes arrived' is a "
+        "measurement rather than a tensor of the right shape")
+
+
+def test_the_POD_loop_reads_no_tensor_file_and_materializes_nothing(
+    projected: Dict[str, Any], bound_store: ModelStore, tmp_path: Path,
+) -> None:
+    """The stubs stay stubs, and no second copy of the tree appears.
+
+    The load succeeding is not by itself proof it streamed: a tier-3
+    materialization would also produce a working pipeline, at 2x the disk, and
+    is exactly what Paul's 2026-08-19 no-fill ruling removed from the serving
+    path. So this measures the FILE SYSTEM afterwards.
+    """
+    from gen_worker.models import materialized_view
+
+    tree = projected["tree"]
+    before = {p: p.stat().st_size for p in projected["stubs"]}
+
+    loop = pod_serve_loop(projected, tmp_path)
+    loop.invoke("probe", {"model": REF, "input": {}}, request_id="pod-2")
+
+    for path, size in before.items():
+        assert projection.stub_at(path) is not None, (
+            f"{path} stopped being a pointer stub — something materialized a "
+            f"tensor container onto the serving tree")
+        assert path.stat().st_size == size, f"{path} changed size"
+
+    view = materialized_view.view_root_for(tree)
+    assert not view.exists(), (
+        f"a materialized view appeared at {view}: the pod filled a full second "
+        f"copy of the tree to read weights it already had in the chunk store")
+    assert materialized_view.serving_streams_weights(), (
+        "binding the engine must ARM the no-fill defect signal, so any later "
+        "tier-3 call in this process logs as a bug and not a burn-down row")
+
+
+def test_the_pre_1544_state_FAILS_this_test(
+    projected: Dict[str, Any], bound_store: ModelStore, tmp_path: Path,
+) -> None:
+    """THE RED ARM. Put the outage back and require this suite to catch it.
+
+    A fence that has never been observed red proves nothing when green, and
+    this suite's entire claim is that it would have caught the outage. So the
+    pre-pgw#1544 production state is reconstructed exactly — `ctx.load`'s
+    projected branch cannot reach `engine_for` — and the request must refuse
+    with the fleet's own error rather than quietly serving from somewhere else.
+
+    Reconstructed by neutering the ASK (`_bind_streaming_engine` answering
+    "no engine bound", which is what the pre-fix code path did when it fell
+    through to the refusal), NOT by injecting a fake engine: an injected
+    engine is the very thing that hid this.
+    """
+    from gen_worker.serving import context as context_mod
+    from gen_worker.serving.context import ProjectedTreeNotStreamable
+
+    original = context_mod.LoadContext._bind_streaming_engine
+
+    def never_asks(self: Any, *, pinned: bool) -> tuple:
+        return False, pinned
+
+    context_mod.LoadContext._bind_streaming_engine = never_asks  # type: ignore[method-assign]
+    try:
+        loop = pod_serve_loop(projected, tmp_path)
+        with pytest.raises(Exception) as caught:
+            loop.invoke("probe", {"model": REF, "input": {}},
+                        request_id="pod-red")
+    finally:
+        context_mod.LoadContext._bind_streaming_engine = original  # type: ignore[method-assign]
+
+    chain = []
+    error: BaseException | None = caught.value
+    while error is not None:
+        chain.append(error)
+        error = error.__cause__ or error.__context__
+    assert any(isinstance(e, ProjectedTreeNotStreamable) for e in chain), (
+        f"the pre-pgw#1544 state must FAIL this suite with the fleet's own "
+        f"refusal. It raised {type(caught.value).__name__}: {caught.value}. "
+        f"If this suite can stay green with the engine ask removed, it does "
+        f"not measure the outage and its green means nothing.")
+
+
+def test_the_pod_loop_hands_down_the_workers_placement_decision(
+    projected: Dict[str, Any], bound_store: ModelStore, tmp_path: Path,
+) -> None:
+    """pgw#1549: `ServeLoop` named no device, so `_placed` placed nothing.
+
+    pgw#1452 fixed exactly this defect — the eager bridge returning a pipeline
+    on the CPU because nobody handed it the worker's placement decision — and
+    landed the fix on `EndpointHost`, which is not the caller a pod uses. On
+    the pod path `LoadContext._device` stayed `""` and `_placed` returned
+    early, for the entire life of the v2 worker.
+
+    The device this box probes to is whatever it is; the claim under test is
+    that the decision is MADE and handed down, never left empty.
+    """
+    from gen_worker.serving.placement import serving_device
+
+    loop = pod_serve_loop(projected, tmp_path)
+    loop.invoke("probe", {"model": REF, "input": {}}, request_id="pod-3")
+
+    contexts = [backend.load_context
+                for backend in loop._backends.values()]
+    assert contexts, "the invoke built no backend, so there is nothing to read"
+    for ctx in contexts:
+        assert ctx._device == serving_device(), (
+            f"the pod's LoadContext carries device={ctx._device!r}; a pod that "
+            f"names no device runs the eager bridge on the CPU and nothing "
+            f"fails — it is simply the wrong processor (pgw#1452)")


### PR DESCRIPTION
The ~21 h fleet serve outage had one shape, and it was not "a missing test": a capability two callers both need was added to each of them separately, and **the pod's caller is the one that got missed** — three times now (pgw#1452 placement, pgw#1380 engine, pgw#1543 repair).

### The live defect this found

**pgw#1452's fix never reached a pod, and was still not reaching one at HEAD.** `ServeLoop._backend_factory` built its `LoadContext` with no `device=`, so `_placed` returned early and every eagerly bridged pipeline on a pod ran on the **CPU** — for the entire life of the v2 worker. Nothing failed. It was simply the wrong processor, which is the exact defect pgw#1452 was filed to delete.

### What lands

- **#1549 — one production load context.** `serving/worker_context.py` is the only place either host assembles one. `EndpointHost` no longer builds an engine: `ctx.load` is the sole binder, so `engine_for` has exactly one production call site and the local CLI and the pod now execute the same code.
- **#1550 — the fence.** `scripts/lint_tensor_read_seam.py` in `fast gates`. Refuses a raw `safe_open`/`load_file`/`torch.load` on a checkpoint path. Exemption is a proof at the line with a mandatory reason. `--selftest` plants violations and requires red. Fixed what it found: w8a8/w4a4 producers, `skeleton.build`'s passthrough branch, and `load_from_pretrained` (an exported eager loader with **no production caller** since pgw#1373 orphaned `provision.load_slot`, silently tier-3 materializing a second copy of any projected tree).
- **#1551 — the test that was always missing.** `ServeLoop` built with exactly the keywords `worker.py` passes on a pod, against a real projected tree with real stubs on a real `ModelStore`. **No mocks on the seam.**
- **#1552 — `docs/projected-trees.md`**, the stub contract and the catalogue of wrong inferences.

### Red proof

Reverting the engine ask in real source turns 3 of the 4 new tests red with the fleet's own refusal:

```
ProjectedTreeNotStreamable: ENGINE DECLINED: the manifest pin ... RESOLVES and this tree is
STREAMABLE — the store is not the problem. No streaming engine was bound for this load ...
```

The guard's `--selftest` goes red on planted violations and green on the seam.

### Verification

4/4 new tests green and red-armed; 105 neighbours green (`test_serve_loop_envelope`, `test_weight_streaming`, `test_projected_tree_reading`, `test_bridge_placement`, `test_model_authoring`, `test_guard_attribution`); mypy clean (647 files); ruff clean; every fast-gates guard green including `lint_pickle_readers`.

`test_serve_loop_envelope::test_the_envelope_serves_end_to_end_with_fake_tensors` fails identically on clean `origin/master` on this box (it expects a machine with no GPU) — attributed by execution, not this PR's.

### Endpoint audit (separate repo, reported not fixed here)

The fence run with the sibling checkout present reproduces 5 live violations in `serverless-endpoints`: `anima/main.py:231` (`safe_open`), `minimax-h3/adaln_skip.py:382` (`safe_open`), and `cozy_rife.py` `torch.load` in ltx-video-2.3 / wan-2.2 / minimax-h3. Separately: **7 endpoints still import the v1 SDK (`@endpoint`/`Slot`), deleted by pgw#1373, and raise `V1SdkDeleted` at import** — verified by execution.