### PR TITLE
pgw#1561: the RUNTIME-mint seam round-trips the store too — publish → fetch → materialize

### DIFF
--- a/changelog.d/pgw1561-envelope-publish.md
+++ b/changelog.d/pgw1561-envelope-publish.md
@@ -12,3 +12,7 @@
   as a miss so a warm run repairs it, its census probes every position's shape
   (two magic bytes), and the pgw#1533 read-back now MATERIALIZES fetched bytes
   through the real loader — presence-only certification is what let this ship.
+  The RUNTIME-mint seam now round-trips too: `_mint_one` publishes, and the test
+  fetches those bytes back through the real store and opens them with
+  `torchcg.serve.materialize`. That seam arms the unpacked directory it just
+  wrote, so nothing it publishes was ever read back — the gap the field found.

--- a/tests/test_mint_publish_shape.py
+++ b/tests/test_mint_publish_shape.py
@@ -173,12 +173,12 @@ def test_a_directory_carrying_no_package_refuses_BY_NAME(tmp_path: Path) -> None
 
 # --------------------------------------------------- the end-to-end mint path
 
-def test_mint_one_compiles_publishes_and_manifests_through_the_REAL_store(
-    tmp_path: Path,
-) -> None:
-    """The path that was broken, end to end, with nothing stubbed but the
-    compiler — which stands in for inductor and returns exactly what
-    `Engine.compile` returns: the unpacked directory."""
+def _run_one_mint(tmp_path: Path, compiler: Any = None) -> Any:
+    """One `_mint_one` against the REAL `LocalGraphStore`.
+
+    Nothing is stubbed but the compiler, which stands in for inductor and
+    returns exactly what `Engine.compile` returns: the unpacked directory.
+    """
     from gen_worker import compile_posture
     from gen_worker._vendor.tensorfs import LocalCAS
     from gen_worker._vendor.torchcg.store import LocalGraphStore
@@ -214,16 +214,83 @@ def test_mint_one_compiles_publishes_and_manifests_through_the_REAL_store(
     box = mint.BackgroundMint(
         host=host, store=store, artifacts_dir=tmp_path / "artifacts",
         posture=compile_posture.FLEET, vcpus=4,
-        compiler=_compiler, program_source=_program_source,
+        compiler=compiler or _compiler, program_source=_program_source,
     )
 
     minted = box._mint_one(record, __import__("threading").Lock())
+    return SimpleNamespace(store=store, minted=minted, armed=armed)
 
-    assert minted.published, "the mint compiled and then published nothing"
-    assert minted.armed and armed == [GRAPH]
+
+def test_mint_one_compiles_publishes_and_manifests_through_the_REAL_store(
+    tmp_path: Path,
+) -> None:
+    """The path that was broken, end to end."""
+    run = _run_one_mint(tmp_path)
+
+    assert run.minted.published, "the mint compiled and then published nothing"
+    assert run.minted.armed and run.armed == [GRAPH]
 
     # The manifest was derived from the ELF INSIDE the package, so it carries
     # the real link table rather than an empty set.
-    manifest = store.get_manifest(GRAPH, ENV)
+    manifest = run.store.get_manifest(GRAPH, ENV)
     assert manifest is not None
     assert manifest.sm_compiled == "sm_89"
+
+
+def test_what_the_mint_PUBLISHED_is_opened_by_the_REAL_boot_loader(
+    tmp_path: Path,
+) -> None:
+    """pgw#1561's missing round-trip: mint → store → fetch → MATERIALIZE.
+
+    `_mint_one` arms the unpacked directory the compiler just wrote, so
+    mint→arm never touches the published bytes at all. Boot adoption is their
+    only reader, and no test had ever been one — which is precisely how the
+    band held bare `model.pt2` ZIPs from pgw#1471 until va#3 arm 2 fetched
+    them and holed 14/14 on `cannot decompress`. Every assertion this seam
+    had (published ref non-empty, manifest present, armed) was TRUE over
+    those unloadable bytes.
+
+    So this drives the published object back OUT through the store adoption
+    reads and opens it with `torchcg.serve.materialize` — the exact function
+    boot-time arming calls — and states the two facts the loader needs:
+    the blob is the gzip envelope, and it carries its own identity.
+    """
+    from gen_worker._vendor.torchcg.serve import materialize
+
+    run = _run_one_mint(tmp_path)
+    assert run.store.artifact_skew(GRAPH, ENV) is None, (
+        "the published position is shaped like something no loader opens")
+
+    fetched = run.store.fetch_artifact(GRAPH, ENV, tmp_path / "fetched")
+    assert fetched is not None, "boot adoption fetches a MISS at a position it minted"
+    with fetched.open("rb") as handle:
+        assert handle.read(2) == b"\x1f\x8b", (
+            f"{fetched} is not the tar+gzip envelope the boot loader reads")
+
+    graph = materialize(fetched, tmp_path / "unpacked")
+    assert graph.key, "the materialized artifact states no compiled_graph_key"
+    assert graph.package.is_file(), "no model.pt2 inside the envelope"
+    # metadata.json — the self-stated identity the bare-ZIP publish DISCARDED.
+    assert graph.metadata.get("compiled_graph_key") == graph.key
+
+
+def test_a_compiler_that_hands_back_the_bare_package_publishes_NOTHING(
+    tmp_path: Path,
+) -> None:
+    """RED ARM. The pre-pgw#1561 world, reconstructed at the seam that made it.
+
+    Every publisher since pgw#1471 banked `artifact_package` — the bare
+    `.pt2` ZIP — and the store took it, so the defect was invisible from here.
+    Handing the publish a package FILE must now be a typed refusal at the
+    mint, not fourteen adoption holes an hour later on a pod.
+    """
+    def _package_only(blob: Path, rec: Any, destination: Path) -> Path:
+        import tcg_artifacts
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        return tcg_artifacts.aoti_package(
+            destination, graph_specialization=GRAPH)
+
+    with pytest.raises(mint.ArtifactUnreadable) as refusal:
+        _run_one_mint(tmp_path, compiler=_package_only)
+    assert "bare package cannot be published" in str(refusal.value)


### PR DESCRIPTION
Follow-on to #1121 (merged `55b01aa1`), closing the one seam that fix left unread.

## What was still missing

#1121 fixed `publish_compiled` to bank the ENVELOPE and taught `compile`'s
read-back witness to MATERIALIZE what it certifies. The **runtime mint**
(`BackgroundMint._mint_one`) publishes through that same fixed function — but
nothing ever reads its bytes back. It arms the UNPACKED directory the compiler
just wrote, so mint→arm never round-trips the store. That is precisely the
lesson pgw#1561 was filed on, and the seam that embodies it had no round-trip
test: every assertion it carried (published ref non-empty, manifest present,
armed) was TRUE over the bare `.pt2` ZIPs that left va#3 arm 2 `0/14 armed`.

## What lands

- **`test_what_the_mint_PUBLISHED_is_opened_by_the_REAL_boot_loader`** — mint
  through the REAL `LocalGraphStore`, fetch the published object back out
  through it, and open it with `torchcg.serve.materialize`, the exact function
  boot-time arming calls. Asserts the gzip envelope magic and the artifact's own
  `compiled_graph_key` — the self-stated identity the bare-ZIP publish discarded.
- **`test_a_compiler_that_hands_back_the_bare_package_publishes_NOTHING`** — the
  pre-envelope world reconstructed at the seam that made it: a package FILE is a
  typed refusal at the mint, not fourteen adoption holes an hour later on a pod.
- `_run_one_mint` extracted so both arms drive one real-store setup.

## Red-armed, $0, no card, no compile

Reverting `artifact_envelope` to `artifact_package` (pgw#1471 behaviour) makes
the round-trip refuse, and the fetched blob — magic `PK\x03\x04` — refuses
through the real loader:

```
fetched magic: b'PK\x03\x04'
LOADER REFUSAL: ArtifactFormatSkew: artifact ... is a bare AOTI .pt2 package (ZIP),
not the compiled-graph envelope (tar+gzip with metadata.json) — a publisher banked
the package file instead of the envelope. Re-publish through a current publisher...
```

That is va#3 arm 2's field failure reproduced on CPU, now naming **re-publish**
as the remedy instead of reading as bytes rotting at rest.

Local: `test_mint_publish_shape.py` 8 passed, `test_compile_servability.py` +
`test_runtime_mint.py` 36 passed. Tests + changelog only; no `src/` change.

## Migration (unchanged from #1561, recorded here for the runbook)

Every artifact in the `(cg-graph-v1, cg-env-v2)` band published before
`55b01aa1` is a bare ZIP. Wipe the v2 artifact refs and re-publish once through
the current `compile`; nothing is rebuilt (the engine cache holds the envelopes,
warm reuse re-publishes in seconds and the CAS dedups against the v1 band). A
run against a skewed store now self-repairs: `_known_present` reads a skewed
position as a MISS and the store's tcg#75 migration arm replaces the incumbent.