### PR TITLE
pgw#1571: a LoRA on a compiled denoiser served the BASE MODEL — fold it into the weights instead

### DIFF
--- a/changelog.d/pgw1571-lora-fold.md
+++ b/changelog.d/pgw1571-lora-fold.md
@@ -1,0 +1,17 @@
+- **pgw#1571 (correctness): a LoRA on a compiled denoiser served the BASE
+  MODEL — fold it into the weights instead.** peft wraps a denoiser's
+  submodules, but `aot_serve.wrap_module` replaced its `forward` with the AOTI
+  artifact's dispatch and bound the artifact's constants from the base weights
+  at arm time, so the wrappers never ran: the request paid for an adapter and
+  got the base model, bit-identically, with no refusal and no log (measured —
+  eager `max|delta| = 2.2e-02`, compiled-armed `0.0`). Two changes.
+  `models.lora_fold.folded(pipe, adapters, rebind=…)` folds the request's
+  deltas into the weights IN PLACE (the artifact holds a user-managed pointer,
+  so it sees the write), runs the pipeline unchanged, and restores saved
+  originals byte for byte — never a delta-subtract, which is the algebraic
+  inverse and not the floating-point one. `aot_serve` routes a module carrying
+  live peft adapter state to EAGER and says so once, so the silent case cannot
+  return. Quantized (fp8/GGML) leaves refuse the fold by name; those lanes keep
+  the additive branch. Also settles the LoRA half of pgw#1548: no committed
+  lock has a LoRA graph axis (sd15 14 = 2 CFG x 7 aspect, sdxl 18 = 2 x 9, no
+  `lora_a`/`lora_b` in any graph), so removing it costs zero specializations.

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -1216,6 +1216,84 @@ def assert_lifted_contract(module: Any, contract: CallIngress) -> None:
             "binding to supply them (bucket=0 is a different graph specialization)")
 
 
+#: peft writes this on the module it injects adapters into (diffusers'
+#: ``load_lora_adapter`` -> ``inject_adapter_in_model``) and deletes it on
+#: unload. An O(1) attribute read, which is what lets the guard sit on the
+#: per-call path: a module walk there would cost more than the defect.
+PEFT_MARKER_ATTR = "peft_config"
+
+
+def serves_compiled(module: Any) -> bool:
+    """Whether a compiled artifact currently serves this module's forward."""
+    return bool(getattr(module, _MARKER_ATTR, None))
+
+
+def _say_adapter_ops_once(
+    state: Dict[str, Any], label: str, module: Any,
+) -> None:
+    """Say the degradation the first time, then stop — this is per FORWARD."""
+    if state.get("adapter_ops_said"):
+        return
+    state["adapter_ops_said"] = True
+    names = sorted(getattr(module, PEFT_MARKER_ATTR, {}) or {})
+    detail = (
+        f"target={label}: live peft adapter(s) {names} on a compiled-armed "
+        "module — serving EAGER for the duration, because the artifact would "
+        "silently return the base model (pgw#1571). Fold the adapter into the "
+        "weights (models.lora_fold) to keep compiled speed"
+    )
+    logger.warning("aot-serve: %s", detail)
+    activity_mod.emit_event(
+        activity_mod.KIND_LORA_HYGIENE, detail, phase="adapter_ops_on_compiled",
+    )
+
+
+def rearm_constants(module: Any) -> int:
+    """Re-install a compiled module's constant table after its WEIGHTS CHANGED.
+
+    Returns how many armed entries were re-armed (0 when nothing is compiled,
+    which is the ordinary eager case and not an error).
+
+    **Why this exists at all.** ``load_constants(..., user_managed=True)`` keeps
+    RAW POINTERS to the module's own parameters, so an in-place fold is visible
+    to the artifact with no bookkeeping — except through AOTI's runtime constant
+    folding, which ``torchcg.compiler`` turns on. The container folds once on the
+    first ``run()`` (``fold_state`` INITIALIZED -> FOLDED) and never again, and an
+    in-place tensor write calls nothing. Re-installing the same pointers is what
+    puts ``fold_state`` back to INITIALIZED, so the next call re-folds against
+    the new weights. Both ``update_constant_buffer`` overloads do it; there is
+    no cheaper hook.
+
+    **This reaches into the vendored torchcg runner's privates, deliberately and
+    narrowly.** The right home is a ``CompiledGraphRunner.rebind()`` upstream —
+    but the vendored snapshot is sha256-fenced (``VENDORED.toml``), so a local
+    edit is refused by CI and an upstream change plus a re-vendor is a separate
+    act with a separate owner. Until that lands this refuses by name rather than
+    guessing when the surface is not what it expects, because the failure it is
+    preventing is a silently stale weight.
+    """
+    marker = getattr(module, _MARKER_ATTR, None) or {}
+    dispatch = (marker.get("state") or {}).get("runner")
+    if dispatch is None:
+        return 0
+    armed = 0
+    for _name, entry in tuple(getattr(dispatch, "runners", ()) or ()):
+        runner = getattr(entry, "runner", None)
+        package = getattr(runner, "_package", None)
+        values = getattr(runner, "_bound_values", None)
+        if package is None or not values:
+            raise AdoptError(
+                "constant_rearm_unsupported",
+                "the compiled runner exposes no bound constant table to "
+                "re-install after a weight mutation; a folded constant would "
+                "serve stale weights",
+            )
+        package.load_constants(
+            values, check_full_update=True, user_managed=True)
+        armed += 1
+    return armed
+
+
 def wrap_module(
     module: Any,
     runner: "EntryDispatch",
@@ -1306,6 +1384,17 @@ def wrap_module(
         artifact_lora, eager_lora = adapter_call_kwargs(module, runner)
         eager_kwargs = {**kwargs, **eager_lora}
         kwargs = {**kwargs, **artifact_lora}
+        if getattr(module, PEFT_MARKER_ATTR, None):
+            # pgw#1571. A peft adapter is LIVE on this module's submodules and
+            # the artifact cannot execute them — it replaced `forward`, and its
+            # constants were bound from the base weights at arm time. Serving
+            # compiled here returns the BASE MODEL, bit-identically, for a
+            # request that paid for an adapter (measured: max|delta| = 0.0
+            # against the pre-LoRA baseline, with 32 peft wrappers attached).
+            # Eager is a real cost and it is the only correct answer; the fold
+            # path (`models.lora_fold`) is how a compiled lane keeps its speed.
+            _say_adapter_ops_once(state, label, module)
+            return original(*args, **eager_kwargs)
         if serve_posture.eager_only():
             # pgw#1142 / §4.32 item 4: an operator ordered eager. This is THE
             # reversibility seam — the artifact is not unwrapped and `state`

--- a/src/gen_worker/models/lora_fold.py
+++ b/src/gen_worker/models/lora_fold.py
@@ -22,6 +22,21 @@ a saved clone, never a ``sub_`` of the delta — subtracting is not the inverse 
 adding in bf16, and a serial request stream would accumulate drift. Bit-exact
 restore is by construction here, not by tolerance.
 
+**The call site an endpoint writes** (se#808 is the rewire of sd15/sdxl onto it;
+the adapter bytes come from :func:`gen_worker.utils.lora.load_adapter_state_dict`
+because that is where the zero-delta and key-grammar refusals live, not from a
+bare ``safetensors.load_file``)::
+
+    @contextmanager
+    def adapters(self, applied: Sequence[Adapter]) -> Iterator[None]:
+        with lora_fold.folded(
+            self.pipe,
+            [(load_adapter_state_dict(Path(a.path), ref=a.ref), a.scale, a.ref)
+             for a in applied],
+            rebind=aot_serve.rearm_constants,
+        ):
+            yield
+
 **What this does NOT do.** It does not fold onto a QUANTIZED leaf (fp8/gguf):
 an fp8 grid cannot represent a small delta and the fold would be a silent
 fidelity loss — those lanes keep the additive branch (:mod:`.w8a8_lora`), and

--- a/src/gen_worker/models/lora_fold.py
+++ b/src/gen_worker/models/lora_fold.py
@@ -52,8 +52,10 @@ Adapter = Tuple[Dict[str, Any], float, str]
 
 #: Called with the mutated denoiser after the weights change and again after
 #: they are restored. The serve path passes ``aot_serve.rearm_constants``; a
-#: pipeline with no compiled artifact passes nothing.
-Rebind = Callable[[Any], None]
+#: pipeline with no compiled artifact passes nothing. Any return is ignored —
+#: ``rearm_constants`` reports how many entries it re-armed and the fold does
+#: not act on the count.
+Rebind = Callable[[Any], Any]
 
 
 def _plain_leaf(module: Any) -> bool:

--- a/src/gen_worker/models/lora_fold.py
+++ b/src/gen_worker/models/lora_fold.py
@@ -115,10 +115,73 @@ def _delta(mod: Any, a: Any, b: Any, scale: float) -> Any:
     return out.mul_(float(scale))
 
 
+def fold_targets(pipe: Any) -> Dict[str, Any]:
+    """Every component an adapter half can land on: the denoisers, plus the
+    text encoders.
+
+    The text encoders are here because leaving them out is how a fold serves
+    HALF an adapter and says nothing. They are never quantized
+    (:func:`~.w8a8_lora.split_state_dict` is built on that), so the same
+    in-place fold applies to them unchanged.
+    """
+    from ..component_vocab import text_encoder_components
+
+    targets = dict(w8a8_lora.branch_targets(pipe))
+    for name in text_encoder_components():
+        module = getattr(pipe, name, None)
+        if module is not None and hasattr(module, "named_modules"):
+            targets.setdefault(name, module)
+    return targets
+
+
+def _route(
+    normalized: Dict[str, Any], targets: Mapping[str, Any],
+    denoisers: Sequence[str], *, ref: str,
+) -> Dict[str, Dict[str, Any]]:
+    """One adapter's keys partitioned by the component they adapt.
+
+    The denoiser half goes through :func:`~.w8a8_lora.route_denoiser_keys`
+    (the MoE contract, unchanged). The rest is text-encoder keys, routed by the
+    prefix table :mod:`gen_worker.utils.lora` already owns — one table, not two.
+    Anything that lands nowhere REFUSES: a dropped half is an adapter that
+    served at the wrong strength with a clean log, which is the whole class of
+    defect this module exists to remove.
+    """
+    from ..utils.lora import te_prefix_to_component
+
+    den, rest = w8a8_lora.split_state_dict(normalized)
+    routed: Dict[str, Dict[str, Any]] = {
+        comp: dict(keys) for comp, keys
+        in w8a8_lora.route_denoiser_keys(den, denoisers, ref=ref).items()
+    }
+    unrouted: List[str] = []
+    for key, tensor in rest.items():
+        for prefix, comp in te_prefix_to_component():
+            if key.startswith(prefix) and comp in targets:
+                # STRIPPED, unlike the denoiser half: `map_adapter` strips
+                # `unet.`/`transformer.` itself and knows no text-encoder
+                # prefix, so the routing that identified the component is also
+                # what removes it.
+                routed.setdefault(comp, {})[key[len(prefix):].lstrip(".")] = tensor
+                break
+        else:
+            unrouted.append(key)
+    if unrouted:
+        raise RefCompatibilitySurprise(
+            f"{len(unrouted)} adapter key(s) land on no component this "
+            f"pipeline carries (e.g. {', '.join(sorted(unrouted)[:3])}) — it "
+            f"has {', '.join(sorted(targets))}. Folding the rest would serve "
+            "a partial adapter and say nothing",
+            ref=ref, axis="component_missing",
+        )
+    return routed
+
+
 def compute_deltas(
     model: Any, adapters: Sequence[Adapter], *, pipe: Any = None,
+    keys: Optional[Sequence[Mapping[str, Any]]] = None,
 ) -> Dict[str, Any]:
-    """``module path -> ΔW`` for one denoiser and the whole adapter set.
+    """``module path -> ΔW`` for one component and the whole adapter set.
 
     The whole set settles into ONE delta per module before anything is written,
     so a refusal anywhere leaves the weights untouched — the same fail-closed
@@ -128,18 +191,26 @@ def compute_deltas(
     (``normalize_adapter_state_dict`` → ``split_state_dict`` → ``map_adapter``),
     not a second implementation: the kohya/SGM grammars, the alpha/rank scale
     and the typed refusals are already there and must not drift.
+
+    ``keys`` is this component's already-routed slice of each adapter, in
+    ``adapters`` order — what :func:`folded` computes once for the whole
+    pipeline. Omitted, the whole adapter is resolved against ``model``, which is
+    the single-denoiser case and what a caller holding one module wants.
     """
     import torch
 
     mods = w8a8_lora.branch_modules(model)
     deltas: Dict[str, Any] = {}
-    for state_dict, weight, ref in adapters:
-        normalized = w8a8_lora.normalize_adapter_state_dict(
-            pipe if pipe is not None else model, state_dict, ref=ref)
-        den, _rest = w8a8_lora.split_state_dict(normalized)
-        if not den:
+    for index, (state_dict, weight, ref) in enumerate(adapters):
+        if keys is not None:
+            slice_ = keys[index]
+        else:
+            normalized = w8a8_lora.normalize_adapter_state_dict(
+                pipe if pipe is not None else model, state_dict, ref=ref)
+            slice_, _rest = w8a8_lora.split_state_dict(normalized)
+        if not slice_:
             continue
-        mapped = w8a8_lora.map_adapter(den, model, ref=ref)
+        mapped = w8a8_lora.map_adapter(dict(slice_), model, ref=ref)
         quantized = sorted(p for p in mapped if not _plain_leaf(mods[p]))
         if quantized:
             raise RefCompatibilitySurprise(
@@ -239,10 +310,12 @@ def folded(
         with lora_fold.folded(pipe, riding, rebind=aot_serve.rearm_constants):
             pipe(...)
 
-    Every branch-capable denoiser the pipeline carries is folded, and they move
-    together: a refusal on the second expert leaves the first restored. Empty
-    ``adapters`` is a no-op that still yields, so the call site needs no
-    conditional.
+    EVERY component an adapter half names is folded — denoisers and text
+    encoders alike — and they move together: a refusal on the second leaves the
+    first restored. A key that lands on no component refuses rather than being
+    dropped, because a dropped half is an adapter that served at the wrong
+    strength with a clean log. Empty ``adapters`` is a no-op that still yields,
+    so the call site needs no conditional.
 
     ``rebind`` is MANDATORY when a compiled artifact is armed. The artifact sees
     the in-place write through its user-managed pointer, but AOTI's runtime
@@ -252,14 +325,28 @@ def folded(
     alternative is a green request whose numbers are silently wrong, which is
     precisely the defect this module exists to remove.
     """
-    targets = w8a8_lora.branch_targets(pipe)
+    targets = fold_targets(pipe)
     if not adapters or not targets:
         yield {}
         return
 
+    # Route every adapter ONCE for the whole pipeline, before any component is
+    # resolved: an unroutable key must refuse before the first weight moves.
+    denoisers = tuple(w8a8_lora.branch_targets(pipe))
+    per_adapter = [
+        _route(
+            w8a8_lora.normalize_adapter_state_dict(pipe, state_dict, ref=ref),
+            targets, denoisers, ref=ref,
+        )
+        for state_dict, _weight, ref in adapters
+    ]
+
     plan: List[Tuple[Any, Dict[str, Any]]] = []
-    for model in targets.values():
-        deltas = compute_deltas(model, adapters, pipe=pipe)
+    for comp, model in targets.items():
+        slices = [routed.get(comp, {}) for routed in per_adapter]
+        if not any(slices):
+            continue
+        deltas = compute_deltas(model, adapters, pipe=pipe, keys=slices)
         if deltas:
             plan.append((model, deltas))
     if not plan:
@@ -281,7 +368,7 @@ def folded(
 
     scopes: List[FoldScope] = []
     stats: Dict[str, Any] = {
-        "denoisers": len(plan),
+        "components": len(plan),
         "modules": sum(len(d) for _m, d in plan),
         "digest": adapter_digest(adapters),
     }
@@ -292,9 +379,9 @@ def folded(
                 rebind(model)
         stats["folded_bytes"] = sum(s.folded_bytes for s in scopes)
         logger.info(
-            "[request_id=%s] lora folded into weights: %d denoiser(s), "
+            "[request_id=%s] lora folded into weights: %d component(s), "
             "%d module(s), %d saved byte(s), set=%s",
-            request_id, stats["denoisers"], stats["modules"],
+            request_id, stats["components"], stats["modules"],
             stats["folded_bytes"], stats["digest"],
         )
         yield stats

--- a/src/gen_worker/models/lora_fold.py
+++ b/src/gen_worker/models/lora_fold.py
@@ -1,0 +1,319 @@
+"""Per-request LoRA FOLD: the delta goes into the weights, then the pipeline
+runs unchanged (pgw#1571, Paul's direct order).
+
+The point is the compiled path. Live adapter ops — peft's ``lora.Linear``
+wrappers, or our own additive branch — put extra modules INSIDE the denoiser,
+and a compiled denoiser does not execute its own submodules: ``aot_serve.
+wrap_module`` replaced ``forward`` with the artifact's dispatch, whose
+constants were bound once at arm time. Measured (pgw#1571): a peft adapter on a
+compiled-armed unet changes the served tensor by exactly 0.0 — the base model,
+bit-identically, with no refusal and no log.
+
+Folding removes the failure mode instead of guarding it. ``W += B @ A * s``
+mutates the weight the artifact ALREADY POINTS AT (``load_constants(...,
+user_managed=True)`` stores raw pointers), so the traced graph is untouched and
+the adapter is simply part of the weights for the duration of the request.
+
+**In place, and the originals are kept as bytes.** Two independent reasons the
+mutation must be in place rather than a fresh tensor swapped onto the module:
+the artifact holds a POINTER, so a swap would be invisible to it; and cudagraph
+static inputs want pointer stability. Restore is therefore a ``copy_`` back from
+a saved clone, never a ``sub_`` of the delta — subtracting is not the inverse of
+adding in bf16, and a serial request stream would accumulate drift. Bit-exact
+restore is by construction here, not by tolerance.
+
+**What this does NOT do.** It does not fold onto a QUANTIZED leaf (fp8/gguf):
+an fp8 grid cannot represent a small delta and the fold would be a silent
+fidelity loss — those lanes keep the additive branch (:mod:`.w8a8_lora`), and
+this module refuses by name. And it does not by itself settle AOTI's runtime
+constant folding: ``compiler.py`` compiles with
+``use_runtime_constant_folding=True``, the fold runs once on the first ``run()``
+and never again, and an in-place weight write resets nothing — so any weight
+feeding a ``from_folded`` constant would go stale. :func:`folded` therefore
+takes ``rebind``, the caller-supplied seam that re-arms the artifact's constant
+table, and REFUSES to run against a compiled-armed module without one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+from ..api.errors import RefCompatibilitySurprise
+from . import w8a8_lora
+
+logger = logging.getLogger(__name__)
+
+#: One adapter as the fold takes it: (state dict, request weight, ref).
+Adapter = Tuple[Dict[str, Any], float, str]
+
+#: Called with the mutated denoiser after the weights change and again after
+#: they are restored. The serve path passes ``aot_serve.rearm_constants``; a
+#: pipeline with no compiled artifact passes nothing.
+Rebind = Callable[[Any], None]
+
+
+def _plain_leaf(module: Any) -> bool:
+    """True for a leaf whose ``weight`` is the real, unquantized tensor.
+
+    Quantized leaves are excluded rather than handled: an fp8 or GGML grid
+    stores the weight through a scale/block code, so ``W += delta`` would round
+    the delta away and serve a confidently wrong adapter. Those lanes have the
+    additive branch for exactly this reason.
+    """
+    import torch.nn as nn
+
+    from .fp8_storage import structural_base
+    from .gguf_torch import is_gguf_leaf
+    from .w8a8 import fp8_scaled_linear_class
+
+    if isinstance(module, fp8_scaled_linear_class()) or is_gguf_leaf(module):
+        return False
+    if structural_base(module) not in (nn.Linear, nn.Conv2d):
+        return False
+    return not bool(getattr(module, "_cozy_fp8_storage_applied", False))
+
+
+def adapter_digest(adapters: Sequence[Adapter]) -> str:
+    """A stable identity for one ADAPTER SET, order and weights included.
+
+    Keys the fold cache. It hashes refs and weights, never tensor bytes — a
+    ``ref`` is already fully pinned (``name@digest``) on every path that
+    reaches serving, so hashing gigabytes to learn what the ref already says
+    would be the expensive way to get the same answer.
+    """
+    h = hashlib.sha256()
+    for _sd, weight, ref in adapters:
+        h.update(str(ref).encode())
+        h.update(b"\0")
+        h.update(f"{float(weight):.12g}".encode())
+        h.update(b"\0")
+    return h.hexdigest()[:32]
+
+
+def _delta(mod: Any, a: Any, b: Any, scale: float) -> Any:
+    """``ΔW`` for one module, accumulated in fp32 and shaped like its weight.
+
+    Linear: ``B[out, r] @ A[r, in]``. Conv2d: ``B`` is the 1×1 up half, so the
+    contraction is over rank alone and ``A``'s kernel extent rides through —
+    which is what makes a LoCon conv pair foldable at all.
+    """
+    import torch
+    import torch.nn as nn
+
+    a32 = a.detach().to(torch.float32)
+    b32 = b.detach().to(torch.float32)
+    if isinstance(mod, nn.Conv2d) or a32.dim() == 4:
+        out = torch.einsum("or,rihw->oihw", b32.reshape(b32.shape[0], b32.shape[1]), a32)
+    else:
+        out = b32 @ a32
+    return out.mul_(float(scale))
+
+
+def compute_deltas(
+    model: Any, adapters: Sequence[Adapter], *, pipe: Any = None,
+) -> Dict[str, Any]:
+    """``module path -> ΔW`` for one denoiser and the whole adapter set.
+
+    The whole set settles into ONE delta per module before anything is written,
+    so a refusal anywhere leaves the weights untouched — the same fail-closed
+    ordering :func:`~.w8a8_lora.apply_branch_adapter_set` has.
+
+    Normalization and key resolution are :mod:`.w8a8_lora`'s
+    (``normalize_adapter_state_dict`` → ``split_state_dict`` → ``map_adapter``),
+    not a second implementation: the kohya/SGM grammars, the alpha/rank scale
+    and the typed refusals are already there and must not drift.
+    """
+    import torch
+
+    mods = w8a8_lora.branch_modules(model)
+    deltas: Dict[str, Any] = {}
+    for state_dict, weight, ref in adapters:
+        normalized = w8a8_lora.normalize_adapter_state_dict(
+            pipe if pipe is not None else model, state_dict, ref=ref)
+        den, _rest = w8a8_lora.split_state_dict(normalized)
+        if not den:
+            continue
+        mapped = w8a8_lora.map_adapter(den, model, ref=ref)
+        quantized = sorted(p for p in mapped if not _plain_leaf(mods[p]))
+        if quantized:
+            raise RefCompatibilitySurprise(
+                f"{len(quantized)} target module(s) store a QUANTIZED weight "
+                f"(e.g. {', '.join(quantized[:3])}) — folding a low-rank delta "
+                "onto an fp8/GGML grid rounds it away and serves a silently "
+                "weakened adapter; this lane keeps the additive branch",
+                ref=ref, axis="state_dict",
+            )
+        for path, (a, b, alpha_scale) in mapped.items():
+            mod = mods[path]
+            w = mod.weight
+            d = _delta(mod, a.to(w.device), b.to(w.device),
+                       alpha_scale * float(weight))
+            if tuple(d.shape) != tuple(w.shape):
+                raise RefCompatibilitySurprise(
+                    f"folded delta for {path!r} is {tuple(d.shape)} but the "
+                    f"weight is {tuple(w.shape)}",
+                    ref=ref, axis="state_dict",
+                )
+            prior = deltas.get(path)
+            deltas[path] = d if prior is None else prior.add_(d)
+    for path in deltas:
+        deltas[path] = deltas[path].to(torch.float32)
+    return deltas
+
+
+@dataclass
+class FoldScope:
+    """One denoiser's live fold: the saved originals that undo it exactly."""
+
+    model: Any
+    saved: List[Tuple[Any, Any]] = field(default_factory=list)
+    folded_bytes: int = 0
+
+    def restore(self) -> None:
+        """Put every mutated weight back, byte for byte. Never raises."""
+        for mod, original in reversed(self.saved):
+            try:
+                mod.weight.data.copy_(original)
+            except Exception:  # noqa: BLE001 — a restore must finish
+                logger.exception(
+                    "lora fold: restoring %s failed; this denoiser now carries "
+                    "an adapter into later requests", type(mod).__name__)
+        self.saved.clear()
+
+
+def apply_fold(model: Any, deltas: Mapping[str, Any]) -> FoldScope:
+    """Write ``deltas`` into the model's weights IN PLACE; return the undo.
+
+    Saves each original BEFORE the first write, so a failure mid-way is
+    undone by the same path as a normal exit. The clone is the exact bytes,
+    which is what makes the restore bit-exact rather than merely close.
+    """
+    import torch
+
+    mods = w8a8_lora.branch_modules(model)
+    scope = FoldScope(model=model)
+    try:
+        with torch.no_grad():
+            for path in sorted(deltas):
+                mod = mods[path]
+                w = mod.weight
+                scope.saved.append((mod, w.data.detach().clone()))
+                scope.folded_bytes += int(w.numel() * w.element_size())
+                w.data.copy_((w.data.to(torch.float32) + deltas[path]).to(w.dtype))
+    except BaseException:
+        scope.restore()
+        raise
+    return scope
+
+
+def _compiled_armed(model: Any) -> bool:
+    """Whether a compiled artifact is currently serving this module's forward.
+
+    Read off ``aot_serve``'s own marker rather than a second flag — the
+    question "is something other than this module's forward serving" has one
+    answer and it lives there.
+    """
+    from .. import aot_serve
+
+    return aot_serve.serves_compiled(model)
+
+
+@contextmanager
+def folded(
+    pipe: Any,
+    adapters: Sequence[Adapter],
+    *,
+    request_id: str = "",
+    rebind: Optional[Rebind] = None,
+) -> Iterator[Dict[str, Any]]:
+    """Serve one request with ``adapters`` folded into the pipeline's weights.
+
+    ::
+
+        with lora_fold.folded(pipe, riding, rebind=aot_serve.rearm_constants):
+            pipe(...)
+
+    Every branch-capable denoiser the pipeline carries is folded, and they move
+    together: a refusal on the second expert leaves the first restored. Empty
+    ``adapters`` is a no-op that still yields, so the call site needs no
+    conditional.
+
+    ``rebind`` is MANDATORY when a compiled artifact is armed. The artifact sees
+    the in-place write through its user-managed pointer, but AOTI's runtime
+    constant folding ran once at the first call and will not re-run on a bare
+    mutation — so a weight feeding a folded constant would go stale and serve a
+    confidently wrong tensor. Refusing here is the only honest default: the
+    alternative is a green request whose numbers are silently wrong, which is
+    precisely the defect this module exists to remove.
+    """
+    targets = w8a8_lora.branch_targets(pipe)
+    if not adapters or not targets:
+        yield {}
+        return
+
+    plan: List[Tuple[Any, Dict[str, Any]]] = []
+    for model in targets.values():
+        deltas = compute_deltas(model, adapters, pipe=pipe)
+        if deltas:
+            plan.append((model, deltas))
+    if not plan:
+        yield {}
+        return
+
+    if rebind is None:
+        armed = [type(m).__name__ for m, _d in plan if _compiled_armed(m)]
+        if armed:
+            raise RefCompatibilitySurprise(
+                f"{', '.join(armed)} is serving a COMPILED artifact and no "
+                "constant re-arm seam was supplied — an in-place weight fold "
+                "is visible to the artifact's user-managed pointers but does "
+                "NOT re-run AOTI's runtime constant folding, so any folded "
+                "constant would serve stale weights. Pass "
+                "rebind=aot_serve.rearm_constants",
+                axis="pipeline_load",
+            )
+
+    scopes: List[FoldScope] = []
+    stats: Dict[str, Any] = {
+        "denoisers": len(plan),
+        "modules": sum(len(d) for _m, d in plan),
+        "digest": adapter_digest(adapters),
+    }
+    try:
+        for model, deltas in plan:
+            scopes.append(apply_fold(model, deltas))
+            if rebind is not None:
+                rebind(model)
+        stats["folded_bytes"] = sum(s.folded_bytes for s in scopes)
+        logger.info(
+            "[request_id=%s] lora folded into weights: %d denoiser(s), "
+            "%d module(s), %d saved byte(s), set=%s",
+            request_id, stats["denoisers"], stats["modules"],
+            stats["folded_bytes"], stats["digest"],
+        )
+        yield stats
+    finally:
+        for model, scope in zip((m for m, _d in plan), scopes):
+            scope.restore()
+            if rebind is not None:
+                try:
+                    rebind(model)
+                except Exception:  # noqa: BLE001 — a restore must finish
+                    logger.exception(
+                        "lora fold: re-arming %s after restore failed",
+                        type(model).__name__)
+
+
+__all__ = [
+    "Adapter",
+    "FoldScope",
+    "Rebind",
+    "adapter_digest",
+    "apply_fold",
+    "compute_deltas",
+    "folded",
+]

--- a/src/gen_worker/models/lora_fold.py
+++ b/src/gen_worker/models/lora_fold.py
@@ -161,7 +161,10 @@ def _route(
                 # STRIPPED, unlike the denoiser half: `map_adapter` strips
                 # `unet.`/`transformer.` itself and knows no text-encoder
                 # prefix, so the routing that identified the component is also
-                # what removes it.
+                # what removes it. A remainder that names no module of that
+                # component then fails typed IN `map_adapter`, by key — the
+                # kohya-flat case (`text_model_encoder_layers_0_…`) lands
+                # there, and loudly, which is the correct place for it.
                 routed.setdefault(comp, {})[key[len(prefix):].lstrip(".")] = tensor
                 break
         else:

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -117,9 +117,12 @@ _KOHYA_TE_ALIASES = (
 )
 
 
-def _te_prefix_to_component() -> tuple[tuple[str, str], ...]:
+def te_prefix_to_component() -> tuple[tuple[str, str], ...]:
     """Component prefix -> pipe attribute, longest first so ``text_encoder_2``
-    wins over ``text_encoder``. Read at call time."""
+    wins over ``text_encoder``. Read at call time.
+
+    Shared with :mod:`gen_worker.models.lora_fold`, which needs the same table
+    to route an adapter's text-encoder half — one alias table, not two."""
     dotted = tuple(
         (c, c) for c in sorted(text_encoder_components(), key=len, reverse=True)
     )
@@ -249,7 +252,7 @@ def _reject_te_keys_on_cast_te(
     block-window/layerwise cast — fail loud, never fight the hooks. Keys
     targeting an UNCAST encoder in a mixed setup stay on the peft path."""
     def component_of(key: str) -> str:
-        for prefix, comp in _te_prefix_to_component():
+        for prefix, comp in te_prefix_to_component():
             if key.startswith(prefix):
                 return comp
         return ""

--- a/tests/test_lora_fold.py
+++ b/tests/test_lora_fold.py
@@ -60,6 +60,7 @@ class _Pipe:
 
     def __init__(self, unet: Any) -> None:
         self.unet = unet
+        self.text_encoder: Any = None
 
 
 def _adapter(unet: Any, seed: int, scale: float = 1.0) -> lora_fold.Adapter:
@@ -414,6 +415,47 @@ def test_a_quantized_leaf_refuses_the_fold_by_name() -> None:
 
     with pytest.raises(RefCompatibilitySurprise, match="QUANTIZED"):
         lora_fold.compute_deltas(unet, [_adapter(_tiny_unet(), 1)])
+
+
+def test_the_text_encoder_half_is_folded_too_and_not_dropped() -> None:
+    """A style LoRA usually carries a text-encoder half. Folding only the
+    denoiser would serve the adapter at the wrong strength with a clean log."""
+    import torch.nn as nn
+
+    class _TinyTE(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.q_proj = nn.Linear(8, 8, bias=False)
+
+        def forward(self, x: Any) -> Any:
+            return self.q_proj(x)
+
+    unet = _tiny_unet()
+    pipe = _Pipe(unet)
+    pipe.text_encoder = _TinyTE()
+    before = pipe.text_encoder.q_proj.weight.detach().clone()
+
+    torch.manual_seed(11)
+    sd, weight, ref = _adapter(unet, 5)
+    sd["text_encoder.q_proj.lora_A.weight"] = torch.randn(_RANK, 8) * 0.05
+    sd["text_encoder.q_proj.lora_B.weight"] = torch.randn(8, _RANK) * 0.05
+
+    with lora_fold.folded(pipe, [(sd, weight, ref)]) as stats:
+        assert stats["components"] == 2, stats
+        assert not torch.equal(pipe.text_encoder.q_proj.weight, before), (
+            "the text-encoder half must actually land")
+    assert torch.equal(pipe.text_encoder.q_proj.weight, before)
+
+
+def test_a_key_that_lands_on_no_component_refuses_rather_than_being_dropped() -> None:
+    unet = _tiny_unet()
+    sd, weight, ref = _adapter(unet, 6)
+    sd["text_encoder_2.q_proj.lora_A.weight"] = torch.randn(_RANK, 8) * 0.05
+    sd["text_encoder_2.q_proj.lora_B.weight"] = torch.randn(8, _RANK) * 0.05
+
+    with pytest.raises(RefCompatibilitySurprise, match="land on no component"):
+        with lora_fold.folded(_Pipe(unet), [(sd, weight, ref)]):
+            pass
 
 
 def test_an_empty_adapter_set_is_a_no_op_that_still_yields() -> None:

--- a/tests/test_lora_fold.py
+++ b/tests/test_lora_fold.py
@@ -1,4 +1,4 @@
-"""pgw#1571: fold the request's LoRA into the weights, restore exactly.
+"""Folding a request's LoRA into the denoiser weights, and undoing it exactly.
 
 The defect these tests exist for, measured on the production seams: a live
 adapter on a COMPILED-ARMED denoiser changes the served tensor by exactly
@@ -43,13 +43,15 @@ def _tiny_unet() -> Any:
     from diffusers import UNet2DConditionModel
 
     torch.manual_seed(0)
-    return UNet2DConditionModel(
+    unet: Any = UNet2DConditionModel(
         sample_size=8, in_channels=4, out_channels=4,
         block_out_channels=(16, 32), layers_per_block=1,
         down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
         up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
         cross_attention_dim=16, attention_head_dim=4, norm_num_groups=8,
-    ).eval()
+    )
+    unet.eval()
+    return unet
 
 
 class _Pipe:

--- a/tests/test_lora_fold.py
+++ b/tests/test_lora_fold.py
@@ -458,6 +458,32 @@ def test_a_key_that_lands_on_no_component_refuses_rather_than_being_dropped() ->
             pass
 
 
+def test_the_kohya_text_encoder_alias_routes_to_the_same_component() -> None:
+    """`lora_te_`/`lora_te1_` are sd-scripts' own grammar and route through the
+    same table as the dotted form — one alias table, checked from both sides."""
+    import torch.nn as nn
+
+    class _TinyTE(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.q_proj = nn.Linear(8, 8, bias=False)
+
+    unet = _tiny_unet()
+    pipe = _Pipe(unet)
+    pipe.text_encoder = _TinyTE()
+    before = pipe.text_encoder.q_proj.weight.detach().clone()
+
+    torch.manual_seed(13)
+    sd, weight, ref = _adapter(unet, 7)
+    sd["lora_te_q_proj.lora_down.weight"] = torch.randn(_RANK, 8) * 0.05
+    sd["lora_te_q_proj.lora_up.weight"] = torch.randn(8, _RANK) * 0.05
+
+    with lora_fold.folded(pipe, [(sd, weight, ref)]) as stats:
+        assert stats["components"] == 2, stats
+        assert not torch.equal(pipe.text_encoder.q_proj.weight, before)
+    assert torch.equal(pipe.text_encoder.q_proj.weight, before)
+
+
 def test_an_empty_adapter_set_is_a_no_op_that_still_yields() -> None:
     unet = _tiny_unet()
     args = _inputs()

--- a/tests/test_lora_fold.py
+++ b/tests/test_lora_fold.py
@@ -493,6 +493,30 @@ def test_an_empty_adapter_set_is_a_no_op_that_still_yields() -> None:
         assert torch.equal(_run(unet, args), baseline)
 
 
+def test_rearm_constants_still_matches_the_real_runner_surface() -> None:
+    """The stand-in above defines `_package`/`_bound_values`, so it would keep
+    passing if the VENDORED runner renamed them and production started
+    refusing every fold. Assert the two names against the real class.
+
+    `rearm_constants` reaches into those privates on purpose: the right home is
+    a `CompiledGraphRunner.rebind()` upstream, but the vendored snapshot is
+    sha256-fenced (`_vendor/VENDORED.toml`) so it cannot be edited here. This
+    is the tripwire that makes the re-vendor land loudly instead of quietly.
+    """
+    import inspect
+
+    from gen_worker._vendor.torchcg.runner import CompiledGraphRunner
+
+    source = inspect.getsource(CompiledGraphRunner)
+    for attribute in ("self._package", "self._bound_values"):
+        assert attribute in source, (
+            f"{attribute} is gone from CompiledGraphRunner — "
+            "aot_serve.rearm_constants reads it to re-install the constant "
+            "table after a fold, and would now refuse every compiled fold. "
+            "Give torchcg a public rebind() and call that instead"
+        )
+
+
 def test_the_set_digest_keys_on_refs_and_weights() -> None:
     unet = _tiny_unet()
     a, b = _adapter(unet, 1, 0.8), _adapter(unet, 2, 0.5)

--- a/tests/test_lora_fold_pgw1571.py
+++ b/tests/test_lora_fold_pgw1571.py
@@ -1,0 +1,430 @@
+"""pgw#1571: fold the request's LoRA into the weights, restore exactly.
+
+The defect these tests exist for, measured on the production seams: a live
+adapter on a COMPILED-ARMED denoiser changes the served tensor by exactly
+``0.0``. ``aot_serve.wrap_module`` replaced ``forward`` with the artifact's
+dispatch and bound its constants from the base weights at arm time; peft (and
+our own additive branch) put their work in SUBMODULES the artifact never runs.
+So the request pays for an adapter and receives the base model, with no
+refusal, no eager fallback and no log.
+
+Everything below runs the real code on CPU: a real tiny diffusers
+``UNet2DConditionModel``, the real ``aot_serve.wrap_module``, the real
+``w8a8_lora`` key resolution under ``lora_fold``. The artifact stand-in is a
+FROZEN DEEP COPY of the pre-fold denoiser called through its own forward —
+semantically exactly what a weightless AOTI package bound once at arm time is:
+the base-weight graph, its own memory, blind to later module surgery. That is
+the property under test, and a stand-in that reproduces it is the honest way to
+test it without a card.
+
+Every arm here is red-armed: the drift test runs a deliberately-broken restore
+(``sub_`` the delta instead of copying the original back) and asserts it is
+CAUGHT, and the guard test asserts the unguarded shape serves the base model.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from gen_worker import aot_serve  # noqa: E402
+from gen_worker.api.errors import RefCompatibilitySurprise  # noqa: E402
+from gen_worker.models import lora_fold  # noqa: E402
+
+_RANK = 4
+
+
+def _tiny_unet() -> Any:
+    from diffusers import UNet2DConditionModel
+
+    torch.manual_seed(0)
+    return UNet2DConditionModel(
+        sample_size=8, in_channels=4, out_channels=4,
+        block_out_channels=(16, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+        up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
+        cross_attention_dim=16, attention_head_dim=4, norm_num_groups=8,
+    ).eval()
+
+
+class _Pipe:
+    """A pipeline that is nothing but its denoiser — which is all
+    ``branch_targets`` reads."""
+
+    def __init__(self, unet: Any) -> None:
+        self.unet = unet
+
+
+def _adapter(unet: Any, seed: int, scale: float = 1.0) -> lora_fold.Adapter:
+    """One adapter in the live kohya-flat diffusers grammar, over an
+    attention projection (Linear) and a resnet conv (the LoCon pair class)."""
+    torch.manual_seed(seed)
+    sd: Dict[str, Any] = {}
+
+    def pair(flat: str, a: Any, b: Any) -> None:
+        sd[f"lora_unet_{flat}.lora_down.weight"] = a
+        sd[f"lora_unet_{flat}.lora_up.weight"] = b
+        sd[f"lora_unet_{flat}.alpha"] = torch.tensor(float(_RANK))
+
+    q = unet.get_submodule(
+        "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_q")
+    pair("down_blocks_1_attentions_0_transformer_blocks_0_attn1_to_q",
+         torch.randn(_RANK, q.in_features) * 0.05,
+         torch.randn(q.out_features, _RANK) * 0.05)
+    r1 = unet.get_submodule("down_blocks.0.resnets.0.conv1")
+    pair("down_blocks_0_resnets_0_conv1",
+         torch.randn(_RANK, r1.in_channels, *r1.kernel_size) * 0.05,
+         torch.randn(r1.out_channels, _RANK, 1, 1) * 0.05)
+    return (sd, scale, f"cozy/probe-{seed}@v1")
+
+
+def _inputs() -> Tuple[Any, Any, Any]:
+    torch.manual_seed(7)
+    return (torch.randn(1, 4, 8, 8), torch.tensor(5), torch.randn(1, 4, 16))
+
+
+def _run(unet: Any, args: Tuple[Any, ...]) -> Any:
+    with torch.inference_mode():
+        return unet(*args, return_dict=False)[0].clone()
+
+
+class _FrozenArtifact:
+    """The AOTI package, in the one respect that matters: it is a copy of the
+    denoiser taken at ARM TIME and it never sees a later module change.
+
+    Implements the ``EntryDispatch`` surface ``wrap_module`` uses.
+    """
+
+    def __init__(self, module: Any) -> None:
+        self._frozen = copy.deepcopy(module).eval()
+        self.calls = 0
+        self.last_selected = "probe-graph"
+        self.runners: Tuple[Any, ...] = (("probe-graph", None),)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        with torch.inference_mode():
+            return self._frozen(*args, **kwargs)
+
+    def excludes(self, names: Any) -> bool:
+        return False
+
+    def remove(self, name: str, reason: str) -> None:
+        self.runners = ()
+
+
+class _RecordingPackage:
+    """The AOTI package surface ``rearm_constants`` drives, and the only one
+    it drives: ``load_constants(values, check_full_update, user_managed)``.
+    Records each re-install so the test can assert the fold told the artifact
+    its constants moved."""
+
+    def __init__(self) -> None:
+        self.loads: List[Dict[str, Any]] = []
+
+    def load_constants(self, values: Any, *, check_full_update: bool,
+                       user_managed: bool = False,
+                       allow_h2d_copy: bool = False) -> None:
+        assert check_full_update and user_managed
+        self.loads.append(dict(values))
+
+
+class _BoundRunner:
+    """``TCGEntryRunner.runner``'s shape: the loaded package plus the constant
+    table that was bound BY REFERENCE at arm time."""
+
+    def __init__(self, module: Any) -> None:
+        self._package = _RecordingPackage()
+        self._bound_values = {
+            name: tensor for name, tensor in module.named_parameters()}
+
+
+class _Entry:
+    def __init__(self, module: Any) -> None:
+        self.runner = _BoundRunner(module)
+
+
+class _PointerArtifact(_FrozenArtifact):
+    """The other half of the truth: an artifact whose constants are the
+    module's OWN tensors, bound by reference (``user_managed=True``). An
+    in-place weight write IS visible to it — which is why the fold is in place
+    and never a tensor swap."""
+
+    def __init__(self, module: Any) -> None:
+        self._frozen = module
+        self.calls = 0
+        self.last_selected = "probe-graph"
+        self.entry = _Entry(module)
+        self.runners = (("probe-graph", self.entry),)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        with torch.inference_mode():
+            return type(self._frozen).forward(self._frozen, *args, **kwargs)
+
+
+def _arm(unet: Any, artifact: Any) -> None:
+    aot_serve.wrap_module(
+        unet, artifact, {"family": "probe", "compiled_graph_key": "probe"},
+        attr="forward", target="unet",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The defect
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_adapter_on_a_compiled_armed_denoiser_serves_the_base_model() -> None:
+    """RED ARM for everything below: without the guard, the served tensor is
+    bit-identical to the base model while the adapter sits attached."""
+    unet = _tiny_unet()
+    args = _inputs()
+    baseline = _run(unet, args)
+
+    artifact = _FrozenArtifact(unet)
+    _arm(unet, artifact)
+    # Exactly the module state peft's `inject_adapter_in_model` leaves behind
+    # (verified against peft 0.19.1: absent -> {'name': cfg} -> absent on
+    # unload). Set directly so the assertion does not need peft installed.
+    scope = lora_fold.compute_deltas(unet, [_adapter(unet, 1)])
+    held = lora_fold.apply_fold(unet, scope)
+    try:
+        served = _run(unet, args)
+    finally:
+        held.restore()
+
+    assert artifact.calls == 1
+    assert torch.equal(served, baseline), (
+        "the frozen artifact must be blind to module-side weight surgery — "
+        "that blindness IS the defect this issue is about"
+    )
+
+
+def test_the_peft_guard_routes_a_compiled_armed_module_to_eager() -> None:
+    unet = _tiny_unet()
+    args = _inputs()
+    artifact = _FrozenArtifact(unet)
+    _arm(unet, artifact)
+    assert _run(unet, args) is not None and artifact.calls == 1
+
+    setattr(unet, aot_serve.PEFT_MARKER_ATTR, {"probe": object()})
+    before = artifact.calls
+    _run(unet, args)
+    assert artifact.calls == before, (
+        "a live peft adapter must NOT reach the artifact — the artifact "
+        "cannot execute peft's submodule wrappers and would serve base"
+    )
+
+    delattr(unet, aot_serve.PEFT_MARKER_ATTR)
+    _run(unet, args)
+    assert artifact.calls == before + 1, "unloading the adapter must resume compiled"
+
+
+# ---------------------------------------------------------------------------
+# The fold
+# ---------------------------------------------------------------------------
+
+
+def test_the_fold_reaches_a_pointer_bound_artifact() -> None:
+    """An in-place fold is visible to an artifact that holds the module's own
+    tensors — the property ``load_constants(user_managed=True)`` provides and
+    the reason the fold must never swap a fresh tensor onto the module."""
+    unet = _tiny_unet()
+    args = _inputs()
+    artifact = _PointerArtifact(unet)
+    _arm(unet, artifact)
+    baseline = _run(unet, args)
+
+    with lora_fold.folded(_Pipe(unet), [_adapter(unet, 1)],
+                          rebind=aot_serve.rearm_constants) as stats:
+        served = _run(unet, args)
+
+    assert stats["modules"] == 2, stats
+    assert not torch.equal(served, baseline), (
+        "the folded adapter must change the served tensor")
+    assert artifact.calls == 2, "both calls went through the artifact"
+    assert torch.equal(_run(unet, args), baseline), "restore must be exact"
+    assert len(artifact.entry.runner._package.loads) == 2, (
+        "the artifact must be told its constants moved on the way IN and on "
+        "the way OUT — AOTI folds once and never re-folds on a bare write")
+
+
+def test_the_fold_matches_the_eager_adapter_it_replaces() -> None:
+    """Folding is not an approximation of the adapter: ``W += B@A*s`` and an
+    additive branch compute the same thing, so the folded weights must agree
+    with the branch path to floating-point noise."""
+    from gen_worker.models import w8a8_lora
+
+    unet = _tiny_unet()
+    args = _inputs()
+    adapter = _adapter(unet, 3)
+
+    branch = copy.deepcopy(unet)
+    w8a8_lora.enable_lora_branches(branch, 16)
+    w8a8_lora.apply_branch_adapters(branch, [adapter], allow_resize=True)
+    branched = _run(branch, args)
+
+    with lora_fold.folded(_Pipe(unet), [adapter]):
+        folded_out = _run(unet, args)
+
+    assert torch.allclose(folded_out, branched, atol=2e-5, rtol=2e-4), (
+        f"max|delta| = {(folded_out - branched).abs().max().item():.3e}")
+
+
+def test_two_adapters_fold_together_and_commute_with_the_branch_sum() -> None:
+    unet = _tiny_unet()
+    args = _inputs()
+    a, b = _adapter(unet, 1, 0.8), _adapter(unet, 2, 0.5)
+    base = _run(unet, args)
+
+    with lora_fold.folded(_Pipe(unet), [a, b]) as stats:
+        both = _run(unet, args)
+    assert stats["modules"] == 2
+    assert not torch.equal(both, base)
+
+    with lora_fold.folded(_Pipe(unet), [a]):
+        only_a = _run(unet, args)
+    assert not torch.equal(both, only_a), "the second adapter must contribute"
+
+
+# ---------------------------------------------------------------------------
+# Restore: bit-exact, and the check is proven able to fail
+# ---------------------------------------------------------------------------
+
+
+def _serial_drift(unet: Any, pipe: Any, adapters: List[Any], args: Any,
+                  *, break_restore: bool = False) -> List[Any]:
+    """Ten serial requests, alternating A / none / B / none. Returns every
+    bare-request output; each must equal the pre-LoRA baseline exactly."""
+    bare: List[Any] = []
+    for step in range(10):
+        riding = [adapters[(step // 2) % len(adapters)]] if step % 2 == 0 else []
+        if not riding:
+            bare.append(_run(unet, args))
+            continue
+        deltas = lora_fold.compute_deltas(unet, riding, pipe=pipe)
+        scope = lora_fold.apply_fold(unet, deltas)
+        _run(unet, args)
+        if break_restore:
+            # THE BROKEN RESTORE the exact one exists to avoid: subtract the
+            # delta instead of copying the original bytes back. Algebraically
+            # the inverse; in floating point it is not, and a serial stream
+            # accumulates the difference.
+            with torch.no_grad():
+                mods = dict(unet.named_modules())
+                for path, d in deltas.items():
+                    w = mods[path].weight
+                    w.data.copy_((w.data.to(torch.float32) - d).to(w.dtype))
+            scope.saved.clear()
+        else:
+            scope.restore()
+    return bare
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_restore_is_bit_exact_over_ten_serial_alternating_requests(dtype: Any) -> None:
+    unet = _tiny_unet().to(dtype)
+    pipe = _Pipe(unet)
+    args = tuple(
+        t.to(dtype) if t.is_floating_point() else t for t in _inputs())
+    adapters = [_adapter(unet, 1), _adapter(unet, 2)]
+    before = {n: p.detach().clone() for n, p in unet.named_parameters()}
+    baseline = _run(unet, args)
+
+    bare = _serial_drift(unet, pipe, adapters, args)
+
+    assert len(bare) == 5
+    for i, out in enumerate(bare):
+        assert torch.equal(out, baseline), f"bare request {i} drifted"
+    for name, original in before.items():
+        assert torch.equal(unet.get_parameter(name), original), (
+            f"{name} did not come back byte for byte")
+
+
+def test_the_drift_check_catches_a_deliberately_broken_restore() -> None:
+    """RED ARM. bf16 is where the delta-subtract restore is visibly wrong; if
+    this ever passes, the drift test above is proving nothing."""
+    unet = _tiny_unet().to(torch.bfloat16)
+    pipe = _Pipe(unet)
+    args = tuple(
+        t.to(torch.bfloat16) if t.is_floating_point() else t for t in _inputs())
+    adapters = [_adapter(unet, 1), _adapter(unet, 2)]
+    before = {n: p.detach().clone() for n, p in unet.named_parameters()}
+    baseline = _run(unet, args)
+
+    bare = _serial_drift(unet, pipe, adapters, args, break_restore=True)
+
+    drifted_outputs = [i for i, out in enumerate(bare)
+                       if not torch.equal(out, baseline)]
+    drifted_weights = [n for n, original in before.items()
+                       if not torch.equal(unet.get_parameter(n), original)]
+    assert drifted_outputs or drifted_weights, (
+        "the delta-subtract restore left no trace — the exactness check "
+        "cannot go red and therefore proves nothing")
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+def test_a_compiled_armed_module_refuses_a_fold_with_no_rebind_seam() -> None:
+    unet = _tiny_unet()
+    _arm(unet, _FrozenArtifact(unet))
+    with pytest.raises(RefCompatibilitySurprise, match="constant re-arm"):
+        with lora_fold.folded(_Pipe(unet), [_adapter(unet, 1)]):
+            pass
+
+
+def test_an_eager_module_needs_no_rebind_seam() -> None:
+    unet = _tiny_unet()
+    args = _inputs()
+    baseline = _run(unet, args)
+    with lora_fold.folded(_Pipe(unet), [_adapter(unet, 1)]):
+        assert not torch.equal(_run(unet, args), baseline)
+    assert torch.equal(_run(unet, args), baseline)
+
+
+def test_a_quantized_leaf_refuses_the_fold_by_name() -> None:
+    """An fp8 grid cannot hold a low-rank delta; folding onto it would round
+    the adapter away and serve a confidently weakened result."""
+    from gen_worker.models.w8a8 import fp8_scaled_linear_class
+
+    unet = _tiny_unet()
+    path = "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_q"
+    parent = unet.get_submodule(path.rpartition(".")[0])
+    old = getattr(parent, "to_q")
+    cls = fp8_scaled_linear_class()
+    new = cls(old.in_features, old.out_features, bias=old.bias is not None,
+              compute_dtype=torch.float32, static_input_scale=False,
+              gemm_mode="pertensor")
+    new.weight = old.weight.detach().to(torch.float8_e4m3fn)
+    new.weight_scale = torch.ones(old.out_features, 1, dtype=torch.float32)
+    setattr(parent, "to_q", new)
+
+    with pytest.raises(RefCompatibilitySurprise, match="QUANTIZED"):
+        lora_fold.compute_deltas(unet, [_adapter(_tiny_unet(), 1)])
+
+
+def test_an_empty_adapter_set_is_a_no_op_that_still_yields() -> None:
+    unet = _tiny_unet()
+    args = _inputs()
+    baseline = _run(unet, args)
+    with lora_fold.folded(_Pipe(unet), []) as stats:
+        assert stats == {}
+        assert torch.equal(_run(unet, args), baseline)
+
+
+def test_the_set_digest_keys_on_refs_and_weights() -> None:
+    unet = _tiny_unet()
+    a, b = _adapter(unet, 1, 0.8), _adapter(unet, 2, 0.5)
+    assert lora_fold.adapter_digest([a, b]) == lora_fold.adapter_digest([a, b])
+    assert lora_fold.adapter_digest([a, b]) != lora_fold.adapter_digest([b, a])
+    heavier = (a[0], 0.9, a[2])
+    assert lora_fold.adapter_digest([a]) != lora_fold.adapter_digest([heavier])

--- a/tests/test_lora_fold_pgw1571.py
+++ b/tests/test_lora_fold_pgw1571.py
@@ -180,9 +180,11 @@ def _arm(unet: Any, artifact: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_a_live_adapter_on_a_compiled_armed_denoiser_serves_the_base_model() -> None:
-    """RED ARM for everything below: without the guard, the served tensor is
-    bit-identical to the base model while the adapter sits attached."""
+def test_an_artifact_bound_by_value_is_blind_to_module_side_weight_surgery() -> None:
+    """The defect in one assertion. An artifact whose constants are a COPY —
+    which is what a bound-and-then-copied table is, and what peft's submodule
+    wrapping is always up against — returns the base model bit-identically
+    while an adapter is live on the module. RED ARM for the guard below."""
     unet = _tiny_unet()
     args = _inputs()
     baseline = _run(unet, args)


### PR DESCRIPTION
Paul's order was to **remove the LoRA ×2 graph-specialization axis**. STEP 1 was to verify what we actually do, and the answer changes the work.

## There is no LoRA axis in any committed lock

Enumerated from `derive.document.graphs.lanes[].graphs[]`, not inferred:

| endpoint | graphs | ingress input names, every graph | `lora_bucket` |
|---|---|---|---|
| sd15 | 14 | `sample, timestep, encoder_hidden_states` | absent ×14 |
| sdxl | 18 | `sample, timestep, encoder_hidden_states, text_embeds, time_ids` | absent ×18 |
| anima | 0 | — | — |

`lora_a`/`lora_b` appear in **zero** graphs; every one is the branchless `bucket=0` specialization. So 14 = 2 CFG × 7 aspect and 18 = 2 × 9 — exactly what pgw#1548's survey found. The ×2 is a *latent* design axis (`torchcg.declaration.Compile.lora_bucket` + `models/lora_lifted.py`, pgw#725/#790) that was never enumerated, and `Compile` no longer exists in the v2 SDK. **Removing it costs zero specializations.**

## What the absence means at serve time is a P0

The production LoRA path for sd15/sdxl is the endpoint's own twelve-line context manager (`serverless-endpoints/sd15/src/sd15/main.py:287`) calling diffusers `load_lora_weights` + `set_adapters` — peft adapter ops, which wrap **submodules**. `aot_serve.wrap_module` replaced the denoiser's `forward` with the artifact's dispatch and bound its constants from the base weights at arm time, so those wrappers never execute.

**The request pays for an adapter and receives the base model, bit-identically, with no refusal, no eager fallback and no log.** Measured on the production seams (CPU, real `wrap_module`, real diffusers `load_lora_adapter`):

```
RED ARM  (eager, no compiled dispatch): max|delta| = 2.227041e-02
ARMED    (compiled dispatch installed): max|delta| = 0.000000e+00
served-with-LoRA vs pre-LoRA BASE     : max|delta| = 0.000000e+00
peft-wrapped submodules on the armed unet: 32
```

Currently masked by sd15 adoption being broken (`0 adopted, 14 holes`) and pgw#1567's FP16-vs-BF16 derive mismatch. It arms itself the moment adoption starts working.

## What this PR does

**`models/lora_fold.py`** — Paul's shape: fold the request's deltas into the weights, run the pipeline unchanged, restore exactly.

- **In place.** `load_constants(..., user_managed=True)` stores raw pointers, so the artifact sees an in-place write; a tensor swap would be invisible to it, and cudagraph static inputs want pointer stability either way.
- **Restore copies saved originals back, never subtracts the delta.** Subtraction is the algebraic inverse and not the floating-point one; a serial stream would accumulate drift. Bit-exactness here is by construction, not by tolerance.
- Key resolution, the kohya/SGM grammars and the alpha/rank scale are `w8a8_lora`'s — not a second implementation.
- **Routing is total.** Every component an adapter half names is folded — denoisers *and* text encoders. `split_state_dict` returns `(denoiser keys, everything else)`, and consuming only the first half would have folded a style LoRA at partial strength with a clean log: the same class of defect this PR exists to remove, one scale down. A key that lands on no component **refuses**, before the first weight moves.
- Quantized leaves (fp8 / GGML) **refuse by name**: an fp8 grid rounds a low-rank delta away, and those lanes have the additive branch for exactly this reason.

**`aot_serve`** — the guard that closes the P0 for the path we have today. A live `peft_config` on a compiled-armed module routes **eager** and says so once (`lora_hygiene`, `phase=adapter_ops_on_compiled`). Eager is a real degradation; a silently wrong tensor is not a degradation, it is a wrong answer.

**`aot_serve.rearm_constants`** — the seam the fold needs on a compiled module. AOTI's runtime constant folding runs once on the first `run()` (`fold_state` INITIALIZED → FOLDED) and never again, and an in-place weight write resets nothing, so any weight feeding a folded constant would go stale. Re-installing the same pointers puts `fold_state` back. `folded()` **refuses** a compiled-armed module with no rebind seam rather than serving from a stale fold.

## Verification

15 tests, real code on CPU, every arm red-armed:

- the drift check runs 10 serial alternating requests (A / none / B / none) in fp32 and bf16 and asserts every bare output and every parameter is **bit-identical** to the pre-LoRA baseline;
- a companion test runs a **deliberately-broken** delta-subtract restore and asserts it is caught — if that ever passes, the exactness check proves nothing;
- mutation-verified: disabling the peft guard fails `test_the_peft_guard_...`; perturbing the restore by 1e-9 fails three tests.

The `$0` probe that found the defect failed its own red arm on the first run (a `prefix='transformer'` mismatch made the eager delta 0.0 too) and was fixed before the measurement arm was believed.

## Fold cost

CPU, single thread, real SD1.5/SDXL attention-projection shapes at rank 16. **A bound, not the production number** — the GPU measurement is owed and needs a window.

| | modules | params | delta (B@A) | fold (clone+add) | restore | total |
|---|---|---|---|---|---|---|
| sd15 attn | 84 | 65.2M / 124 MiB | 178 ms | 557 ms | 29 ms | **764 ms** |
| sdxl attn | 144 | 253M / 482 MiB | 460 ms | 1622 ms | 118 ms | **2199 ms** |

The fold is bandwidth-bound (~4× the touched bytes), so a card should put it in single-digit ms against a 1-2 s denoise.

## Still owed (tracked in pgw#1571)

- endpoint-side rewire of `Sd15Model.adapters` / `SdxlModel.adapters` onto this seam (serverless-endpoints);
- a `CompiledGraphRunner.rebind()` upstream in torchcg, so `rearm_constants` stops reaching into a vendored private — the vendored snapshot is sha256-fenced, so it cannot be edited here;
- GPU window: how many of the unet graph's constants are `from_folded` at all (plausibly zero, in which case the re-arm is free), per-request re-fold cost, and RT with 0/1/2 LoRAs compiled vs eager.
