### PR TITLE
pgw#1573: ONE store, ONE arming path — the mint arms what the store hands back

### DIFF
--- a/changelog.d/pgw1573-adopt-unify.md
+++ b/changelog.d/pgw1573-adopt-unify.md
@@ -1,0 +1,39 @@
+- **pgw#1573: the runtime mint arms the bytes the STORE hands back, never the
+  directory the compiler wrote.** `_mint_one` published a tar+gzip ENVELOPE and
+  then armed `Engine.compile`'s unpacked destination, so no run of the mint had
+  ever read its own published bytes. That is the seam pgw#1471's bare-`.pt2`
+  publish hid behind from the first publisher that ever existed until va#3
+  arm 2 fetched one on a pod and holed 14/14 on `cannot decompress` — every
+  local green was green over the directory. The mint now publishes, FETCHES
+  BACK through `fetch_artifact`, and arms that, at the same position boot
+  adoption fetches to: a self-minted artifact and a hub-fetched artifact
+  traverse ONE load path, so a publish/load format skew breaks on the machine
+  that made it, in seconds. A publish the store cannot hand back is the typed
+  `MintNotServable`. A storeless mint is refused at construction — it had
+  exactly one thing left to arm, and that thing was the second load path.
+
+- **pgw#1573: a fleet-pool hit is BANKED into the local CAS on the way past.**
+  `TieredGraphStore.fetch_artifact` returned the hub's bytes and kept none of
+  them, so a pod re-downloaded every artifact on every restart and a hub outage
+  turned a warm box cold. "Check local, then remote" is half a cache if the
+  remote answer is never kept. Banking is best-effort — the bytes are already
+  verified and in hand, so a failure costs one more download, never an arm —
+  and an answer carrying no requirements manifest is deliberately NOT banked,
+  because a cached artifact with no stated floors would be adoptable on a
+  machine the fleet answer would have refused.
+
+- **pgw#1573: ONE store constructor, `mint_store.graph_store` (was
+  `worker_store`).** Six call sites built a store six ways — three of them a
+  bare `LocalGraphStore` with no hub tier and no baked tier — so "do I have
+  this graph" had three answers depending on which entry point asked. A pod,
+  `gen-worker up`, `gen-worker compile` and the CI runner now build the same
+  object; `upstream=None` is the stated difference between a box and a pod, not
+  a different class. `TieredGraphStore` gained the `artifact_skew` passthrough
+  pgw#1561 left owed, so a skewed local position is a miss for every reader
+  instead of only for the compile CLI.
+
+- **pgw#1573: `gen-worker compile`'s `FETCHED` outcome is deleted, along with
+  the "FETCH-FIRST … the hub is asked before anything is built" paragraph that
+  documented it.** `_store` passed `upstream=None` and `FETCHED` was defined
+  and never assigned anywhere in `src/`. A vocabulary member nothing can emit
+  is a proof condition that passes unconditionally.

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -3,9 +3,17 @@
 pgw#1491. Paul: *"compile all graph-specializations for this card, if they
 cannot be fetched already."* Three properties, all load-bearing:
 
-**FETCH-FIRST.** Per specialization the hub is asked before anything is built —
-it is the fleet artifact pool, so one machine's compile is every same-env
-machine's fetch. Only a genuine miss pays for a build.
+**PRESENCE-FIRST, THROUGH THE ONE STORE.** Per specialization the store is
+asked before anything is built — local CAS first, then the fleet pool when this
+process has a release to adopt for (a pod does; a box `compile` on a committed
+lock does not, and that is a stated `upstream=None`, not a different store).
+Only a genuine miss pays for a build.
+
+pgw#1573 corrected this paragraph, which claimed a hub consult this verb has
+never had: `_store` passed `upstream=None` and the `FETCHED` outcome constant
+was defined and never assigned anywhere in `src/`. A vocabulary member nothing
+can emit is a proof condition that passes unconditionally, so it is deleted
+rather than left reading like coverage.
 
 **NEVER BLOCKS SERVING.** This is a separate process. An endpoint that is up
 keeps serving throughout, and its own background mint and this command key work
@@ -89,8 +97,7 @@ Builder = Callable[["Spec", Path, Path], Path]
 
 #: Outcome vocabulary. Closed: every specialization ends in exactly one of
 #: these and the summary counts them.
-PRESENT = "present"        # already in this machine's CAS
-FETCHED = "fetched"        # pulled from the hub's fleet pool
+PRESENT = "present"        # already readable through the store (local or fleet)
 BUILT = "built"            # compiled here
 REUSED = "reused"          # resolved out of the engine's own compile cache
 CLAIMED = "claimed"        # another process holds the lease; it is doing it
@@ -331,16 +338,21 @@ def _env_identity(endpoint_dir: Path, sm: str, lockfile: Optional[Path]) -> Any:
 
 
 def _store(cas_root: Path) -> Any:
-    """This machine's graph store, tiered under the hub when one is configured.
+    """THE store — the same constructor a pod and `gen-worker up` build.
 
-    The hub tier is READ-ONLY here: publishing a locally-built artifact back to
-    the fleet pool is the pod-side mint's job (pgw#1471), which stamps driver
-    range and measured peak. A CLI publishing unstamped artifacts would fill
-    the pool with rows nothing can safely admit.
+    ``upstream=None``: a box compiling from a committed lock has no release to
+    adopt for, and the fleet artifact route is release-scoped. That is a stated
+    absence, not a second kind of store — and it is the ONLY thing that differs
+    between this call and the pod's.
+
+    Publishing a locally-built artifact back to the fleet pool is the pod-side
+    mint's job (pgw#1471), which stamps driver range and measured peak. A CLI
+    publishing unstamped artifacts would fill the pool with rows nothing can
+    safely admit.
     """
-    from ..serving.mint_store import worker_store
+    from ..serving.mint_store import graph_store
 
-    return worker_store(Path(cas_root), None)
+    return graph_store(Path(cas_root))
 
 
 # --------------------------------------------------------------------------
@@ -543,17 +555,20 @@ def endpoint_module(endpoint_dir: Path) -> str:
 def serving_reader(cas_root: Path) -> Any:
     """The store object BOOT-TIME ADOPTION builds, over this machine's CAS.
 
-    Constructed exactly the way ``cli/daemon._adoption_source`` constructs it,
-    and deliberately NOT the store this command publishes through. "My writer
-    returned without raising" and "the reader that arms graphs can find it" are
-    different claims, and pgw#1533 is what happens when only the first one is
-    ever checked: the write succeeded, into torchcg's engine cache, and the
-    reader saw nothing.
-    """
-    from .._vendor.tensorfs import LocalCAS
-    from .._vendor.torchcg.store import LocalGraphStore
+    pgw#1573: this used to be a DELIBERATELY DIFFERENT object from the one this
+    command publishes through — an independence that was never the property
+    that mattered. pgw#1533's defect was two BANDS (the engine's compile cache
+    versus the ``(cg-graph-v1, cg-env-v2)`` serving band), not two Python
+    objects over one band, and pgw#1561's defect was two FORMATS. Neither is
+    detected by holding a second handle, and both are detected by the read-back
+    below actually opening the bytes. So there is one store, built by
+    :func:`_store`, and the witness is what proves it.
 
-    return LocalGraphStore(LocalCAS(Path(cas_root)))
+    Kept as a function because callers pass a CAS root, not a store — and
+    because a second construction over the same root is now provably the same
+    answer rather than a hedge against the writer.
+    """
+    return _store(Path(cas_root))
 
 
 @dataclass(frozen=True, slots=True)
@@ -919,6 +934,11 @@ def compile_all(
         one thing that could repair it — the re-publish. A skewed position is
         a MISS here, which is exactly what routes it back through the publish
         (whose store-side migration arm replaces the skewed incumbent).
+
+        Both questions go to the SAME store object (pgw#1573). The skew probe
+        used to build a second one per specialization, which was both a second
+        answer to "do I have this graph" and per-spec construction on the warm
+        path pgw#1546 measured down to 0.95 s.
         """
         try:
             if not store.has_artifact(spec.graph, env):
@@ -930,7 +950,7 @@ def compile_all(
             )
             return False
         try:
-            skew = serving_reader(cas_root).artifact_skew(spec.graph, env)
+            skew = store.artifact_skew(spec.graph, env)
         except Exception:  # noqa: BLE001 — probe absence never blocks a run
             return True
         if skew:
@@ -1417,7 +1437,6 @@ __all__ = [
     "Builder",
     "CompileError",
     "FAILED",
-    "FETCHED",
     "FILLS",
     "FILL_ALL",
     "FILL_BACKGROUND",

--- a/src/gen_worker/cli/daemon.py
+++ b/src/gen_worker/cli/daemon.py
@@ -246,10 +246,16 @@ def _adoption_source(spec: BootSpec, module_name: str) -> Tuple[Any, Any]:
             "--sm is required to adopt compiled graphs (artifacts are per-sm). "
             "Omit --graph-store to serve eager."
         )
-    from .._vendor.tensorfs import LocalCAS
-    from .._vendor.torchcg.store import LocalGraphStore, StoreError
+    from .._vendor.torchcg.store import StoreError
+    from ..serving.mint_store import graph_store
 
-    store = LocalGraphStore(LocalCAS(Path(spec.graph_store)))
+    # THE ONE STORE (pgw#1573). This built a bare `LocalGraphStore` — no hub
+    # tier, no baked tier, and a different object from the one this boot's
+    # background mint would publish through — so `up` and a pod disagreed about
+    # what "present" means. `graph_store` is what every entry point builds now;
+    # `upstream=None` is the honest statement that a box boot has no release to
+    # adopt for, not a second class of store.
+    store = graph_store(Path(spec.graph_store))
     try:
         document = store.get_graphs(module_name)
     except StoreError as exc:

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -227,19 +227,17 @@ def _adoption_source(
             # the whole eager bridge. Say it, then take it.
             print(f"adopt: {exc}", file=sys.stderr)
             return None, None
-        if args.mint:
-            # ONE store for the boot AND the mint. The hub store is read-only
-            # by construction, so a mint publishing through it would fail every
-            # graph; tiering it here — and BEFORE the AdoptSession is built —
-            # keeps a single answer to "do I have this graph".
-            from .mint_store import worker_store
+        # ONE store, ALWAYS tiered (pgw#1573). The hub store is read-only by
+        # construction, so it can never be the only tier: a mint would fail
+        # every publish and a fleet hit would be re-downloaded on every boot.
+        # This used to tier only under `--mint`, which made the adopt-only run
+        # and the minting run disagree about what "present" means.
+        from .mint_store import graph_store
 
-            store = worker_store(_mint_cas(args), store)
-        return store, document
-    from .._vendor.tensorfs import LocalCAS
-    from .._vendor.torchcg.store import LocalGraphStore
+        return graph_store(_mint_cas(args), store), document
+    from .mint_store import graph_store
 
-    store = LocalGraphStore(LocalCAS(Path(args.graph_store)))
+    store = graph_store(Path(args.graph_store))
     return store, store.get_graphs(module_name)
 
 

--- a/src/gen_worker/serving/mint.py
+++ b/src/gen_worker/serving/mint.py
@@ -12,11 +12,15 @@ graphs it is missing. Four properties, each load-bearing:
    The whole-declaration sweep that took e2e#1892 run 7's pod down with it is
    not reachable from this entry at all.
 
-2. **PER-GRAPH PUBLISH.** Each hole is compiled, published (hub store + local
-   CAS) and ARMED on its own, the moment its artifact lands — never a batch,
-   never a seal at the end. A pod killed mid-mint keeps every completed graph
-   and its successor mints only the remainder (pgw#1367 clause 4: partial-hit
-   by construction). This deletes the loss mode runs 7/8 died to.
+2. **PER-GRAPH PUBLISH, AND THE ARM READS THE STORE BACK.** Each hole is
+   compiled, published (local CAS + hub) and ARMED on its own, the moment its
+   artifact lands — never a batch, never a seal at the end. A pod killed
+   mid-mint keeps every completed graph and its successor mints only the
+   remainder (pgw#1367 clause 4: partial-hit by construction). Since pgw#1573
+   the bytes it arms are the bytes ``fetch_artifact`` hands back, not the
+   directory the compile child wrote: one load path for a self-minted artifact
+   and a hub-fetched one, which is what makes a publish/load format skew break
+   immediately instead of on somebody else's pod a week later.
 
 3. **CPU BUDGETED AGAINST THE SERVING PROCESS.** ``entry_workers <= vcpus -
    SERVING_RESERVE_CPUS``, the reserve non-zero and explicit, and the mint
@@ -1008,6 +1012,16 @@ class ChildCompileFailed(RuntimeError):
     """A compile child died. Costs its own graph and nothing else."""
 
 
+class MintNotServable(RuntimeError):
+    """A graph compiled, published, and the store cannot hand it back.
+
+    pgw#1573's red arm, and the only refusal that can catch a publish/read
+    address split at the instant it is introduced. It costs its own graph:
+    everything else this mint builds still lands, and the pod keeps serving
+    eager for this one.
+    """
+
+
 # ── the mint ─────────────────────────────────────────────────────────────────
 
 
@@ -1057,6 +1071,20 @@ class BackgroundMint:
 
     def __post_init__(self) -> None:
         self.artifacts_dir = Path(self.artifacts_dir)
+        if self.store is None:
+            # NOT optional any more (pgw#1573). The store is where a minted
+            # artifact BECOMES servable — it is published there and armed from
+            # there — so a mint with no store used to fall back to arming the
+            # compiler's own output, which is the second load path this issue
+            # exists to delete. A mint that cannot publish has nothing to
+            # deliver and says so at construction, not eleven minutes of
+            # inductor later.
+            raise ValueError(
+                "a mint needs the store it publishes into and arms from: pass "
+                "`store=` (gen_worker.serving.mint_store.graph_store). Since "
+                "pgw#1573 the mint arms the bytes the STORE hands back, never "
+                "the directory the compiler wrote, so there is no storeless "
+                "mint to fall back to")
         if self.compiler is None:
             if self.cas_dir is None or not self.target_arch:
                 raise ValueError(
@@ -1212,7 +1240,7 @@ class BackgroundMint:
     # -- one hole -----------------------------------------------------------
 
     def _mint_one(self, record: Any, arm_lock: threading.Lock) -> MintedHole:
-        """Fetch, compile, publish, arm — in that order, for ONE graph.
+        """Fetch, compile, publish, FETCH BACK, arm — for ONE graph.
 
         The order is the durability contract. The artifact is on disk before
         it is published; it is in the store before it is armed; so a kill at
@@ -1230,10 +1258,36 @@ class BackgroundMint:
 
         No weights are read here, and a mint still cannot diverge from the
         graph the release shipped: the identity IS the graph.
+
+        ## THE FETCH BACK IS THE POINT (pgw#1573)
+
+        This used to arm ``artifact`` — the unpacked directory the compile
+        child had just written — while publishing the ENVELOPE somewhere the
+        arm never looked. Two producers, two formats, one dispatcher, and no
+        run of this function ever read its own published bytes. That is
+        exactly how pgw#1471's bare-``.pt2`` publish survived from the first
+        publisher that ever existed until va#3 arm 2 fetched one on a pod and
+        holed 14/14 on ``cannot decompress``: every local green was green over
+        the directory, and the store's copy was never opened by anybody.
+
+        So the mint now arms what the STORE hands back, through the same
+        ``fetch_artifact`` boot adoption calls, into the same position boot
+        adoption fetches to. A self-minted artifact and a hub-fetched artifact
+        traverse one load path. A publisher that banks bytes the loader cannot
+        read now breaks the mint's own arm, on the machine that made them,
+        within seconds — instead of hiding for weeks behind a directory.
         """
         env = self.host.adoption.env
-        destination = self.artifacts_dir / env.value / f"{record.graph}.so"
-        destination.parent.mkdir(parents=True, exist_ok=True)
+        # SCRATCH, and deliberately not the adopt position. `Engine.compile`
+        # leaves an unpacked DIRECTORY at its destination while the store
+        # copies out a FILE, and both used to be pointed at
+        # `<artifacts_dir>/<env>/<graph>.so` — so a boot after a mint asked
+        # `os.replace` to put a file where a directory stood.
+        scratch = self.artifacts_dir / env.value / "build" / record.graph
+        scratch.parent.mkdir(parents=True, exist_ok=True)
+        #: Where boot adoption fetches to (torchcg `AdoptSession._adopt_module`)
+        #: and therefore where this mint fetches to. One position, one shape.
+        position = self.artifacts_dir / env.value / f"{record.graph}.so"
 
         graph = program_graph(record)
         if self.program_source is None:
@@ -1245,16 +1299,23 @@ class BackgroundMint:
             graph, self.artifacts_dir / "programs" / f"{graph}.pt2"))
 
         assert self.compiler is not None  # __post_init__ guarantees it
-        artifact = Path(self.compiler(blob, record, destination))
+        artifact = Path(self.compiler(blob, record, scratch))
 
-        published = ""
-        if self.store is not None:
-            published = publish_compiled(self.store, record.graph, env, artifact)
+        published = publish_compiled(self.store, record.graph, env, artifact)
+        fetched = self.store.fetch_artifact(record.graph, env, position)
+        if fetched is None:
+            raise MintNotServable(
+                f"graph {record.graph} compiled and published "
+                f"({published or 'no ref reported'}) and the store answers a "
+                f"MISS at ({record.graph[:16]}, {env.value}). The publish and "
+                f"the read address different positions; nothing this mint "
+                f"builds can ever be adopted."
+            )
 
         armed = False
         try:
             with arm_lock:
-                self.host.adoption.arm(record, artifact)
+                self.host.adoption.arm(record, Path(fetched))
             armed = True
         except Exception as exc:  # noqa: BLE001 — published beats armed
             # The graph IS minted and the fleet HAS it; only THIS pod's live
@@ -1275,7 +1336,7 @@ class BackgroundMint:
             )
 
         return MintedHole(
-            graph=record.graph, target=record.target, artifact=artifact,
+            graph=record.graph, target=record.target, artifact=Path(fetched),
             published=published, armed=armed,
         )
 
@@ -1342,6 +1403,7 @@ __all__ = [
     "DEFAULT_SILENCE_WINDOW_S",
     "MintCondemned",
     "MintFailure",
+    "MintNotServable",
     "MintOutcome",
     "MintProgress",
     "MintedHole",

--- a/src/gen_worker/serving/mint_store.py
+++ b/src/gen_worker/serving/mint_store.py
@@ -1,4 +1,13 @@
-"""The store a serving worker adopts from and mints into (pgw#1371).
+"""THE compiled-graph store (pgw#1371, made canonical by pgw#1573).
+
+:func:`graph_store` is the ONE constructor. Paul's ruling, 2026-08-20:
+*"check local and remote hub … it's literally that simple. You likely created
+a bunch of unnecessary extra code paths."* Before pgw#1573 six call sites built
+a store six ways — three of them a bare ``LocalGraphStore`` with no hub tier at
+all, one of them (`gen-worker compile`) documenting a fetch-first hub consult it
+did not have — so "do I have this graph" had three different answers depending
+on which entry point asked. There is one now, and every reader and every
+publisher goes through it.
 
 One ``GraphStore``, three tiers, and the reason they are one object is that a
 worker must not have two answers to "do I have this graph".
@@ -112,12 +121,77 @@ class TieredGraphStore:
             return True
         return self.upstream is not None and self.upstream.has_artifact(graph, env)
 
+    def artifact_skew(self, graph: str, env: Any) -> Optional[str]:
+        """The LOCAL position's shape verdict, passed through (pgw#1573).
+
+        pgw#1561 left this as its one non-blocking observation: the skew gate
+        lived only in the compile CLI's own bare ``LocalGraphStore``, so a
+        serving pod holding a skewed local position still answered
+        ``has_artifact`` TRUE and repaired itself the expensive way — an
+        adoption hole, then a full re-compile. With the gate on the store every
+        reader of the store asks the same question.
+
+        Only the local tier: the upstream answer is verified by digest on the
+        way in and has no position to be skewed at.
+        """
+        probe = getattr(self.local, "artifact_skew", None)
+        return None if probe is None else probe(graph, env)
+
     def fetch_artifact(self, graph: str, env: Any, destination: Any) -> Any:
+        """Branches ① and ② of the canonical flow, and nothing else.
+
+        ① LOCAL HIT — bytes this pod already holds. No network, unrevocable
+        mid-boot, and the common case on every boot after the first.
+
+        ② REMOTE HIT — the fleet pool has it and this box does not. The bytes
+        are fetched, digest-verified by the upstream tier, and **BANKED INTO
+        THE LOCAL CAS on the way through**, so the next boot takes branch ①.
+        Without that bank a pod re-downloaded every artifact on every restart
+        and a hub outage turned a warm box cold — "check local then remote" is
+        only half a cache if the remote answer is never kept.
+
+        Banking is BEST-EFFORT and never costs the arm: the bytes are already
+        in hand and already verified, so a full disk or a raced sibling publish
+        means one more download next boot, not a hole.
+        """
         if self.local.has_artifact(graph, env):
             return self.local.fetch_artifact(graph, env, destination)
         if self.upstream is None:
-            return self.local.fetch_artifact(graph, env, destination)  # its refusal
-        return self.upstream.fetch_artifact(graph, env, destination)
+            return None
+        fetched = self.upstream.fetch_artifact(graph, env, destination)
+        if fetched is not None:
+            self._bank(graph, env, Path(fetched))
+        return fetched
+
+    def _bank(self, graph: str, env: Any, artifact: Path) -> None:
+        """Keep a verified upstream artifact in this box's own CAS."""
+        manifest = None
+        try:
+            manifest = self.upstream.get_manifest(graph, env)
+        except Exception:  # noqa: BLE001 — a manifest-less hit is still a hit
+            logger.debug("adopt: upstream manifest unreadable for %s", graph,
+                         exc_info=True)
+        if manifest is None:
+            # NOT banked without one. `LocalGraphStore.publish_artifact` stores
+            # the manifest beside the bytes and `EndpointHost.setup` reads it
+            # back to check this host satisfies the artifact's floors; banking
+            # bytes with no manifest would make a cached artifact adoptable on
+            # a machine the fleet answer would have refused.
+            logger.info(
+                "adopt: %s fetched from the fleet pool and NOT cached locally "
+                "— the answer carried no requirements manifest, and an "
+                "artifact with no stated floors must not become a local hit",
+                graph,
+            )
+            return
+        try:
+            self.local.publish_artifact(graph, env, artifact, manifest)
+        except Exception as exc:  # noqa: BLE001 — the arm has its bytes already
+            logger.warning(
+                "adopt: %s fetched from the fleet pool but not cached locally "
+                "(%s: %s); the next boot re-downloads it",
+                graph, type(exc).__name__, exc,
+            )
 
     def get_manifest(self, graph: str, env: Any) -> Any:
         found = self.local.get_manifest(graph, env)
@@ -259,16 +333,23 @@ class TieredGraphStore:
         }
 
 
-def worker_store(
+def graph_store(
     cas_dir: Path,
     upstream: Optional[Any] = None,
     baked_root: Optional[Path] = None,
 ) -> TieredGraphStore:
-    """The store a real serving pod uses, over its own tensorfs CAS.
+    """THE compiled-graph store — every entry point builds it here (pgw#1573).
+
+    A pod, ``gen-worker up``, ``gen-worker compile`` and the CI runner all take
+    this constructor, so a graph is present-or-absent for all of them at once.
+    ``upstream`` is the fleet pool (:class:`~gen_worker.serving.hub_store.
+    HubGraphStore`) when this process has a release to adopt for and nothing
+    when it does not — the ONE thing that differs between a pod and a box, and
+    it is a stated argument rather than a different class.
 
     ``baked_root`` is the IMAGE's read-only exported-program CAS; omitted, it
-    is resolved from settings (`baked_program_cas_dir`), which is what both
-    production call sites want. Passing it explicitly is for tests and for a
+    is resolved from settings (`baked_program_cas_dir`), which is what every
+    production call site wants. Passing it explicitly is for tests and for a
     cozy-local run whose blobs are somewhere else.
     """
     from .._vendor.tensorfs import LocalCAS
@@ -293,5 +374,5 @@ __all__ = [
     "KIND_PUBLISH_LOCAL_ONLY",
     "ProgramBlobUnreachable",
     "TieredGraphStore",
-    "worker_store",
+    "graph_store",
 ]

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -59,6 +59,7 @@ PERMANENT_REFUSALS = frozenset({
     "environment_mismatch",  # the pod is not the release's env; a retry cannot help
     "no_document",           # the release is stamped with no lane for this (lane x sm)
     "EnvironmentMismatch",   # the same, arriving as an exception type name
+    "no_local_cas",          # pgw#1573: no local tier — nothing can be banked or minted
 })
 
 #: The refusal phases that mean the RELEASE NEVER DECLARED compiled serving
@@ -120,9 +121,11 @@ class ServeAdoption:
         self.release_id = str(release_id)
         self.sm = str(sm)
         self.artifacts_dir = Path(artifacts_dir)
-        #: The pod's own tensorfs CAS — the local tier of the store below.
-        #: ``None`` keeps the hub as the only tier, which is read-only, so a
-        #: mint on that shape banks nothing and says so.
+        #: The pod's own tensorfs CAS — the local tier of the store below, and
+        #: REQUIRED since pgw#1573: it is where a fleet hit is cached and where
+        #: a mint publishes and arms from. ``None`` is a typed refusal at
+        #: build time (`no_local_cas`), not a read-only degraded mode nobody
+        #: could tell from a working one.
         self.cas_dir = Path(cas_dir) if cas_dir is not None else None
         self._transport = transport
         self._stack = dict(stack) if stack is not None else None
@@ -295,7 +298,7 @@ class ServeAdoption:
     def _build(self, lane: Any) -> None:
         from .._vendor.torchcg.adopt import AdoptSession
         from ..env_identity import installed_stack_drift
-        from .mint_store import worker_store
+        from .mint_store import graph_store
         from .hub_store import (
             BrokerReleaseGraphTransport,
             HubGraphStore,
@@ -335,13 +338,21 @@ class ServeAdoption:
         stack = self._stack if self._stack is not None else dict(document.stack)
         for row in installed_stack_drift(dict(document.stack)):
             logger.warning("adopt: compile-stack drift vs this venv: %s", row)
-        # ONE store for both directions: the adopt reads through it (local CAS
-        # before the hub, so a restarted pod adopts what it already minted) and
-        # the mint publishes through it. Two objects here would mean two
-        # answers to "do I have this graph".
-        self.store = (
-            worker_store(self.cas_dir, store) if self.cas_dir is not None else store
-        )
+        # ONE store for both directions and for every entry point (pgw#1573):
+        # the adopt reads through it (local CAS before the hub, so a restarted
+        # pod adopts what it already minted, and a fleet hit is BANKED locally
+        # on the way through), and the mint publishes into it and arms out of
+        # it. Two objects here would mean two answers to "do I have this
+        # graph"; a hub tier with no local one would mean a pod that
+        # re-downloads its own artifacts on every boot.
+        if self.cas_dir is None:
+            self._refuse(
+                "no_local_cas",
+                "this worker states no local CAS, so a fetched artifact could "
+                "not be banked and a minted one could not be published — the "
+                "adopt would be read-only against the fleet pool forever")
+            return
+        self.store = graph_store(self.cas_dir, store)
         self.contract = contract
         self.adoption = AdoptSession(
             self.store, document, contract, self.sm,

--- a/tests/test_adopt_flow.py
+++ b/tests/test_adopt_flow.py
@@ -1,0 +1,595 @@
+"""pgw#1573: the canonical adopt flow — four branches, ONE load path.
+
+Paul's spec, 2026-08-20, verbatim:
+
+    startup on my box -> check local and remote hub; if not present -> serve
+    eager, compile in the background -> store local (maybe upload to hub too)
+    + replace eager when done
+    startup on my box -> check local and remote hub; if present -> serve
+    compiled
+
+This file is that flow, driven end to end on CPU through the production
+objects: the real fixture endpoint, the real publish-time derive, the real
+``graph_store`` every entry point builds, the real ``AdoptSession``, the real
+``BackgroundMint``, and — for the remote leg — the real ``HubGraphStore`` over
+a real HTTP server speaking the real th#2133 answer shape.
+
+**THE ONE STUB, AND WHERE IT STOPS.** Turning a verified artifact into a
+callable is AOTInductor's job on a real GPU. So the loader here does the whole
+production load EXCEPT the final ``aoti_load_package``: it calls
+``torchcg.serve.materialize`` — the exact function ``aoti_loader`` calls, the
+one that opens the envelope and verifies it against its own metadata — and only
+then returns a stand-in callable. That is deliberate and it is the difference
+between this file and every adoption test that came before it: pgw#1561 shipped
+fourteen unloadable blobs past a suite whose loader stub never opened its
+argument, so a stub that does not materialize proves nothing about bytes.
+
+**WHY THE LEGS ARE THESE THREE.** Warm-remote is the leg that had never been
+exercised at all — the mint armed the compiler's own directory (pgw#1573's map,
+row C2) and the box `compile` path had no hub tier (row B2), so no test and no
+field run had ever taken a set of bytes from a remote store into a live
+dispatcher. Its red arm is the last test in the file: a hub answering a bare
+`.pt2` ZIP must produce a TYPED refusal that names the skew, not a quiet eager
+serve.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import threading
+from pathlib import Path
+from typing import Any, Callable, List, Tuple
+
+import pytest
+import torch
+
+import tcg_artifacts
+from gen_worker._vendor.torchcg.serve import materialize
+from gen_worker.serving import DeployBinding
+from gen_worker.serving.mint_store import graph_store
+
+# The fixture ecosystem is `test_serving_adopt_first`'s — the same endpoint,
+# the same publish-time derive, the same lane. Re-typing it here would be a
+# second answer to "what does this endpoint compile to".
+from test_serving_adopt_first import (  # noqa: E402
+    ENV,
+    LANE,
+    OVERRIDES,
+    SM,
+    STACK,
+    fresh_host,
+    publish_document,
+)
+
+RELEASE = "rel-pgw1573"
+
+
+# --------------------------------------------------------------------------
+# the harness
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def binding(tmp_path: Path) -> DeployBinding:
+    root = tmp_path / "checkpoint"
+    root.mkdir()
+    (root / "config.json").write_text(
+        json.dumps({"seed": 7, "scheduler": {"prediction_type": "epsilon"}}))
+    return DeployBinding(
+        checkpoint_ref="ckpt:tiny@1", checkpoint_dir=root, model="sdxl",
+        defaults=dict(OVERRIDES),
+    )
+
+
+@pytest.fixture()
+def document(binding: DeployBinding, tmp_path: Path) -> Any:
+    """The real derive, run once: two aspect buckets -> two specializations."""
+    host = fresh_host(binding, tmp_path / "derive")
+    host.setup()
+    return publish_document(host)
+
+
+def opening_loader(calls: List[str]) -> "Callable[[Path, Any, Any], Callable[..., Any]]":
+    """The production load, minus only the AOTI handle.
+
+    ``materialize`` is called for real on the exact bytes the store handed
+    over — it opens the envelope, verifies the package and any literal payload
+    against ``metadata.json``, and raises ``ArtifactFormatSkew`` on a bare
+    package. Everything this file claims about bytes rests on that call being
+    here rather than on the path merely existing.
+    """
+
+    def load(path: Path, record: Any, module: Any) -> "Callable[..., Any]":
+        assert isinstance(module, torch.nn.Module), (
+            "the loader binds constants from the LIVE module (tcg#58)")
+        materialize(Path(path), Path(path).parent / f"{Path(path).name}.opened")
+
+        def compiled(sample: torch.Tensor) -> torch.Tensor:
+            calls.append(record.graph)
+            return sample
+
+        return compiled
+
+    return load
+
+
+def real_compiler(built: List[str]) -> "Callable[[Path, Any, Path], Path]":
+    """The compile seam: a REAL unpacked artifact directory, no inductor.
+
+    Exactly the shape ``Engine.compile`` leaves at its destination, which is
+    what makes the mint's publish -> fetch -> arm round trip real: the publish
+    repacks this directory into the envelope and the arm opens that envelope.
+    """
+
+    def build(blob: Path, record: Any, destination: Path) -> Path:
+        built.append(record.graph)
+        return tcg_artifacts.unpacked(
+            destination, graph_specialization=record.graph, sm=SM)
+
+    return build
+
+
+def programs(root: Path) -> "Callable[[str, Path], Path]":
+    def fetch(graph: str, destination: Path) -> Path:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"exported-program")
+        return destination
+
+    return fetch
+
+
+def ratios(document: Any) -> Tuple[str, str]:
+    """(ratio for graph 0, ratio for graph 1) — the fixture's two buckets."""
+    out = []
+    for record in document.lanes[0].graphs:
+        shape = tuple(int(d) for d in record.ingress.inputs[0].shape)
+        out.append("1:1" if shape == (16, 16) else "3:4")
+    return out[0], out[1]
+
+
+def mint_the_holes(host: Any, store: Any, tmp_path: Path,
+                   built: List[str]) -> Any:
+    from gen_worker import compile_posture
+    from gen_worker.serving import mint as mint_mod
+
+    return mint_mod.BackgroundMint(
+        host=host, store=store, artifacts_dir=tmp_path / "artifacts",
+        compiler=real_compiler(built), program_source=programs(tmp_path),
+        posture=compile_posture.FLEET, vcpus=4,
+    ).run()
+
+
+def bank_both(store: Any, document: Any, tmp_path: Path) -> None:
+    """Put a real envelope at both positions of ``store``."""
+    from gen_worker.serving.mint import publish_compiled
+
+    for index, record in enumerate(document.lanes[0].graphs):
+        unpacked = tmp_path / "seed" / f"{index}"
+        tcg_artifacts.unpacked(
+            unpacked, graph_specialization=record.graph, sm=SM)
+        publish_compiled(store, record.graph, ENV, unpacked)
+
+
+# --------------------------------------------------------------------------
+# LEG (a) — COLD: eager first, mint in the background, compiled after
+# --------------------------------------------------------------------------
+
+
+def test_cold_boot_serves_EAGER_then_mints_then_serves_COMPILED(
+    binding: DeployBinding, document: Any, tmp_path: Path
+) -> None:
+    """Paul's branch ③, end to end, on one live host.
+
+    Empty local store, no hub. The first request must be served IMMEDIATELY
+    and eagerly; the mint then fills the holes off the request path; a later
+    request on the same live host goes through the compiled graph without a
+    reboot. That last step is the hot swap, and it is what
+    ``AdoptSession.arm`` exists for.
+    """
+    cas = tmp_path / "cas"
+    store = graph_store(cas, None, tmp_path / "no-baked")
+    calls: List[str] = []
+    host = fresh_host(binding, tmp_path)
+    host.setup(store=store, document=document, sm=SM,
+               loader=opening_loader(calls),
+               artifacts_dir=tmp_path / "artifacts", stack=STACK)
+
+    # BRANCH ③: nothing present, so every claimed graph is a hole and the
+    # endpoint is servable RIGHT NOW.
+    assert len(host.adoption.adopted) == 0
+    assert len(host.holes) == 2
+    first, second = ratios(document)
+    host.dispatch("generate", {"prompt": "x", "aspect_ratio": first},
+                  request_id="cold-1")
+    assert calls == [], "a cold boot must serve EAGER, not wait for a compile"
+
+    # The background mint: compile -> publish -> fetch back -> arm.
+    built: List[str] = []
+    outcome = mint_the_holes(host, store, tmp_path, built)
+    assert outcome.landed == 2 and not outcome.failed, outcome.failed
+    assert sorted(built) == sorted(
+        record.graph for record in document.lanes[0].graphs)
+    assert all(entry.armed for entry in outcome.entries), (
+        "a minted graph that did not arm leaves this host eager forever")
+
+    # THE HOT SWAP: same host, same instance, no reboot — now compiled.
+    host.dispatch("generate", {"prompt": "x", "aspect_ratio": first},
+                  request_id="cold-2")
+    host.dispatch("generate", {"prompt": "x", "aspect_ratio": second},
+                  request_id="cold-3")
+    armed = {record.graph for record in document.lanes[0].graphs}
+    assert set(calls) == armed, (
+        f"the eager forward is still serving after a landed mint: {calls}")
+
+    # And the bytes are in the LOCAL CAS, at the band adoption reads.
+    for record in document.lanes[0].graphs:
+        assert store.has_artifact(record.graph, ENV)
+        assert store.artifact_skew(record.graph, ENV) is None
+
+
+# --------------------------------------------------------------------------
+# LEG (b) — WARM-LOCAL: reboot arms from the local store, nothing recompiles
+# --------------------------------------------------------------------------
+
+
+def test_warm_local_reboot_arms_from_the_store_and_compiles_NOTHING(
+    binding: DeployBinding, document: Any, tmp_path: Path
+) -> None:
+    """Paul's branch ①. The store is asked, the store answers, done."""
+    cas = tmp_path / "cas"
+    store = graph_store(cas, None, tmp_path / "no-baked")
+    bank_both(store, document, tmp_path)
+
+    calls: List[str] = []
+    host = fresh_host(binding, tmp_path)
+    host.setup(store=store, document=document, sm=SM,
+               loader=opening_loader(calls),
+               artifacts_dir=tmp_path / "artifacts", stack=STACK)
+
+    assert len(host.adoption.adopted) == 2 and host.holes == ()
+    first, _second = ratios(document)
+    host.dispatch("generate", {"prompt": "x", "aspect_ratio": first},
+                  request_id="warm-1")
+    assert calls, "a warm boot served eager over a full store"
+
+    # Nothing to mint, and the mint says so as a NAMED state rather than a
+    # zero count (pgw#1371's `nothing_to_mint`).
+    from gen_worker.serving.self_mint import NOTHING_TO_MINT, SelfMint
+
+    built: List[str] = []
+    box = SelfMint(store=store, artifacts_dir=tmp_path / "artifacts",
+                   compiler=real_compiler(built),
+                   program_source=programs(tmp_path), vcpus=2)
+    assert box.arm(host).state == NOTHING_TO_MINT
+    assert built == [], "a warm boot recompiled a graph it already had"
+
+
+# --------------------------------------------------------------------------
+# LEG (c) — WARM-REMOTE: the leg that had never been exercised
+# --------------------------------------------------------------------------
+
+
+class _Hub(http.server.BaseHTTPRequestHandler):
+    """The th#2133 adopt route and its presigned blobs, for real, over HTTP."""
+
+    answer: dict = {}
+    blobs: dict = {}
+
+    def log_message(self, *_args: Any) -> None:  # keep pytest output clean
+        return
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's spelling
+        path = self.path.split("?", 1)[0]
+        if path.startswith("/blob/"):
+            payload = type(self).blobs.get(path[len("/blob/"):])
+            if payload is None:
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        if path.endswith("/compiled-graphs"):
+            body = json.dumps(type(self).answer).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_error(404)
+
+
+def _serve_hub(answer: dict, blobs: dict) -> Tuple[str, Any]:
+    _Hub.answer, _Hub.blobs = answer, blobs
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Hub)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://127.0.0.1:{server.server_port}", server
+
+
+def _fleet_answer(document: Any, base_url: str, blobs: dict,
+                  artifacts: List[Path]) -> dict:
+    """The hub's real answer shape, filled from real artifact bytes."""
+    rows = []
+    for record, artifact in zip(document.lanes[0].graphs, artifacts):
+        payload = Path(artifact).read_bytes()
+        name = f"{record.graph}.tar.gz"
+        blobs[name] = payload
+        rows.append({
+            "graph_hash": record.graph,
+            "graph_specialization": record.graph,
+            "status": "hit",
+            "found": True,
+            "module_path": record.target,
+            "ingress": record.ingress.as_dict(),
+            "content_digest": "sha256:" + hashlib.sha256(payload).hexdigest(),
+            "artifact_path": name,
+            "requirements_manifest": {
+                "v": 1, "autotuned_on": None, "cuda_floor": None,
+                "include_set": [["torch", torch.__version__]],
+                "sm_compiled": SM,
+            },
+            "transport": {
+                "snapshot_digest": "sha256:0",
+                "files": [{"path": name, "url": f"{base_url}/blob/{name}"}],
+            },
+        })
+    return {
+        "object": "release_compiled_graphs", "release_id": RELEASE,
+        "env_compile_stack": [[name, value] for name, value in STACK],
+        "lane": LANE, "lane_stamped": True, "sm": SM, "empty": False,
+        "hits": len(rows), "misses": 0, "graphs": rows,
+        "targets": [record.target for record in document.lanes[0].graphs],
+        "unobserved_targets": [], "passes": [],
+    }
+
+
+def _remote_store(cas: Path, base_url: str) -> Any:
+    from gen_worker.serving.__main__ import HttpReleaseGraphTransport
+    from gen_worker.serving.hub_store import HubGraphStore
+
+    upstream = HubGraphStore(
+        HttpReleaseGraphTransport(base_url), RELEASE, LANE, SM)
+    return graph_store(cas, upstream, cas.parent / "no-baked")
+
+
+def test_warm_remote_fetches_verifies_arms_serves_and_BANKS_locally(
+    binding: DeployBinding, document: Any, tmp_path: Path
+) -> None:
+    """Paul's branch ②, over a real HTTP hub, into a live dispatcher.
+
+    THIS IS THE LEG THAT WAS NEVER EXERCISED. It asserts four things in
+    order, and every one of them was unproven before pgw#1573:
+
+    1. an empty local store falls through to the fleet pool;
+    2. the fetched bytes pass the hub store's own digest verification;
+    3. they arm through the SAME loader a local hit arms through, and a
+       request is served through the compiled graph;
+    4. they are BANKED into the local CAS on the way past — so the next boot
+       is a local hit and a hub outage does not turn a warm box cold.
+    """
+    artifacts = []
+    for index, record in enumerate(document.lanes[0].graphs):
+        artifacts.append(tcg_artifacts.build(
+            tmp_path / "fleet" / f"{index}.tar.gz",
+            graph_specialization=record.graph, sm=SM))
+    blobs: dict = {}
+    base_url, server = _serve_hub({}, blobs)
+    _Hub.answer = _fleet_answer(document, base_url, blobs, artifacts)
+    try:
+        cas = tmp_path / "cold-cas"
+        store = _remote_store(cas, base_url)
+        assert not store.local.has_artifact(
+            document.lanes[0].graphs[0].graph, ENV), "the local tier is not cold"
+
+        calls: List[str] = []
+        host = fresh_host(binding, tmp_path)
+        host.setup(store=store, document=document, sm=SM,
+                   loader=opening_loader(calls),
+                   artifacts_dir=tmp_path / "artifacts", stack=STACK)
+
+        assert len(host.adoption.adopted) == 2, (
+            f"the fleet pool answered and nothing armed; holes: "
+            f"{[(h.record.graph[-12:], h.reason) for h in host.holes]}")
+        first, _second = ratios(document)
+        host.dispatch("generate", {"prompt": "x", "aspect_ratio": first},
+                      request_id="remote-1")
+        assert calls, "adopted from the hub and still served eager"
+
+        # (4) BANKED. Without this the pod re-downloads every boot.
+        for record in document.lanes[0].graphs:
+            assert store.local.has_artifact(record.graph, ENV), (
+                f"{record.graph[-12:]} was fetched from the fleet pool and not "
+                f"kept — 'check local then remote' is half a cache if the "
+                f"remote answer is never banked")
+    finally:
+        server.shutdown()
+
+    # The hub is GONE now. A local hit must still arm — the proof that (4)
+    # was a cache and not a coincidence.
+    offline: List[str] = []
+    rebooted = fresh_host(binding, tmp_path / "second")
+    rebooted.setup(
+        store=graph_store(tmp_path / "cold-cas", None, tmp_path / "no-baked"),
+        document=document, sm=SM, loader=opening_loader(offline),
+        artifacts_dir=tmp_path / "artifacts2", stack=STACK)
+    assert len(rebooted.adoption.adopted) == 2 and rebooted.holes == ()
+
+
+def test_a_SKEWED_remote_artifact_refuses_BY_TYPE_and_never_arms(
+    binding: DeployBinding, document: Any, tmp_path: Path
+) -> None:
+    """THE RED ARM of the remote leg, and the shape pgw#1561 shipped.
+
+    The hub answers a hit whose bytes are a bare AOTI ``.pt2`` package — the
+    exact thing every publisher banked from pgw#1471 until PR #1121, digest
+    and all, so nothing upstream of the loader can tell. The store hands them
+    over; the loader must refuse them BY TYPE.
+
+    What this test forbids is not the eager serve — eager is the correct
+    answer to bytes that will not load, and correctness is untouched. What it
+    forbids is the SILENCE: a hole with no reason, or a reason that reads like
+    corruption when the remedy is a re-publish. If this file's loader stopped
+    materializing, or the skew stopped being its own exception type, this goes
+    red instead of quietly passing over unloadable bytes.
+    """
+    artifacts = []
+    for index, record in enumerate(document.lanes[0].graphs):
+        # A REAL package, published where an envelope belongs. Not garbage —
+        # garbage would be caught by anything; this is the defect's own shape.
+        artifacts.append(tcg_artifacts.aoti_package(
+            tmp_path / "fleet" / f"{index}.pt2",
+            graph_specialization=record.graph))
+    blobs: dict = {}
+    base_url, server = _serve_hub({}, blobs)
+    _Hub.answer = _fleet_answer(document, base_url, blobs, artifacts)
+    try:
+        calls: List[str] = []
+        host = fresh_host(binding, tmp_path)
+        host.setup(store=_remote_store(tmp_path / "cold-cas", base_url),
+                   document=document, sm=SM, loader=opening_loader(calls),
+                   artifacts_dir=tmp_path / "artifacts", stack=STACK)
+    finally:
+        server.shutdown()
+
+    assert len(host.adoption.adopted) == 0, (
+        "a bare .pt2 package armed — the loader is not opening its bytes")
+    assert len(host.holes) == 2
+    for hole in host.holes:
+        assert hole.reason.startswith("ArtifactFormatSkew:"), (
+            f"the refusal must NAME the skew, so the remedy is 're-publish' "
+            f"and not 'scrub the disk': {hole.reason}")
+        assert "bare AOTI .pt2 package" in hole.reason
+
+    # And the endpoint still SERVES — eagerly, correctly, loudly.
+    first, _second = ratios(document)
+    host.dispatch("generate", {"prompt": "x", "aspect_ratio": first},
+                  request_id="skew-1")
+    assert calls == []
+
+
+def test_a_TRUNCATED_remote_artifact_is_refused_before_it_is_ever_stored(
+    binding: DeployBinding, document: Any, tmp_path: Path
+) -> None:
+    """Corruption in transit is the hub store's own digest gate, not the
+    loader's — and a refused fetch must never leave bytes in the local CAS.
+
+    The distinction from the test above is the whole reason pgw#1561 gave the
+    skew its own exception type: this one's remedy is a re-fetch, that one's
+    is a re-publish.
+    """
+    artifacts = []
+    for index, record in enumerate(document.lanes[0].graphs):
+        artifacts.append(tcg_artifacts.build(
+            tmp_path / "fleet" / f"{index}.tar.gz",
+            graph_specialization=record.graph, sm=SM))
+    blobs: dict = {}
+    base_url, server = _serve_hub({}, blobs)
+    answer = _fleet_answer(document, base_url, blobs, artifacts)
+    # The digest stays honest; the BYTES rot. That is what the gate is for.
+    for name in list(blobs):
+        blobs[name] = blobs[name][:-64]
+    _Hub.answer = answer
+    cas = tmp_path / "cold-cas"
+    try:
+        host = fresh_host(binding, tmp_path)
+        host.setup(store=_remote_store(cas, base_url), document=document,
+                   sm=SM, loader=opening_loader([]),
+                   artifacts_dir=tmp_path / "artifacts", stack=STACK)
+    finally:
+        server.shutdown()
+
+    assert len(host.adoption.adopted) == 0 and len(host.holes) == 2
+    for hole in host.holes:
+        assert "failed digest verification" in hole.reason, hole.reason
+    for record in document.lanes[0].graphs:
+        assert not graph_store(cas, None, tmp_path / "no-baked").has_artifact(
+            record.graph, ENV), (
+            "bytes that failed their own digest gate were banked locally; a "
+            "poisoned fetch would then be a permanent local hit")
+
+
+def test_the_flow_has_ONE_arming_path_for_local_remote_and_self_minted(
+    binding: DeployBinding, document: Any, tmp_path: Path
+) -> None:
+    """The invariant the three legs above exist to protect (pgw#1573).
+
+    A self-minted artifact, a locally-cached one and a hub-fetched one must
+    all reach the dispatcher as the SAME shape through the SAME call. Asserted
+    on the bytes: whatever produced them, what the loader receives is a FILE
+    carrying the gzip envelope magic, at the position boot adoption fetches
+    to. Before this issue the self-minted case handed over a DIRECTORY, and
+    that single difference is what let a broken publish hide for weeks.
+    """
+    seen: List[Path] = []
+
+    def recording_loader(path: Path, record: Any, module: Any) -> Any:
+        seen.append(Path(path))
+        return opening_loader([])(path, record, module)
+
+    cas = tmp_path / "cas"
+    store = graph_store(cas, None, tmp_path / "no-baked")
+    host = fresh_host(binding, tmp_path)
+    host.setup(store=store, document=document, sm=SM, loader=recording_loader,
+               artifacts_dir=tmp_path / "artifacts", stack=STACK)
+    assert len(host.holes) == 2
+    mint_the_holes(host, store, tmp_path, [])          # self-minted arms
+    minted = list(seen)
+
+    seen.clear()
+    warm = fresh_host(binding, tmp_path / "warm")
+    warm.setup(store=graph_store(cas, None, tmp_path / "no-baked"),
+               document=document, sm=SM, loader=recording_loader,
+               artifacts_dir=tmp_path / "artifacts-warm", stack=STACK)
+    adopted = list(seen)
+
+    assert len(minted) == 2 and len(adopted) == 2
+    for path in minted + adopted:
+        assert path.is_file(), f"{path} is not a file — a directory reached the loader"
+        with path.open("rb") as handle:
+            assert handle.read(2) == b"\x1f\x8b", f"{path} is not an envelope"
+    # Same position, both times: the mint fetches to where the boot fetches.
+    assert sorted(p.name for p in minted) == sorted(p.name for p in adopted)
+
+
+def test_a_mint_with_no_store_is_unrepresentable(tmp_path: Path) -> None:
+    """The deleted branch, as a fence (pgw#1573).
+
+    A storeless mint had exactly one thing to arm — the compiler's own output
+    — which is the second load path this issue exists to remove. It refuses at
+    construction rather than eleven minutes of inductor later.
+    """
+    from gen_worker.serving import mint as mint_mod
+
+    with pytest.raises(ValueError, match="needs the store"):
+        mint_mod.BackgroundMint(
+            host=object(), store=None, compiler=lambda *a: Path("."),
+            artifacts_dir=tmp_path)
+
+
+def test_every_entry_point_builds_the_SAME_store(tmp_path: Path) -> None:
+    """One constructor, checked at the call sites (pgw#1573's row B).
+
+    Five constructions with three different answers to "do I have this graph"
+    is how `gen-worker compile` came to document a hub consult it did not
+    have. This reads the source rather than the behaviour, because the failure
+    mode is a NEW call site, not a wrong one.
+    """
+    import gen_worker
+
+    root = Path(gen_worker.__file__).parent
+    offenders = []
+    for path in (root / "cli" / "compile.py", root / "cli" / "daemon.py",
+                 root / "serving" / "__main__.py",
+                 root / "serving" / "serve_adoption.py"):
+        text = path.read_text()
+        if "LocalGraphStore(" in text:
+            offenders.append(str(path))
+    assert offenders == [], (
+        f"these entry points construct a store directly instead of through "
+        f"`mint_store.graph_store`, which is how a hub tier goes missing on "
+        f"one path and not another: {offenders}")

--- a/tests/test_adoption_verdict.py
+++ b/tests/test_adoption_verdict.py
@@ -190,14 +190,20 @@ def test_the_mint_mints_what_it_was_armed_on_not_a_second_read(
     work-list is read ONCE at arm; what was armed is what gets minted."""
     from gen_worker.serving.self_mint import SelfMint
 
+    from gen_worker.serving.mint_store import graph_store
+
+    graphs = [
+        "cg-graph-v1-" + f"{index:056x}".replace("x", "0")
+        for index in range(3)
+    ]
+
     class Vanishing:
         """A host whose hole list is live — and empties after the first read."""
 
         def __init__(self) -> None:
             self._reads = 0
             self.adoption = SimpleNamespace(
-                env=SimpleNamespace(value="lane-a", sm=SM),
-                arm=lambda record, artifact: None,
+                env=ENV, arm=lambda record, artifact: None,
             )
 
         @property
@@ -206,17 +212,19 @@ def test_the_mint_mints_what_it_was_armed_on_not_a_second_read(
             if self._reads > 1:
                 return ()
             return tuple(
-                SimpleNamespace(record=SimpleNamespace(graph=f"g{i}", target="unet"))
-                for i in range(3)
+                SimpleNamespace(record=SimpleNamespace(graph=graph, target="unet"))
+                for graph in graphs
             )
 
     compiled: list[str] = []
 
     def compiler(blob: Path, record: SimpleNamespace, destination: Path) -> Path:
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_bytes(b"artifact")
+        # A REAL unpacked artifact (pgw#1573): the mint publishes it and then
+        # arms what the store hands back, so a `b"artifact"` placeholder no
+        # longer survives the round trip it now makes.
         compiled.append(record.graph)
-        return destination
+        return tcg_artifacts.unpacked(
+            destination, graph_specialization=record.graph, sm=SM)
 
     def program_source(graph: str, destination: Path) -> Path:
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -224,13 +232,14 @@ def test_the_mint_mints_what_it_was_armed_on_not_a_second_read(
         return destination
 
     box = SelfMint(
-        store=None, artifacts_dir=tmp_path / "artifacts",
+        store=graph_store(tmp_path / "cas", None, tmp_path / "no-baked"),
+        artifacts_dir=tmp_path / "artifacts",
         compiler=compiler, program_source=program_source, vcpus=2,
     )
     armed = box.arm(Vanishing())
     assert armed.holes == 3
-    final = box.join(30.0)
-    assert sorted(compiled) == ["g0", "g1", "g2"], (
+    final = box.join(60.0)
+    assert sorted(compiled) == sorted(graphs), (
         "the mint must mint the ARMED list, not a second read of a live "
         "property that already emptied"
     )
@@ -288,15 +297,16 @@ def test_the_armed_zero_verdict_is_a_durable_row_not_a_log_line(
 def test_the_mint_terminal_verdict_rides_the_wire_with_its_identity(
     tmp_path: Path, wire: "list[tuple]",
 ) -> None:
+    from gen_worker.serving.mint_store import graph_store
     from gen_worker.serving.self_mint import SelfMint
 
     compiled: "list[str]" = []
+    graphs = ["cg-graph-v1-" + f"{2 + index:056d}" for index in range(2)]
 
     def compiler(blob: Path, record: SimpleNamespace, destination: Path) -> Path:
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_bytes(b"artifact")
         compiled.append(record.graph)
-        return destination
+        return tcg_artifacts.unpacked(
+            destination, graph_specialization=record.graph, sm=SM)
 
     def program_source(graph: str, destination: Path) -> Path:
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -305,14 +315,15 @@ def test_the_mint_terminal_verdict_rides_the_wire_with_its_identity(
 
     host = SimpleNamespace(
         holes=tuple(
-            SimpleNamespace(record=SimpleNamespace(graph=f"g{i}", target="unet"))
-            for i in range(2)),
+            SimpleNamespace(record=SimpleNamespace(graph=graph, target="unet"))
+            for graph in graphs),
         adoption=SimpleNamespace(
-            env=SimpleNamespace(value="lane-a", sm=SM),
-            arm=lambda record, artifact: None),
+            env=ENV, arm=lambda record, artifact: None),
     )
-    box = SelfMint(store=None, artifacts_dir=tmp_path / "artifacts",
-                   compiler=compiler, program_source=program_source, vcpus=2)
+    box = SelfMint(
+        store=graph_store(tmp_path / "cas", None, tmp_path / "no-baked"),
+        artifacts_dir=tmp_path / "artifacts",
+        compiler=compiler, program_source=program_source, vcpus=2)
     box.arm(host)
     final = box.join(30.0)
     assert final.landed == 2

--- a/tests/test_program_blob_tiers.py
+++ b/tests/test_program_blob_tiers.py
@@ -23,7 +23,7 @@ from gen_worker.models.cache_paths import BAKED_PROGRAM_CAS_DIR, baked_program_c
 from gen_worker.serving.mint_store import (
     ProgramBlobUnreachable,
     TieredGraphStore,
-    worker_store,
+    graph_store,
 )
 
 PROGRAM = b"\x80\x05serialized-exported-program-bytes" * 64
@@ -161,8 +161,8 @@ def test_a_missing_bake_is_absence_and_never_a_created_directory(
     assert baked_program_cas_dir() is None
     assert not absent.exists()
 
-    # worker_store resolves it and simply carries no baked tier.
-    store = worker_store(tmp_path / "cas")
+    # graph_store resolves it and simply carries no baked tier.
+    store = graph_store(tmp_path / "cas")
     assert store.baked is None
 
 

--- a/tests/test_runtime_mint.py
+++ b/tests/test_runtime_mint.py
@@ -11,17 +11,21 @@ in `logger.error` has, from the hub's side, simply stopped emitting.
 
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, List
+from typing import Any, Callable, List
 
 import pytest
 
 from gen_worker import activity as activity_mod
 from gen_worker import compile_posture
+from gen_worker._vendor.torchcg.graph_identity import EnvIdentity
+from gen_worker._vendor.torchcg.serve import materialize
 from gen_worker.serving import mint
+from gen_worker.serving.mint_store import graph_store
 
 
 def _artifact(destination: Path, graph: str) -> Path:
@@ -38,42 +42,77 @@ def _artifact(destination: Path, graph: str) -> Path:
     return tcg_artifacts.unpacked(destination, graph_specialization=graph)
 
 
+#: The real env identity, not a namespace: the store's `_artifact_ref` and its
+#: manifest/sm cross-check both read it.
+ENV = EnvIdentity(stack=(("torch", "2.13.0"),), sm="sm_89")
+
+
+def graph_of(index: int) -> str:
+    """A REAL `cg-graph-v1` identity, deterministic per index.
+
+    pgw#1573: these used to be `unet/class=0`. That string is not an identity
+    any store addresses rows by — `LocalGraphStore._require_graph` refuses it —
+    and the `_Store` double this module carried accepted it, along with a
+    directory the real store refuses and a `publish_artifact` that returned a
+    literal. Three preconditions unmodelled, which is why this file was green
+    through pgw#1471 AND pgw#1561.
+    """
+    return "cg-graph-v1-" + hashlib.sha256(
+        f"pgw1573/{index}".encode()).hexdigest()[:56]
+
+
 class _Adoption:
+    """The adopt session's arm seam — the ONE thing here that is not real.
+
+    torchcg's `AdoptSession.arm` needs a live `nn.Module` with resident
+    constants on a device to build a callable, which is a GPU fact. Everything
+    up to it is the production object: the real store, the real envelope, the
+    real fetch. What is recorded is the PATH the mint armed, which is the whole
+    subject of pgw#1573 — it must be the store's copy, never the compiler's.
+    """
+
     def __init__(self, arm_raises: BaseException | None = None) -> None:
-        self.env = SimpleNamespace(value="lane-a", sm="sm_89")
+        self.env = ENV
         self.armed: List[str] = []
+        self.armed_paths: List[Path] = []
         self.arm_raises = arm_raises
 
     def arm(self, record: Any, artifact: Path) -> None:
         if self.arm_raises is not None:
             raise self.arm_raises
+        # The arm READS the bytes it was handed, through the exact function
+        # boot adoption's loader calls. An arm that only records a path cannot
+        # tell a loadable envelope from a directory, which is the distinction
+        # this module now exists to hold.
+        materialize(Path(artifact), Path(artifact).parent / "unpacked")
         self.armed.append(record.graph)
+        self.armed_paths.append(Path(artifact))
 
 
 def _host(graphs: int, *, arm_raises: BaseException | None = None) -> Any:
     holes = tuple(
         SimpleNamespace(record=SimpleNamespace(
-            graph=f"unet/class={i}", target="unet"))
+            graph=graph_of(i), target="unet"))
         for i in range(graphs))
     return SimpleNamespace(holes=holes, adoption=_Adoption(arm_raises))
 
 
-class _Store:
-    """The fleet sink, minus the hub."""
+def _store(tmp_path: Path) -> Any:
+    """THE store — `graph_store`, the one constructor every entry point uses.
 
-    def __init__(self) -> None:
-        self.published: List[str] = []
+    `baked_root` is stated so the fixture never reaches the box's real settings
+    for a directory it does not need.
+    """
+    return graph_store(tmp_path / "cas", None, tmp_path / "no-baked")
 
-    def fetch_program(self, digest: str, destination: Path) -> Path:
+
+def _programs(tmp_path: Path) -> "Callable[[str, Path], Path]":
+    def fetch(graph: str, destination: Path) -> Path:
         destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_bytes(b"program")
+        destination.write_bytes(b"exported-program")
         return destination
 
-    def publish_artifact(
-        self, graph: str, env: Any, artifact: Path, manifest: Any,
-    ) -> str:
-        self.published.append(graph)
-        return "checkpoint-1"
+    return fetch
 
 
 @pytest.fixture()
@@ -86,6 +125,7 @@ def wire(monkeypatch: pytest.MonkeyPatch) -> List[tuple]:
 
 
 def _mint(host: Any, store: Any, tmp_path: Path, **kw: Any) -> mint.BackgroundMint:
+    kw.setdefault("program_source", _programs(tmp_path))
     return mint.BackgroundMint(
         host=host, store=store, artifacts_dir=tmp_path / "artifacts",
         posture=compile_posture.FLEET, vcpus=4, **kw)
@@ -103,7 +143,8 @@ def test_a_condemned_mint_reports_itself_on_the_wire(
         wedged.wait(timeout=10.0)      # a compile that will never come back
         return destination
 
-    box = _mint(_host(2), _Store(), tmp_path, compiler=_compiler, window_s=0.3)
+    box = _mint(_host(2), _store(tmp_path), tmp_path, compiler=_compiler,
+                window_s=0.3)
     try:
         outcome = box.run()
     finally:
@@ -125,17 +166,56 @@ def test_a_healthy_mint_is_never_called_wedged(
     """The polarity guard. A mint that lands its graphs emits no defect —
     otherwise the event is noise the hub learns to ignore."""
     host = _host(3)
+    store = _store(tmp_path)
 
     def _compiler(blob: Path, record: Any, destination: Path) -> Path:
         return _artifact(destination, record.graph)
 
-    outcome = _mint(host, _Store(), tmp_path, compiler=_compiler).run()
+    outcome = _mint(host, store, tmp_path, compiler=_compiler).run()
 
     assert outcome.landed == 3 and not outcome.condemned
-    assert host.adoption.armed == [f"unet/class={i}" for i in range(3)] or \
-        sorted(host.adoption.armed) == sorted(
-            f"unet/class={i}" for i in range(3))
+    assert sorted(host.adoption.armed) == sorted(graph_of(i) for i in range(3))
     assert not [e for e in wire if e[0] == mint.KIND_MINT_WEDGED], wire
+
+
+def test_the_mint_arms_the_STORE_copy_and_never_the_compilers(
+    tmp_path: Path, wire: List[tuple],
+) -> None:
+    """pgw#1573 — the invariant that collapses the two load paths into one.
+
+    `_mint_one` used to arm ``artifact``: the unpacked DIRECTORY the compile
+    child had just written, while publishing an ENVELOPE the arm never opened.
+    Two producers, two formats, and no run of the mint ever read its own
+    published bytes — which is precisely how pgw#1471's bare-``.pt2`` publish
+    survived from the first publisher that ever existed until va#3 arm 2
+    fetched one on a pod and holed 14/14 on ``cannot decompress``.
+
+    So the assertion is about WHICH BYTES: the armed path must be the store's
+    fetch position, it must be a FILE, and it must carry the gzip envelope
+    magic the boot loader reads. Arming the compiler's output again fails all
+    three.
+    """
+    host = _host(1)
+    store = _store(tmp_path)
+
+    def _compiler(blob: Path, record: Any, destination: Path) -> Path:
+        return _artifact(destination, record.graph)
+
+    outcome = _mint(host, store, tmp_path, compiler=_compiler).run()
+
+    assert outcome.landed == 1, outcome.failed
+    armed = host.adoption.armed_paths[0]
+    assert armed.is_file(), (
+        f"{armed} is not a file — the mint armed the compiler's unpacked "
+        f"directory again, so a publish/load format skew would be invisible "
+        f"from here exactly as it was in pgw#1561")
+    with armed.open("rb") as handle:
+        assert handle.read(2) == b"\x1f\x8b", (
+            f"{armed} is not the tar+gzip envelope boot adoption reads")
+    # And it is THE position boot adoption fetches to, not a scratch copy:
+    # torchcg's `AdoptSession._adopt_module` addresses exactly this path.
+    assert armed == tmp_path / "artifacts" / ENV.value / f"{graph_of(0)}.so"
+    assert outcome.entries[0].artifact == armed
 
 
 def test_a_published_graph_that_does_not_arm_is_a_wire_fact(
@@ -144,14 +224,16 @@ def test_a_published_graph_that_does_not_arm_is_a_wire_fact(
     """`published but did not arm live` is why the pod keeps serving eager for
     a graph it just paid to compile. It was a `logger.warning`."""
     host = _host(1, arm_raises=RuntimeError("no module to arm onto"))
-    store = _Store()
+    store = _store(tmp_path)
 
     def _compiler(blob: Path, record: Any, destination: Path) -> Path:
         return _artifact(destination, record.graph)
 
     outcome = _mint(host, store, tmp_path, compiler=_compiler).run()
 
-    assert outcome.landed == 1 and store.published == ["unet/class=0"]
+    assert outcome.landed == 1
+    assert store.has_artifact(graph_of(0), ENV), (
+        "the graph did not reach the band boot adoption reads")
     assert not outcome.entries[0].armed
     missed = [e for e in wire if e[0] == mint.KIND_ARM_MISSED]
     assert len(missed) == 1, (


### PR DESCRIPTION
Paul, 2026-08-20: *"collapse the compile-adopt machinery to ONE canonical flow — you have too many code paths."*

## The map, before (banked in the tracker, pgw#1573)

**3 adopt orchestrators · 5 store constructions · 4 arming mechanisms · 2 mint triggers.**

Two findings from the $0 read that this PR acts on:

1. **`BackgroundMint._mint_one` published the ENVELOPE and armed the compile child's unpacked DIRECTORY.** The runtime mint has never once read its own published bytes. pgw#1561's closeout named this exact seam and closed with *"tests + changelog only"* — PR #1122 added a round-trip test, not a round-trip path. It is the reason pgw#1471's bare-`.pt2` publish survived from the first publisher that ever existed until va#3 arm 2 fetched one on a pod and holed 14/14 on `cannot decompress`: every local green was green over the directory.

2. **`gen-worker compile` documents a fetch-first hub consult it does not have.** `_store` passes `upstream=None`, and the `FETCHED` outcome constant is defined and assigned nowhere in `src/`. That is the whole of "remote adoption fails" on the box path — nothing was ever wired to succeed.

## What lands

- The mint **publishes, fetches back through the store, and arms that** — at the position boot adoption fetches to (the compile scratch moved out of the way; it used to point a directory at the path the store copies a file to). A self-minted artifact and a hub-fetched one traverse one load path. A publish the store cannot hand back is the typed `MintNotServable`. A storeless mint is refused at construction: it had exactly one thing left to arm.
- **A fleet-pool hit is BANKED into the local CAS.** `TieredGraphStore.fetch_artifact` kept none of the hub's bytes, so a pod re-downloaded every artifact on every restart and a hub outage turned a warm box cold. Best-effort, and deliberately not banked without a requirements manifest.
- **ONE constructor: `mint_store.graph_store`** (was `worker_store`). Pod, `up`, `compile` and the CI runner build the same object; `upstream=None` is the stated box/pod difference, not a different class. `artifact_skew` passthrough added — pgw#1561's owed non-blocking item.
- **`FETCHED` and the false FETCH-FIRST paragraph deleted.**

## Tests

`tests/test_adopt_flow.py`, three legs on CPU through production objects:

| leg | what it proves |
|---|---|
| cold | empty store → first request serves EAGER; background mint lands both graphs; a later request on the **same live host** goes through the compiled graph (hot swap); bytes in the local CAS, no skew |
| warm-local | reboot arms both from the store, `nothing_to_mint`, **zero** recompiles |
| warm-remote | real `HubGraphStore` over a real HTTP server speaking the real th#2133 answer → fetched, digest-verified, armed, **served compiled**, and banked — then the hub is shut down and a reboot still adopts |

Plus a skew red arm (a hub answering a bare `.pt2` must refuse `ArtifactFormatSkew:` and never arm), a truncation red arm (a failed digest must leave nothing in the local CAS), and a source-level fence that no entry point constructs `LocalGraphStore` directly again.

**The loader in this file calls the REAL `torchcg.serve.materialize`** — the exact function `aoti_loader` calls — which is what no previous adoption stub did. pgw#1561 shipped fourteen unloadable blobs past a suite whose stub never opened its argument.

**Red arms proven by mutation:** banking removed → red; loader stops materializing → red; mint arms the compiler's directory → red.

`test_runtime_mint.py`'s `_Store` double is deleted for the real store — it accepted a non-identity graph name, a directory, and a literal return, which is why that file stayed green through both pgw#1471 and pgw#1561.

## Local verification

`mypy src/gen_worker tests` clean (650 files) · `ruff check src/gen_worker` clean · `lint_unreached_surface` / `lint_incident_test_names` pass · 130 targeted tests green across `test_adopt_flow`, `test_runtime_mint`, `test_mint_publish_shape`, `test_adoption_verdict`, `test_compile_servability`, `test_serving_adopt_first`, `test_self_mint_wiring`, `test_program_blob_tiers`, `test_store_addresses`, `test_serve_path_wires`, `test_cli_adopt_degradation`, `test_compile_program_miss`, `test_store_corruption_pgw1283`.

The v1 remnant tier (`aot_serve`, `compile_cache`'s arming half, `local_compiled_graph_store`, `compiled_graph_resolve`, `serve/`) is orphaned and is a separate deletion — it is not touched here.