### PR TITLE
pgw#1555: the boot ladder closed BEFORE any weight moved, so the fleet's download phase was never recorded

### DIFF
--- a/src/gen_worker/boot_materialize.py
+++ b/src/gen_worker/boot_materialize.py
@@ -69,6 +69,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, Mapping, Optional, Tuple
 
+from . import boot_phases
+from . import weight_position
 from .models.refs import WireRef
 from .models.store import ModelStore
 from .pb import worker_scheduler_pb2 as pb
@@ -261,7 +263,18 @@ class CheckpointMaterialization:
         for ref in config.refs:
             snapshot = config.snapshots.get(ref)
             try:
-                if await self._store.announce_resident(ref, snapshot):
+                # pgw#1555: TIMED, because a `resident` verdict deletes the
+                # only other row this ref would have produced. The check is a
+                # verified manifest match (pgw#1511), so on a warm 134 GB
+                # volume it IS the boot — and until this span existed that
+                # boot rendered as an empty ladder.
+                with boot_phases.span(
+                    boot_phases.PHASE_RESIDENCY_CHECK, ref=str(ref),
+                ) as check:
+                    check.note(f"tree_bytes={weight_position.snapshot_bytes(snapshot)}")
+                    resident = await self._store.announce_resident(ref, snapshot)
+                    check.classify("resident" if resident else "absent")
+                if resident:
                     # The volume-staged case, and the ordinary warm reboot.
                     # Asking the funnel to "fetch" bytes the pod holds opens a
                     # transfer record for zero bytes — the 0-of-N phantom

--- a/src/gen_worker/boot_phases.py
+++ b/src/gen_worker/boot_phases.py
@@ -96,6 +96,18 @@ PHASE_SDK_READY = "sdk_ready"
 #: four components inside a 200 s `weights_fetch` that each measure 180 s were
 #: overlapped, and that is the fact an overlap optimization needs.
 PHASE_COMPONENT_FETCH = "component_fetch"
+#: pgw#1555. The VERIFIED answer to "is this ref already on this pod", per ref,
+#: measured where it is asked (`boot_materialize._materialize`). `reason` is
+#: `resident` or `absent` and `detail` carries `tree_bytes=`.
+#:
+#: It moves no bytes and it is not free: the answer is a manifest match, not an
+#: `is_dir()` (pgw#1511), so on the flagship warm-volume case it re-reads the
+#: whole tree — and a `resident` verdict makes the fetch that follows it VANISH
+#: (`_materialize` `continue`s past `ensure_local`, so no `weights_fetch` row is
+#: ever opened). Without this row the entire boot of a warm 134 GB pod is a hole
+#: in the ladder, and "the volume made the pull a near-no-op" stays a claim
+#: nothing measured.
+PHASE_RESIDENCY_CHECK = "residency_check"
 #: `env_seal.establish` — the settings declaration digest, the boot-frozen
 #: loaded-library digest and the sm/host-ISA derivation that together make the
 #: `toolchain` and `sm` key axes. Guessed at "ms"; this proves it.
@@ -170,6 +182,9 @@ _CLASS_BY_PHASE: Dict[str, str] = {
     PHASE_FIRST_REQUEST_SERVABLE: CLASS_SETUP,
     PHASE_SDK_READY: CLASS_SETUP,
     PHASE_COMPONENT_FETCH: CLASS_FETCH,
+    # FETCH, not SETUP: the verified answer re-reads the tree, so its seconds
+    # are disk bytes and belong beside the fetch they replace.
+    PHASE_RESIDENCY_CHECK: CLASS_FETCH,
     PHASE_ENV_ESTABLISH: CLASS_SETUP,
     PHASE_LIB_MEMO: CLASS_SETUP,
     PHASE_DECLARATION_COMPOSE: CLASS_SETUP,
@@ -246,6 +261,9 @@ _class_override: Dict[int, str] = {}
 #: Every CUMULATIVE milestone's ms-from-process-start, first write wins. Read
 #: by :func:`reconciliation` and :func:`completeness`.
 _milestone_ms: Dict[str, int] = {}
+#: pgw#1555. Answers "can this worker serve RIGHT NOW", from the one object that
+#: decides it. See :func:`bind_servable_probe` and :func:`in_boot`.
+_servable_probe: Optional[Callable[[], bool]] = None
 
 _process_start_unix: float = 0.0
 
@@ -824,18 +842,65 @@ def servable_ms() -> Optional[int]:
         return _servable_ms
 
 
+def bind_servable_probe(probe: Optional[Callable[[], bool]]) -> None:
+    """Tell the recorder how to ask whether this worker can serve right now.
+
+    ONE authority, and it is the one the hub already routes on: the worker
+    passes `CheckpointMaterialization.ready`, the same value `_state_delta`
+    turns into `available_functions` vs `loading_functions`. A PROBE rather
+    than a pair of open/close calls on purpose — a mismatched pair leaks the
+    window open forever, which is the unbounded table growth :func:`in_boot`
+    exists to prevent. Unbound (tests, cozy-local) behaves exactly as before.
+    """
+    global _servable_probe
+    with _lock:
+        _servable_probe = probe
+
+
 def in_boot() -> bool:
-    """True until :data:`PHASE_FIRST_REQUEST_SERVABLE` is marked.
+    """True while this worker CANNOT SERVE — not merely before its first
+    :data:`PHASE_FIRST_REQUEST_SERVABLE`.
 
     The gate for instrumenting a call site that runs BOTH during boot and in
     steady state — the weights materializer is the load-bearing case:
     it owns the ~230s of a cold boot, and it also runs every time the hub
     delivers a new ref hours later. Recording the steady-state calls would put
     non-boot spans in a boot ladder (so `residual_ms` stops reconciling) and
-    grow the table without bound. Boot ends where the boot number ends.
+    grow the table without bound.
+
+    **pgw#1555: a one-way latch on `_servable_ms` closed the window before any
+    weight moved.** `on_hello_ack` marks the servable milestone the instant
+    `materialization.ready` is true, and a checkpoint config that names NO refs
+    makes that true immediately (`configure` short-circuits to `STATE_READY`).
+    So on the fleet the latch tripped ~1 ms after `hello`, and the config that
+    actually named refs arrived on a LATER ack — with the window already shut.
+    Measured on the standing stack: every one of the last 15 boots carries only
+    `hello` + `first_request_servable` (+ sometimes `eager_ready`) and `bytes=0`
+    in every row, while `worker_activity_events` shows the same pods moving
+    2.74 GB of sd15 fourteen seconds after the window closed. The boot ladder
+    could not see the one phase the whole table exists to measure.
+
+    So the predicate is now the honest one. A worker whose configured refs are
+    materializing is advertising `loading_functions` and the hub is routing
+    elsewhere; it is not in steady state by any definition, and the fetch it is
+    doing is exactly the fetch worth a row. `_servable_ms` itself stays
+    first-write-wins, so THE cold-boot number and every aggregate over it are
+    unchanged — this widens what gets instrumented, never what gets reported as
+    the boot time.
     """
     with _lock:
-        return _servable_ms is None
+        if _servable_ms is None:
+            return True
+        probe = _servable_probe
+    # Outside the lock: the probe reads another object's state and must never
+    # be able to deadlock the recorder against it.
+    if probe is None:
+        return False
+    try:
+        return not probe()
+    except Exception:  # noqa: BLE001 — a broken probe must not gate the work
+        logger.debug("servable probe raised; treating boot as closed", exc_info=True)
+        return False
 
 
 def _union_ms(intervals: List[Tuple[int, int]]) -> int:
@@ -1206,7 +1271,7 @@ def recorded_rows() -> List[pb.BootPhase]:
 def reset_for_tests() -> None:
     """Clear all recorder state. Test-only."""
     global _ordinal, _truncated, _servable_ms, _sink
-    global _hello_seen, _pending_servable
+    global _hello_seen, _pending_servable, _servable_probe
     with _lock:
         _rows.clear()
         _ordinal = 0
@@ -1215,6 +1280,7 @@ def reset_for_tests() -> None:
         _sink = None
         _hello_seen = False
         _pending_servable = None
+        _servable_probe = None
         _class_override.clear()
         _milestone_ms.clear()
     _stack_var.set(())
@@ -1224,6 +1290,7 @@ __all__ = [
     "BOOT_ID",
     "BootSpan",
     "bind_sink",
+    "bind_servable_probe",
     "in_boot",
     "unbind_sink",
     "span",

--- a/src/gen_worker/boot_stages.py
+++ b/src/gen_worker/boot_stages.py
@@ -209,6 +209,11 @@ _STAGE_BY_PHASE: Final[Mapping[str, Stage]] = {
     boot_phases.PHASE_LIB_MEMO: Stage.IMPORTS,
     boot_phases.PHASE_WEIGHTS_FETCH: Stage.SNAPSHOT_PULL,
     boot_phases.PHASE_COMPONENT_FETCH: Stage.SNAPSHOT_PULL,
+    # pgw#1555. SNAPSHOT_PULL and not a stage of its own: it answers the same
+    # question the pull does — how long until this pod holds the tree — and on
+    # a warm volume it REPLACES the pull entirely, so its seconds belong in the
+    # bucket a reader compares warm boots against cold ones in.
+    boot_phases.PHASE_RESIDENCY_CHECK: Stage.SNAPSHOT_PULL,
     boot_phases.PHASE_PIPELINE_LOAD: Stage.MODEL_LOAD,
     boot_phases.PHASE_DECLARATION_COMPOSE: Stage.KEYSET,
     boot_phases.PHASE_TRACE_FOR_KEY: Stage.KEYSET,

--- a/src/gen_worker/weight_position.py
+++ b/src/gen_worker/weight_position.py
@@ -104,6 +104,9 @@ class FetchPosition:
         self._emitted_at = 0.0
         self._opened = False
         self._closed = False
+        #: When `open()` stated position 0. Used by the TERMINAL row only —
+        #: see `_terminal_detail`.
+        self._opened_at = 0.0
 
     # -- the position itself ------------------------------------------------
 
@@ -123,6 +126,7 @@ class FetchPosition:
         if self._opened:
             return
         self._opened = True
+        self._opened_at = time.monotonic()
         self._emit(PHASE_STARTED)
 
     def progress(self, done: int, total: Optional[int] = None) -> None:
@@ -170,6 +174,31 @@ class FetchPosition:
 
     # -- emission -----------------------------------------------------------
 
+    def _terminal_detail(self) -> str:
+        """`elapsed_ms=` and `mib_s=` for a transfer that is OVER.
+
+        pgw#1555. This does NOT reintroduce a clock into the liveness
+        judgment the module docstring rules out: the "no clocks" doctrine is
+        about *is the position advancing*, which is still answered by
+        differencing positions, and these fields exist only on `fetched` /
+        `abandoned` — rows that describe a span that has already ended. Without
+        them "how fast does this fleet pull weights" is a self-join over
+        `started` and `fetched` timestamps that nobody writes; with them it is
+        a column. A speed nobody can select is a speed nobody optimizes.
+
+        Absent, never zero, when there is no open instant to measure from:
+        `already_resident` opens and closes in one row, and rendering that as
+        `mib_s=0` would put an infinitely fast warm boot in the same bucket as
+        a wedge.
+        """
+        if not self._opened_at:
+            return ""
+        elapsed = max(0.0, time.monotonic() - self._opened_at)
+        out = f" elapsed_ms={int(elapsed * 1000)}"
+        if elapsed > 0 and self._pos_bytes > 0:
+            out += f" mib_s={(self._pos_bytes / MIB) / elapsed:.1f}"
+        return out
+
     def _emit(self, phase: str) -> None:
         pos = self.position_mib
         self._emitted_mib = pos
@@ -178,6 +207,8 @@ class FetchPosition:
             f"ref={_token(self.ref)} pos_mib={pos} total_mib={self.total_mib} "
             f"pos_bytes={self._pos_bytes} total_bytes={self._total_bytes}"
         )
+        if phase in (PHASE_FETCHED, PHASE_ABANDONED):
+            detail += self._terminal_detail()
         try:
             # Lazy: `activity` pulls in protobuf and psutil, and this module is
             # imported from the download path the discovery build keeps thin.

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -1304,6 +1304,13 @@ class Worker:
 
         activity_mod.bind_sink(self._send, loop)
         boot_mod.bind_sink(self._send, loop)
+        # pgw#1555: the boot recorder asks THIS object whether the worker can
+        # serve, because this is the object the hub's routing already reads
+        # (`_state_delta`). Without it `in_boot()` latched shut ~1 ms after
+        # `hello` on every pod whose first ack named no refs, and the
+        # `weights_fetch` span — the one phase the boot table exists for — was
+        # never opened on any of them.
+        boot_mod.bind_servable_probe(lambda: self.materialization.ready)
 
         # BOOT-TIME TRUTH, and it must run HERE. On a warm pod with the
         # endpoint volume attached this is what turns already-staged bytes into

--- a/tests/test_boot_materialize.py
+++ b/tests/test_boot_materialize.py
@@ -31,6 +31,7 @@ from typing import Any, List
 import pytest
 
 from gen_worker import activity
+from gen_worker import boot_phases
 from gen_worker.boot_materialize import (
     STATE_FAILED,
     STATE_MATERIALIZING,
@@ -519,5 +520,179 @@ def test_a_TRUNCATED_warm_tree_is_refused_quarantined_and_refetched(
         checker = _store(_Wire(), cas)
         ok, bad = checker._verify_snapshot_tree(final[0], snapshot)
         assert ok, f"the recovered tree still fails verification: {bad}"
+    finally:
+        origin.close()
+
+
+# ---------------------------------------------------------------------------
+# pgw#1555 — THE BOOT LADDER CAN SEE THE FETCH
+#
+# The instrument that exists to answer "where did the boot's seconds go" was
+# blind to weights on every pod. `in_boot()` latched shut at the FIRST servable
+# mark, `on_hello_ack` marks servable the instant `materialization.ready` is
+# true, and a config naming NO refs makes that true immediately — so a fleet
+# whose first ack was empty closed its boot window ~1 ms after `hello` and then
+# downloaded gigabytes with nothing recording. Read off the standing stack:
+# 15/15 recent boots hold only `hello` + `first_request_servable` (+ sometimes
+# `eager_ready`) with `bytes = 0` in every row, while `worker_activity_events`
+# shows the same pods moving 2,742,235,508 bytes of sd15 fourteen seconds later.
+# ---------------------------------------------------------------------------
+
+
+def _fetch_rows(phase: str) -> List[Any]:
+    return [r for r in boot_phases.recorded_rows()
+            if r.phase == phase and r.terminal]
+
+
+def test_a_pull_that_follows_an_EMPTY_config_still_lands_in_the_boot_ladder(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """The field sequence, exactly: empty config, servable, THEN the real one.
+
+    The hub's first ack named no refs, so the pod was legitimately ready with
+    nothing to hold and `first_request_servable` was stamped. The config that
+    named the checkpoint arrived on a later ack. Everything after that point
+    is the boot this table exists to measure, and before this fix none of it
+    was recorded — not one `weights_fetch` row, not one byte.
+    """
+    origin = _Origin()
+    try:
+        snapshot = _blobs(origin)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            mat = CheckpointMaterialization(store)
+            # The recorder asks the same object the hub routes on, which is
+            # what `Worker.arun` binds in production.
+            boot_phases.bind_servable_probe(lambda: mat.ready)
+
+            # Ack #1: no refs. Ready with nothing to materialize, and the
+            # worker marks the servable milestone — both correct.
+            mat.configure(CheckpointConfig.from_wire(pb.DesiredResidency(generation=1)))
+            assert mat.ready
+            boot_phases.mark_once(boot_phases.PHASE_HELLO)
+            boot_phases.mark_once(boot_phases.PHASE_FIRST_REQUEST_SERVABLE)
+            assert boot_phases.servable_ms() is not None
+
+            # Ack #2: the checkpoint. The pod stops being routable, so it is
+            # not in steady state and the fetch is a boot fact.
+            mat.configure(_config(2, _REF, snapshot))
+            assert not mat.ready
+            assert boot_phases.in_boot(), (
+                "a worker that is advertising `loading_functions` and holds "
+                "none of its configured weights is NOT past its boot — that "
+                "reading is what blinded the ladder on every field pod")
+            await _settle(mat)
+            assert mat.ready
+
+        asyncio.run(run())
+
+        rows = _fetch_rows(boot_phases.PHASE_WEIGHTS_FETCH)
+        assert rows, (
+            "the pull produced NO `weights_fetch` row. This is the fleet "
+            "defect verbatim: 2.74 GB moved and the boot ladder recorded "
+            f"nothing. rows={[r.phase for r in boot_phases.recorded_rows()]}")
+        assert sum(r.bytes for r in rows) > 0, (
+            "a `weights_fetch` row with bytes=0 over a real transfer is the "
+            "other half of the field reading — every stored row had bytes=0")
+        # And the window closing again is what keeps the table bounded: a
+        # steady-state materialization hours later must NOT land in the ladder.
+        assert not boot_phases.in_boot()
+    finally:
+        origin.close()
+
+
+def test_a_WARM_volume_boot_is_a_TIMED_ROW_and_not_a_hole_in_the_ladder(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """The flagship case, and the one with no instrument at all.
+
+    `_materialize` `continue`s past `ensure_local` when the tree is already
+    resident, so the row `ensure_local` would have opened never exists — a
+    warm 134 GB pod rendered as an EMPTY boot ladder. The check it does
+    instead is not free (a verified manifest match, pgw#1511), and on a warm
+    volume it IS the boot, so it gets the row.
+    """
+    origin = _Origin()
+    try:
+        snapshot = _blobs(origin)
+        cas = tmp_path / "endpoint-volume-cas"
+
+        async def stage() -> None:
+            wire = _Wire()
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            mat = CheckpointMaterialization(_store(wire, cas))
+            mat.configure(_config(1, _REF, snapshot))
+            await _settle(mat)
+
+        asyncio.run(stage())
+        boot_phases.reset_for_tests()
+
+        warm = _Wire()
+
+        async def boot() -> None:
+            store = _store(warm, cas)
+            activity.bind_sink(warm.send, asyncio.get_running_loop())
+            store.rescan_disk()
+            mat = CheckpointMaterialization(store)
+            boot_phases.bind_servable_probe(lambda: mat.ready)
+            mat.configure(_config(1, _REF, snapshot))
+            await _settle(mat)
+            assert mat.state == STATE_READY
+
+        asyncio.run(boot())
+
+        rows = _fetch_rows(boot_phases.PHASE_RESIDENCY_CHECK)
+        assert len(rows) == 1, (
+            "one row per configured ref, whichever way the answer goes; got "
+            f"{[(r.phase, r.reason) for r in boot_phases.recorded_rows()]}")
+        assert rows[0].reason == "resident", (
+            f"a warm volume answers `resident`; row said {rows[0].reason!r}")
+        assert rows[0].bytes == 0, (
+            "the bytes column means BYTES MOVED and a resident tree moves "
+            "none — putting the tree size here would make a warm boot read as "
+            "the fastest transfer the fleet ever did")
+        assert f"tree_bytes={OBJECTS * OBJECT_BYTES}" in rows[0].detail, (
+            "the size it did NOT have to move belongs on the row, in a field "
+            f"that is not `bytes`; detail={rows[0].detail!r}")
+        assert boot_phases.phase_class(rows[0].phase) == boot_phases.CLASS_FETCH
+    finally:
+        origin.close()
+
+
+def test_an_ABSENT_ref_records_the_check_it_lost_before_the_fetch_it_starts(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """Both arms, or the row is a survivorship filter.
+
+    If only the `resident` arm emitted, the ladder would show a population in
+    which residency checks are always free and always win — and the cold boot's
+    check time would silently join `residual_ms`. The reconciliation this
+    module promises is a union of MEASURED spans; an unmeasured one is a lie
+    of omission, not a gap.
+    """
+    origin = _Origin()
+    try:
+        snapshot = _blobs(origin)
+        wire = _Wire()
+        store = _store(wire, tmp_path / "cas")
+
+        async def run() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            mat = CheckpointMaterialization(store)
+            boot_phases.bind_servable_probe(lambda: mat.ready)
+            mat.configure(_config(3, _REF, snapshot))
+            await _settle(mat)
+
+        asyncio.run(run())
+
+        rows = _fetch_rows(boot_phases.PHASE_RESIDENCY_CHECK)
+        assert len(rows) == 1 and rows[0].reason == "absent", (
+            "a cold pod's residency check must leave a row saying it lost; "
+            f"got {[(r.phase, r.reason) for r in rows]}")
+        assert _fetch_rows(boot_phases.PHASE_WEIGHTS_FETCH), (
+            "and the fetch it fell through to must be its own row")
     finally:
         origin.close()


### PR DESCRIPTION
`in_boot()` was a one-way latch on the first `first_request_servable` mark, and
`on_hello_ack` stamps that milestone the instant `materialization.ready` is
true. A checkpoint config naming NO refs makes it true immediately
(`configure` short-circuits to `STATE_READY`), so on the fleet the latch
tripped ~1 ms after `hello` — and the config that actually named a checkpoint
arrived on a LATER ack, with the window already shut.

Read off the standing stack, 15/15 recent boots:

    phases                                    n  bytes
    hello, first_request_servable             2      0
    hello, first_request_servable, eager_ready 3     0

Not one `weights_fetch` row, not one `component_fetch` row, `bytes=0`
everywhere — while `worker_activity_events` shows the same pods moving
2,742,235,508 bytes of sd15 fourteen seconds after the window closed. The one
phase `worker_boot_phases` exists to measure was the one phase it could not see.

Reproduced on clean master ($0, no GPU, no pod), through the REAL ModelStore,
a real HTTP origin and a real CAS:

    in_boot() while the real pull runs = False
    boot rows = [('hello', 0), ('first_request_servable', 0)]
    bytes actually transferred = 9437184
    weights_fetch rows = 0

and on this branch, same probe:

    in_boot() while the real pull runs = True
    boot rows = [hello, first_request_servable, residency_check,
                 component_fetch(9437184), weights_fetch(9437184)]

## The predicate is now the honest one

`in_boot()` asks a PROBE — `CheckpointMaterialization.ready`, the same value
`_state_delta` turns into `available_functions` vs `loading_functions` and the
hub already routes on. A worker whose configured refs are materializing is
advertising `loading_functions`; it is not in steady state by any definition,
and the fetch it is doing is exactly the fetch worth a row. A probe rather than
paired open/close calls on purpose: a mismatched pair leaks the window open
forever, which is the unbounded table growth the gate exists to prevent.
`_servable_ms` stays first-write-wins, so THE cold-boot number and every
aggregate over it are unchanged — this widens what is instrumented, never what
is reported as the boot time.

## The warm-volume boot was a hole, not a gap

`_materialize` `continue`s past `ensure_local` when `announce_resident` wins,
so the row `ensure_local` would have opened never exists: the flagship warm
134 GB pod rendered as an EMPTY ladder, and "the staged volume made the pull a
near-no-op" was a claim nothing measured. The check it does instead is not free
— it is a verified manifest match (pgw#1511), which re-reads the tree — so it
gets `residency_check`, one row per configured ref, `reason` = `resident` or
`absent`. BOTH arms emit: a resident-only row would describe a population in
which residency checks always win and always cost nothing.

`bytes` stays 0 on that row because the column means BYTES MOVED and a resident
tree moves none; the size it did not have to move rides `detail` as
`tree_bytes=`. Classified FETCH and folded into `Stage.SNAPSHOT_PULL`, which is
what makes a warm boot and a cold boot comparable in one bucket.

## Throughput is a column, not a self-join

The terminal `weight_fetch` row (`fetched` / `abandoned` only) now carries
`elapsed_ms=` and `mib_s=`. This does not reintroduce a clock into the liveness
judgment `weight_position`'s docstring rules out — that doctrine is about *is
the position advancing*, still answered by differencing positions, and these
fields describe a span that has already ended. Absent, never zero, when there
is no open instant to measure from: `already_resident` opens and closes in one
row, and `mib_s=0` there would bucket an infinitely fast warm boot with a wedge.

Red/green: the three new cases fail on `ee09d0cd`, pass here; 71 neighbours
green across the five boot/position files. `test_boot_stages_pgw1355`'s
unmapped-phase guard caught the new phase and is now satisfied by a decision
rather than by silence. Pinned ruff 0.15.21 clean over all of `src/gen_worker`;
whole-src mypy identical SET to master (93 = 93, zero new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)