### PR TITLE
pgw#1561: the publish banks the ENVELOPE, and the witness LOADS what it certifies

### DIFF
--- a/changelog.d/pgw1561-envelope-publish.md
+++ b/changelog.d/pgw1561-envelope-publish.md
@@ -1,0 +1,14 @@
+- **pgw#1561: the v2 artifact band was NEVER loadable by adoption — the
+  publisher banked the bare `model.pt2` ZIP, the boot loader reads the tar+gzip
+  envelope.** Latent since publishing existed (pgw#1471); va#3 arm 2 was the
+  first real-loader exercise and holed 14/14 as `cannot decompress`, minutes
+  after `SERVABLE` was printed over the same store. `publish_compiled` now
+  repacks the ENVELOPE from the unpacked artifact (deterministic, validated
+  against the package, carrying the metadata and literals the bare ZIP
+  discarded — and byte-identical to the engine cache's object, so the CAS
+  dedups the bands). torchcg tcg#75: a ZIP in the envelope band raises typed
+  `ArtifactFormatSkew` (re-publish, not re-mint) and an envelope REPLACES a
+  skewed incumbent at publish. `compile` treats a present-but-skewed position
+  as a miss so a warm run repairs it, its census probes every position's shape
+  (two magic bytes), and the pgw#1533 read-back now MATERIALIZES fetched bytes
+  through the real loader — presence-only certification is what let this ship.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,7 +696,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "2a38ff2be91e2823b311f31b9f665048b7d0db55" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "7f927a42f434bb27e548d7c81dc4776c89af003c" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -306,7 +306,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "2a38ff2be91e2823b311f31b9f665048b7d0db55"
+rev = "7f927a42f434bb27e548d7c81dc4776c89af003c"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -511,18 +511,18 @@ rewrites = [
 "writer.py" = "f44e74d983d2f642e8479f85a3682bb737dd76ffbd62c3fe7d684ae5c0c71ca1"
 
 [packages.torchcg.files]
-"__init__.py" = "0948c32c9e5f3772bc0995855a0b1acdcba5f75f7c4733eae5a3ae841915459e"
+"__init__.py" = "14bbdb65947b78fff1a6a1e1230e8aac7173609d536bc0827750d054cc82eda9"
 "__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
 "_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
 "_wrapper_split.py" = "1d5a3bc1ccabadeaa2b8b54f1492cba10723e53074a0022b8c7453565a86a4ce"
 "adopt.py" = "7cc8965a48e9f2ea5867e80ccc3dec506d33fe86896de37528a6652fe80c19e9"
-"artifact.py" = "fb8c1ad62b94abb075915fd8e58514c740f03ec5f8384a5ab97c17917b8061e5"
+"artifact.py" = "5b61f1b0d06d01b733d55ac123190da5e6a33ea2ec8663402a49e80bfb567a62"
 "cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
 "compiler.py" = "6ee54b26286b215eef8867dffb133d023a6808379574ac69f8007a64c477045a"
-"contracts/KEY_GRAMMAR_DIGEST" = "0503f3251f2eb48b794961736f021915cd56c14930798ac844c90112fa2af69d"
+"contracts/KEY_GRAMMAR_DIGEST" = "2ff20e741b25779e73158a884222922d60446b680a1584e771845f05614e7ab3"
 "contracts/__init__.py" = "9693f0ebc4672ef35d6b56b8973022e268de89d7456ed0fae8e218461360381d"
 "contracts/call_ingress_v1.json" = "3af3437ec20b15156892055ab89bf21621378cee9f0f72f63bc4626f69f242dc"
-"contracts/compiled_graph_key_vectors.json" = "a274c5702b8c167ca119758d9fb1f98c40ddfdb3dbf6c58b4aacd580803e8c2b"
+"contracts/compiled_graph_key_vectors.json" = "5dcadf72b8ce19086e1a95bb767252e5b6521e74721aefa518dbd810112db15f"
 "contracts/graph_specialization_identity_v4.json" = "295b1281b339e97a986719c7ad17e362e68f97930e98cfeffd60e693d10aab48"
 "contracts/ingress_selection_v1.json" = "28e2c5922f5be4d336d1d53299e190bfdf322dec6e2d9284954da14939e2de4a"
 "contracts/literal_identity_v1.json" = "50cb80e750a8124a45b982415258d8590c37f90ca804326588dfde1b368c6863"
@@ -548,5 +548,5 @@ rewrites = [
 "serve.py" = "a1f3b6fe5e46305bc9aea9848ac5935537b7bb37e2586ae3f0393f66cead2ade"
 "spans.py" = "4776fac2006967b1f17ffcbec03e50147d511120fd50cf085ac3b6b4702e5539"
 "storage.py" = "6e1e94523ee9c1449538aa57dbfaf8e20e24997d09297b3fd09cc88d17d02354"
-"store.py" = "29570d7013fadbdc593c86d2f553fcfc81f24b04d925381f0b68beef5836614c"
+"store.py" = "a294417b552371d8e5f50307021afb23cc1809dfda8761cc59a00dced8b42670"
 "transform.py" = "34a82af6cbf7def844730b0a21416e478e81684b92480b6055d177d5f3219071"

--- a/src/gen_worker/_vendor/torchcg/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/__init__.py
@@ -7,7 +7,12 @@ from .adopt import (
     Hole,
     UnclaimedMark,
 )
-from .artifact import ARTIFACT_METADATA_FIELDS, COMPILED_GRAPH_FORMAT, ArtifactError
+from .artifact import (
+    ARTIFACT_METADATA_FIELDS,
+    COMPILED_GRAPH_FORMAT,
+    ArtifactError,
+    ArtifactFormatSkew,
+)
 from .compiler import CompileError
 from .declaration import (
     GRAPH_INTERFACE_FORMAT,
@@ -195,6 +200,7 @@ __all__ = [
     "AdoptSession",
     "ArtifactCandidate",
     "ArtifactError",
+    "ArtifactFormatSkew",
     "ArtifactLoader",
     "CompileError",
     "COMPILED_GRAPH_FORMAT",

--- a/src/gen_worker/_vendor/torchcg/artifact.py
+++ b/src/gen_worker/_vendor/torchcg/artifact.py
@@ -132,6 +132,18 @@ class ArtifactError(ValueError):
     """A compiled-graph envelope is malformed or internally inconsistent."""
 
 
+class ArtifactFormatSkew(ArtifactError):
+    """The bytes are a recognizable NON-envelope format, not corruption.
+
+    tcg#75 / pgw#1561: a publisher banked the bare AOTI ``.pt2`` package (a
+    ZIP) where the reader serves the tar+gzip envelope, and for as long as the
+    two shared one exception the field failure read as "corrupted at rest" —
+    sending operators to scrub disks over a wiring defect. A skew's remedy is
+    RE-PUBLISH through a correct publisher; corruption's is re-mint. Different
+    remedies, so a different type.
+    """
+
+
 def _fsync_dir(path: Path) -> None:
     descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
     try:
@@ -652,6 +664,23 @@ def verify_package(package: str | Path, metadata: Mapping[str, Any]) -> None:
 
 
 def _validate_single_gzip_member(artifact: Path) -> None:
+    try:
+        with artifact.open("rb") as sniff:
+            magic = sniff.read(4)
+    except OSError as exc:
+        raise ArtifactError(f"cannot read artifact {artifact}: {exc}") from exc
+    if magic[:4] == b"PK\x03\x04":
+        # A ZIP is the bare AOTI package, not the envelope — a publisher-side
+        # format skew (tcg#75/pgw#1561), never bytes rotting at rest. Named
+        # BEFORE the gzip decode so the refusal states the remedy instead of
+        # "cannot decompress".
+        raise ArtifactFormatSkew(
+            f"artifact {artifact} is a bare AOTI .pt2 package (ZIP), not the "
+            f"compiled-graph envelope (tar+gzip with metadata.json) — a "
+            f"publisher banked the package file instead of the envelope. "
+            f"Re-publish through a current publisher; the bytes are not "
+            f"corrupt, they are the wrong artifact shape."
+        )
     decoder = zlib.decompressobj(wbits=16 + zlib.MAX_WBITS)
     uncompressed = 0
     try:

--- a/src/gen_worker/_vendor/torchcg/contracts/KEY_GRAMMAR_DIGEST
+++ b/src/gen_worker/_vendor/torchcg/contracts/KEY_GRAMMAR_DIGEST
@@ -3,4 +3,4 @@
 # its own byte-identical copy; scripts/grammar-vector-drift.sh proves the two
 # files are equal. Changing the corpus is a coupled cross-repo cut: pgw lands
 # first, then both digests move in one window.
-a274c5702b8c167ca119758d9fb1f98c40ddfdb3dbf6c58b4aacd580803e8c2b
+5dcadf72b8ce19086e1a95bb767252e5b6521e74721aefa518dbd810112db15f

--- a/src/gen_worker/_vendor/torchcg/contracts/compiled_graph_key_vectors.json
+++ b/src/gen_worker/_vendor/torchcg/contracts/compiled_graph_key_vectors.json
@@ -3,7 +3,7 @@
   "grammar": "<scheme>-<56 lowercase hex>, whole token <= 96 bytes of [a-z0-9][a-z0-9._-]*",
   "authorities": [
     "tensorhub internal/orchestrator/compilecache.IsCompiledGraphKey",
-    "python-gen-worker gen_worker.cell_key.is_key"
+    "python-gen-worker gen_worker._vendor.torchcg.identity.is_compiled_graph_key"
   ],
   "note": "This file is the CONTRACT between the two, vendored byte-identically in python-gen-worker (tests/testdata/) and fenced by scripts/grammar-vector-drift.sh. th#1897 exists because there was no such file: both implementations were internally consistent, they disagreed about `cg-key-v1`, and nothing in either CI could see it \u2014 the first mint on the new scheme would have compiled for 45+ minutes and been refused at publish. A change to either implementation that is not a change to this file is the same defect again.",
   "vectors": [
@@ -130,7 +130,7 @@
     {
       "key": "root/family-sdxl#cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
       "valid": false,
-      "note": "A cell REF is not a key; KeyRef composes them, KeyFromRef splits them."
+      "note": "A compiled-graph REF is not a key; KeyRef composes them, KeyFromRef splits them."
     },
     {
       "key": "manifest-7692c3ad3540bb803c020b3aee66cd8887123234",

--- a/src/gen_worker/_vendor/torchcg/store.py
+++ b/src/gen_worker/_vendor/torchcg/store.py
@@ -390,6 +390,34 @@ class LocalGraphStore:
     def has_artifact(self, graph: str, env: EnvIdentity) -> bool:
         return self.cas.read_ref(_artifact_ref(graph, env)) is not None
 
+    def artifact_skew(self, graph: str, env: EnvIdentity) -> str | None:
+        """A sentence when the stored blob is a recognizable NON-envelope, else
+        ``None`` — the census-grade shape probe (tcg#75/pgw#1561).
+
+        Two magic bytes, not a decode: a per-boot census over every position
+        must stay proportional to positions, not to artifact bytes. Absence is
+        ``None`` here — ``has_artifact`` owns that question — and full
+        verification stays where it always was, on the fetch path.
+        """
+
+        ref = self.cas.read_ref(_artifact_ref(graph, env))
+        if ref is None:
+            return None
+        try:
+            with self.cas.object_path(ref).open("rb") as handle:
+                magic = handle.read(4)
+        except (OSError, ValueError):
+            return None  # unreadable-at-rest is the fetch path's verdict
+        if magic[:2] == b"\x1f\x8b":
+            return None
+        if magic == b"PK\x03\x04":
+            return (
+                "stored blob is a bare AOTI .pt2 package (ZIP), not the "
+                "compiled-graph envelope — published by a pre-envelope "
+                "publisher; re-publish"
+            )
+        return "stored blob is not a compiled-graph envelope (unknown format)"
+
     def fetch_artifact(self, graph: str, env: EnvIdentity, destination: str | Path) -> Path | None:
         ref = self.cas.read_ref(_artifact_ref(graph, env))
         if ref is None:
@@ -443,6 +471,33 @@ class LocalGraphStore:
             if current == candidate:
                 self._ensure_manifest(graph, env, manifest_candidate)
                 return PublishOutcome.PRESENT
+            if self._envelope_supersedes(current, source):
+                # tcg#75 / pgw#1561: the occupied position holds bytes NO
+                # reader of this store can load — the bare `.pt2` package a
+                # pre-envelope publisher banked. That is not a diverged mint;
+                # it is a shape this store's own loaders refuse by type
+                # (`ArtifactFormatSkew`), so under tcg#69's doctrine the
+                # incumbent is ABSENT-equivalent derived bytes and an envelope
+                # replaces it. A real envelope-vs-envelope divergence still
+                # refuses below.
+                try:
+                    self.cas.compare_and_swap_ref(ref_name, candidate, expected=current)
+                except RefConflict:
+                    if self.cas.read_ref(ref_name) != candidate:
+                        raise StoreError(
+                            f"artifact position ({graph}, {env.value}) moved "
+                            f"during envelope repair"
+                        ) from None
+                reclaimed = self._discard_object(current)
+                logger.warning(
+                    "torchcg: REPLACED artifact (%s, %s) — the position held a "
+                    "non-envelope blob (a bare package from a pre-envelope "
+                    "publisher, unloadable by every reader of this store); the "
+                    "envelope now stands. Reclaimed %d byte(s).",
+                    graph, env.value, reclaimed,
+                )
+                self._ensure_manifest(graph, env, manifest_candidate)
+                return PublishOutcome.PUBLISHED
             raise StoreError(
                 f"artifact position ({graph}, {env.value}) already holds "
                 f"different bytes; a deterministic mint diverged"
@@ -459,6 +514,29 @@ class LocalGraphStore:
             ) from None
         self._ensure_manifest(graph, env, manifest_candidate)
         return PublishOutcome.PUBLISHED
+
+    def _envelope_supersedes(self, incumbent: CASRef, candidate_file: Path) -> bool:
+        """Whether ``candidate_file`` is a gzip envelope while the incumbent
+        object is NOT — the one migration this store performs (tcg#75).
+
+        Sniffed off magic bytes, never decoded here: the candidate is fully
+        verified on the way out by every reader, and the incumbent needs only
+        to be recognized as unloadable-by-shape. An incumbent whose object is
+        MISSING counts too — a live ref over absent bytes fails every fetch,
+        so replacing it with verified bytes is a repair, not an arbitration.
+        """
+
+        try:
+            with Path(candidate_file).open("rb") as handle:
+                if handle.read(2) != b"\x1f\x8b":
+                    return False
+        except OSError:
+            return False
+        try:
+            with self.cas.object_path(incumbent).open("rb") as handle:
+                return handle.read(2) != b"\x1f\x8b"
+        except (OSError, ValueError):
+            return True
 
     def _ensure_manifest(self, graph: str, env: EnvIdentity, candidate: CASRef) -> None:
         """First manifest wins; an interrupted earlier publish is repaired."""

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -603,7 +603,58 @@ def unservable(cas_root: Path, specs: Tuple[Spec, ...], env: Any, module: str) -
             gaps.append(Gap(
                 spec.graph,
                 f"artifact {spec.short}: absent at ({spec.short}, {env.value})"))
+            continue
+        # PRESENCE IS NOT LOADABILITY (pgw#1561). For as long as this census
+        # stopped at `has_artifact`, a store full of bare `.pt2` ZIPs — bytes
+        # the adopt loader refuses by TYPE — printed `SERVABLE`, and va#3
+        # arm 2 paid the difference: 0/14 armed over 14 present positions. The
+        # probe is two magic bytes per position (`artifact_skew`), so the
+        # fully-warm census stays proportional to positions, not bytes; the
+        # full open-through-the-real-loader proof runs where bytes change, in
+        # :func:`witness_materializes` on every publish.
+        try:
+            skew = reader.artifact_skew(spec.graph, env)
+        except Exception as exc:  # noqa: BLE001 — an unreadable probe is a gap
+            skew = f"format probe failed ({exc})"
+        if skew:
+            gaps.append(Gap(spec.graph, f"artifact {spec.short}: {skew}"))
     return gaps
+
+
+def witness_materializes(cas_root: Path, graph: str, env: Any) -> Optional[str]:
+    """Fetch through the store adoption uses and OPEN through the real loader.
+
+    ``None`` means the artifact will load at boot; a sentence names why it
+    will not. This is the [[pgw#1533]] read-back with its blind spot removed
+    (pgw#1561): `has_artifact` proved presence, and presence was never the
+    gap — the freshly-built probe artifact of 2026-08-20 09:22 was PRESENT,
+    `SERVABLE` was printed, and its bytes were a ZIP no loader opens. So the
+    witness now materializes the fetched bytes with ``torchcg.serve
+    .materialize`` — the exact function boot-time arming calls — and only
+    that is allowed to say servable.
+
+    Runs once per PUBLISHED artifact (14 × ~0.3 s on a full sd15 backfill),
+    never on the warm present path — the census's two-byte skew probe covers
+    that at position cost.
+    """
+    import tempfile
+
+    from .._vendor.torchcg.serve import materialize
+
+    reader = serving_reader(cas_root)
+    with tempfile.TemporaryDirectory(prefix="pgw1561-witness-") as raw:
+        destination = Path(raw) / "artifact"
+        try:
+            fetched = reader.fetch_artifact(graph, env, destination)
+        except Exception as exc:  # noqa: BLE001 — a failed fetch is the verdict
+            return f"fetch through the adoption store failed: {exc}"
+        if fetched is None:
+            return f"absent at ({graph[:16]}, {env.value})"
+        try:
+            materialize(fetched, Path(raw) / "unpacked")
+        except Exception as exc:  # noqa: BLE001 — an unloadable blob is the verdict
+            return f"fetched but does not MATERIALIZE ({type(exc).__name__}: {exc})"
+    return None
 
 
 def _publish_document(cas_root: Path, lock_path: Path, module: str) -> None:
@@ -861,14 +912,34 @@ def compile_all(
     module = module or endpoint_module(endpoint_dir)
 
     def _known_present(spec: Spec) -> bool:
+        """Present AND shaped like something a boot can load (pgw#1561).
+
+        A position holding a bare-package blob from a pre-envelope publisher
+        answered ``has_artifact`` TRUE, so every run short-circuited past the
+        one thing that could repair it — the re-publish. A skewed position is
+        a MISS here, which is exactly what routes it back through the publish
+        (whose store-side migration arm replaces the skewed incumbent).
+        """
         try:
-            return bool(store.has_artifact(spec.graph, env))
+            if not store.has_artifact(spec.graph, env):
+                return False
         except Exception as exc:  # noqa: BLE001 — a store miss is not fatal
             logger.warning(
                 "%s: store lookup failed (%s); treating as a miss",
                 spec.short, exc,
             )
             return False
+        try:
+            skew = serving_reader(cas_root).artifact_skew(spec.graph, env)
+        except Exception:  # noqa: BLE001 — probe absence never blocks a run
+            return True
+        if skew:
+            logger.warning(
+                "%s: present but NOT loadable (%s) — treating as a miss so the "
+                "publish path replaces it", spec.short, skew,
+            )
+            return False
+        return True
 
     reuse = _EngineReuse(Path(cas_root), sm)
 
@@ -948,19 +1019,19 @@ def compile_all(
         across two processes it is the ONLY thing that could be.
         """
         started = time.monotonic()
-        try:
-            if store.has_artifact(spec.graph, env):
-                logger.info("%s: present", label)
-                return Outcome(spec, PRESENT, wall_s=time.monotonic() - started)
-        except Exception as exc:  # noqa: BLE001 — a store miss is not fatal
-            logger.warning("%s: store lookup failed (%s); treating as a miss", label, exc)
+        if _known_present(spec):
+            logger.info("%s: present", label)
+            return Outcome(spec, PRESENT, wall_s=time.monotonic() - started)
 
         destination = artifacts_dir / spec.short
         try:
             with work_ledger.lease(Path(cas_root), f"{spec.graph}/{env.value}"):
                 # Re-check under the lease: the holder we queued behind may
-                # have landed exactly this artifact while we waited.
-                if store.has_artifact(spec.graph, env):
+                # have landed exactly this artifact while we waited. The same
+                # loadability gate as everywhere (pgw#1561): a present-but-
+                # skewed position must fall THROUGH to the publish that
+                # replaces it, never short-circuit as done.
+                if _known_present(spec):
                     logger.info("%s: present (landed while claimed)", label)
                     return Outcome(spec, PRESENT, wall_s=time.monotonic() - started)
                 # REUSE BEFORE BUILD (pgw#1546): the engine cache may already
@@ -982,14 +1053,18 @@ def compile_all(
                 # The reuse arm runs the SAME two steps — a resolve that never
                 # reached the serving band is the original defect exactly.
                 published = publish_compiled(store, spec.graph, env, artifact)
-                if not serving_reader(cas_root).has_artifact(spec.graph, env):
+                # The read-back MATERIALIZES (pgw#1561): `has_artifact` here
+                # certified fourteen ZIPs no loader opens, on the strength of
+                # their refs existing. Only bytes the real loader opens count.
+                problem = witness_materializes(cas_root, spec.graph, env)
+                if problem is not None:
                     raise CompileError(
                         f"{state} {spec.short} and the publish reported "
-                        f"{published or 'nothing'}, and the store adoption "
-                        f"reads at boot still has no artifact at "
-                        f"({spec.short}, {env.value}). The build is not the "
-                        f"deliverable — an artifact the serving reader can "
-                        f"find is."
+                        f"{published or 'nothing'}, and through the store "
+                        f"boot-time adoption reads the artifact is NOT "
+                        f"loadable: {problem}. The build is not the "
+                        f"deliverable — an artifact the serving loader can "
+                        f"OPEN is."
                     )
                 logger.info(
                     "%s: %s and servable (%s)", label, state,
@@ -1365,6 +1440,7 @@ __all__ = [
     "select",
     "serving_reader",
     "specializations",
+    "witness_materializes",
     "summarize",
     "unservable",
 ]

--- a/src/gen_worker/serving/mint.py
+++ b/src/gen_worker/serving/mint.py
@@ -744,6 +744,57 @@ def artifact_manifest(env: Any, package: Path) -> Any:
     )
 
 
+def artifact_envelope(artifact: Path, workspace: Path) -> Path:
+    """The tar+gzip ENVELOPE these bytes publish as (pgw#1561).
+
+    An unpacked artifact DIRECTORY (``metadata.json`` + ``model.pt2``
+    [+ ``constants.safetensors``]) is repacked with torchcg's own
+    DETERMINISTIC ``pack_artifact`` — which also validates the metadata
+    against the package on the way, so a publish is now a conformance proof
+    rather than a byte copy, and a re-publish of the same members is
+    byte-identical (idempotent ``present``, and the same object the engine
+    cache already holds, so the CAS dedups the two bands for free).
+
+    A FILE that already carries the gzip magic passes through as the envelope
+    it is. ANY other file — above all the bare ``model.pt2`` ZIP — is a typed
+    refusal: pgw#1561 is fourteen adoptions holing on ``cannot decompress``
+    because the pre-envelope publisher banked exactly that ZIP, `SERVABLE` on
+    its lips, and a publisher that can be handed a package and quietly bank it
+    is the same defect waiting to be re-introduced.
+    """
+    from .._vendor.torchcg.artifact import pack_artifact
+
+    source = Path(artifact)
+    if source.is_file():
+        with source.open("rb") as handle:
+            if handle.read(2) == b"\x1f\x8b":
+                return source
+        raise ArtifactUnreadable(
+            f"{source} is a file but not a compiled-graph envelope — a bare "
+            f"package cannot be published (pgw#1561: the serving loader reads "
+            f"the ENVELOPE, and a package file carries no metadata to build "
+            f"one from). Hand the unpacked artifact DIRECTORY instead."
+        )
+    if not source.is_dir():
+        raise ArtifactUnreadable(f"{source} is neither a file nor a directory")
+    metadata_path = source / "metadata.json"
+    if not metadata_path.is_file():
+        raise ArtifactUnreadable(
+            f"{source} carries no metadata.json — not an unpacked "
+            f"compiled-graph artifact; nothing publishable can be built from it"
+        )
+    import json
+
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    literals = source / "constants.safetensors"
+    return pack_artifact(
+        artifact_package(source),
+        workspace / "compiled_graph.tar.gz",
+        metadata,
+        literals=literals if literals.is_file() else None,
+    )
+
+
 def publish_compiled(store: Any, graph: str, env: Any, artifact: Path) -> str:
     """Put one freshly-compiled artifact WHERE THE SERVING PATH READS IT.
 
@@ -761,12 +812,23 @@ def publish_compiled(store: Any, graph: str, env: Any, artifact: Path) -> str:
     holes. One compile path with two publishers was always going to drift; this
     is the single one, and both callers go through it.
 
-    ``publish_artifact`` takes the package FILE, not the unpacked directory the
-    compiler returns (pgw#1471): an artifact position addresses ONE set of bytes
-    by digest and a directory has no digest.
+    WHAT IS PUBLISHED IS THE ENVELOPE (pgw#1561). pgw#1471 published
+    ``artifact_package`` — the bare ``model.pt2`` ZIP — and the adopt loader
+    reads the tar+gzip envelope, so no artifact this function ever banked
+    could be loaded by the path it was banked for: va#3 arm 2 measured
+    ``0/14 armed``, every hole ``cannot decompress``. The envelope also
+    carries what the bare package silently discarded — ``metadata.json`` (the
+    artifact's own key, sm, toolchain, constants table) and any literal
+    payload.
     """
-    package = artifact_package(Path(artifact))
-    outcome = store.publish_artifact(graph, env, package, artifact_manifest(env, package))
+    import tempfile
+
+    source = Path(artifact)
+    package = artifact_package(source)  # the ELF the manifest is read off
+    manifest = artifact_manifest(env, package)
+    with tempfile.TemporaryDirectory(prefix="pgw-envelope-") as raw:
+        envelope = artifact_envelope(source, Path(raw))
+        outcome = store.publish_artifact(graph, env, envelope, manifest)
     return str(getattr(outcome, "value", outcome) or "")
 
 

--- a/tests/tcg_artifacts.py
+++ b/tests/tcg_artifacts.py
@@ -161,3 +161,39 @@ def key_of(artifact: Path) -> str:
     from gen_worker._vendor.torchcg.artifact import read_metadata
 
     return str(read_metadata(artifact).get("compiled_graph_key") or "")
+
+
+def unpacked(
+    destination: Path,
+    *,
+    graph_specialization: str = GRAPH_CLASS,
+    witness: str = "fedcba9876543210",
+    sm: str = "sm_89",
+    toolchain: Optional[Mapping[str, str]] = None,
+) -> Path:
+    """A real UNPACKED artifact directory at ``destination``.
+
+    What ``Engine.compile`` leaves behind (``metadata.json`` + ``model.pt2``),
+    and since pgw#1561 the only builder output ``publish_compiled`` accepts —
+    the publish repacks it into the ENVELOPE the adopt loader reads, so a
+    bare ``model.pt2`` in a directory with no metadata is now unrepresentable
+    on the publish path rather than silently banked.
+
+    ``destination`` must not exist yet: ``unpack_artifact`` materializes
+    atomically and refuses an occupied target, exactly like the engine.
+    """
+    from gen_worker._vendor.torchcg.artifact import unpack_artifact
+
+    envelope = destination.parent / f".{destination.name}.envelope.tar.gz"
+    build(
+        envelope,
+        graph_specialization=graph_specialization,
+        witness=witness,
+        sm=sm,
+        toolchain=toolchain,
+    )
+    try:
+        unpack_artifact(envelope, destination)
+    finally:
+        envelope.unlink(missing_ok=True)
+    return destination

--- a/tests/test_compile_servability.py
+++ b/tests/test_compile_servability.py
@@ -140,14 +140,28 @@ def _seed_programs(store: LocalGraphStore, tmp_path: Path) -> None:
         store.put_program(graph, blob)
 
 
+@pytest.fixture(autouse=True)
+def _box_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every run's mint scratch lands in THIS test's tmpdir, never the box cache.
+
+    The old builders `mkdir(exist_ok=True)`-ed into the REAL
+    `~/.cache/cozy/compiled-graphs` and leaked fixture directories there for
+    every suite run on a developer box; `tcg_artifacts.unpacked` materializes
+    atomically (refusing occupied destinations, like the engine) and turned
+    that leak into a cross-run flake. The suite was always supposed to be
+    hermetic; now it is.
+    """
+    monkeypatch.setattr(
+        workspace, "artifacts_root", lambda: tmp_path / "box-artifacts"
+    )
+
+
 def _builder(built: List[str]) -> compile_cli.Builder:
     """A compile that really produces an artifact, without inductor or a card."""
 
     def build(spec: compile_cli.Spec, program: Path, destination: Path) -> Path:
         assert program.is_file(), "the builder must be handed this box's program"
-        destination.mkdir(parents=True, exist_ok=True)
-        tcg_artifacts.aoti_package(
-            destination / "model.pt2", graph_specialization=spec.graph)
+        tcg_artifacts.unpacked(destination, graph_specialization=spec.graph)
         built.append(spec.graph)
         return destination
 
@@ -226,9 +240,7 @@ def test_a_build_lands_in_the_box_cache_and_never_in_the_endpoint_tree(
 
     def build(spec: compile_cli.Spec, program: Path, destination: Path) -> Path:
         destinations.append(destination)
-        destination.mkdir(parents=True, exist_ok=True)
-        tcg_artifacts.aoti_package(
-            destination / "model.pt2", graph_specialization=spec.graph)
+        tcg_artifacts.unpacked(destination, graph_specialization=spec.graph)
         return destination
 
     report = _run(endpoint, cas, store=store, builder=build)
@@ -321,7 +333,7 @@ def test_a_compile_that_publishes_nowhere_fails_loudly(
     assert store.publishes == len(GRAPHS)
     # And every one of them is a FAILURE, at the moment it happened.
     assert {outcome.state for outcome in report.outcomes} == {compile_cli.FAILED}
-    assert all("serving reader" in outcome.detail for outcome in report.outcomes)
+    assert all("NOT loadable" in outcome.detail for outcome in report.outcomes)
     assert len(report.unservable) == len(GRAPHS)
     summary, code = compile_cli.summarize(report)
     assert code == 1
@@ -613,6 +625,98 @@ def test_a_cached_mint_on_a_different_toolchain_is_not_reused(
     assert report.unservable == []
 
 
+# --------------------------------------------------------------------------
+# pgw#1561: the published bytes are the ENVELOPE, and the witness LOADS them
+# --------------------------------------------------------------------------
+
+
+def test_published_bytes_are_the_envelope_and_materialize(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """The publish banks what the boot loader reads: tar+gzip, metadata and
+    all — not the bare `.pt2` ZIP that left va#3 arm 2 with 0/14 armed over a
+    band `SERVABLE` had just certified."""
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+
+    report = _run(endpoint, cas, store=store, builder=_builder([]))
+    assert report.unservable == []
+
+    reader = compile_cli.serving_reader(cas)
+    for graph in GRAPHS:
+        fetched = reader.fetch_artifact(graph, ENV, tmp_path / "out" / graph[-8:])
+        assert fetched is not None
+        with fetched.open("rb") as handle:
+            assert handle.read(2) == b"\x1f\x8b", (
+                f"{graph}: the published blob is not a gzip envelope"
+            )
+        assert compile_cli.witness_materializes(cas, graph, ENV) is None
+
+
+def test_a_legacy_bare_package_position_is_named_and_then_replaced(
+    endpoint: Path, tmp_path: Path
+) -> None:
+    """Tonight's field failure as a fixture (pgw#1561, va#3 arm 2).
+
+    A position seeded the way every pre-envelope publisher seeded it — the
+    bare `model.pt2` — must (1) read as a NAMED gap in the census, never as
+    `SERVABLE`, and (2) read as a MISS to the next run, whose publish
+    REPLACES the skewed incumbent through the store's tcg#75 migration arm.
+    """
+    from gen_worker._vendor.torchcg import RequirementsManifest
+
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+    legacy = tcg_artifacts.aoti_package(
+        tmp_path / "legacy.pt2", graph_specialization=GRAPHS[0])
+    store.publish_artifact(
+        GRAPHS[0], ENV, legacy,
+        RequirementsManifest(include_set=(("torch", ">=2.13.0"),), sm_compiled=SM),
+    )
+
+    # (1) The census names the skew — this exact state used to print SERVABLE.
+    specs = compile_cli.specializations(endpoint / el.LOCK_FILENAME)
+    gaps = compile_cli.unservable(cas, specs[:1], ENV, "some.other")
+    assert any("bare AOTI .pt2 package" in str(gap) for gap in gaps), gaps
+
+    # (2) The next run treats it as a miss and the publish replaces it.
+    built: List[str] = []
+    report = _run(endpoint, cas, store=store, builder=_builder(built))
+    assert GRAPHS[0] in built, "a skewed position must route back through the publish"
+    assert report.unservable == []
+    for graph in GRAPHS:
+        assert compile_cli.witness_materializes(cas, graph, ENV) is None
+    assert compile_cli.summarize(report)[1] == 0
+
+
+def test_the_witness_goes_red_when_the_publisher_banks_the_package(
+    endpoint: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RED ARM, the coordinator's fixture: revert the publish fix and the
+    witness must refuse — a `has_artifact` read-back certified exactly this
+    state as SERVABLE on 2026-08-20 09:22, minutes after the defect was filed
+    against it."""
+    from gen_worker.serving import mint as mint_mod
+
+    monkeypatch.setattr(
+        mint_mod, "artifact_envelope",
+        lambda artifact, workspace: mint_mod.artifact_package(Path(artifact)),
+    )
+
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+
+    report = _run(endpoint, cas, store=store, builder=_builder([]))
+
+    assert {outcome.state for outcome in report.outcomes} == {compile_cli.FAILED}
+    assert all("MATERIALIZE" in outcome.detail for outcome in report.outcomes)
+    summary, code = compile_cli.summarize(report)
+    assert code == 1 and "NOT SERVABLE" in summary
+
+
 def test_an_unreadable_module_name_is_a_typed_refusal_not_a_traceback(
     tmp_path: Path,
 ) -> None:
@@ -755,9 +859,7 @@ def test_the_graph_set_document_is_published_before_the_first_build(
 
     def build(spec: compile_cli.Spec, program: Path, destination: Path) -> Path:
         seen.append(compile_cli.serving_reader(cas).get_graphs(MODULE))
-        destination.mkdir(parents=True, exist_ok=True)
-        tcg_artifacts.aoti_package(
-            destination / "model.pt2", graph_specialization=spec.graph)
+        tcg_artifacts.unpacked(destination, graph_specialization=spec.graph)
         return destination
 
     _run(endpoint, cas, store=store, builder=build, fill=compile_cli.FILL_NONE)

--- a/tests/test_mint_publish_shape.py
+++ b/tests/test_mint_publish_shape.py
@@ -198,8 +198,13 @@ def test_mint_one_compiles_publishes_and_manifests_through_the_REAL_store(
 
     def _compiler(blob: Path, rec: Any, destination: Path) -> Path:
         # What Engine.compile does: resolve the key INTO destination, leaving
-        # an unpacked directory.
-        return _unpacked_artifact(destination)
+        # an unpacked directory. A CONFORMING one (pgw#1561): the publish now
+        # repacks the envelope and torchcg validates metadata against the
+        # package on the way, so the loose `_unpacked_artifact` shape that the
+        # direct-reader tests keep using no longer publishes anywhere.
+        import tcg_artifacts
+
+        return tcg_artifacts.unpacked(destination, graph_specialization=GRAPH)
 
     def _program_source(digest: str, destination: Path) -> Path:
         destination.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_runtime_mint.py
+++ b/tests/test_runtime_mint.py
@@ -24,20 +24,18 @@ from gen_worker import compile_posture
 from gen_worker.serving import mint
 
 
-def _elf(path: Path) -> Path:
-    """A minimal 64-bit ELF with no sections.
+def _artifact(destination: Path, graph: str) -> Path:
+    """A real UNPACKED artifact directory — what `Engine.compile` leaves.
 
-    `needed_libraries` reads DT_NEEDED off the artifact itself, and an
-    artifact naming no libraries is a legitimate answer (all-embedded
-    Triton/SASS) rather than a recording bug — so this is the honest smallest
-    fixture, not a stub of the reader.
+    This used to be a bare 64-byte ELF file, and the `_Store` double accepted
+    it — which is the exact modeling gap pgw#1561 measured in the field: the
+    REAL publisher now repacks the ENVELOPE from the unpacked directory
+    (validating metadata against the package on the way), so a compiler seam
+    handing back anything less no longer publishes anywhere.
     """
-    raw = bytearray(64)
-    raw[:4] = b"\x7fELF"
-    raw[4:7] = bytes((2, 1, 1))          # ELFCLASS64, little-endian, v1
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(bytes(raw))
-    return path
+    import tcg_artifacts
+
+    return tcg_artifacts.unpacked(destination, graph_specialization=graph)
 
 
 class _Adoption:
@@ -129,7 +127,7 @@ def test_a_healthy_mint_is_never_called_wedged(
     host = _host(3)
 
     def _compiler(blob: Path, record: Any, destination: Path) -> Path:
-        return _elf(destination)
+        return _artifact(destination, record.graph)
 
     outcome = _mint(host, _Store(), tmp_path, compiler=_compiler).run()
 
@@ -149,7 +147,7 @@ def test_a_published_graph_that_does_not_arm_is_a_wire_fact(
     store = _Store()
 
     def _compiler(blob: Path, record: Any, destination: Path) -> Path:
-        return _elf(destination)
+        return _artifact(destination, record.graph)
 
     outcome = _mint(host, store, tmp_path, compiler=_compiler).run()
 

--- a/tests/test_self_mint_wiring.py
+++ b/tests/test_self_mint_wiring.py
@@ -148,7 +148,12 @@ class FakeCompiler:
         self.calls.append(record.graph)
         if self.block is not None:
             self.block.wait(timeout=20.0)
-        return elf(destination)
+        # A CONFORMING unpacked artifact (pgw#1561): the publish repacks the
+        # ENVELOPE from this directory and validates the metadata against the
+        # package — a bare ELF file no longer publishes anywhere.
+        import tcg_artifacts
+
+        return tcg_artifacts.unpacked(destination, graph_specialization=record.graph)
 
 
 def programs(tmp_path: Path) -> Callable[[str, Path], Path]:
@@ -181,7 +186,11 @@ def counting_loader(
     """
 
     def load(path: Path, record: Any, module: Any) -> Callable[..., Any]:
-        assert path.is_file(), "an armed artifact must exist on disk"
+        # File OR directory: torchcg's `materialize` accepts both shapes — a
+        # store fetch hands the packed envelope, a runtime mint hands the
+        # unpacked directory `Engine.compile` resolved (the shape the seam
+        # compiler produces since pgw#1561).
+        assert path.is_file() or path.is_dir(), "an armed artifact must exist on disk"
         assert isinstance(module, torch.nn.Module), (
             "the loader is handed the module its constants bind from")
         armed.append(record.graph)

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=2a38ff2be91e2823b311f31b9f665048b7d0db55" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=7f927a42f434bb27e548d7c81dc4776c89af003c" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=2a38ff2be91e2823b311f31b9f665048b7d0db55#2a38ff2be91e2823b311f31b9f665048b7d0db55" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=7f927a42f434bb27e548d7c81dc4776c89af003c#7f927a42f434bb27e548d7c81dc4776c89af003c" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
Field failure (va#3 arm 2): boot adoption 0/14 armed, every hole 'cannot decompress' — the v2 band has held bare model.pt2 ZIPs since publishing existed (pgw#1471) while the boot loader reads the tar+gzip envelope. Confirmed decisively on a FRESH build published at 09:22: SERVABLE printed, blob magic PK\x03\x04.

- publish_compiled repacks the ENVELOPE from the unpacked artifact (torchcg deterministic pack_artifact: validated against the package, carries metadata.json + literals the ZIP discarded, byte-identical to the engine-cache object so CAS dedups the bands). A non-envelope file publish is a typed refusal.
- torchcg tcg#75 (7f927a42, re-vendored): ArtifactFormatSkew (skew=re-publish vs corruption=re-mint, distinguishable HOLE reason), envelope-replaces-skewed-incumbent migration at publish (one-directional), artifact_skew() two-byte census probe.
- compile: present-but-skewed positions read as a MISS (a ~15s warm run REPAIRS a legacy store); census names skewed positions; the pgw#1533/#1546 read-back now fetches AND MATERIALIZES through the real loader before saying SERVABLE.
- fixtures upgraded to real unpacked artifacts (tcg_artifacts.unpacked); servability suite stops leaking into the real box cache.

Red arms (all verified red by mutation): witness weakened to presence; skew gate removed; store migration arm removed; publisher reverted to bare package (in-suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)