### PR TITLE
pgw#1545: build the specialization the first request needs FIRST, background-fill the rest

### DIFF
--- a/changelog.d/pgw1545-first-graph-first.md
+++ b/changelog.d/pgw1545-first-graph-first.md
@@ -1,0 +1,50 @@
+- **`gen-worker compile` builds the specialization you are about to RUN first, and can hand the
+  rest to a background fill.** Paul, 2026-08-20: *"prioritize generating the graph specialization
+  for what we want to run first; the other specializations can be compiled in the background
+  while we do inference using the .so that was compiled for the workflow we're actually using."*
+  Measured before this: 14 specializations at ~111 s each and **nothing servable for ~26 minutes**,
+  because the verb built every one of them eagerly and published the graph-set document last.
+
+  `--first SELECTOR` names the one to build first — a comma-separated conjunction over lane
+  contract, target module path, input parameter, dtype, `AxBxC` shape, or a graph-identity prefix,
+  matched against facets read off the ingress the lock actually carries. Unstated, it is the
+  document's own first record, which is not "whatever came first": graph order is semantic and
+  the derive puts the all-defaults specialization there (pgw#1384). A selector that matches
+  nothing **refuses and prints what IS addressable** — silently building the default instead
+  would report success over a specialization nobody asked for.
+
+  `--fill background` returns as soon as that one artifact is servable and finishes the rest in a
+  detached `nice -n 19` child; `--fill none` builds only the first; `--fill all` is the default
+  and is the old behaviour, in priority order. The fill is not a second code path with its own
+  resume state — it is **this verb** with `--fill all` and every resolved input restated on its
+  argv (sm, CAS, module name, lock), so everything already built resolves as PRESENT and it
+  continues from there. A killed fill therefore resumes as reuse, and `--verdict PATH` gives it
+  somewhere durable to state its result per specialization, since a detached child's exit status
+  reaches nobody.
+
+- **The graph-set document is now published BEFORE the first build, and that reversal is what
+  makes an incremental run servable at all.** It used to land last, on the runtime mint's
+  durability rule that nothing is announced before it exists. That rule is about ARTIFACTS and
+  still governs them — but the document is not a claim that artifacts exist. It is the authored
+  lane list read out of the committed lock, and `AdoptSession` turns every record it cannot fetch
+  into a HOLE: eager for that graph, queued for the mint, **never a refusal**. Publishing it last
+  meant a partly-filled store adopted exactly nothing, because the one row adoption enumerates
+  FROM had not landed yet.
+
+- **A deferred specialization is not a missing one, and the verdict can tell them apart.** Every
+  census row is now attributed to its graph (`Gap`), so a gap this run promised to close is still
+  `NOT SERVABLE` with rc=1 while a deliberately deferred one is reported as pending with rc=0.
+  The all-complete `SERVABLE — ... all N artifact(s)` line is chosen by asking the serving reader
+  which artifacts it can still not find, never by asking what the run intended, so **no
+  arrangement of half-done work reaches it**. pgw#1533's witness is untouched: every build is
+  still read back through a store object the run did not publish through.
+
+- **13 red arms, 13 caught** (`tests/test_compile_servability.py`, extended): ordering ignored, a
+  selector silently falling back to the default, the document published last again, deferred gaps
+  counted as fatal, promised gaps laundered as deferred, the all-complete line printed regardless,
+  the presence short-circuit removed so a resume rebuilds, the fill never handed its specs, the
+  fill child forgetting the resolved module name, a fill that will not start killing the run, no
+  verdict written, an unmatched call refusing instead of serving eager, and the late arm made a
+  no-op. The last two are the serving half, driven through the real `AdoptSession`: a request
+  needing a specialization nobody has built yet runs the author's own forward, and the fill arms
+  into the LIVE module with no reboot — which is the whole reason deferring is safe.

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -31,6 +31,18 @@ artifact had no graph-set document to be found through. Both are now this
 command's job, and the read-back is what proves it: a count of builds that
 returned cannot go red on either failure, and did not.
 
+**FIRST THE ONE THAT IS NEEDED (pgw#1545).** Paul, 2026-08-20: *"prioritize
+generating the graph specialization for what we want to run first; the other
+specializations can be compiled in the background while we do inference using
+the .so that was compiled for the workflow we're actually using."* So the unit
+of delivery is not the run, it is the FIRST SPECIALIZATION: ``--first`` names
+the one the caller's workflow needs (defaulting to the document's own first
+record, which the derive states is the all-defaults specialization — tcg
+``document.py``, pgw#1384), the graph-set document is published BEFORE any
+build, and under ``--fill background`` the verb returns the instant that one
+artifact is servable while a detached child fills the rest. Measured before
+this: 14 specializations at ~111 s each, nothing servable for ~26 minutes.
+
 ## Address-free programs
 
 Paul ruled the exported-program blob ADDRESS-FREE: ``torch.export.save`` is
@@ -83,6 +95,13 @@ BUILT = "built"            # compiled here
 CLAIMED = "claimed"        # another process holds the lease; it is doing it
 BELOW_FLOOR = "below_floor"  # no grant this run targets could arm it
 FAILED = "failed"
+
+#: What this run does with the specializations that are NOT the first one.
+#: Closed, and stated rather than inferred from a flag combination.
+FILL_ALL = "all"                # build them here, in this process, in order
+FILL_BACKGROUND = "background"  # hand them to a detached child and return
+FILL_NONE = "none"              # build only the first one; say what was left
+FILLS = (FILL_ALL, FILL_BACKGROUND, FILL_NONE)
 
 
 class CompileError(RuntimeError):
@@ -144,6 +163,88 @@ def specializations(lock_path: Path) -> Tuple[Spec, ...]:
                 )
             )
     return tuple(out)
+
+
+# --------------------------------------------------------------------------
+# Which specialization goes first
+# --------------------------------------------------------------------------
+
+
+def facets(spec: Spec) -> Tuple[str, ...]:
+    """Every name ``--first`` may address ONE specialization by.
+
+    A specialization has no single human name — it is a graph identity, and an
+    operator asking for "the 512x512 unet" is naming properties of its ingress.
+    So the selector matches FACETS: the graph identity (and its short form),
+    the lane contract, the target module path, and, from the ingress contract,
+    each input's parameter name, dtype and ``AxBxC`` shape. One relation, so a
+    refusal can print exactly what was addressable.
+    """
+    out: List[str] = [spec.graph, spec.short, spec.contract, spec.target]
+    ingress = spec.ingress if isinstance(spec.ingress, dict) else {}
+    for row in ingress.get("inputs") or ():
+        if not isinstance(row, dict):
+            continue
+        out.append(str(row.get("param") or ""))
+        out.append(str(row.get("dtype") or ""))
+        shape = row.get("shape")
+        if isinstance(shape, (list, tuple)) and shape:
+            out.append("x".join(str(dimension) for dimension in shape))
+    return tuple(dict.fromkeys(name for name in out if name))
+
+
+def _selects(spec: Spec, term: str) -> bool:
+    """One selector term against one specialization.
+
+    Equality against a facet, or a prefix of the graph identity — a graph hash
+    is 68 characters and nobody types one, but a distinguishing prefix is how
+    every other content-addressed tool is driven. Eight characters minimum, so
+    a short word can never accidentally prefix-match a hash.
+    """
+    if term in facets(spec):
+        return True
+    return len(term) >= 8 and spec.graph.startswith(term)
+
+
+def select(specs: Tuple[Spec, ...], selector: str) -> Spec:
+    """The specialization ``selector`` names — the one built FIRST.
+
+    An empty selector is the DOCUMENT'S OWN default: the first record in
+    document order. That is not "whatever happens to be first" — graph order is
+    semantic and the derive states it, putting the all-defaults specialization
+    first (torchcg ``document.py``, pgw#1384), which is exactly the one an
+    unstated workflow runs.
+
+    A selector matching nothing REFUSES. Falling back to the default would
+    build a specialization the caller did not ask for and report success, and
+    the whole point of the argument is that the first artifact is the one that
+    serves.
+    """
+    if not selector.strip():
+        return specs[0]
+    terms = [term.strip() for term in selector.split(",") if term.strip()]
+    for spec in specs:
+        if all(_selects(spec, term) for term in terms):
+            return spec
+    addressable = sorted({name for spec in specs for name in facets(spec)
+                          if not name.startswith("cg-graph-v1-")})
+    raise CompileError(
+        f"--first {selector!r} names no specialization this endpoint has.\n"
+        f"  {len(specs)} specialization(s) are addressable by lane contract, "
+        f"target, input parameter, dtype, AxBxC shape, or a graph-identity "
+        f"prefix (>= 8 chars).\n"
+        f"  Addressable names here: {', '.join(addressable) or '(none)'}"
+    )
+
+
+def order(specs: Tuple[Spec, ...], selector: str) -> Tuple[Spec, ...]:
+    """``specs`` with the selected one first, everything else in document order.
+
+    Document order is preserved for the remainder rather than re-sorted: it is
+    the producer's stated priority for everything after the caller's own ask.
+    """
+    first = select(specs, selector)
+    return (first,) + tuple(spec for spec in specs if spec is not first)
 
 
 # --------------------------------------------------------------------------
@@ -454,7 +555,25 @@ def serving_reader(cas_root: Path) -> Any:
     return LocalGraphStore(LocalCAS(Path(cas_root)))
 
 
-def unservable(cas_root: Path, specs: Tuple[Spec, ...], env: Any, module: str) -> List[str]:
+@dataclass(frozen=True, slots=True)
+class Gap:
+    """One thing the serving reader cannot find, ATTRIBUTED to its graph.
+
+    ``graph`` is ``""`` for the graph-set document row. The attribution is what
+    lets the verdict tell a gap this run promised to close from one it
+    deliberately deferred to the background fill (pgw#1545) — a bare sentence
+    could only be told apart by matching prose, which is how a vocabulary
+    becomes folklore.
+    """
+
+    graph: str
+    detail: str
+
+    def __str__(self) -> str:
+        return self.detail
+
+
+def unservable(cas_root: Path, specs: Tuple[Spec, ...], env: Any, module: str) -> List[Gap]:
     """What the serving reader still cannot find. Empty means servable.
 
     Reports the DOCUMENT as its own row: an endpoint whose artifacts are all
@@ -465,22 +584,24 @@ def unservable(cas_root: Path, specs: Tuple[Spec, ...], env: Any, module: str) -
     ``up`` served eager over a full store.
     """
     reader = serving_reader(cas_root)
-    gaps: List[str] = []
+    gaps: List[Gap] = []
     try:
         document = reader.get_graphs(module)
     except Exception as exc:  # noqa: BLE001 — unreadable IS unservable
         document = None
-        gaps.append(f"graph-set document {module!r}: unreadable ({exc})")
+        gaps.append(Gap("", f"graph-set document {module!r}: unreadable ({exc})"))
     if document is None and not gaps:
-        gaps.append(f"graph-set document {module!r}: absent")
+        gaps.append(Gap("", f"graph-set document {module!r}: absent"))
     for spec in specs:
         try:
             present = reader.has_artifact(spec.graph, env)
         except Exception as exc:  # noqa: BLE001
-            gaps.append(f"artifact {spec.short}: unreadable ({exc})")
+            gaps.append(Gap(spec.graph, f"artifact {spec.short}: unreadable ({exc})"))
             continue
         if not present:
-            gaps.append(f"artifact {spec.short}: absent at ({spec.short}, {env.value})")
+            gaps.append(Gap(
+                spec.graph,
+                f"artifact {spec.short}: absent at ({spec.short}, {env.value})"))
     return gaps
 
 
@@ -521,10 +642,107 @@ class Report:
     separate fields because they answer different questions and the whole of
     pgw#1533 is that the narrative was mistaken for the verdict: fourteen
     ``BUILT`` rows and rc=0 over a serving path that could arm nothing.
+
+    ``deferred`` is the third question (pgw#1545) and it is deliberately not
+    folded into either: a specialization this run CHOSE not to build yet is
+    absent from the store for a reason, and a verdict that cannot tell it from
+    one that was promised and missing is back to guessing.
     """
 
     outcomes: List[Outcome]
-    unservable: List[str]
+    unservable: List[Gap]
+    #: The specialization built FIRST, because it is the one that serves.
+    priority: Optional[Spec] = None
+    #: Handed to the background fill (or left unbuilt under ``--fill none``).
+    deferred: Tuple[Spec, ...] = ()
+    #: Where the background fill's own verdict lands. Empty = none started.
+    fill: str = ""
+
+
+# --------------------------------------------------------------------------
+# The background fill
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Fill:
+    """The specializations this run deferred, and the two ways to run them.
+
+    ``run`` builds them HERE, through the same per-specialization path the
+    foreground used — it exists so the deferral is testable without a detached
+    process, and production never calls it. ``argv`` is the real one: a whole
+    ``gen-worker compile`` for the same endpoint with ``--fill all``, which
+    resolves everything already built as PRESENT and continues from there. The
+    fill is not a special mode with its own resume state; it is this verb.
+    """
+
+    specs: Tuple[Spec, ...]
+    argv: Tuple[str, ...]
+    log: Path
+    verdict: Path
+    run: Callable[[], List[Outcome]]
+
+
+#: Start the fill and answer where its verdict will land. The production
+#: implementation is :func:`detach`; an explicit one is the local seam.
+FillRunner = Callable[[Fill], str]
+
+
+def detach(fill: Fill) -> str:
+    """Run the deferred specializations in a DETACHED, niced child.
+
+    Detached, because the foreground's whole promise is that it returns as soon
+    as the first artifact is servable — a caller that goes on to ``gen-worker
+    up`` must not be waiting on the remainder. ``start_new_session`` puts the
+    child in its own session so the parent's exit, its terminal and its process
+    group signals do not take the fill with them.
+
+    Niced, and only niced: CPU priority is what this process can actually give
+    away. It does NOT arbitrate the card — what keeps the fill from starving
+    live inference there is that it compiles one specialization at a time in a
+    process of its own, which a serving process on the same card preempts the
+    same way any other tenant does.
+    """
+    fill.log.parent.mkdir(parents=True, exist_ok=True)
+    with open(fill.log, "ab", buffering=0) as handle:
+        process = subprocess.Popen(
+            list(fill.argv),
+            stdin=subprocess.DEVNULL, stdout=handle, stderr=handle,
+            start_new_session=True,
+        )
+    return f"pid {process.pid}, log {fill.log}, verdict {fill.verdict}"
+
+
+def _fill_argv(
+    *, endpoint_dir: Path, lock_path: Path, cas_root: Path, sm: str,
+    lockfile: Optional[Path], only: int, vram_budget_gb: float, module: str,
+    first: str, verdict: Path,
+) -> Tuple[str, ...]:
+    """The child that finishes this run: THIS verb, stated in full.
+
+    Every input the parent resolved is restated explicitly — the sm it chose,
+    the CAS it published into, the module name it published the document under.
+    A child that re-derived any of them could publish under a different name or
+    build for a different card and still exit 0, and nothing would disagree.
+    """
+    argv = [
+        "nice", "-n", "19",
+        sys.executable, "-m", "gen_worker.cli", "compile", str(endpoint_dir),
+        "--sm", sm,
+        "--graph-store", str(cas_root),
+        "--lock", str(lock_path),
+        "--module", module,
+        "--first", first,
+        "--fill", FILL_ALL,
+        "--verdict", str(verdict),
+    ]
+    if lockfile is not None:
+        argv += ["--env-lockfile", str(lockfile)]
+    if only:
+        argv += ["--only", str(only)]
+    if vram_budget_gb > 0.0:
+        argv += ["--vram-budget", str(vram_budget_gb)]
+    return tuple(argv)
 
 
 def compile_all(
@@ -539,16 +757,28 @@ def compile_all(
     module: str = "",
     store: Any = None,
     builder: Optional[Builder] = None,
+    first: str = "",
+    fill: str = FILL_ALL,
+    fill_runner: Optional[FillRunner] = None,
 ) -> Report:
+    if fill not in FILLS:
+        raise CompileError(f"--fill must be one of {FILLS}, got {fill!r}")
     specs = specializations(lock_path)
-    if only:
-        specs = specs[:only]
     if not specs:
         logger.info(
             "compile: this endpoint's lock claims no compiled specializations "
             "— nothing to build (it serves eager by declaration)"
         )
         return Report([], [])
+    # THE PRIORITY ORDER, taken FIRST (pgw#1545): `--first` names the
+    # specialization the caller's workflow actually runs and everything else
+    # keeps document order behind it. Resolved here, before the floor probe
+    # imports torch, so a selector that names nothing refuses in milliseconds
+    # rather than after a load. `--only` then truncates the PRIORITY order,
+    # which is the only reading of a bring-up aid that can honour both flags.
+    specs = order(specs, first)
+    if only:
+        specs = specs[:only]
 
     floor = declared_floor_gb(endpoint_dir)
     grant = grant_gb(vram_budget_gb)
@@ -609,15 +839,18 @@ def compile_all(
             rederive_ran[0] = True
             _rederive_programs(endpoint_dir, cas_root, lockfile)
 
-    outcomes: List[Outcome] = []
-    for index, spec in enumerate(specs, start=1):
+    def satisfy(spec: Spec, label: str) -> Outcome:
+        """One specialization: present, or leased-built-published-witnessed.
+
+        Returns an outcome for every path including failure — one graph's
+        failure has never been the run's, and now that the run may be split
+        across two processes it is the ONLY thing that could be.
+        """
         started = time.monotonic()
-        label = f"[{index}/{len(specs)}] {spec.contract} {spec.short}"
         try:
             if store.has_artifact(spec.graph, env):
                 logger.info("%s: present", label)
-                outcomes.append(Outcome(spec, PRESENT, wall_s=time.monotonic() - started))
-                continue
+                return Outcome(spec, PRESENT, wall_s=time.monotonic() - started)
         except Exception as exc:  # noqa: BLE001 — a store miss is not fatal
             logger.warning("%s: store lookup failed (%s); treating as a miss", label, exc)
 
@@ -628,10 +861,7 @@ def compile_all(
                 # have landed exactly this artifact while we waited.
                 if store.has_artifact(spec.graph, env):
                     logger.info("%s: present (landed while claimed)", label)
-                    outcomes.append(
-                        Outcome(spec, PRESENT, wall_s=time.monotonic() - started)
-                    )
-                    continue
+                    return Outcome(spec, PRESENT, wall_s=time.monotonic() - started)
                 logger.info("%s: building", label)
                 program = _ensure_program(spec, store, rederive, artifacts_dir)
                 artifact = build(spec, program, destination)
@@ -650,30 +880,89 @@ def compile_all(
                         f"find is."
                     )
                 logger.info("%s: built and servable (%s)", label, published or "published")
-                outcomes.append(
-                    Outcome(spec, BUILT, published, wall_s=time.monotonic() - started)
-                )
+                return Outcome(spec, BUILT, published, wall_s=time.monotonic() - started)
         except work_ledger.Busy:
             logger.info(
                 "%s: claimed by another process — skipping (the work ledger is "
                 "how compile and a serving mint share this)", label,
             )
-            outcomes.append(Outcome(spec, CLAIMED, wall_s=time.monotonic() - started))
+            return Outcome(spec, CLAIMED, wall_s=time.monotonic() - started)
         except Exception as exc:  # noqa: BLE001 — one failure is not the run
             logger.error("%s: FAILED: %s: %s", label, type(exc).__name__, exc)
-            outcomes.append(
-                Outcome(spec, FAILED, f"{type(exc).__name__}: {exc}",
-                        wall_s=time.monotonic() - started)
-            )
+            return Outcome(spec, FAILED, f"{type(exc).__name__}: {exc}",
+                           wall_s=time.monotonic() - started)
 
-    # The document is published for the WHOLE run, not per specialization: it
-    # names every lane the lock claims, so a partial run still leaves adoption
-    # able to enumerate and the mint able to fill the rest. Publishing it after
-    # the artifacts is the same durability order the runtime mint uses —
-    # nothing is announced before it exists.
+    def satisfy_all(batch: Tuple[Spec, ...], *, offset: int) -> List[Outcome]:
+        return [
+            satisfy(spec, f"[{offset + index}/{len(specs)}] "
+                          f"{spec.contract} {spec.short}")
+            for index, spec in enumerate(batch, start=1)
+        ]
+
+    # The split. `specs` is already in priority order.
+    priority = specs[0]
+    foreground = specs if fill == FILL_ALL else specs[:1]
+    deferred = () if fill == FILL_ALL else specs[1:]
+    if deferred:
+        logger.info(
+            "compile: building %s FIRST (%s); %d specialization(s) deferred to "
+            "the %s fill — the first artifact is what serves",
+            priority.short, first or "the document's own default (all-defaults "
+            "specialization, stated first by the derive)",
+            len(deferred), fill,
+        )
+
+    # THE DOCUMENT FIRST, and this is a REVERSAL (pgw#1545). It used to be
+    # published after every build, on the runtime mint's durability rule that
+    # nothing is announced before it exists. That rule is about ARTIFACTS and
+    # still governs them — but the document is not a claim that artifacts
+    # exist. It is the authored lane list, read out of the committed lock, and
+    # `AdoptSession` turns every record it cannot fetch into a HOLE: eager for
+    # that graph, queued for the mint, never a refusal. Publishing it last is
+    # therefore what made an incremental run unservable — thirteen artifacts on
+    # disk and adoption unable to enumerate a single one, because the one row
+    # it enumerates FROM had not landed yet.
     _publish_document(cas_root, lock_path, module)
+
+    outcomes = satisfy_all(foreground, offset=0)
+
+    fill_detail = ""
+    if deferred and fill == FILL_BACKGROUND:
+        verdict = _fill_dir(module) / "fill.json"
+        runner = fill_runner if fill_runner is not None else detach
+        try:
+            fill_detail = runner(Fill(
+                specs=deferred,
+                argv=_fill_argv(
+                    endpoint_dir=endpoint_dir, lock_path=lock_path,
+                    cas_root=cas_root, sm=sm, lockfile=lockfile, only=only,
+                    vram_budget_gb=vram_budget_gb, module=module, first=first,
+                    verdict=verdict,
+                ),
+                log=_fill_dir(module) / "fill.log",
+                verdict=verdict,
+                run=lambda: satisfy_all(deferred, offset=1),
+            ))
+        except Exception as exc:  # noqa: BLE001 — a fill that will not start is
+            # not a foreground failure: the priority artifact is servable and
+            # this endpoint runs. It is stated, and the deferred rows stay
+            # deferred, so the next `compile` finishes them.
+            logger.error("compile: the background fill did not start: %s: %s",
+                         type(exc).__name__, exc)
+            fill_detail = f"NOT STARTED ({type(exc).__name__}: {exc})"
+
     gaps = unservable(cas_root, specs, env, module)
-    return Report(outcomes, gaps)
+    return Report(outcomes, gaps, priority=priority, deferred=deferred,
+                  fill=fill_detail)
+
+
+def _fill_dir(module: str) -> Path:
+    """Where a background fill's log and verdict live — one place per module,
+    reused across runs so an operator has ONE path to read rather than a
+    timestamped pile nobody prunes."""
+    safe = "".join(char if char.isalnum() or char in "._-" else "-"
+                   for char in module) or "endpoint"
+    return workspace.artifacts_root() / "fill" / safe
 
 
 def _rederive_programs(
@@ -725,11 +1014,14 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
         "compile",
         help="Pre-warm this card's compiled graphs: fetch else build.",
         description=(
-            "Satisfy every graph specialization the committed endpoint.lock "
-            "claims, for this card's sm and this venv's compile stack. Fetches "
-            "from the hub's fleet pool when it can, builds when it must, and "
-            "shares the work with any serving process's background mint "
-            "through the CAS work ledger. Weightless — no checkpoint needed."
+            "Satisfy the graph specializations the committed endpoint.lock "
+            "claims, for this card's sm and this venv's compile stack, "
+            "starting with the one --first names. Fetches from the hub's fleet "
+            "pool when it can, builds when it must, and shares the work with "
+            "any serving process's background mint through the CAS work "
+            "ledger. Weightless — no checkpoint needed. A specialization that "
+            "is not built yet costs eager execution at request time and never "
+            "a refusal, which is what makes --fill background safe."
         ),
     )
     parser.add_argument("endpoint_dir", nargs="?", default=".",
@@ -745,6 +1037,28 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
                              "endpoint's own)")
     parser.add_argument("--only", type=int, default=0, metavar="N",
                         help="stop after N specializations (bring-up aid)")
+    parser.add_argument("--first", default="", metavar="SELECTOR",
+                        help="build THIS specialization first — the one the "
+                             "workflow you are about to run needs. A "
+                             "comma-separated conjunction over lane contract, "
+                             "target, input parameter, dtype, AxBxC shape, or "
+                             "a graph-identity prefix. Default: the "
+                             "document's own first record (the all-defaults "
+                             "specialization).")
+    parser.add_argument("--fill", default=FILL_ALL, choices=list(FILLS),
+                        help="what to do with the specializations that are not "
+                             "--first. `all` (default) builds them here; "
+                             "`background` returns as soon as the first one is "
+                             "servable and finishes the rest in a detached "
+                             "niced child; `none` builds only the first.")
+    parser.add_argument("--module", default="", metavar="NAME",
+                        help="publish the graph-set document under this module "
+                             "name instead of importing the endpoint to read "
+                             "it (for a tree this box cannot import)")
+    parser.add_argument("--verdict", default="", metavar="PATH",
+                        help="also write the verdict here as JSON: rc, the "
+                             "state of every specialization, and every "
+                             "remaining gap")
     parser.add_argument("--vram-budget", type=float, default=0.0, metavar="GB",
                         help="the grant this compile targets; below the "
                              "endpoint's compiled floor it no-ops by name. "
@@ -770,16 +1084,24 @@ def summarize(report: Report) -> Tuple[str, int]:
         + ", ".join(f"{state}={counts[state]}" for state in sorted(counts))
         + f" (of {len(report.outcomes)})\n"
     ]
-    if report.unservable:
+    # A gap this run DEFERRED is not a gap it failed to close (pgw#1545), and
+    # the two are told apart by the gap's own attribution rather than by its
+    # prose. Everything not attributable to a deferred specialization — the
+    # graph-set document row included, because the document is published in the
+    # foreground precisely so the deferred ones can land into it — is fatal.
+    deferred_graphs = {spec.graph for spec in report.deferred}
+    pending = [gap for gap in report.unservable if gap.graph in deferred_graphs]
+    fatal = [gap for gap in report.unservable if gap.graph not in deferred_graphs]
+    if fatal:
         # NOT a warning. A run that leaves the serving path unable to arm what
         # it was asked for has failed at the only thing it was for, and saying
         # so quietly beside a green summary is the defect this fixed, not a
         # style choice.
         lines.append(
-            f"gen-worker compile: NOT SERVABLE — {len(report.unservable)} "
+            f"gen-worker compile: NOT SERVABLE — {len(fatal)} "
             f"gap(s) in the store `gen-worker up` adopts from:\n"
         )
-        lines.extend(f"  - {gap}\n" for gap in report.unservable)
+        lines.extend(f"  - {gap.detail}\n" for gap in fatal)
         lines.append(
             "  A build that returned is not an artifact the serving path can "
             "find; this command reports the second.\n"
@@ -789,10 +1111,31 @@ def summarize(report: Report) -> Tuple[str, int]:
         return "".join(lines), 1
     if counts.get(BELOW_FLOOR) or not report.outcomes:
         return "".join(lines), 0
+    if pending:
+        # THE PARTIAL VERDICT, and it is a different sentence on purpose. The
+        # all-complete line below is a claim about EVERY specialization, so no
+        # arrangement of half-done work may reach it: this branch is chosen by
+        # asking the serving reader which deferred artifacts it still cannot
+        # find, not by asking what this run intended.
+        first = report.priority.short if report.priority is not None else "?"
+        lines.append(
+            f"gen-worker compile: SERVABLE FOR {first} — the graph-set "
+            f"document and the {len(report.outcomes)} artifact(s) built here "
+            f"are readable through the store boot-time adoption uses. "
+            f"{len(pending)} specialization(s) are NOT built yet; serving arms "
+            f"each one as it lands and falls back to eager for the rest.\n"
+        )
+        lines.extend(f"  - pending: {gap.detail}\n" for gap in pending)
+        lines.append(
+            f"  background fill: {report.fill}\n" if report.fill else
+            "  no fill was started — re-run `gen-worker compile` to finish "
+            "them (everything built already resolves as present).\n"
+        )
+        return "".join(lines), 0
     lines.append(
         f"gen-worker compile: SERVABLE — the graph-set document and all "
-        f"{len(report.outcomes)} artifact(s) are readable through the store "
-        f"boot-time adoption uses.\n"
+        f"{len(report.outcomes) + len(report.deferred)} artifact(s) are "
+        f"readable through the store boot-time adoption uses.\n"
     )
     return "".join(lines), 0
 
@@ -812,6 +1155,7 @@ def run_compile(args: argparse.Namespace) -> int:
         return 2
     lock_path = Path(args.lock) if args.lock else endpoint_dir / el.LOCK_FILENAME
     cas_root = Path(args.graph_store) if args.graph_store else workspace.graph_cas_root()
+    verdict_path = Path(args.verdict) if getattr(args, "verdict", "") else None
     try:
         report = compile_all(
             endpoint_dir=endpoint_dir,
@@ -821,13 +1165,59 @@ def run_compile(args: argparse.Namespace) -> int:
             lockfile=Path(args.env_lockfile) if args.env_lockfile else None,
             only=int(args.only or 0),
             vram_budget_gb=float(args.vram_budget or 0.0),
+            module=str(getattr(args, "module", "") or ""),
+            first=str(getattr(args, "first", "") or ""),
+            fill=str(getattr(args, "fill", FILL_ALL) or FILL_ALL),
         )
     except CompileError as exc:
         sys.stderr.write(f"gen-worker compile: {exc}\n")
+        if verdict_path is not None:
+            _write_verdict(verdict_path, None, str(exc), 1)
         return 1
     summary, code = summarize(report)
     sys.stderr.write(summary)
+    if verdict_path is not None:
+        _write_verdict(verdict_path, report, summary, code)
     return code
+
+
+def _write_verdict(
+    path: Path, report: Optional[Report], summary: str, code: int
+) -> None:
+    """The run's verdict, durably, per specialization.
+
+    THE BACKGROUND FILL'S ONLY WAY TO BE READ (pgw#1545). A detached child's
+    exit status reaches nobody: its parent is gone by the time it finishes, and
+    a serve pod's stdout goes nowhere. So the fill states its result where a
+    later reader — an operator, the next `compile`, a test — can find it, and
+    it states it PER SPECIALIZATION, because "the fill failed" over fourteen
+    graphs is not a fact anyone can act on.
+
+    Never raises: a verdict that could not be written must not turn a finished
+    compile into a failed one.
+    """
+    payload: Dict[str, Any] = {"rc": int(code), "summary": summary}
+    if report is not None:
+        payload["priority"] = (
+            report.priority.graph if report.priority is not None else "")
+        payload["fill"] = report.fill
+        payload["deferred"] = [spec.graph for spec in report.deferred]
+        payload["specializations"] = [
+            {"graph": outcome.spec.graph, "contract": outcome.spec.contract,
+             "target": outcome.spec.target, "state": outcome.state,
+             "detail": outcome.detail, "wall_s": round(outcome.wall_s, 3)}
+            for outcome in report.outcomes
+        ]
+        payload["unservable"] = [
+            {"graph": gap.graph, "detail": gap.detail}
+            for gap in report.unservable
+        ]
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True),
+                        encoding="utf-8")
+    except OSError as exc:
+        logger.warning("compile: could not write the verdict to %s (%s)", path, exc)
 
 
 __all__ = [
@@ -838,14 +1228,25 @@ __all__ = [
     "CompileError",
     "FAILED",
     "FETCHED",
+    "FILLS",
+    "FILL_ALL",
+    "FILL_BACKGROUND",
+    "FILL_NONE",
+    "Fill",
+    "FillRunner",
+    "Gap",
     "Outcome",
     "PRESENT",
     "Report",
     "Spec",
     "add_subparser",
     "compile_all",
+    "detach",
     "endpoint_module",
+    "facets",
+    "order",
     "run_compile",
+    "select",
     "serving_reader",
     "specializations",
     "summarize",

--- a/tests/test_compile_servability.py
+++ b/tests/test_compile_servability.py
@@ -8,16 +8,28 @@ verdict and the exit code are computed from a reader rather than from a tally,
 and that the mint child can find a CUDA root on the box it is actually running
 on (no root, no artifact, so it belongs to the same claim).
 
+pgw#1545 extends the same contract to a run that is deliberately INCOMPLETE:
+the specialization the caller names is built first, the rest are deferred, and
+the verdict has to stay honest about which is which — a deferred artifact is
+not a missing one, and no arrangement of half-done work may print the
+all-complete line. Its last two tests close the loop on the serving side,
+because deferring is only safe if a specialization that is not built yet costs
+eager execution and never a refusal.
+
 Every test drives the REAL ``compile_all`` — its work ledger, its store, its
 publish, its census — with only the inductor child replaced by a seam emitting a
-real torchcg artifact (``tests/tcg_artifacts``: no torch, no GPU). The red arms
-are the point, because each of them was once GREEN.
+real torchcg artifact (``tests/tcg_artifacts``: no inductor, no GPU), and the
+serving pair drives the real ``AdoptSession`` with only the bytes->callable
+loader seamed. The red arms are the point, because each of them was once GREEN.
 """
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
+import os
+import sys
 from pathlib import Path
 from typing import Any, List, Tuple
 
@@ -40,33 +52,38 @@ MODULE = "sd15.main"
 LANE = "sd15.diffusers-bf16@1"
 TARGET = "unet"
 
-#: Two graphs, because "all of them" and "some of them" are different verdicts
-#: and a one-graph fixture cannot tell them apart.
+#: Three graphs, because "all of them", "some of them" and "the ONE the caller
+#: asked for first" are three different verdicts, and a one-graph fixture can
+#: tell none of them apart. They differ in the two facets `--first` selects on
+#: — target module path and input shape — because a fixture whose
+#: specializations are indistinguishable cannot prove an ORDER was honoured.
 GRAPHS = (
     "cg-graph-v1-" + "a" * 56,
     "cg-graph-v1-" + "b" * 56,
+    "cg-graph-v1-" + "c" * 56,
 )
+TARGETS = ("unet", "unet", "vae")
+SHAPES = ((2, 64, 64), (2, 128, 128), (1, 64, 64))
 
 
-def _ingress() -> CallIngress:
+def _ingress(shape: Tuple[int, ...] = (2,)) -> CallIngress:
     return CallIngress(
         parameters=("value",),
         flat_arity=1,
-        inputs=(CallInput("value", 0, "value", 0, (), "value", "float32", (2,)),),
+        inputs=(CallInput("value", 0, "value", 0, (), "value", "float32", shape),),
     )
 
 
 def document() -> GraphSetDocument:
-    ingress = _ingress()
     return GraphSetDocument(
         stack=STACK,
         lanes=(
             LaneGraphs(
                 contract=LANE,
-                targets=(TARGET,),
+                targets=tuple(dict.fromkeys(TARGETS)),
                 graphs=tuple(
-                    GraphRecord(graph=graph, target=TARGET, ingress=ingress)
-                    for graph in GRAPHS
+                    GraphRecord(graph=graph, target=target, ingress=_ingress(shape))
+                    for graph, target, shape in zip(GRAPHS, TARGETS, SHAPES)
                 ),
             ),
         ),
@@ -165,9 +182,9 @@ def test_a_built_graph_lands_where_boot_time_adoption_reads_it(
 
     report = _run(endpoint, cas, store=store, builder=_builder(built))
 
-    assert built == list(GRAPHS), "both specializations must have been built"
-    assert [outcome.state for outcome in report.outcomes] == [
-        compile_cli.BUILT, compile_cli.BUILT]
+    assert built == list(GRAPHS), "every specialization must have been built"
+    assert [outcome.state for outcome in report.outcomes] == (
+        [compile_cli.BUILT] * len(GRAPHS))
     assert report.unservable == []
 
     # The witness that matters: a store object this run did not publish
@@ -216,8 +233,8 @@ def test_a_build_lands_in_the_box_cache_and_never_in_the_endpoint_tree(
 
     report = _run(endpoint, cas, store=store, builder=build)
 
-    assert [outcome.state for outcome in report.outcomes] == [
-        compile_cli.BUILT, compile_cli.BUILT]
+    assert [outcome.state for outcome in report.outcomes] == (
+        [compile_cli.BUILT] * len(GRAPHS))
     assert destinations, "the builder was never reached"
     for destination in destinations:
         assert box in destination.parents, destination
@@ -332,7 +349,9 @@ def test_an_unpublished_graph_set_document_is_a_gap_even_when_every_artifact_is_
     # Ask under a name nothing published: the artifacts are still all present,
     # and that is not enough.
     gaps = compile_cli.unservable(cas, specs, ENV, "some.other")
-    assert gaps == ["graph-set document 'some.other': absent"]
+    assert [gap.detail for gap in gaps] == [
+        "graph-set document 'some.other': absent"]
+    assert [gap.graph for gap in gaps] == [""], "the document row names no graph"
 
 
 def test_an_artifact_under_the_wrong_env_is_absent_to_the_reader(
@@ -353,7 +372,9 @@ def test_an_artifact_under_the_wrong_env_is_absent_to_the_reader(
     other = EnvIdentity(stack=STACK, sm="sm_90")
     gaps = compile_cli.unservable(cas, specs, other, MODULE)
     assert len(gaps) == len(GRAPHS)
-    assert all("absent at" in gap for gap in gaps)
+    assert all("absent at" in gap.detail for gap in gaps)
+    assert {gap.graph for gap in gaps} == set(GRAPHS), (
+        "every gap is attributed, so a deferred one can be told from a missing one")
 
 
 # --------------------------------------------------------------------------
@@ -373,7 +394,9 @@ def test_the_shell_learns_unservable_even_when_every_build_returned() -> None:
 
     lying = compile_cli.Report(
         [compile_cli.Outcome(spec, compile_cli.BUILT)],
-        ["artifact cg-graph-v1-aaa: absent at (cg-graph-v1-aaa, cg-env-v2-x)"],
+        [compile_cli.Gap(
+            GRAPHS[0],
+            "artifact cg-graph-v1-aaa: absent at (cg-graph-v1-aaa, cg-env-v2-x)")],
     )
     summary, code = compile_cli.summarize(lying)
     assert code == 1, "a build that returned is not an artifact anyone can serve"
@@ -479,3 +502,467 @@ def test_an_unreadable_module_name_is_a_typed_refusal_not_a_traceback(
     assert "cannot read" in message
     assert "graph-set document" in message, "it says WHY the name is needed"
     assert str(empty) in message, "and which endpoint it was asked about"
+
+
+# --------------------------------------------------------------------------
+# pgw#1545: FIRST the specialization the workflow needs; the rest in the
+# background. Time-to-first-served is the number, not total mint wall.
+# --------------------------------------------------------------------------
+
+
+def _cas_with_programs(tmp_path: Path) -> Tuple[Path, LocalGraphStore]:
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+    return cas, store
+
+
+def test_the_selector_addresses_a_specialization_by_the_facets_it_has(
+    endpoint: Path,
+) -> None:
+    """A specialization has no human name, so `--first` matches its FACETS.
+
+    Asserted through the real `specializations()` output rather than a hand-built
+    Spec, because the facets are read off the ingress the lock actually carries.
+    """
+    specs = compile_cli.specializations(endpoint / el.LOCK_FILENAME)
+
+    assert compile_cli.select(specs, "").graph == GRAPHS[0], (
+        "an unstated selector is the document's own first record")
+    assert compile_cli.select(specs, "vae").graph == GRAPHS[2]
+    assert compile_cli.select(specs, "2x128x128").graph == GRAPHS[1]
+    assert compile_cli.select(specs, "unet,2x128x128").graph == GRAPHS[1], (
+        "terms are a conjunction: both must hold of the same specialization")
+    assert compile_cli.select(specs, GRAPHS[2][:20]).graph == GRAPHS[2], (
+        "a graph-identity prefix addresses one exactly")
+    assert compile_cli.select(specs, LANE).graph == GRAPHS[0], (
+        "a lane matches every graph in it, and the first one wins")
+
+    ordered = compile_cli.order(specs, "vae")
+    assert [spec.graph for spec in ordered] == [GRAPHS[2], GRAPHS[0], GRAPHS[1]], (
+        "the selected one moves to the front; the rest keep document order")
+
+
+def test_a_selector_that_names_nothing_refuses_rather_than_building_the_default(
+    endpoint: Path,
+) -> None:
+    """The whole point of the argument is that the FIRST artifact is the one
+    that serves. Silently building the default instead would report success
+    over a specialization the caller never asked for."""
+    specs = compile_cli.specializations(endpoint / el.LOCK_FILENAME)
+
+    with pytest.raises(compile_cli.CompileError) as refusal:
+        compile_cli.select(specs, "controlnet")
+
+    message = str(refusal.value)
+    assert "names no specialization" in message
+    assert "vae" in message and "unet" in message, "it prints what IS addressable"
+
+
+def test_only_truncates_the_PRIORITY_order_not_the_document_order(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """The two bring-up flags have to compose.
+
+    `--only` truncating before `--first` was resolved would make
+    `--only 1 --first vae` refuse — the selector would be asked about a list the
+    truncation had already removed its answer from.
+    """
+    cas, store = _cas_with_programs(tmp_path)
+    built: List[str] = []
+
+    report = _run(endpoint, cas, store=store, builder=_builder(built),
+                  first="vae", only=1)
+
+    assert built == [GRAPHS[2]]
+    assert [outcome.spec.graph for outcome in report.outcomes] == [GRAPHS[2]]
+    assert report.unservable == [], (
+        "the census covers what this run took on, which is the truncated set")
+
+
+def test_the_named_specialization_is_the_only_one_built_and_it_is_servable(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """THE ACCEPTANCE, in miniature: one build, and the endpoint serves it.
+
+    ``--fill none`` is the sharpest form of the claim — no background process
+    to confuse the reading, so the store's contents are exactly what the
+    priority build put there.
+    """
+    cas, store = _cas_with_programs(tmp_path)
+    built: List[str] = []
+
+    report = _run(endpoint, cas, store=store, builder=_builder(built),
+                  first="vae", fill=compile_cli.FILL_NONE)
+
+    assert built == [GRAPHS[2]], "only the specialization the caller named was built"
+    assert report.priority is not None and report.priority.graph == GRAPHS[2]
+    assert [spec.graph for spec in report.deferred] == [GRAPHS[0], GRAPHS[1]]
+
+    reader = compile_cli.serving_reader(cas)
+    assert reader.get_graphs(MODULE) == document(), (
+        "the document is published, so adoption can enumerate and arm this one")
+    assert reader.has_artifact(GRAPHS[2], ENV)
+    assert not reader.has_artifact(GRAPHS[0], ENV)
+    assert not reader.has_artifact(GRAPHS[1], ENV)
+
+
+def test_the_graph_set_document_is_published_before_the_first_build(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """A REVERSAL, and the property that makes incremental serving possible.
+
+    The document used to be published after every build, so a run that had
+    landed some artifacts and not others left adoption unable to enumerate a
+    single one: the row it enumerates FROM had not landed. Observed from inside
+    the builder — the only place that can see the store as it was BEFORE any
+    artifact existed.
+    """
+    cas, store = _cas_with_programs(tmp_path)
+    seen: List[Any] = []
+
+    def build(spec: compile_cli.Spec, program: Path, destination: Path) -> Path:
+        seen.append(compile_cli.serving_reader(cas).get_graphs(MODULE))
+        destination.mkdir(parents=True, exist_ok=True)
+        tcg_artifacts.aoti_package(
+            destination / "model.pt2", graph_specialization=spec.graph)
+        return destination
+
+    _run(endpoint, cas, store=store, builder=build, fill=compile_cli.FILL_NONE)
+
+    assert seen == [document()], (
+        "the first build already ran against a store adoption can enumerate")
+
+
+def test_a_deferred_run_never_reports_the_all_complete_line(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """rc semantics: servable FOR the priority artifact, rc 0, and the
+    all-complete sentence is unreachable while the reader still has holes."""
+    cas, store = _cas_with_programs(tmp_path)
+
+    report = _run(endpoint, cas, store=store, builder=_builder([]),
+                  fill=compile_cli.FILL_NONE)
+    summary, code = compile_cli.summarize(report)
+
+    assert code == 0, "a deferred specialization is not a failure"
+    assert f"SERVABLE FOR {report.outcomes[0].spec.short}" in summary
+    assert "and all 3 artifact(s) are readable" not in summary
+    assert summary.count("pending:") == 2
+    assert "re-run `gen-worker compile`" in summary, (
+        "no fill was started, so it says how they get finished")
+
+
+def test_a_gap_in_what_this_run_PROMISED_is_still_fatal(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """Deferral must not become a way to launder a failure.
+
+    The priority build publishes nowhere — the pgw#1533 defect — while two
+    specializations are legitimately deferred. The deferred ones stay silent;
+    the promised one is NOT SERVABLE and rc is 1.
+    """
+    cas, real = _cas_with_programs(tmp_path)
+    store = PublishesNowhere(real)
+
+    report = _run(endpoint, cas, store=store, builder=_builder([]),
+                  fill=compile_cli.FILL_NONE)
+    summary, code = compile_cli.summarize(report)
+
+    assert code == 1
+    assert "NOT SERVABLE — 1 gap(s)" in summary, (
+        "one gap is fatal; the other two were never promised by this run")
+    assert {outcome.state for outcome in report.outcomes} == {compile_cli.FAILED}
+
+
+def test_the_background_fill_finishes_what_the_foreground_deferred(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """The fill runs the SAME per-specialization path, and the verdict is
+    computed from the reader afterwards — which is the only way the
+    all-complete line is ever reached."""
+    cas, store = _cas_with_programs(tmp_path)
+    built: List[str] = []
+    handed: List[Tuple[str, ...]] = []
+
+    def inline(fill: compile_cli.Fill) -> str:
+        handed.append(tuple(spec.graph for spec in fill.specs))
+        fill.run()
+        return "ran inline"
+
+    report = _run(endpoint, cas, store=store, builder=_builder(built),
+                  first="vae", fill=compile_cli.FILL_BACKGROUND,
+                  fill_runner=inline)
+    summary, code = compile_cli.summarize(report)
+
+    assert built == [GRAPHS[2], GRAPHS[0], GRAPHS[1]], (
+        "priority first, then the rest in document order")
+    assert handed == [(GRAPHS[0], GRAPHS[1])]
+    assert report.unservable == []
+    assert code == 0
+    assert "and all 3 artifact(s) are readable" in summary
+
+
+def test_the_detached_fill_is_THIS_verb_with_every_input_restated(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """The fill is not a second code path with its own resume state.
+
+    It is ``gen-worker compile --fill all`` for the same endpoint, so
+    everything already built resolves as PRESENT and it continues from there.
+    Every resolved input is restated on the argv: a child that re-derived its
+    sm or its module name could publish somewhere else and still exit 0.
+    """
+    cas, store = _cas_with_programs(tmp_path)
+    seen: List[compile_cli.Fill] = []
+
+    def capture(fill: compile_cli.Fill) -> str:
+        seen.append(fill)
+        return f"pid 4242, log {fill.log}"
+
+    _run(endpoint, cas, store=store, builder=_builder([]), first="vae",
+         fill=compile_cli.FILL_BACKGROUND, fill_runner=capture)
+
+    argv = seen[0].argv
+    assert argv[:3] == ("nice", "-n", "19"), "the fill yields the CPU"
+    assert "compile" in argv and str(endpoint) in argv
+    for flag, value in (
+        ("--sm", SM), ("--graph-store", str(cas)), ("--module", MODULE),
+        ("--first", "vae"), ("--fill", compile_cli.FILL_ALL),
+        ("--lock", str(endpoint / el.LOCK_FILENAME)),
+        ("--verdict", str(seen[0].verdict)),
+    ):
+        assert argv[argv.index(flag) + 1] == value, flag
+    # And the argv is a real one: the parser this verb installs accepts it.
+    parser = argparse.ArgumentParser()
+    compile_cli.add_subparser(parser.add_subparsers(dest="verb"))
+    parsed = parser.parse_args(list(argv[argv.index("compile"):]))
+    assert parsed.fill == compile_cli.FILL_ALL and parsed.module == MODULE
+
+
+def test_detach_really_spawns_a_surviving_child_and_captures_its_output(
+    tmp_path: Path
+) -> None:
+    """The PRODUCTION runner, exercised — not just the seam it hides behind.
+
+    Every other test here states its own `fill_runner`, so `detach` would
+    otherwise be correct code no test path calls, which is the exact defect
+    class this repo keeps finding (pgw#1543 C1). Driven over a harmless argv:
+    what is under test is that a child is started, survives being detached, and
+    lands its output where the returned sentence says it will.
+    """
+    log = tmp_path / "fill" / "fill.log"
+    fill = compile_cli.Fill(
+        specs=(),
+        argv=("nice", "-n", "19", sys.executable, "-c",
+              "import os; print('filling', os.getsid(0) != %d)" % os.getsid(0)),
+        log=log, verdict=tmp_path / "fill" / "fill.json",
+        run=lambda: [],
+    )
+
+    detail = compile_cli.detach(fill)
+
+    assert detail.startswith("pid ") and str(log) in detail
+    pid = int(detail.split()[1].rstrip(","))
+    _, status = os.waitpid(pid, 0)
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert log.read_text(encoding="utf-8").strip() == "filling True", (
+        "the child ran, in a session of its own, with its output captured")
+
+
+def test_a_fill_that_cannot_start_is_stated_and_is_not_a_failure(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """The priority artifact is servable and the endpoint runs. A fill that
+    will not spawn leaves work undone, not a broken deliverable."""
+    cas, store = _cas_with_programs(tmp_path)
+
+    def refuses(fill: compile_cli.Fill) -> str:
+        raise OSError("no fork for you")
+
+    report = _run(endpoint, cas, store=store, builder=_builder([]),
+                  fill=compile_cli.FILL_BACKGROUND, fill_runner=refuses)
+    summary, code = compile_cli.summarize(report)
+
+    assert code == 0
+    assert "NOT STARTED (OSError: no fork for you)" in report.fill
+    assert "NOT STARTED" in summary
+
+
+def test_a_killed_fill_resumes_as_reuse_and_finishes_the_remainder(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """Interruption safety, over the real store rather than a resume file.
+
+    The fill dies after one of its two specializations. The re-run rebuilds
+    NOTHING that landed — the finished ones resolve as PRESENT through the same
+    store lookup a warm run uses — and builds only what is missing.
+    """
+    cas, store = _cas_with_programs(tmp_path)
+    first_pass: List[str] = []
+
+    def dies_after_one(fill: compile_cli.Fill) -> str:
+        """A fill that lands ONE of its two and is then killed.
+
+        Modelled the way production actually looks: the runner returns a pid
+        and the parent goes on. A detached child's death is invisible to the
+        foreground by construction, so the resume can only be proved by what is
+        in the store afterwards — which is the point.
+        """
+        compile_cli.compile_all(
+            endpoint_dir=endpoint, lock_path=endpoint / el.LOCK_FILENAME,
+            cas_root=cas, sm=SM, lockfile=None, module=MODULE, store=store,
+            builder=_builder(first_pass), first=fill.specs[0].graph,
+            fill=compile_cli.FILL_NONE,
+        )
+        return "pid 4242 (killed after one)"
+
+    _run(endpoint, cas, store=store, builder=_builder(first_pass), first="vae",
+         fill=compile_cli.FILL_BACKGROUND, fill_runner=dies_after_one)
+    assert first_pass == [GRAPHS[2], GRAPHS[0]], "two of three landed"
+
+    second_pass: List[str] = []
+    report = _run(endpoint, cas, store=store, builder=_builder(second_pass),
+                  first="vae")
+
+    assert second_pass == [GRAPHS[1]], "only the unfinished one was rebuilt"
+    assert {outcome.state for outcome in report.outcomes} == {
+        compile_cli.PRESENT, compile_cli.BUILT}
+    assert report.unservable == []
+    assert compile_cli.summarize(report)[1] == 0
+
+
+def test_the_verb_writes_a_durable_per_specialization_verdict(
+    endpoint: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A detached fill's exit status reaches nobody, so it states its result
+    where a later reader can find it — per specialization, because "the fill
+    failed" over fourteen graphs is not a fact anyone can act on.
+
+    Driven through argparse and :func:`run_compile`, so the flags, the handler
+    and the writer are all the real ones.
+    """
+    cas, store = _cas_with_programs(tmp_path)
+    monkeypatch.setattr(workspace, "artifacts_root", lambda: tmp_path / "box")
+    _run(endpoint, cas, store=store, builder=_builder([]))  # everything present
+
+    verdict = tmp_path / "fill" / "fill.json"
+    parser = argparse.ArgumentParser()
+    compile_cli.add_subparser(parser.add_subparsers(dest="verb"))
+    args = parser.parse_args([
+        "compile", str(endpoint), "--sm", SM, "--graph-store", str(cas),
+        "--lock", str(endpoint / el.LOCK_FILENAME), "--module", MODULE,
+        "--verdict", str(verdict),
+    ])
+
+    assert args._handler(args) == 0
+
+    banked = json.loads(verdict.read_text(encoding="utf-8"))
+    assert banked["rc"] == 0
+    assert "SERVABLE" in banked["summary"]
+    assert [row["graph"] for row in banked["specializations"]] == list(GRAPHS)
+    assert {row["state"] for row in banked["specializations"]} == {compile_cli.PRESENT}
+    assert banked["unservable"] == []
+
+
+# --------------------------------------------------------------------------
+# ...and what SERVING does with a store that is only partly filled. This is
+# the other half of pgw#1545: deferring is only safe because a specialization
+# that is not built yet costs eager execution and NEVER a refusal.
+# --------------------------------------------------------------------------
+
+
+def _adopt_session(cas: Path, artifacts: Path, armed: List[str]) -> Any:
+    """A REAL ``AdoptSession`` over the store `compile` published into.
+
+    Only the bytes->callable loader is seamed (there is no card here); the
+    fetch, the claim, the per-graph arm and the dispatcher are torchcg's own.
+    """
+    from gen_worker._vendor.torchcg.adopt import AdoptSession
+
+    def loader(artifact: Path, record: Any, module: Any) -> Any:
+        armed.append(record.graph)
+        return lambda value: ("compiled", record.graph)
+
+    return AdoptSession(
+        LocalGraphStore(LocalCAS(cas)), document(), LANE, SM,
+        loader=loader, artifacts_dir=artifacts, stack=STACK,
+    )
+
+
+def _marked_module() -> Any:
+    import torch
+
+    class Denoiser(torch.nn.Module):
+        def forward(self, value: Any) -> Any:
+            return ("eager", tuple(value.shape))
+
+    return Denoiser()
+
+
+def test_a_specialization_that_is_not_built_yet_serves_EAGER_and_never_refuses(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """The property the whole deferral rests on.
+
+    One artifact in the store, three in the document. The call that matches it
+    dispatches compiled; the calls that do not run the author's own forward.
+    Neither refuses, and neither waits for a build.
+    """
+    import torch
+
+    cas, store = _cas_with_programs(tmp_path)
+    _run(endpoint, cas, store=store, builder=_builder([]), first="vae",
+         fill=compile_cli.FILL_NONE)
+
+    armed: List[str] = []
+    session = _adopt_session(cas, tmp_path / "adopted", armed)
+    module = session.adopt(_marked_module())
+
+    assert armed == [GRAPHS[2]], "only the built specialization was armed"
+    assert [record.graph for record in session.adopted] == [GRAPHS[2]]
+    assert [hole.record.graph for hole in session.holes] == [GRAPHS[0], GRAPHS[1]], (
+        "the unbuilt ones are the mint work-list, in document order")
+
+    assert module(torch.zeros(SHAPES[2])) == ("compiled", GRAPHS[2])
+    assert module(torch.zeros(SHAPES[0])) == ("eager", SHAPES[0]), (
+        "a request needing a specialization nobody built runs eager")
+    assert module(torch.zeros((7, 7))) == ("eager", (7, 7)), (
+        "and so does a shape no specialization in the document covers")
+
+
+def test_the_fill_ARMS_into_a_live_session_without_a_reboot(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """Per-artifact adoption: each specialization arms the instant it lands.
+
+    The session is built while two specializations are still missing, a request
+    is served eager for one of them, then the fill lands it and the SAME live
+    module dispatches compiled — no restart, no re-adopt.
+    """
+    import torch
+
+    cas, store = _cas_with_programs(tmp_path)
+    _run(endpoint, cas, store=store, builder=_builder([]), first="vae",
+         fill=compile_cli.FILL_NONE)
+
+    armed: List[str] = []
+    session = _adopt_session(cas, tmp_path / "adopted", armed)
+    module = session.adopt(_marked_module())
+    assert module(torch.zeros(SHAPES[0])) == ("eager", SHAPES[0])
+
+    # The fill lands the deferred specializations, exactly as `--fill
+    # background` would, through the same verb.
+    _run(endpoint, cas, store=store, builder=_builder([]))
+
+    hole = session.holes[0]
+    fetched = LocalGraphStore(LocalCAS(cas)).fetch_artifact(
+        hole.record.graph, session.env, tmp_path / "late" / "model")
+    session.arm(hole.record, fetched)
+
+    assert armed == [GRAPHS[2], GRAPHS[0]]
+    assert module(torch.zeros(SHAPES[0])) == ("compiled", GRAPHS[0]), (
+        "the live module took the late artifact")
+    assert module(torch.zeros(SHAPES[1])) == ("eager", SHAPES[1]), (
+        "and the one still unarmed is still eager, not refused")
+    assert [hole.record.graph for hole in session.holes] == [GRAPHS[1]]


### PR DESCRIPTION
Paul, 2026-08-20: *"prioritize generating the graph specialization for what we want to run first; the other specializations can be compiled in the background while we do inference using the .so that was compiled for the workflow we're actually using."*

Measured before this: `gen-worker compile` built all 14 sd15 specializations eagerly at ~111 s each **and published the graph-set document LAST**, so nothing was servable for ~26 minutes. Time-to-first-served is the number users feel; total mint wall is not.

## What changed

- **`--first SELECTOR`** names the specialization to build first, matched against FACETS read off the ingress the lock actually carries — lane contract, target module path, input parameter, dtype, `AxBxC` shape, or a graph-identity prefix (>= 8 chars) — comma-separated terms as a conjunction. Unstated it is the document's own first record, which is not "whatever came first": graph order is semantic and the derive puts the all-defaults specialization there (pgw#1384). **A selector matching nothing REFUSES** and prints what is addressable; silently building the default would report success over a specialization nobody asked for.
- **`--fill background`** returns as soon as that one artifact is servable and finishes the rest in a detached `nice -n 19` child. The fill is not a second code path with its own resume state — it is **this verb** with `--fill all` and every resolved input restated on its argv (sm, CAS, module name, lock), so everything already built resolves as PRESENT and a killed fill resumes as reuse. `--verdict PATH` is where it states its per-specialization result, because a detached child's exit status reaches nobody. `--fill all` remains the default and is the old behaviour, in priority order.
- **The graph-set document is published BEFORE the first build** — a deliberate reversal. The durability rule *"nothing is announced before it exists"* governs ARTIFACTS and still does, but the document is the authored lane list read out of the committed lock, and `AdoptSession` turns every record it cannot fetch into a **HOLE**: eager for that graph, queued for the mint, never a refusal. Publishing it last is exactly what made a partly-filled store adopt nothing — the one row adoption enumerates FROM had not landed.
- **A deferred specialization is not a missing one.** Census rows are now attributed to their graph (`Gap`), so a gap this run promised to close is still `NOT SERVABLE` / rc=1 while a deferred one is reported as pending / rc=0. The all-complete `SERVABLE — ... all N artifact(s)` line is chosen by asking the serving reader which artifacts it still cannot find, **never by asking what the run intended**, so no arrangement of half-done work reaches it. pgw#1533's read-back witness (a store object the run did not publish through) is untouched.
- `--only` now truncates the PRIORITY order rather than document order, so `--only 1 --first vae` composes instead of refusing.

## Evidence

27 tests in `tests/test_compile_servability.py`, driving the real `compile_all` — its work ledger, its store, its publish, its census — with only the inductor child seamed, plus the real `AdoptSession` (only the bytes->callable loader seamed) for the serving half.

**16 mutations, 16 caught:** ordering ignored · selector silently falling back to the default · document published last again · deferred gaps counted as fatal · promised gaps laundered as deferred · the all-complete line printed regardless · the presence short-circuit removed so a resume rebuilds · the fill never handed its specs · the fill child forgetting the resolved module name · a fill that will not start killing the run · no verdict written · the fill child not detached from this session · its output thrown away · `--only` truncating before `--first` resolves · an unmatched call refusing instead of serving eager · the late arm made a no-op.

The last two are the serving half and they are why deferring is safe: a request needing a specialization nobody has built yet runs the author's own forward, and the fill arms into the LIVE module with no reboot.

`detach` — the production runner — is exercised for real over a harmless argv rather than left as correct code no test path calls (pgw#1543's C1 class).

ruff clean, mypy clean, 12 fast-gates lints green (unreached surface, config reads, settings writers, incident test names, tcg vocabulary, retired cell/graph-class spellings, serving-process compiles, http timeouts, raw aoti load, phase enum emitters, fence symbols), changelog fragment gate green. Neighbours green: `test_runtime_mint`, `test_mint_publish_shape`, `test_compile_duration_th1322`, `test_compile_program_miss`, `test_mint_child_compile`, `test_self_mint_wiring`, `test_adopt_compile_attribution_pgw1262`, `test_forward_wrapper_signatures` — 80 passed.

## Deferred

The **acceptance measurement on the real verb** (cold sd1.5, foreground return time vs ~28 min) is a pending follow-up: the card is running the SDXL/anima benchmark campaign, and 13x111 s of niced multi-core inductor work would contaminate its timed compile legs. Slot granted after that queue drains; banked in the tracker.