### PR TITLE
pgw#1564 close: durable verdicts that state the bytes that produced them

### DIFF
--- a/changelog.d/pgw1564-durable-verdict.md
+++ b/changelog.d/pgw1564-durable-verdict.md
@@ -1,0 +1,10 @@
+- **pgw#1564 (close): the armed-zero and mint-terminal verdicts are DURABLE
+  rows, not log lines — and they state the executed code identity.** The L4
+  rental that falsified the read-once fix could neither read the log naming
+  WHY (SSH dead) nor prove which bytes ran ("pin inferred from the build
+  chain"). `SelfMint._settle` now emits a terminal activity row per mint
+  (state, landed/failed vs ARMED count — a divergence between armed and
+  run-processed is named on the row as the 13/23 ms no-op class —
+  `gen_worker_version` + parent contract digest); the host's armed-zero
+  warning also rides the wire with its deduped hole reasons. The next $0.07
+  rental reads WHY and WHAT-RAN from the hub instead of buying a blind leg.

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -417,6 +417,7 @@ class EndpointHost:
                     len(session.unclaimed), len(marks),
                 )
                 seen: set[str] = set()
+                reasons: list[str] = []
                 for hole in session.holes:
                     # One line per distinct reason, not per graph: fourteen
                     # copies of one sentence is how a reason gets skimmed past.
@@ -424,12 +425,36 @@ class EndpointHost:
                     if reason_class in seen:
                         continue
                     seen.add(reason_class)
-                    logger.warning(
-                        "adopt:   hole %s: %s", hole.record.graph[-16:],
-                        str(hole.reason)[:300],
+                    reasons.append(
+                        f"{hole.record.graph[-16:]}: {str(hole.reason)[:300]}"
                     )
+                    logger.warning("adopt:   hole %s", reasons[-1])
                     if len(seen) >= 6:
                         break
+                # DURABLE, not log-only (pgw#1564, second lesson): the 09:41
+                # zero was diagnosable from this exact list, and the list
+                # lived in a resident log; the NEXT instance is on a pod
+                # whose SSH is dead two rentals running. The row is what a
+                # $0.07 rental reads from the hub instead of buying blind.
+                try:
+                    from .. import activity as activity_mod
+                    from .self_mint import KIND_SKIPPED
+
+                    activity_mod.emit_event(
+                        KIND_SKIPPED,
+                        f"lane={lane_contract} sm={sm}: boot armed ZERO of "
+                        f"{len(session.adopted) + len(session.holes)} claimed "
+                        f"graph(s) ({len(session.holes)} hole(s), "
+                        f"{len(session.ambiguous)} ambiguous, "
+                        f"{len(marks)} unmatched mark(s)); hole reasons: "
+                        + ("; ".join(reasons) or "none recorded"),
+                        phase="armed_zero",
+                        step=0,
+                        total_steps=len(session.adopted) + len(session.holes),
+                    )
+                except Exception:  # noqa: BLE001 — the row never costs the boot
+                    logger.debug("adopt: armed-zero row failed to emit",
+                                 exc_info=True)
         self.adoption = session
         self._booted = True
 

--- a/src/gen_worker/serving/self_mint.py
+++ b/src/gen_worker/serving/self_mint.py
@@ -359,6 +359,59 @@ class SelfMint:
         with self._lock:
             self._status = status
         logger.info("self-mint: %s", status.facts())
+        self._say_verdict(status, outcome, holes)
+
+    def _say_verdict(
+        self, status: SelfMintStatus, outcome: Optional[MintOutcome], armed_holes: int,
+    ) -> None:
+        """The mint's TERMINAL verdict as a DURABLE activity row (pgw#1564).
+
+        Twice in one day a pod's mint declared itself done in milliseconds and
+        the one line naming WHY lived in a log no SSH could reach (the
+        pgw#1541/#1542 lesson, relearned). So the verdict rides the wire:
+
+        * the COUNTS, armed-at-arm vs processed-at-run — a divergence between
+          them IS the 13/23 ms no-op class, named here instead of being
+          inferred across two other rows that disagree;
+        * the REASON (failures / condemnation / error), deduped upstream;
+        * the EXECUTED CODE IDENTITY — the falsifying rental could only say
+          "pin inferred from the build chain"; a verdict that states its own
+          `gen_worker_version` + parent contract digest ends that inference.
+
+        Never raises: a verdict emitter that can kill the worker it reports on
+        is worse than the silence it replaces.
+        """
+        try:
+            from ..compile_cache import gen_worker_version
+            from .mint_child import contract_digest
+
+            run_holes = outcome.holes if outcome is not None else 0
+            divergence = ""
+            if run_holes != armed_holes:
+                divergence = (
+                    f" DIVERGENT WORK-LIST: armed {armed_holes} hole(s), the "
+                    f"run processed {run_holes} — the pgw#1564 no-op class; "
+                    f"a second live read (or older bytes) emptied the list."
+                )
+            try:
+                identity = (
+                    f"gen-worker {gen_worker_version()}, "
+                    f"contract {contract_digest() or 'no-source'}"
+                )
+            except Exception:  # noqa: BLE001 — identity must not cost the row
+                identity = "identity unreadable"
+            activity_mod.emit_event(
+                KIND,
+                f"self-mint TERMINAL: {status.state} — landed "
+                f"{status.landed}, failed {status.failed}, armed "
+                f"{armed_holes} hole(s), {status.elapsed_s:.3f}s."
+                f"{divergence} reason: {status.reason or 'none'}; {identity}",
+                phase=f"terminal_{status.state}",
+                step=status.landed,
+                total_steps=armed_holes,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("self-mint: verdict row failed to emit", exc_info=True)
 
     def _beat(self, act: activity_mod.Activity, stop: threading.Event) -> None:
         """Carry the counter to the hub on this mint's OWN thread.

--- a/tests/test_adoption_verdict.py
+++ b/tests/test_adoption_verdict.py
@@ -235,3 +235,117 @@ def test_the_mint_mints_what_it_was_armed_on_not_a_second_read(
         "property that already emptied"
     )
     assert final.landed == 3 and not final.running
+
+
+@pytest.fixture()
+def wire(monkeypatch: pytest.MonkeyPatch) -> "list[tuple]":
+    from gen_worker import activity as activity_mod
+
+    seen: "list[tuple]" = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, phase="", **kw: seen.append((kind, phase, detail, kw)))
+    return seen
+
+
+def test_the_armed_zero_verdict_is_a_durable_row_not_a_log_line(
+    tmp_path: Path, wire: "list[tuple]", caplog: pytest.LogCaptureFixture
+) -> None:
+    """pgw#1564, second lesson: the 09:41 zero was diagnosable from the hole
+    reasons — which lived in a resident log; the next instance was on a pod
+    whose SSH was dead. The reasons now ride the wire."""
+    import tcg_artifacts
+    from gen_worker._vendor.torchcg.requirements import RequirementsManifest
+    from test_serving_adopt_first import fresh_host, publish_document
+
+    binding = make_binding(tmp_path)
+    host = fresh_host(binding, tmp_path)
+    host.setup()
+    document = publish_document(host)
+    store = LocalGraphStore(LocalCAS(tmp_path / "cas"))
+    for record in document.lanes[0].graphs:
+        bare = tcg_artifacts.aoti_package(
+            tmp_path / f"{record.graph[-8:]}.pt2",
+            graph_specialization=record.graph)
+        store.publish_artifact(
+            record.graph, ENV, bare,
+            RequirementsManifest(
+                include_set=(("torch", torch.__version__),), sm_compiled=SM))
+
+    booted = fresh_host(binding, tmp_path)
+    with caplog.at_level(logging.WARNING):
+        booted.setup(store=store, document=document, sm=SM,
+                     artifacts_dir=tmp_path / "adopted", stack=STACK)
+
+    rows = [row for row in wire if row[1] == "armed_zero"]
+    assert len(rows) == 1, wire
+    _kind, _phase, detail, counts = rows[0]
+    assert "armed ZERO" in detail and "ArtifactFormatSkew" in detail
+    assert counts["step"] == 0 and counts["total_steps"] == len(
+        document.lanes[0].graphs)
+
+
+def test_the_mint_terminal_verdict_rides_the_wire_with_its_identity(
+    tmp_path: Path, wire: "list[tuple]",
+) -> None:
+    from gen_worker.serving.self_mint import SelfMint
+
+    compiled: "list[str]" = []
+
+    def compiler(blob: Path, record: SimpleNamespace, destination: Path) -> Path:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"artifact")
+        compiled.append(record.graph)
+        return destination
+
+    def program_source(graph: str, destination: Path) -> Path:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"program")
+        return destination
+
+    host = SimpleNamespace(
+        holes=tuple(
+            SimpleNamespace(record=SimpleNamespace(graph=f"g{i}", target="unet"))
+            for i in range(2)),
+        adoption=SimpleNamespace(
+            env=SimpleNamespace(value="lane-a", sm=SM),
+            arm=lambda record, artifact: None),
+    )
+    box = SelfMint(store=None, artifacts_dir=tmp_path / "artifacts",
+                   compiler=compiler, program_source=program_source, vcpus=2)
+    box.arm(host)
+    final = box.join(30.0)
+    assert final.landed == 2
+
+    terminal = [row for row in wire if row[1].startswith("terminal_")]
+    assert len(terminal) == 1, wire
+    _kind, phase, detail, counts = terminal[0]
+    assert phase == "terminal_complete"
+    assert "gen-worker " in detail and "contract " in detail, (
+        "the executed code identity must ride the verdict — 'pin inferred "
+        "from the build chain' is what this row exists to end")
+    assert "DIVERGENT" not in detail
+    assert counts["step"] == 2 and counts["total_steps"] == 2
+
+
+def test_a_divergent_work_list_is_named_on_the_verdict(
+    tmp_path: Path, wire: "list[tuple]",
+) -> None:
+    """The 13/23 ms no-op class, as ONE named fact: the run processed fewer
+    holes than were armed. Constructed directly — a pod running older bytes
+    cannot emit new instruments, so the row's job is to make the NEXT
+    executed-bytes question answerable, not to time-travel."""
+    from gen_worker.serving.mint import MintOutcome
+    from gen_worker.serving.self_mint import SelfMint
+
+    box = SelfMint(
+        store=None, artifacts_dir=tmp_path,
+        compiler=lambda blob, record, destination: Path(destination),
+        program_source=lambda graph, destination: Path(destination),
+    )
+    box._settle(MintOutcome(holes=0, width=0, elapsed_s=0.001), "", 14)
+
+    terminal = [row for row in wire if row[1].startswith("terminal_")]
+    assert len(terminal) == 1
+    detail = terminal[0][2]
+    assert "DIVERGENT WORK-LIST: armed 14 hole(s), the run processed 0" in detail


### PR DESCRIPTION
The pod falsification's two blindfolds, removed: (1) SelfMint._settle emits a terminal activity row — state, landed/failed vs ARMED count (armed-vs-run divergence named as the 13/23ms no-op class), reason, and the executed gen_worker_version + contract digest ('pin inferred from the build chain' ends here); (2) the host armed-zero warning also rides the wire with its deduped hole reasons. Pod-entry code read: worker._arm -> production_mint -> SelfMint.arm IS covered by the read-once fix; the 23ms zero-failure signature is unreachable with e49965d5 executing, making executed-bytes identity the open variable the row now answers. 3 new tests, 3 mutations red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)