### PR TITLE
pgw#1556: the volume fill hashed every byte twice and moved one object at a time — 2.8x median, 7.9x best

### DIFF
--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -29,6 +29,7 @@ import re
 import shutil
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, Sequence
 
@@ -42,7 +43,7 @@ from gen_worker._vendor.tensorfs import (
     RepositoryManifest,
     project_snapshot,
 )
-from gen_worker.transfer.grants import TransferGrant, download
+from gen_worker.transfer.grants import DEFAULT_PARALLEL, TransferGrant, download
 
 from .. import activity as _activity
 from .. import boot_phases
@@ -202,6 +203,34 @@ def _filter_resolved_components(
         files=[file for file in resolved.files if file.path in keep],
     )
 
+
+
+def _scan_fanout(
+    account: Callable[[TransferGrant], None],
+    grants: Sequence[TransferGrant],
+) -> None:
+    """Run the residency/fill verdict over every grant, `DEFAULT_PARALLEL`-wide.
+
+    pgw#1556. Called from ONE `asyncio.to_thread` rather than one per object,
+    so the event loop is released for the whole scan (unchanged, and the
+    reason the off-thread hop exists) while the objects themselves overlap.
+
+    A failure is never swallowed here: `account` already converts every
+    per-object verdict, including the failures, into `missing` — the fetch
+    that follows is the recovery. What must not happen is a thread dying with
+    an exception nobody reads, so the pool is drained by RESULT and the first
+    exception is re-raised at the caller, on the caller's thread.
+    """
+    width = max(1, min(DEFAULT_PARALLEL, len(grants)))
+    if width == 1:
+        for grant in grants:
+            account(grant)
+        return
+    with ThreadPoolExecutor(
+        max_workers=width, thread_name_prefix="fill-scan"
+    ) as pool:
+        for future in [pool.submit(account, grant) for grant in grants]:
+            future.result()
 
 def _manifest(files: Sequence[WorkerResolvedRepoFile]) -> RepositoryManifest:
     return RepositoryManifest(tuple(_manifest_entry(file) for file in files))
@@ -504,13 +533,36 @@ class CozySnapshotDownloader:
                 return False
 
         def filled(grant: TransferGrant) -> bool:
+            """Volume -> pod CAS, hashing every byte ONCE (pgw#1556).
+
+            This used to call `fill.verify_object` first, which reads and
+            SHA-256s the whole source purely to check it, and then handed the
+            same path to `put_file`, which reads it again and hashes it again
+            while copying. Two full hash passes over every byte on the exact
+            path the flagship 134 GB warm-volume boot runs down.
+
+            **Digest verification is NOT relaxed — it is deduplicated.**
+            `put_file(expected=..., size=...)` already hashes streaming
+            alongside the copy and raises `DigestMismatch` on any mismatch, and
+            it additionally fstats the source before and after to refuse a file
+            that changed mid-read. The deleted pass proved nothing the surviving
+            pass does not prove, one read earlier. Measured on this box over 48
+            synthetic 64 MiB objects (paired alternation, min of 3):
+            203.6 -> 348.9 MiB/s sequential, 1.71x, and it compounds with the
+            fan-out below.
+
+            `object_path` is presence-free by design, so a source that is not on
+            the volume raises `FileNotFoundError` out of `put_file`'s own open —
+            the same verdict `verify_object` used to return, from the layer that
+            was going to open the file anyway.
+            """
             if fill is None:
                 return False
             try:
-                source = fill.verify_object(grant.digest, size=grant.size_bytes)
+                source = fill.object_path(CASRef.parse(grant.digest))
                 cas.put_file(source, expected=grant.digest, size=grant.size_bytes)
                 return True
-            except (DigestMismatch, FileNotFoundError, OSError):
+            except (DigestMismatch, FileNotFoundError, OSError, ValueError):
                 return False
 
         # Every check re-hashes the object — ~1.0s of solid CPU per GiB WARM,
@@ -531,20 +583,72 @@ class CozySnapshotDownloader:
         filled_objects = 0
         filled_bytes = 0
         report_residency()
-        for grant in grants:
-            if await asyncio.to_thread(resident, grant):
-                done += grant.size_bytes
-                resident_objects += 1
-                resident_bytes += grant.size_bytes
-                settle(grant.digest, boot_phases.SOURCE_LOCAL)
-            elif await asyncio.to_thread(filled, grant):
-                done += grant.size_bytes
-                filled_objects += 1
-                filled_bytes += grant.size_bytes
-                settle(grant.digest, boot_phases.SOURCE_VOLUME)
+
+        # pgw#1556: ONE OBJECT AT A TIME was the whole cost model.
+        #
+        # `await asyncio.to_thread(...)` inside a `for` buys zero parallelism —
+        # it is awaited in the loop body, so exactly one object is ever in
+        # flight. Its purpose (above) is real and is preserved: keep the hash
+        # off the event loop so the heartbeat is not stranded. But the fetch
+        # path RIGHT BESIDE THIS ONE has run `DEFAULT_PARALLEL`-wide since
+        # pgw#1308, so the same pod that pulls 8 objects at once from R2 filled
+        # them from an attached volume strictly serially — and volume fill is
+        # the path the ops-side pre-warm exists to make fast.
+        #
+        # The work is `hashlib` + read + write, all of which release the GIL, so
+        # threads are real concurrency here rather than interleaving. Same width
+        # and the same constant as the transfer path: two fan-outs over one
+        # uplink and one disk should not be able to disagree about how wide the
+        # machine is.
+        #
+        # Measured on this box, 48 synthetic 64 MiB objects, paired alternation,
+        # min of 3 reps, against the REAL `LocalCAS`:
+        #
+        #     sequential + double hash (before)   203.6 MiB/s   1.00x
+        #     sequential + single hash            348.9 MiB/s   1.71x
+        #     8-wide     + single hash            880.3 MiB/s   4.32x
+        #
+        # ORDER IS NOT PRESERVED and does not need to be: `settle` is already
+        # lock-guarded and per-object, `missing` is drained by a fan-out
+        # downloader that reorders anyway, and the byte position is an
+        # AGGREGATE (`done`), not a cursor. What order DOES still buy is the
+        # ordering of `config.refs` one layer up (boot_materialize), which is
+        # untouched — a pod still finishes the 134 GB checkpoint before the
+        # 22 MB interpolator.
+        tally_lock = threading.Lock()
+
+        def account(grant: TransferGrant) -> None:
+            nonlocal done, resident_objects, resident_bytes
+            nonlocal filled_objects, filled_bytes
+            # The verdict is taken OUTSIDE the lock — it is the expensive part,
+            # and holding a mutex across a 64 MiB hash would rebuild the serial
+            # loop this replaces with extra steps.
+            if resident(grant):
+                source = boot_phases.SOURCE_LOCAL
+            elif filled(grant):
+                source = boot_phases.SOURCE_VOLUME
             else:
-                missing.append(grant)
-            report_residency()
+                source = ""
+            with tally_lock:
+                if source == boot_phases.SOURCE_LOCAL:
+                    done += grant.size_bytes
+                    resident_objects += 1
+                    resident_bytes += grant.size_bytes
+                elif source == boot_phases.SOURCE_VOLUME:
+                    done += grant.size_bytes
+                    filled_objects += 1
+                    filled_bytes += grant.size_bytes
+                else:
+                    missing.append(grant)
+                # Inside the lock so a slower thread can never publish a
+                # position an earlier one already passed: the hub advances on
+                # STRICT INCREASE and a regressing position reads as a wedge.
+                report_residency()
+            if source:
+                settle(grant.digest, source)
+
+        if grants:
+            await asyncio.to_thread(_scan_fanout, account, grants)
 
         # SIZE WHAT IS ACTUALLY WRITTEN, and nothing else. This arithmetic has
         # been wrong in both directions (pgw#1296(b)): it first sized only the

--- a/src/gen_worker/transfer/grants.py
+++ b/src/gen_worker/transfer/grants.py
@@ -19,7 +19,12 @@ from typing import Protocol
 from gen_worker._vendor.tensorfs.local import DigestMismatch, LocalCAS
 from gen_worker._vendor.tensorfs.refs import CASRef
 
-_DEFAULT_PARALLEL = 8
+#: How many objects one machine moves at once. ONE number for every fan-out
+#: this worker runs over its uplink and its disk: the R2 downloader below and
+#: (pgw#1556) the volume-fill scan in `models/cozy_snapshot`, which was serial
+#: while this path was 8-wide on the same pod. Public because a second copy of
+#: it in the other module is a second answer to "how wide is this machine".
+DEFAULT_PARALLEL = 8
 _PROCESS_TRANSFER_BUDGET = threading.BoundedSemaphore(16)
 _EXPIRY_MARGIN_SECONDS = 120.0
 _RFC3339_UTC = re.compile(
@@ -342,7 +347,7 @@ def _upload(
     source: LocalCAS,
     *,
     transport: _GrantTransport,
-    parallel: int = _DEFAULT_PARALLEL,
+    parallel: int = DEFAULT_PARALLEL,
     max_attempts: int = 5,
     sleep: Callable[[float], None] = time.sleep,
     progress: Callable[[CASRef, int], None] | None = None,
@@ -366,7 +371,7 @@ def upload(
     grants: Sequence[TransferGrant],
     source: LocalCAS,
     *,
-    parallel: int = _DEFAULT_PARALLEL,
+    parallel: int = DEFAULT_PARALLEL,
     max_attempts: int = 5,
     progress: Callable[[CASRef, int], None] | None = None,
 ) -> TransferReport:
@@ -387,7 +392,7 @@ def _download(
     destination: LocalCAS,
     *,
     transport: _GrantTransport,
-    parallel: int = _DEFAULT_PARALLEL,
+    parallel: int = DEFAULT_PARALLEL,
     max_attempts: int = 5,
     sleep: Callable[[float], None] = time.sleep,
     progress: Callable[[CASRef, int], None] | None = None,
@@ -424,7 +429,7 @@ def download(
     grants: Sequence[TransferGrant],
     destination: LocalCAS,
     *,
-    parallel: int = _DEFAULT_PARALLEL,
+    parallel: int = DEFAULT_PARALLEL,
     max_attempts: int = 5,
     progress: Callable[[CASRef, int], None] | None = None,
 ) -> TransferReport:

--- a/tests/test_managed_tier_fill_source.py
+++ b/tests/test_managed_tier_fill_source.py
@@ -19,7 +19,7 @@ import os
 from pathlib import Path
 
 from gen_worker._vendor.tensorfs import CASRef
-from gen_worker.transfer.grants import TransferReport
+from gen_worker.transfer.grants import DEFAULT_PARALLEL, TransferReport
 
 import projection_fixture
 import gen_worker.models.cozy_snapshot as snap_mod
@@ -157,6 +157,143 @@ def test_corrupt_volume_blob_falls_through_to_r2(tmp_path: Path, monkeypatch) ->
     assert projection_fixture.bytes_at(snap, "model.safetensors") == _PAYLOAD  # real bytes
     assert calls == [1]  # fell through to R2, not the corrupt volume copy
     assert scope.network_bytes == len(_PAYLOAD)
+
+
+# ---------------------------------------------------------------------------
+# pgw#1556 — HOW FAST the volume fill is, as behaviour rather than as a comment
+#
+# `test_corrupt_volume_blob_falls_through_to_r2` above is the revert-turns-red
+# guard for the RULING (digest verification of volume-read blobs is mandatory)
+# and it stays green through both changes below. That is the load-bearing fact:
+# the hash pass that was deleted proved nothing the surviving one does not.
+# ---------------------------------------------------------------------------
+
+
+def test_a_volume_fill_hashes_the_source_ONCE(tmp_path: Path, monkeypatch) -> None:
+    """Two full SHA-256 passes over every byte, on the flagship 134 GB path.
+
+    `filled()` called `fill.verify_object` — a whole-file read and hash whose
+    only product is a verdict — and then handed the same path to `put_file`,
+    which reads it again and hashes it again while copying. Measured on this
+    box over 48 synthetic 64 MiB objects through the REAL `LocalCAS` (paired
+    alternation, min of 3): 203.6 MiB/s with both passes, 348.9 MiB/s with one,
+    1.71x, before any fan-out.
+
+    The verification is not relaxed: `put_file(expected=..., size=...)` hashes
+    streaming alongside the copy and raises `DigestMismatch`, which is what
+    keeps the corrupt-blob test above green.
+    """
+    calls: list = []
+    _stub_r2(monkeypatch, calls)
+    volume = tmp_path / "volume"
+    local = tmp_path / "local"
+    blob = _blob(volume)
+    blob.parent.mkdir(parents=True, exist_ok=True)
+    blob.write_bytes(_PAYLOAD)
+
+    read_bytes = [0]
+    real_open = Path.open
+
+    def counting_open(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        handle = real_open(self, *args, **kwargs)
+        if self == blob and "r" in (args[0] if args else kwargs.get("mode", "r")):
+            class _Counted:
+                def __init__(self, inner): self._inner = inner
+                def read(self, *a):  # noqa: ANN
+                    data = self._inner.read(*a)
+                    read_bytes[0] += len(data)
+                    return data
+                def __getattr__(self, name): return getattr(self._inner, name)
+                def __enter__(self): self._inner.__enter__(); return self
+                def __exit__(self, *e): return self._inner.__exit__(*e)
+            return _Counted(handle)
+        return handle
+
+    monkeypatch.setattr(Path, "open", counting_open)
+
+    ref = TensorhubRef(owner="org", repo="model")
+    snap = asyncio.run(ensure_snapshot_async(
+        base_dir=local, ref=ref, resolved=_resolved(), fill_source_dir=volume,
+    ))
+    assert projection_fixture.bytes_at(snap, "model.safetensors") == _PAYLOAD
+    assert calls == []
+    assert read_bytes[0] == len(_PAYLOAD), (
+        "the volume source was read "
+        f"{read_bytes[0] / len(_PAYLOAD):.1f}x — a fill that hashes every byte "
+        "twice is half the throughput of one that hashes it once, on the one "
+        "path a staged endpoint volume exists to make fast")
+
+
+def test_the_residency_and_fill_scan_runs_MORE_THAN_ONE_OBJECT_AT_A_TIME(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """`await asyncio.to_thread(...)` inside a `for` buys zero parallelism.
+
+    It is awaited in the loop body, so exactly one object is ever in flight —
+    while the R2 fetch on the very same pod has run `DEFAULT_PARALLEL`-wide
+    since pgw#1308. The barrier below is the proof, and it is the honest one:
+    if the scan is serial, no two objects are ever inside it at once and the
+    barrier times out rather than the test passing on a timing coincidence.
+    """
+    import threading as _threading
+
+    calls: list = []
+    _stub_r2(monkeypatch, calls)
+    volume = tmp_path / "volume"
+    local = tmp_path / "local"
+    payloads = [_PAYLOAD + bytes([i]) for i in range(DEFAULT_PARALLEL)]
+    files = []
+    for body in payloads:
+        digest = hashlib.sha256(body).hexdigest()
+        blob = _blob_at(volume, digest)
+        blob.parent.mkdir(parents=True, exist_ok=True)
+        blob.write_bytes(body)
+        files.append(WorkerResolvedRepoFile(
+            path=f"shard-{digest[:8]}.safetensors",
+            size_bytes=len(body),
+            digest="sha256:" + digest,
+            url="https://tensorhub.invalid/authorized-blob",
+        ))
+    resolved = WorkerResolvedRepo(snapshot_digest="d9" * 32, files=files)
+
+    barrier = _threading.Barrier(len(payloads), timeout=15.0)
+    peak = [0]
+    live = [0]
+    guard = _threading.Lock()
+    real_put_file = snap_mod.LocalCAS.put_file
+
+    def gated_put_file(self, source, **kwargs):  # type: ignore[no-untyped-def]
+        with guard:
+            live[0] += 1
+            peak[0] = max(peak[0], live[0])
+        try:
+            # Every object must be inside the scan simultaneously, or this
+            # raises BrokenBarrierError and the test names the reason.
+            barrier.wait()
+        except _threading.BrokenBarrierError as exc:  # pragma: no cover
+            raise AssertionError(
+                "the residency/fill scan is SERIAL: fewer than "
+                f"{len(payloads)} objects were ever in flight at once "
+                f"(peak {peak[0]}). One object at a time is the whole of the "
+                "134 GB warm-volume boot's cost model."
+            ) from exc
+        finally:
+            with guard:
+                live[0] -= 1
+        return real_put_file(self, source, **kwargs)
+
+    monkeypatch.setattr(snap_mod.LocalCAS, "put_file", gated_put_file)
+
+    ref = TensorhubRef(owner="org", repo="model")
+    snap = asyncio.run(ensure_snapshot_async(
+        base_dir=local, ref=ref, resolved=resolved, fill_source_dir=volume,
+    ))
+    assert calls == [], "every object came off the volume; nothing hit R2"
+    assert peak[0] == len(payloads), (
+        f"peak concurrency was {peak[0]}, expected {len(payloads)}")
+    for body in payloads:
+        digest = hashlib.sha256(body).hexdigest()
+        assert projection_fixture.bytes_at(snap, f"shard-{digest[:8]}.safetensors") == body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_snapshot_residency_progress_pgw1289.py
+++ b/tests/test_snapshot_residency_progress_pgw1289.py
@@ -81,13 +81,10 @@ def test_a_resident_grant_advances_progress_before_the_scan_finishes(
     )
 
     total = len(first) + len(second)
-    caller = threading.current_thread()
     beats: list[tuple[int, int | None]] = []
-    threads: list[threading.Thread] = []
 
     def progress(done: int, reported: int | None) -> None:
         beats.append((done, reported))
-        threads.append(threading.current_thread())
         # The gate opens on a RECORDED mid-scan beat, so it cannot be satisfied
         # by the leading 0/total or by the final one.
         if 0 < done < total:
@@ -106,7 +103,17 @@ def test_a_resident_grant_advances_progress_before_the_scan_finishes(
     assert beats[-1] == (total, total)
     # And it moved while the scan was still running.
     assert any(0 < done < total for done, _total in beats)
-    assert set(threads) == {caller}
+    # pgw#1556: the scan is now `DEFAULT_PARALLEL`-wide, so this used to assert
+    # `set(threads) == {caller}` and cannot any more. What that line was really
+    # protecting is the POSITION, and the position is protected properly now:
+    # the hub advances on STRICT INCREASE, so a beat that arrives out of order
+    # renders a healthy transfer as a wedge. `_ensure_objects` emits under the
+    # tally lock, which makes `done` monotone across every scan thread — a
+    # stronger guarantee than single-threadedness, and one the R2 half of this
+    # same fetch never had (`_progress`'s own docstring: "Called from the fetch
+    # thread", `DEFAULT_PARALLEL`-wide, since pgw#1308).
+    assert [done for done, _t in beats] == sorted(done for done, _t in beats), (
+        f"the reported position went BACKWARDS across scan threads: {beats}")
 
 
 def test_the_scan_yields_the_event_loop_between_grants(
@@ -120,6 +127,16 @@ def test_the_scan_yields_the_event_loop_between_grants(
     ends — measured at 1.0 s of blocked loop per GiB scanned, on a warm page
     cache. This pins the yield: a ticker task must observe wall time passing
     while the scan is still in flight.
+
+    **pgw#1556 widened the mechanism and this test's PROBE had to follow.** The
+    scan runs `DEFAULT_PARALLEL`-wide inside ONE `to_thread`, so the loop is
+    free for the whole scan rather than for a turn between grants — strictly
+    more of the property this test exists for. The old probe asked whether a
+    tick landed between the FIRST and LAST `contains` ENTRY, and under a
+    fan-out every entry happens at once, so that window closes to ~0 µs and the
+    probe reports failure over an improvement. The window is now entry-of-first
+    to RETURN-of-last, which is the interval "while the scan is in flight"
+    actually names.
     """
 
     bodies = [b"grant-%d" % index for index in range(4)]
@@ -127,13 +144,17 @@ def test_the_scan_yields_the_event_loop_between_grants(
     digests = [store.put_bytes(body) for body in bodies]
     ticks: list[float] = []
     scanned: list[float] = []
+    finished: list[float] = []
 
     real_contains = LocalCAS.contains
 
     def slow_contains(self: Any, ref: Any, *, size: int | None = None) -> bool:
         scanned.append(time.monotonic())
         time.sleep(0.05)
-        return real_contains(self, ref, size=size)
+        try:
+            return real_contains(self, ref, size=size)
+        finally:
+            finished.append(time.monotonic())
 
     monkeypatch.setattr(LocalCAS, "contains", slow_contains)
 
@@ -170,8 +191,10 @@ def test_the_scan_yields_the_event_loop_between_grants(
     asyncio.run(scenario())
 
     assert len(scanned) == len(bodies)
-    assert any(scanned[0] < tick < scanned[-1] for tick in ticks), (
-        "the event loop never ran between residency checks — every heartbeat "
-        "and every queued progress event is stranded for the whole scan "
-        f"(scan {scanned[0]:.3f}..{scanned[-1]:.3f}, ticks {ticks})"
+    assert len(finished) == len(bodies)
+    first_entry, last_return = min(scanned), max(finished)
+    assert any(first_entry < tick < last_return for tick in ticks), (
+        "the event loop never ran WHILE the residency scan was in flight — "
+        "every heartbeat and every queued progress event is stranded for the "
+        f"whole scan (scan {first_entry:.3f}..{last_return:.3f}, ticks {ticks})"
     )


### PR DESCRIPTION
The path a staged endpoint volume exists to make fast was the slowest thing in
the boot, for two reasons that are both visible in nine lines of
`_ensure_objects`.

**It hashed every byte twice.** `filled()` called `fill.verify_object`, which
reads and SHA-256s the whole source and returns a verdict, and then handed the
same path to `put_file`, which reads it again and hashes it again while
copying. **It moved one object at a time.** `await asyncio.to_thread(...)`
inside a `for` buys zero parallelism — it is awaited in the loop body — while
the R2 fetch on the very same pod has run `DEFAULT_PARALLEL`-wide since
pgw#1308. So a pod that pulls eight objects at once from the internet filled
them from an attached local volume strictly serially, hashing each one twice.

## Measured, end to end, through `ensure_snapshot_async`

3.00 GiB of synthetic random bytes in 48 objects at the 64 MiB grid, real
`LocalCAS`, real projection, fill source populated and no R2 reachable. Seven
paired-alternation reps (master, branch, master, branch, ...) so run order
cannot manufacture a winner — the box was shared with other lanes at load 20+,
which is what the spread is:

    BEFORE  19.74 19.95 18.63 17.68 20.04 41.52 13.63 s   median 19.74s  155.6 MiB/s
    AFTER    7.53  7.32  1.94  6.97  1.73  2.28  8.90 s   median  6.97s  441.0 MiB/s

    median   2.83x     best-of-7  13.63s -> 1.73s = 7.9x

Isolated against `LocalCAS` alone (48 x 64 MiB, paired, min of 3), the two
levers separate cleanly:

    sequential + double hash (before)   203.6 MiB/s   1.00x
    sequential + single hash            348.9 MiB/s   1.71x
    8-wide     + single hash            880.3 MiB/s   4.32x

Projected onto the flagship warm-volume case at the MEDIAN rates, 134 GB goes
from ~14.7 min to ~5.2 min of fill.

## Digest verification is deduplicated, NOT relaxed

`put_file(expected=..., size=...)` already hashes streaming alongside the copy
and raises `DigestMismatch`, and it fstats the source before and after to
refuse a file that changed mid-read. The deleted pass proved nothing the
surviving pass does not prove, one read earlier. The proof is that
`test_corrupt_volume_blob_falls_through_to_r2` — the revert-turns-red guard for
Paul's mandatory-verification ruling, a same-SIZE wrong-content volume blob —
stays green through both changes without being touched.

## Order, and what actually depended on it

Nothing did. `settle` was already lock-guarded and per-object, `missing` is
drained by a fan-out downloader that reorders anyway, and the byte position is
an AGGREGATE, not a cursor. The ordering that IS load-bearing — `config.refs`
order, so a pod finishes the 134 GB checkpoint before the 22 MB interpolator —
lives a layer up in `boot_materialize` and is untouched.

The position is protected properly rather than accidentally: emission happens
under the tally lock, so `done` is monotone across every scan thread. The hub
advances on STRICT INCREASE, so a beat that arrives out of order renders a
healthy transfer as a wedge — and this is a stronger guarantee than the
single-threadedness it replaces, which the R2 half of the same fetch never had
(`_progress`'s own docstring: "Called from the fetch thread").

`_DEFAULT_PARALLEL` becomes `DEFAULT_PARALLEL`: two fan-outs over one uplink
and one disk must not be able to disagree about how wide the machine is.

## What is NOT in here, and why

`resident()`'s `cas.contains()` is a full SHA-256 re-hash of every
already-present object on every boot (~913 MiB/s measured here, so ~150 s of
pure CPU per 134 GiB warm boot). Upstream tensorfs SOLVED this — canonical
`LocalCAS.contains` is one `lstat`, "presence, not integrity", with
`verify_object` kept as the scrub — but the vendored snapshot predates it and
`_vendor` is digest-fenced at a rev whose bump would delete symbols with no
successor (VENDORED.toml). More to the point it is not a free win here: a
PROJECTED tree is verified structurally and never hashed (pgw#1308), so this
re-hash is currently the only digest-level check on pod-local CAS objects at
boot. Dropping it is a correctness-vs-speed trade, not an optimization. Filed
as pgw#1557 with the numbers; it wants a ruling, not a lane.

Red/green: both new cases fail on `ee09d0cd` with the measurement in the
message ("the volume source was read 2.0x", "the scan is SERIAL ... peak 1")
and pass here; 76 green across nine snapshot/fill/boot files.
`test_snapshot_residency_progress_pgw1289`'s two cases pinned the OLD mechanism
(caller-thread emission; a tick between two ENTRIES) while asserting invariants
this change strengthens, and now assert the invariants: the position never goes
backwards, and the loop runs while the scan is IN FLIGHT. Pinned ruff 0.15.21
clean over all of `src/gen_worker`; whole-src mypy identical SET to master
(93 = 93, zero new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)