### PR TITLE
pgw#1575: the vendored tensorfs snapshot is ONE rev on ONE lineage — the pre-genesis 8bafdfbb write plane is deleted

### DIFF
--- a/changelog.d/pgw1575.md
+++ b/changelog.d/pgw1575.md
@@ -1,0 +1,18 @@
+- **The vendored tensorfs snapshot is ONE rev on ONE lineage.** It carried three, and the one it
+  called `rev` — `8bafdfbb` — was not merely behind upstream: `git merge-base` finds NO common
+  ancestor between it and tensorfs master at all. It predates upstream's v0.1.0 genesis restart and
+  survives only on the `shelf/tensorfsd` branch, so `VENDORED.toml` was certifying byte-fidelity to
+  a rev nobody would ever fix, and two more revs (`read_plane_rev`, `contract_plane_rev`) were
+  bolted on beside it because the dead one could not supply the planes this repo actually reads.
+  Everything now comes from `da1f3d2`, the master commit tensorhub's `go.mod` pins.
+  It was held for five `LocalCAS` methods, and none of them needed a lineage. `ingest_file` and
+  `collect_garbage` are first-party at `gen_worker/cas/`, where the retention policy already lived
+  and where the object grid had already been forked (pgw#1365's `planner.py`, which existed at no
+  upstream rev and has stopped pretending to be vendored). `materialize` is upstream's own tier-3
+  hatch, `TensorReader.materialize`. `ingest_repository` had zero callers in `src/` and is a test
+  fixture. `materialize_repository` had zero callers anywhere and is deleted. The two surviving
+  rewrites — `contract.py`'s validator and `tensors.py`'s `_MappedObject` — are unchanged and exist
+  for the one pgw#1310 reason: a source-vendored wheel cannot carry a compiled extension.
+  `test_the_tensorfs_snapshot_is_one_rev` refuses a second `*_rev` key and
+  `test_the_write_plane_is_first_party_and_never_returns` refuses the five symbols by name, so the
+  dead lineage cannot come back as "just one more file".

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -27,277 +27,106 @@
 
 [packages.tensorfs]
 repo = "https://github.com/cozy-creator/tensorfs"
-rev = "8bafdfbb112be57cc96c0c71c38fd987091cbf51"
+rev = "da1f3d2f91efc0a12de4ed2b74a8d43009a577d5"
 subdir = "python/src/tensorfs"
-# Why THIS rev and not the tip: upstream `master` is a v0.1.0 genesis restart
-# that deleted this data plane outright (no `transfer`, `journal`, `chunking`);
-# `8bafdfbb` is the merge of tensorfs#41, the last lineage that still carries
-# `LocalCAS` + `download`/`upload` AND the pgw#1287 progress-emission fix
-# (`626a3de` per-object emission + `6c1f2ab` resident objects advance too).
-# A 31.6 GB snapshot reporting `0 / total` for its whole duration is what got
-# correctly-downloading pods condemned by the hub's 6-minute freshness window.
+# ONE REV, ONE LINEAGE (pgw#1575), on Paul's release-policy ruling of
+# 2026-08-20, verbatim: "it's fine if old wheels are on pypi historically. I
+# just mean, get rid of the vendored copies, etc. Remove the v1's from the
+# codebase fully."
 #
-# pgw#1308: the TRANSFER PLANE LEFT THIS SNAPSHOT and is now first-party at
-# `gen_worker/transfer/`. It was never storage — `TransferGrant.from_wire`
-# parses TENSORHUB's grant JSON, and the retry ladder, the fan-out width and
-# the per-object progress emission are this worker's policy about this
-# worker's uplink. Upstream agrees: current tensorfs has no Python transfer
-# plane at all (its client is the Rust `sync.rs` pack/blob lane, which a
-# pure-Python wheel cannot carry). So the two modules were pinned to a
-# lineage upstream had ABANDONED, and calling that a "vendored snapshot" was
-# the part that had stopped being true — a digest fence certifying fidelity
-# to a rev nobody would ever fix. The `daemon` module went with them, for the
-# adjacent reason: it is a FUSE client in a wheel that provably cannot mount
-# (pgw#1295 — `CAP_SYS_ADMIN` absent from the container's bounding set,
-# measured on a real pod), and nothing in this repo imported it.
+# This file used to declare a THREE-REV split and call it "the STEADY STATE …
+# a release-policy decision (Paul), not a lane's". The decision happened.
 #
-# What is LEFT is genuinely storage — `LocalCAS`, the chunk manifest, refs —
-# and it is byte-identical to `8bafdfbb` except for the `rewrites` below.
+# What the split was, and what was wrong with it. `rev` was `8bafdfbb` — and
+# that rev is not merely behind master, it shares NO ANCESTOR WITH IT AT ALL
+# (`git merge-base 8bafdfbb da1f3d2` finds nothing; upstream restarted at a
+# v0.1.0 genesis and the old lineage survives only on `shelf/tensorfsd`). It
+# was held for exactly five methods upstream deleted — `LocalCAS.ingest_file`,
+# `ingest_repository`, `collect_garbage`, `materialize`,
+# `materialize_repository` — and for a `planner.py` that exists at NO upstream
+# rev whatsoever. `read_plane_rev` and `contract_plane_rev` were master
+# ancestors bolted on beside it because the dead rev could not supply the
+# consumption plane or the contract plane.
 #
-# pgw#1330: THE SNAPSHOT IS SPLIT AT TWO REVS, ON PURPOSE, PERMANENTLY (see
-# the ownership ruling below), AND THIS IS THE ONLY RECORD OF IT. Every file in
-# `read_plane_files` comes from `read_plane_rev` below, NOT from `rev`. They are
-# the consumption plane the whole mixed-CAS cutover rests on — TFSSTUB1
-# render/parse, tree projection, the direct tensor reader and (pgw#1344) the
-# tensor WRITER — and they DID NOT EXIST at `8bafdfbb`.
+# Where the five went, and none of them needed a lineage:
 #
-# Why not simply bump `rev`: the newer lineage DELETED `LocalCAS.ingest_file`,
-# `LocalCAS.ingest_repository`, `LocalCAS.collect_garbage`,
-# `LocalCAS.materialize` and `LocalCAS.materialize_repository`.
+#   * `ingest_file` / `ingest_repository` — FIRST-PARTY, `gen_worker/cas/
+#     admission.py`. The old argument was that admission is the store's
+#     identity contract and forking it would put a second implementation of
+#     the hub's dedup rule in this repo. But the identity contract is the
+#     OBJECT GRID, and pgw#1365 had already forked that into `planner.py` and
+#     pinned it to upstream's released `spec/v1/planner-vectors` corpus. What
+#     was actually left in `local.py` was forty lines of plan, put, hash and
+#     refuse-if-it-moved, calling a module this repo already owned.
+#   * `collect_garbage` — FIRST-PARTY, `gen_worker/cas/retention.py`. Its own
+#     upstream docstring said "TensorFS deliberately owns no retention
+#     policy", and the policy was already `models/disk_gc.py`'s. Master has no
+#     successor at all: the Rust `ObjectStore` collects abandoned TEMPORARIES,
+#     which is a lease sweep, not a reachability pass.
+#   * `materialize` — UPSTREAM'S, and it moved rather than died:
+#     `TensorReader.materialize`, tier 3 of the access ladder Paul fixed on
+#     2026-08-17, which upstream's own no-whole-tree-materialization fence
+#     exempts by name. Two callers, `aot_delivery.py` and
+#     `models/materialized_view.py`, each carrying its inline
+#     `mixed-cas-hatch:` marker naming the §9 row it is priced under.
+#   * `materialize_repository` — DELETED. Zero callers since pgw#1308 step 6
+#     made the chokepoint PROJECT rather than materialize.
 #
-# pgw#1308 STEP 6 ANSWERED THE OWNERSHIP QUESTION, and the answer is NOT the
-# one this file used to imply. It said the split ends when the chokepoint
-# flips. It does not:
+# `planner.py` MOVED OUT (`gen_worker/cas/planner.py`). It was never a vendored
+# file: it is this repo's pure-Python port of
+# `crates/tensorfs-core/src/planner/{mod,safetensors,gguf}.rs`, written because
+# upstream deleted the Python chunker at `00c57c1` ("one chunker — the legacy
+# Python data plane is gone") and pgw#1310 rules a compiled extension out of a
+# source-vendored wheel. Carrying it under `_vendor/` made the digest table
+# certify fidelity to bytes no upstream rev has. Its two knowing divergences
+# are unchanged and still tested by name: `plan_chunks` cuts a >64 MiB blob on
+# the fixed grid (tensorhub's single-PUT promotion cap — pgw#1366), and a
+# duplicate GGUF metadata key plans as `gguf-v1` here and `blob-v1` upstream.
 #
-#   * `materialize_repository` — DEAD. The chokepoint projects (pgw#1308 step
-#     6, `models/cozy_snapshot.py:_publish_snapshot`), so this repo has zero
-#     callers. The definition below is all that is left of it.
-#   * `materialize` (single file) — KEPT, and the name is now the SHARED one.
-#     The pinned rev has always called it `materialize`; upstream called the
-#     same operation `extract()` until tensorfs#107 renamed it to match
-#     (Paul's #1303 ruling). So the two-spelling hazard that once made the
-#     hatch census read zero is gone: one name here and upstream. It is tier 3 of the access
-#     ladder — permanent, not separately priced — and upstream's own
-#     no-whole-tree-materialization fence exempts it by name. ONE live user
-#     since pgw#1342 — `aot_delivery.py`, declared to the lint against
-#     `docs/mixed-cas-layout.md` section 9 with an inline marker. The vendored
-#     `torchcg/storage.py` was the second until its blob cutover; it untars
-#     straight out of the store now and reaches no hatch.
-#   * `ingest_file` / `ingest_repository` — TENSORFS'S, not ours. Admission is
-#     the store's identity contract: the chunk grid, the whole-file digest,
-#     the concurrent-mutation refusal. Upstream did not abandon it the way it
-#     abandoned the Python transfer plane; it PORTED it to Rust
-#     (`Plan`/`HashedPlan`/`AdmittedObject`/`ObjectStore`) and added
-#     `TensorWriter`. Forking it first-party would put a second implementation
-#     of the rule that decides hub dedup in this repo.
-#   * `collect_garbage` — TENSORFS'S, same shape. Reachability over the
-#     store's own ref and manifest formats; its own docstring says tensorfs
-#     owns no retention policy, and the retention policy is already
-#     first-party in `models/disk_gc.py`.
+# `manifest.py` is now master's, which DROPS the 64 MiB cap on a chunkless
+# entry. The old note kept `8bafdfbb`'s stricter parser deliberately; that
+# reason is spent, because the stricter parser only ever refused a manifest
+# this repo cannot emit — `plan_chunks` still cuts an oversized blob for the
+# hub's sake, so nothing here produces a chunkless entry above the cap either
+# way. Relaxing the parser removes a divergence and adds no admission.
 #
-# So the split at two revs is the STEADY STATE. It ends when pgw can depend on
-# a PUBLISHED, COMPILED tensorfs — upstream's successors for ingest and GC are
-# the Rust extension, and pgw#1310 rules a compiled extension out of a
-# source-vendored wheel. That is a release-policy decision (Paul), not a lane's.
-# Do not "finish the bump": it would delete two symbols with no reachable
-# successor.
+# WHY IT IS STILL VENDORED AT ALL. pgw#1310 is unchanged: `[tool.uv.sources]`
+# is workspace-only metadata stripped from a published wheel, so a git pin
+# leaves every consumer of the artifact unable to resolve `gen-worker`.
+# tensorfs is NOT on PyPI today — `https://pypi.org/pypi/tensorfs/json` is a
+# 404 and the repo carries no `v*` tag — even though its release pipeline is
+# built and merged (`publish.yaml` + `wheels.yaml`: six abi3 platform wheels,
+# trusted publishing, a post-publish verify job) and `pyproject.toml` says
+# version 0.1.0. THE DAY A `v0.1.0` TAG IS CUT, this whole directory goes and
+# both rewrites below go with it, because the compiled extension becomes
+# installable. That is the end state; it is a tensorfs release act, not a pgw
+# lane's, and it is the only thing that retires pgw#1310.
 #
-# Why the split is SAFE rather than merely convenient: the three read-plane
-# modules import nothing from `local.py` at runtime beyond `object_path`,
-# `load_manifest` and `_store_lock` — all three present and unchanged at
-# `8bafdfbb` — plus `manifest.py` and `refs.py`. `refs.py` is byte-identical
-# across the two revs. `manifest.py` differs ONLY in that the newer rev drops
-# the 64 MiB cap on a chunkless entry; the older, STRICTER parser is the one
-# in force here, so nothing the read plane is handed can be a manifest the
-# storage half would have refused. `tests/test_projected_tree_pgw1330.py`
-# proves the pairing executes rather than asserting it from imports.
+# THE TWO SURVIVING REWRITES are listed under `rewrites` and both exist for
+# that same one reason — upstream reaches for `tensorfs.native`, and a
+# source-vendored wheel cannot carry the extension.
 #
-# pgw#1344: THE CONSUMPTION PLANE IS NOW A READ **AND WRITE** PLANE, and its
-# rev advances from `333bb10` to `21cec66` (tensorfs#106) to get `writer.py`.
-# `TensorWriter` composes a snapshot one tensor at a time in safetensors OR
-# GGUF on the seal planner's own object grid, which is the only way a converted
-# GGUF can share tensor objects with its safetensors source instead of being a
-# second copy of every byte. `convert/gguf_native.py` is its first caller.
-# `__init__.py` comes from this rev too and is now upstream's VERBATIM — the
-# pgw#1308 rewrite that used to live here is gone, because upstream itself no
-# longer re-exports a Python transfer plane. `project.py` is byte-identical at
-# both revs, so nothing about the projection half moved.
+# The 21 `_contracts/*.json` documents are upstream's VERBATIM and are the
+# wheel spelling of `spec/v1/contracts` (a source checkout symlinks them, so
+# they are copied dereferenced). They are the same files the Rust core embeds,
+# and the set is EQUAL to upstream's — `test_lane_contracts.py` runs upstream's
+# released `spec/v1/contract-vectors` corpus over them. Three of them declare
+# no top-level dtype on purpose — `dit.blocks-fused-qkv`,
+# `sdxl.clip-g-fused-qkv`, `sdxl.clip-g-split-qkv` — because they are FRAGMENTS
+# (a family-shared block spelling and two CLIP component spellings) that a
+# `lanes=` header never names on its own. Do not "fix" them, and do not let a
+# declaration-time dtype read treat them as lanes.
+# `stable-audio.diffusers-fp16` is the only document whose top-level dtype is
+# `float16`; the served checkpoints histogram {F16: 445} and the hub records
+# dtype=fp16, so do not correct it toward its siblings.
 #
-# ONE REWRITE IS REAL, and it is in `tensors.py`. At `21cec66` upstream's
-# `TensorReader._map` maps through the compiled extension
-# (`from .native import MappedObject`) and its comment says there is NO
-# fallback. pgw#1310 rules a compiled extension out of a source-vendored wheel,
-# so a straight take of that file would have deleted native tensor reads from
-# this repo outright. The rewrite restores the mapping in pure Python —
-# `_MappedObject`, an `mmap` exported through PEP 688's `__buffer__` — and it
-# is a restoration rather than a downgrade: upstream needed exactly two things
-# from the extension at that call site, a WEAK-REFERENCEABLE handle (so
-# `_maps` can stay the `WeakValueDictionary` that keeps an 8 GiB shard from
-# ending up resident) and a buffer that keeps its mapping alive for as long as
-# some view of it exists. A bare `mmap.mmap` supplies neither; a py3.12 class
-# with `__buffer__` supplies both, and py3.12 is this package's floor. Nothing
-# else in the file is touched, so every other line is still upstream's.
-# pgw#1365: THE ADMISSION GRID JOINS THE REWRITE, FOR THE SAME REASON, AND IT
-# IS THE LAST HALF OF THE SNAPSHOT THAT WAS STILL ANSWERING A RETIRED QUESTION.
-#
-# `chunking.py` at `8bafdfbb` was the GREEDY SMALL-TENSOR PACKER: tensors under
-# 64 MiB were accumulated into one object, and every non-tensor file was cut on
-# a fixed 64 MiB grid. Upstream DELETED that file at `00c57c1` ("pgw#1259: one
-# chunker — the legacy Python data plane is gone", Paul's ruling: two chunker
-# implementations, pick one, hard cut) because its grid disagreed with the Rust
-# planner's — a packed object spans two tensors, owns neither's digest, and can
-# therefore be inherited by nothing. The mixed-CAS ruling says verbatim "one
-# chunker (the Rust planner is canonical)". `hubio/client.py::publish_v2` calls
-# `LocalCAS.ingest_file`, so until this lane EVERY FLEET UPLOAD cut its objects
-# on the retired grid: measured against upstream's released conformance corpus,
-# 3 of 12 cases disagreed — a safetensors pair packed 3+5 bytes into one object
-# where the planner emits two, and BOTH GGUF cases were planned as raw blobs
-# because the retired module had no GGUF planner at all. That last one is the
-# expensive half: pgw#1344 had just taught `convert/gguf_native.py` to COMPOSE
-# GGUFs on the planner grid, and publishing one re-cut it.
-#
-# `planner.py` REPLACES it, and the pgw#1344 precedent is exactly why it is a
-# rewrite rather than a rev bump: upstream's successor is
-# `crates/tensorfs-core/src/planner/`, reachable from Python only through the
-# compiled extension, and pgw#1310 rules a compiled extension out of a
-# source-vendored wheel. So the grid is restored in pure Python and pinned to
-# the ORACLE UPSTREAM SHIPS — `spec/v1/planner-vectors`, the language-neutral
-# corpus Rust, Go and Python must all satisfy — vendored at
-# `tests/testdata/planner-vectors/` with its own digest and a sibling-checkout
-# comparison. All twelve cases now agree object-for-object AND digest-for-digest.
-# The safetensors structural proof (`_tensor_spans`) is the retired module's,
-# unchanged: it was already a faithful port of `safetensors.rs::read_layout`,
-# and only the packing it fed died.
-#
-# ONE DEVIATION, and it is the HUB's constraint, not a preference. `blob-v1` is
-# one unchunked object of ANY size; `plan_chunks` still cuts a blob above
-# 64 MiB on the fixed grid, because tensorhub's publish-v2 lane promotes an
-# object with a SINGLE PUT (`internal/s3/sha256_cas.go`: "verified promote:
-# size %d is outside the HashRepo single-PUT range 0..67108864") and would
-# refuse the whole-blob entry terminally. Files at or below 64 MiB are already
-# exactly `blob-v1`, so the residual is only large non-tensor files; it is
-# pgw#1366, it closes when publish-v2 grants ride th#2064's multipart blob
-# lane, and `test_the_oversized_blob_deviation_is_the_only_one` fails the
-# moment anyone widens it. `manifest.py` stays at `8bafdfbb` for the same
-# reason — its chunkless 64 MiB cap is the older, stricter parser, and nothing
-# this snapshot emits can violate it.
-read_plane_rev = "21cec66a580cb232210facbfccfa580a16d7196e"
-read_plane_files = ["__init__.py", "gguf.py", "project.py", "tensors.py", "writer.py"]
-# pgw#1391: A THIRD REV, AND THE SAME REASON AS THE SECOND — the CONTRACT plane
-# did not exist at either of the two above. `rev` predates tensorfs's genesis
-# restart entirely and `read_plane_rev` predates tensorfs#111/#113/#114, so
-# neither carries `contract.py`, `contracts.py` or `_contracts/`. This is the
-# plane that makes a lane stamp FALSIFIABLE: without it a `Model` header could
-# claim `sd15.diffusers-bf16@1`, a document that exists nowhere, and every
-# surface in this repo accepted it (pgw#1391's measured reproduction).
-#
-# `contracts.py` and the six `_contracts/*.v1.json` documents are upstream's
-# VERBATIM. The documents are the wheel spelling of `spec/v1/contracts` (a
-# source checkout symlinks them, so they are copied dereferenced) and are the
-# same files the Rust core embeds.
-#
-# `contract.py` is a REWRITE, listed below, for exactly the `planner.py`
-# reason: upstream's version delegates to the compiled extension
-# (`from .native import contract_info`) and pgw#1310 rules a compiled extension
-# out of a source-vendored wheel. Taking it straight would have imported a
-# module that cannot exist here.
-#
-# TWENTY documents, not six, and this bump is the se#769 WAVE-WIDE SYNC — one
-# writer, one cut rev, the whole wave's lane documents at once. Before it, five
-# lanes were each bumping this file on their own schedule and racing through
-# one table; the arbitration was that the qwen lane landed a SUBSET (honest for
-# pgw's own set-equality fence, but it hand-trimmed the vendored corpus to match
-# rather than shipping upstream's bytes), everyone else held, and this sync
-# brings the set back to EQUAL the real upstream corpus.
-#
-# `contract_plane_rev` advanced c3a831d -> `107b8ac` (tensorfs#121) ->
-# `2abc1b76` (#124/#125) -> `b8bb39fd` (#134) -> `272103e4` -> `86bfa80f`
-# (tensorfs#140, the audio lane's document — pgw#1442, this bump). The
-# documents arriving here belong to OTHER LANES and are vendored bytes-only,
-# named so the ownership is readable rather than implied:
-#
-#   flux1.diffusers-bf16          se#778   tensorfs#136
-#   qwen-image / z-image          se#776   tensorfs#131   (already present)
-#   internvl-u.diffusers-bf16     se#779   tensorfs#137
-#   ltx-2.diffusers-bf16          se#772   tensorfs#135
-#   trellis2.dit-bf16             se#775   tensorfs#132
-#   ernie.diffusers-bf16          se#—     tensorfs#142
-#   minimax.h3-dit-fp8-rowwise    —        tensorfs#128
-#   sdxl.diffusers-fp8-rowwise    —        tensorfs#128
-#   stable-audio.diffusers-fp16   se#769   tensorfs#140   (THIS bump, pgw#1442)
-#
-# `stable-audio.diffusers-fp16` is the FIRST vendored document whose top-level
-# dtype is `float16` rather than `bfloat16` — the served checkpoints histogram
-# {F16: 445} and the hub records dtype=fp16, so the document describes the
-# bytes the fleet actually serves. Do not "correct" it toward its siblings, and
-# do not widen its per-tensor `dtypes` to admit BF16: a bf16 repack of this
-# architecture would be a SEPARATE document (`stable-audio.diffusers-bf16@1`),
-# the way sdxl carries both a bf16 and an fp8-rowwise lane. It is also the only
-# document serving TWO checkpoints deliberately — `stable-audio-open` and
-# `foundation-1` share an identical transformer header sha256 and differ only
-# in weight values, which is a checkpoint row rather than a second layout.
-#
-# #121 authored the four se#757 blocker-A lane documents (`sd15`, `sd2`,
-# `hidream-o1`, `wan22` — sd15 and sd2 are SEPARATE documents with separate
-# digests) and gave `minimax.h3-dit-diffusers@1` the top-level `dtype` it owed;
-# #124 added `flux2-klein.diffusers-bf16@1` and then `flux1.diffusers-bf16@1`.
-# Clearing the FIVE `MissingContract` sentinels in `models/model_types.py` took
-# NO code change, which is the property the sentinel shape exists to have —
-# `Flux1.canonical_contract` resolves now purely because its document is here.
-#
-# THE FENCE READS TWO TABLES AND A BUMP MUST TOUCH BOTH. `contract_plane_files`
-# is the contract-plane inventory; `[packages.tensorfs.files]` is the
-# path -> sha256 table `test_every_vendored_file_matches_its_recorded_digest`
-# enforces AS A SET. Updating one and not the other is the defect this sync
-# exists to stop repeating — and the failure modes differ, so neither catches
-# the other: the digest fence caught three documents "only on disk", while a
-# list that silently GREW duplicate rows (34 entries for a 20-document library)
-# was invisible to it, because the fence reads the other table.
-#
-# Two documents RE-DIGESTED across that bump and it is deliberate upstream:
-# `minimax.h3-dit-diffusers@1` gained its dtype, and `sdxl.diffusers-bf16@1`
-# was re-declared COMPLETE over the shipped checkpoint header (detection
-# specificity is the count of a file's keys a contract explains, so a sampled
-# document loses to a complete document for a neighbouring architecture).
-# Both kept version `@1`, so any release published before this bump recorded a
-# digest that no longer matches the document behind the same stamp.
-#
-# Three vendored documents declare NO top-level dtype on purpose —
-# `dit.blocks-fused-qkv`, `sdxl.clip-g-fused-qkv`, `sdxl.clip-g-split-qkv`.
-# They are FRAGMENTS (a family-shared block spelling and two CLIP component
-# spellings) that a `lanes=` header never names on its own. Do not "fix" them,
-# and do not let a declaration-time dtype read treat them as lanes.
-contract_plane_rev = "86bfa80fd42cf8c107f16ab649a2afcebc45dd88"
-contract_plane_files = [
-  "contract.py",
-  "contracts.py",
-  "_contracts/dit.blocks-fused-qkv.v1.json",
-  "_contracts/ernie.diffusers-bf16.v1.json",
-  "_contracts/flux1.diffusers-bf16.v1.json",
-  "_contracts/flux2-klein.diffusers-bf16.v1.json",
-  "_contracts/hidream-o1.diffusers-bf16.v1.json",
-  "_contracts/internvl-u.diffusers-bf16.v1.json",
-  "_contracts/ltx-2.diffusers-bf16.v1.json",
-  "_contracts/minimax.h3-dit-diffusers.v1.json",
-  "_contracts/minimax.h3-dit-fp8-rowwise.v1.json",
-  "_contracts/minimax.h3-dit-native.v1.json",
-  "_contracts/qwen-image.diffusers-bf16.v1.json",
-  "_contracts/sd15.diffusers-bf16.v1.json",
-  "_contracts/sd2.diffusers-bf16.v1.json",
-  "_contracts/sdxl.clip-g-fused-qkv.v1.json",
-  "_contracts/sdxl.clip-g-split-qkv.v1.json",
-  "_contracts/sdxl.diffusers-bf16.v1.json",
-  "_contracts/sdxl.diffusers-fp8-rowwise.v1.json",
-  "_contracts/stable-audio.diffusers-fp16.v1.json",
-  "_contracts/trellis2.dit-bf16.v1.json",
-  "_contracts/wan22.diffusers-bf16.v1.json",
-  "_contracts/z-image.diffusers-bf16.v1.json",
-]
+# THE FENCE READS ONE TABLE NOW. `[packages.tensorfs.files]` is the
+# path -> sha256 inventory `test_every_vendored_file_matches_its_recorded_
+# digest` enforces AS A SET, and `test_the_tensorfs_snapshot_is_one_rev`
+# refuses the reappearance of a second `*_rev` key.
 rewrites = [
-  "`contract.py` (pgw#1391): the parse/validate/canonical/digest half is restored in pure Python instead of `from .native import contract_info`, because pgw#1310 rules a compiled extension out of a source-vendored wheel — the `planner.py` precedent exactly. The PUBLIC SURFACE is upstream's attribute for attribute (`Contract.from_document`, `.name/.version/.digest/.stamp/.label/.document/.description/.tensors/.sets`, the RAISING `.dtype`, `MissingDtype`, `TensorDecl`/`Fusion`/`Permute`), so a future pure-Python upstream re-vendor is a deletion rather than a migration. It adds one name upstream does not export, `ContractError`, carrying the kebab-case `reason` label the Rust and Go validators already share — the refusal corpus is keyed on it. Conformance is NOT asserted: `tests/test_lane_contracts.py` runs upstream's released `spec/v1/contract-vectors` corpus (tensorfs#114, the same one the Rust and Go implementations satisfy), vendored at `tests/testdata/contract-vectors/`, over the TWENTY VENDORED DOCUMENTS plus the two anonymous customs — 22 golden digests and 19 typed refusals. A SHA-256 over a hand-built line rendering cannot agree by luck. It has already caught a real divergence rather than merely certifying agreement: tensorfs#121 relaxed the contract-name grammar to admit a hyphen in the PRODUCER segment (`hidream-o1`, `flux-2`, `wan-2`; a LEADING hyphen still refuses) and the port refused `hidream-o1.diffusers-bf16` until it followed. NO KNOWN DIVERGENCE TODAY.",
-  "`tensors.py`: `TensorReader._map` maps through a pure-Python `_MappedObject` (an `mmap` exported via PEP 688) instead of the compiled `tensorfs.native.MappedObject`, because pgw#1310 rules a compiled extension out of a source-vendored wheel. Upstream's weak-mapping ownership rule is preserved exactly; see the paragraph above. No other file is edited, so the remaining digests are upstream's verbatim.",
-  "`planner.py` REPLACES `chunking.py` (pgw#1365): a pure-Python port of `crates/tensorfs-core/src/planner/{mod,safetensors,gguf}.rs` at `read_plane_rev`, because upstream deleted the Python chunker at `00c57c1` in favour of the Rust planner and pgw#1310 rules a compiled extension out of a source-vendored wheel. Conformance is asserted against upstream's released `spec/v1/planner-vectors` corpus, vendored at `tests/testdata/planner-vectors/`. Two knowing divergences, both tested by name: `plan_chunks` cuts a >64 MiB blob on the fixed grid (tensorhub's single-PUT promotion cap — pgw#1366), and a duplicate GGUF metadata key is planned as `gguf-v1` here and `blob-v1` upstream, because `gguf.read_header` does not record metadata keys.",
-  "`local.py`: one line — `from .chunking import plan_chunks` becomes `from .planner import plan_chunks`. Every other line is `8bafdfbb`'s verbatim.",
+  "`contract.py` (pgw#1391): the parse/validate/canonical/digest half is restored in pure Python instead of `from .native import contract_info`, because pgw#1310 rules a compiled extension out of a source-vendored wheel. The PUBLIC SURFACE is upstream's attribute for attribute (`Contract.from_document`, `.name/.version/.digest/.stamp/.label/.document/.description/.tensors/.sets`, the RAISING `.dtype`, `MissingDtype`, `TensorDecl`/`Fusion`/`Permute`), so a future re-vendor against a published wheel is a deletion rather than a migration. It adds one name upstream does not export, `ContractError`, carrying the kebab-case `reason` label the Rust and Go validators already share — the refusal corpus is keyed on it. Conformance is NOT asserted: `tests/test_lane_contracts.py` runs upstream's released `spec/v1/contract-vectors` corpus (tensorfs#114, the same one the Rust and Go implementations satisfy), vendored at `tests/testdata/contract-vectors/`, over the twenty-one vendored documents plus the two anonymous customs. A SHA-256 over a hand-built line rendering cannot agree by luck. It has already caught a real divergence rather than merely certifying agreement: tensorfs#121 relaxed the contract-name grammar to admit a hyphen in the PRODUCER segment (`hidream-o1`, `flux-2`, `wan-2`; a LEADING hyphen still refuses) and the port refused `hidream-o1.diffusers-bf16` until it followed. NO KNOWN DIVERGENCE TODAY.",
+  "`tensors.py`: `TensorReader._map` maps through a pure-Python `_MappedObject` (an `mmap` exported via PEP 688) instead of the compiled `tensorfs.native.MappedObject`, because pgw#1310 rules a compiled extension out of a source-vendored wheel. Upstream needed exactly two things from the extension at that call site — a WEAK-REFERENCEABLE handle, so `_maps` can stay the `WeakValueDictionary` that keeps an 8 GiB shard from ending up resident, and a buffer that keeps its mapping alive as long as some view of it exists. A bare `mmap.mmap` supplies neither; a py3.12 class with `__buffer__` supplies both, and py3.12 is this package's floor. Nothing else in the file is touched, so every other line is upstream's.",
 ]
 
 [packages.torchcg]
@@ -470,7 +299,7 @@ rewrites = [
 ]
 
 [packages.tensorfs.files]
-"__init__.py" = "a66ced3cd03e042989602b9e122e4b3988be6be6611aacdb05b852c8a968ec7b"
+"__init__.py" = "80affc975c054134411f4b22167d73aaa5ee5e969a71bff61e3b42afa7db2fcf"
 "_contracts/dit.blocks-fused-qkv.v1.json" = "95681781643548fc3bb696b84fee3d4c421f42e5fa5633c82fa6aae31f8e51e0"
 "_contracts/ernie.diffusers-bf16.v1.json" = "b4879a6c02962b873c81495acd561922c0271b809a6816f217d580b174a92514"
 "_contracts/flux1.diffusers-bf16.v1.json" = "74deb96dc6e295496ef107f12dd34932d31deadb14c8dec264cfbabccb405fa6"
@@ -495,13 +324,12 @@ rewrites = [
 "contract.py" = "b007d534da4f0a131bc7fe79001472cf08a94be0feedf229c0bba32fbb8c1d38"
 "contracts.py" = "7435a6e9569ce5da748c50aece447b74e427d841f5d757740b5fb4958b25dee9"
 "gguf.py" = "ced89fc42009ab2e69406d2726c9b0caf43254c51ab16bdcf37c5ad239a2d7be"
-"local.py" = "186401e38a14f74e70d20991fa47fdda4e10dc3f1c82b44c540eee73220b1f86"
-"manifest.py" = "a93ee850992c17dd90a57946441875d282367556703b9e9d1c8be057ea12bed4"
-"planner.py" = "3771ebd6d2a537c56736d740d0b0bfc72b74135dd84782509a923acd3b45ff4f"
-"project.py" = "2471c26e013b287a7554cecda51ff9b42c09f71cd6d6d57dd33ed4ef242c40cd"
+"local.py" = "8268a4134df41bafd192f4f31581bdc43ec8d7e1bd7b1b10c2785e1a74ca7a97"
+"manifest.py" = "6600d900fcd613091878c8558603126f5c732f163d91f2ce926fc85ec058ac79"
+"project.py" = "3d68606dfd76535c33418f79fc071edab8a5147c3f0d640d123625ddd9680598"
 "py.typed" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 "refs.py" = "f3a144543f423a6b01043294b21104ababaafdbfb31798560de678b69f27ac2f"
-"tensors.py" = "12ce32fdecebb1fd61b898cab0c40d9b13835af0353e2af95b4fa160bd4a4ad6"
+"tensors.py" = "7876bc45dd13ca9bff141d437e16762189c74cd12b08e7439012e6cdc028f47c"
 "writer.py" = "f44e74d983d2f642e8479f85a3682bb737dd76ffbd62c3fe7d684ae5c0c71ca1"
 
 [packages.torchcg.files]

--- a/src/gen_worker/_vendor/tensorfs/__init__.py
+++ b/src/gen_worker/_vendor/tensorfs/__init__.py
@@ -1,6 +1,9 @@
 """Content-addressed local storage and direct tensor reads and writes."""
 
-from .local import DigestMismatch, LocalCAS, RefConflict
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+from .local import DigestMismatch, LocalCAS, Reclaimed, RefConflict, TempCollection
 from .manifest import MAX_CHUNK_SIZE, Chunk, FileEntry, RepositoryManifest
 from .project import (
     STUB_MAGIC,
@@ -45,10 +48,12 @@ __all__ = [
     "LocalCAS",
     "MAX_CHUNK_SIZE",
     "ProjectionError",
+    "Reclaimed",
     "RefConflict",
     "RepositoryManifest",
     "Stub",
     "TensorError",
+    "TempCollection",
     "TensorReader",
     "TensorView",
     "TensorWriter",
@@ -61,4 +66,37 @@ __all__ = [
     "read_stub",
     "stub_bytes",
     "tree_bytes",
+    "Contract",
+    "Fusion",
+    "MissingDtype",
+    "Permute",
+    "TensorDecl",
+    "contracts",
 ]
+
+if TYPE_CHECKING:
+    from . import contracts
+    from .contract import Contract, Fusion, MissingDtype, Permute, TensorDecl
+
+# The contract surface needs the compiled extension (construction runs the
+# Rust validator), while `import tensorfs` alone must stay pure-Python — the
+# projection path is vendored extension-free. PEP 562 keeps both true: the
+# extension loads on first ACCESS of a contract name, never at import.
+_CONTRACT_EXPORTS = {
+    "Contract": "contract",
+    "Fusion": "contract",
+    "MissingDtype": "contract",
+    "Permute": "contract",
+    "TensorDecl": "contract",
+    "contracts": "contracts",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _CONTRACT_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(f".{module_name}", __name__)
+    value: Any = module if name == "contracts" else getattr(module, name)
+    globals()[name] = value
+    return value

--- a/src/gen_worker/_vendor/tensorfs/local.py
+++ b/src/gen_worker/_vendor/tensorfs/local.py
@@ -1,23 +1,44 @@
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import os
 import shutil
 import tempfile
-import time
-from collections.abc import Iterable, Iterator
-from contextlib import contextmanager
+from collections.abc import Iterator
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
+from stat import S_ISREG
 from typing import BinaryIO
 
-from .planner import plan_chunks
-from .manifest import Chunk, FileEntry, RepositoryManifest
+from .manifest import RepositoryManifest
 from .refs import CASRef
 
+try:
+    import fcntl
+except ModuleNotFoundError as exc:  # pragma: no cover - not reachable on POSIX
+    # There is no Windows wheel and `import tensorfs` cannot succeed there:
+    # the store's advisory locking is `fcntl.flock`, and `msvcrt.locking` is
+    # byte-range with no shared mode, so it is not a drop-in. Say that here
+    # rather than leaving a bare `No module named 'fcntl'`, which names the
+    # symptom and not the support boundary. Restoring Windows means writing a
+    # real POSIX-lock replacement (tensorfs#57), not editing a wheel matrix.
+    raise ImportError(
+        "tensorfs supports Linux and macOS only. This interpreter has no "
+        "`fcntl` module, so the content store cannot take its advisory locks."
+    ) from exc
+
 _COPY_BUFFER = 1 << 20
+
+# The namespace every temporary this library creates lives in, and nothing
+# else does. A file under `tmp/` outside it was made by a caller, carries no
+# lease, and is never collected.
+_TEMP_PREFIX = "tfs-"
+
+# Half-built projection trees. The rest of the name is the lease token, so a
+# reaper correlates the two without a registry.
+_BUILDING_PREFIX = ".building-"
 
 
 class DigestMismatch(ValueError):
@@ -28,14 +49,56 @@ class RefConflict(RuntimeError):
     """A logical ref changed from the value the caller observed."""
 
 
-@dataclass(frozen=True, slots=True)
-class GCReport:
-    """One reachability collection pass."""
+@dataclass(frozen=True)
+class Reclaimed:
+    """One abandoned artifact, described while it still exists."""
 
-    examined: int
-    reachable: int
-    deleted: int
+    name: str
+    creator: int | None
     bytes_deleted: int
+
+
+@dataclass(frozen=True)
+class TempCollection:
+    """What one sweep of the temporary directory examined and reclaimed.
+
+    ``reclaimed`` is the evidence, captured before each unlink: a sweep that
+    reports only a count leaves nobody able to say afterwards whose resources
+    it freed, which is how the orphaned-FUSE-connection incident (#96) stayed
+    invisible. It travels out in the report so a caller can log it wherever
+    survives the process that swept.
+    """
+
+    examined: int = 0
+    deleted: int = 0
+    bytes_deleted: int = 0
+    reclaimed: tuple[Reclaimed, ...] = ()
+
+
+def _tree_bytes(root: Path) -> int:
+    """What a scratch tree occupies, counted without following links."""
+
+    total = 0
+    for directory, _subdirectories, files in os.walk(root):
+        for name in files:
+            try:
+                total += os.lstat(Path(directory) / name).st_size
+            except OSError:
+                continue
+    return total
+
+
+def _creator_of(name: str) -> int | None:
+    """The pid a library artifact's name records, for evidence only."""
+
+    parts = name.split("-")
+    return int(parts[2]) if len(parts) > 3 and parts[2].isdigit() else None
+
+
+def _identity(status: os.stat_result) -> tuple[int, int, int, int]:
+    """The inode a name resolved to, so a recycled name is never mistaken."""
+
+    return (status.st_dev, status.st_ino, status.st_size, status.st_mtime_ns)
 
 
 class _ObjectWriter:
@@ -114,6 +177,200 @@ class LocalCAS:
             finally:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
+    @contextmanager
+    def _leased_temp(
+        self, kind: str, *, store_locked: bool = False
+    ) -> Iterator[tuple[BinaryIO, Path]]:
+        """A temporary file that exists only while its creator does.
+
+        The lease is an exclusive ``flock`` on the temp's own descriptor, held
+        for the whole write, verification and installation lifetime, and taken
+        while the store lock is held. Collection runs under the exclusive store
+        lock, so it can never observe a temp that is not yet leased -- which is
+        why reclaiming needs no clock at all.
+        """
+
+        guard = nullcontext() if store_locked else self._store_lock()
+        with guard:
+            # The pid is in the NAME as evidence for whoever reads a reap
+            # report, never as the ownership test -- that is the lease.
+            prefix = f"{_TEMP_PREFIX}{kind}-{os.getpid()}-"
+            descriptor, raw_path = tempfile.mkstemp(prefix=prefix, dir=self.tmp)
+            path = Path(raw_path)
+            try:
+                # A freshly created unique name cannot already be leased.
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                handle: BinaryIO = os.fdopen(descriptor, "wb")
+            except BaseException:
+                os.close(descriptor)
+                path.unlink(missing_ok=True)
+                raise
+        try:
+            yield handle, path
+        finally:
+            handle.close()
+            path.unlink(missing_ok=True)
+
+    @contextmanager
+    def open_temp(self) -> Iterator[Path]:
+        """A leased temporary file for a caller to fill and then ``adopt_file``.
+
+        Bytes staged through this path are reclaimable the instant this process
+        dies and are never reclaimed while it lives. A temporary the caller
+        creates itself holds no lease, so the collector leaves it alone.
+        """
+
+        with self._leased_temp("adopt") as (_handle, path):
+            yield path
+
+    @contextmanager
+    def scratch_lease(self) -> Iterator[str]:
+        """A token that names projection scratch, leased while it exists.
+
+        Held for the whole build and rename, so ``reap_projection_scratch``
+        can tell a projection that crashed from one that is merely slow. The
+        lease is a file in this store's ``tmp/`` named by the token itself,
+        because a directory cannot portably carry an advisory lock.
+        """
+
+        with self._leased_temp("scratch") as (_handle, path):
+            yield path.name
+
+    def reap_projection_scratch(self, parent: str | Path) -> TempCollection:
+        """Removes projection scratch under ``parent`` whose creator is gone.
+
+        Scratch is built beside the tree it will become, which can be any
+        directory, so the caller names it. Liveness decides and nothing else:
+        a half-built tree goes only when the lease naming it is free or has
+        already been reclaimed, so a projection still running -- for a second
+        or for an hour -- is never touched.
+        """
+
+        examined = 0
+        evidence: list[Reclaimed] = []
+        with os.scandir(parent) as entries:
+            for entry in entries:
+                if not entry.name.startswith(_BUILDING_PREFIX) or not entry.is_dir(
+                    follow_symlinks=False
+                ):
+                    continue
+                token = entry.name[len(_BUILDING_PREFIX) :]
+                # Only tokens this library issued: anything else is a foreign
+                # `.building-…` and is left alone, the way a foreign temp is.
+                if not token.startswith(_TEMP_PREFIX):
+                    continue
+                examined += 1
+                if not self._lease_is_free(self.tmp / token):
+                    continue
+                # Measured and recorded BEFORE the removal: afterwards
+                # nothing on disk can say who left it or what it cost.
+                freed = _tree_bytes(Path(entry.path))
+                creator = _creator_of(token)
+                try:
+                    shutil.rmtree(entry.path)
+                except OSError:
+                    continue
+                evidence.append(Reclaimed(entry.name, creator, freed))
+        return TempCollection(
+            examined,
+            len(evidence),
+            sum(item.bytes_deleted for item in evidence),
+            tuple(evidence),
+        )
+
+    @staticmethod
+    def _lease_is_free(path: Path) -> bool:
+        """Whether no live process holds this lease.
+
+        One sample answers it. A drain check across two samples -- the shape
+        #96 needs for a wedged FUSE connection, which has no owner left to
+        ask -- could only repeat this answer, because here the owner IS the
+        lock.
+        """
+
+        try:
+            descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False
+        finally:
+            os.close(descriptor)
+        return True
+
+    def collect_abandoned_temps(self) -> TempCollection:
+        """Reclaims the temporaries of creators that are gone.
+
+        No age and no clock: a library temp is leased before it is visible to
+        this sweep and stays leased until it is installed or removed, so a
+        candidate whose lease this call can take has no live holder. That is
+        strictly better than a wall-clock grace, which must either delete a
+        slow writer's temp or keep a crashed writer's forever.
+
+        Cadence stays with the caller; there is no background thread and no
+        startup scan.
+        """
+
+        examined = 0
+        evidence: list[Reclaimed] = []
+        with self._store_lock(exclusive=True):
+            with os.scandir(self.tmp) as entries:
+                for entry in entries:
+                    if not entry.name.startswith(_TEMP_PREFIX):
+                        continue
+                    try:
+                        listed = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        continue
+                    if not S_ISREG(listed.st_mode):
+                        continue
+                    examined += 1
+                    reclaimed = self._reclaim_temp(Path(entry.path), listed)
+                    if reclaimed is not None:
+                        evidence.append(
+                            Reclaimed(entry.name, _creator_of(entry.name), reclaimed)
+                        )
+            if evidence:
+                _fsync_dir(self.tmp)
+        return TempCollection(
+            examined,
+            len(evidence),
+            sum(item.bytes_deleted for item in evidence),
+            tuple(evidence),
+        )
+
+    @staticmethod
+    def _reclaim_temp(path: Path, listed: os.stat_result) -> int | None:
+        """Bytes reclaimed, or ``None`` when either guard retains the file.
+
+        The guards are the lease, which decides liveness, and the inode this
+        name resolved to at listing, so a name recycled between the listing
+        and the open is never the file that gets unlinked.
+        """
+
+        try:
+            descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError:
+            return None
+        try:
+            held = os.fstat(descriptor)
+            if _identity(held) != _identity(listed):
+                return None
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                return None
+            os.unlink(path)
+        except OSError:
+            return None
+        finally:
+            os.close(descriptor)
+        return held.st_size
+
     def object_path(self, ref: str | CASRef) -> Path:
         parsed = CASRef.parse(ref)
         return self.root / parsed.object_key()
@@ -138,11 +395,24 @@ class LocalCAS:
                 return self._verify_object_unlocked(parsed, size)
 
     def contains(self, ref: str | CASRef, *, size: int | None = None) -> bool:
+        """Whether the object is resident. Presence, not integrity.
+
+        One ``lstat``. Bytes are verified once, by the writer that admits
+        them, and this store never rehashes to answer "do I have it?" -- the
+        question a resume journal, a plan or a fetch decision actually asks.
+        A declared ``size`` is compared against the stat already taken, so a
+        truncated object still answers False for free; bytes corrupted in
+        place answer True, by design. ``verify_object`` is the scrub for
+        suspicion, and it is the only thing that rehashes.
+        """
+
         try:
-            self.verify_object(ref, size=size)
-        except FileNotFoundError:
+            status = self.object_path(ref).stat(follow_symlinks=False)
+        except (FileNotFoundError, NotADirectoryError):
             return False
-        return True
+        if not S_ISREG(status.st_mode):
+            return False
+        return size is None or status.st_size == size
 
     @staticmethod
     def _require_identity(path: Path, expected: tuple[int, int]) -> None:
@@ -211,17 +481,11 @@ class LocalCAS:
                     pass
                 else:
                     return ref
-        fd, raw_path = tempfile.mkstemp(prefix="put-", dir=self.tmp)
-        temporary = Path(raw_path)
-        try:
-            with os.fdopen(fd, "wb") as handle:
-                handle.write(data)
-                handle.flush()
-                os.fsync(handle.fileno())
+        with self._leased_temp("put") as (handle, temporary):
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
             self._commit_temp(temporary, ref, len(data))
-        except BaseException:
-            temporary.unlink(missing_ok=True)
-            raise
         return ref
 
     @contextmanager
@@ -240,25 +504,17 @@ class LocalCAS:
         expected_ref = CASRef.parse(expected)
         if type(size) is not int or size < 0:
             raise ValueError("object size must be a non-negative integer")
-        fd, raw_path = tempfile.mkstemp(prefix="stream-", dir=self.tmp)
-        temporary = Path(raw_path)
-        try:
-            with os.fdopen(fd, "wb") as handle:
-                writer = _ObjectWriter(handle)
-                yield writer
-                writer.flush()
-                os.fsync(writer.fileno())
-                written = os.fstat(writer.fileno()).st_size
-                if writer.size != size or written != size:
-                    raise DigestMismatch(
-                        f"{expected_ref}: stream is {written} bytes, expected {size}"
-                    )
-                if writer.ref != expected_ref:
-                    raise DigestMismatch(f"stream hashes to {writer.ref}, expected {expected_ref}")
+        with self._leased_temp("stream") as (handle, temporary):
+            writer = _ObjectWriter(handle)
+            yield writer
+            writer.flush()
+            os.fsync(writer.fileno())
+            written = os.fstat(writer.fileno()).st_size
+            if writer.size != size or written != size:
+                raise DigestMismatch(f"{expected_ref}: stream is {written} bytes, expected {size}")
+            if writer.ref != expected_ref:
+                raise DigestMismatch(f"stream hashes to {writer.ref}, expected {expected_ref}")
             self._commit_temp(temporary, expected_ref, size)
-        except BaseException:
-            temporary.unlink(missing_ok=True)
-            raise
 
     def adopt_file(
         self,
@@ -330,16 +586,13 @@ class LocalCAS:
             raise DigestMismatch(
                 f"{source_path}: source is {initial.st_size} bytes, expected {expected_size}"
             )
-        fd, raw_path = tempfile.mkstemp(prefix="put-", dir=self.tmp)
-        temporary = Path(raw_path)
-        try:
-            with os.fdopen(fd, "wb") as writer:
-                with source_path.open("rb") as reader:
-                    before = os.fstat(reader.fileno())
-                    digest, copied = _copy_and_hash(reader, writer)
-                    after = os.fstat(reader.fileno())
-                writer.flush()
-                os.fsync(writer.fileno())
+        with self._leased_temp("put") as (writer, temporary):
+            with source_path.open("rb") as reader:
+                before = os.fstat(reader.fileno())
+                digest, copied = _copy_and_hash(reader, writer)
+                after = os.fstat(reader.fileno())
+            writer.flush()
+            os.fsync(writer.fileno())
             if (
                 copied != expected_size
                 or before.st_size != expected_size
@@ -353,156 +606,6 @@ class LocalCAS:
                 raise DigestMismatch(f"{source_path}: bytes hash to {ref}, expected {expected_ref}")
             self._commit_temp(temporary, ref, copied)
             return ref
-        except BaseException:
-            temporary.unlink(missing_ok=True)
-            raise
-
-    def ingest_file(
-        self,
-        source: str | Path,
-        *,
-        manifest_path: str | None = None,
-    ) -> FileEntry:
-        path = Path(source)
-        initial = path.stat()
-        whole = hashlib.sha256()
-        chunks: list[Chunk] = []
-        copied = 0
-        with path.open("rb") as handle:
-            before = os.fstat(handle.fileno())
-            chunk_lengths = plan_chunks(handle, initial.st_size)
-            if not chunk_lengths:
-                return FileEntry(
-                    manifest_path or path.name,
-                    initial.st_size,
-                    self.put_file(path, size=initial.st_size),
-                )
-            handle.seek(0)
-            for length in chunk_lengths:
-                data = handle.read(length)
-                if len(data) != length:
-                    raise OSError(f"{path} ended while it was being ingested")
-                copied += len(data)
-                whole.update(data)
-                digest = self.put_bytes(data)
-                chunks.append(Chunk(digest, len(data)))
-            if handle.read(1):
-                raise OSError(f"{path} grew while it was being ingested")
-            after = os.fstat(handle.fileno())
-        if (
-            copied != initial.st_size
-            or before.st_size != initial.st_size
-            or after.st_size != initial.st_size
-            or after.st_mtime_ns != before.st_mtime_ns
-        ):
-            raise OSError(f"{path} changed while it was being ingested")
-        return FileEntry(
-            manifest_path or path.name,
-            copied,
-            CASRef(whole.hexdigest()),
-            tuple(chunks),
-        )
-
-    def ingest_repository(
-        self,
-        source: str | Path,
-    ) -> RepositoryManifest:
-        """Ingest every regular file below a directory into one manifest.
-
-        V1 manifests describe files, not symlinks or empty directories. Refusing
-        those filesystem entry types keeps materialization portable and prevents
-        a source-tree link from escaping the repository root.
-        """
-
-        root = Path(source)
-        if not root.is_dir():
-            raise NotADirectoryError(root)
-        entries: list[FileEntry] = []
-        for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
-            if path.is_symlink():
-                raise ValueError(f"repository contains a symlink: {path.relative_to(root)}")
-            if path.is_dir():
-                continue
-            if not path.is_file():
-                relative = path.relative_to(root)
-                raise ValueError(f"repository contains a non-regular file: {relative}")
-            entries.append(
-                self.ingest_file(
-                    path,
-                    manifest_path=path.relative_to(root).as_posix(),
-                )
-            )
-        return RepositoryManifest(tuple(entries))
-
-    def materialize(self, entry: FileEntry, destination: str | Path) -> Path:
-        with self._store_lock():
-            return self._materialize_unlocked(entry, Path(destination))
-
-    def _materialize_unlocked(self, entry: FileEntry, target: Path) -> Path:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        fd, raw_path = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
-        temporary = Path(raw_path)
-        whole = hashlib.sha256()
-        total = 0
-        try:
-            with os.fdopen(fd, "wb") as writer:
-                for ref, size in entry.objects():
-                    with self._object_lock(ref):
-                        source = self._verify_object_unlocked(ref, size)
-                    with source.open("rb") as reader:
-                        object_hash = hashlib.sha256()
-                        remaining = size
-                        while remaining:
-                            data = reader.read(min(_COPY_BUFFER, remaining))
-                            if not data:
-                                raise DigestMismatch(f"{ref}: object ended before {size} bytes")
-                            writer.write(data)
-                            object_hash.update(data)
-                            whole.update(data)
-                            total += len(data)
-                            remaining -= len(data)
-                        if reader.read(1):
-                            raise DigestMismatch(f"{ref}: object exceeds {size} bytes")
-                    if object_hash.hexdigest() != ref.digest:
-                        raise DigestMismatch(f"{ref}: object changed while materializing")
-                writer.flush()
-                os.fsync(writer.fileno())
-            if total != entry.size_bytes or whole.hexdigest() != entry.digest.digest:
-                raise DigestMismatch(
-                    f"{entry.path}: reconstructed bytes do not match the file manifest"
-                )
-            os.replace(temporary, target)
-            _fsync_dir(target.parent)
-            return target
-        except BaseException:
-            temporary.unlink(missing_ok=True)
-            raise
-
-    def materialize_repository(
-        self, manifest: RepositoryManifest, destination: str | Path
-    ) -> Path:
-        """Atomically publish a complete repository tree at an absent path."""
-
-        target = Path(destination)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        if target.exists():
-            raise FileExistsError(target)
-        with self._store_lock():
-            stage = Path(tempfile.mkdtemp(prefix=f".{target.name}.", dir=target.parent))
-            try:
-                for entry in manifest.files:
-                    self._materialize_unlocked(entry, stage / entry.path)
-                directories = [stage, *(path for path in stage.rglob("*") if path.is_dir())]
-                for directory in sorted(
-                    directories, key=lambda item: len(item.parts), reverse=True
-                ):
-                    _fsync_dir(directory)
-                os.rename(stage, target)
-                _fsync_dir(target.parent)
-                return target
-            except BaseException:
-                shutil.rmtree(stage, ignore_errors=True)
-                raise
 
     def store_manifest(self, manifest: RepositoryManifest) -> CASRef:
         return self.put_bytes(manifest.canonical_bytes())
@@ -568,14 +671,11 @@ class LocalCAS:
         desired = CASRef.parse(target) if target is not None else None
         expected_ref = CASRef.parse(expected) if expected is not None else None
         with self._store_lock():
-            if desired is not None:
-                try:
-                    with self._object_lock(desired):
-                        self._verify_object_unlocked(desired, None)
-                except FileNotFoundError:
-                    raise FileNotFoundError(
-                        f"cannot point {name!r} at absent object {desired}"
-                    ) from None
+            # Presence, not integrity: pointing a ref at an object is not an
+            # admission, and rehashing a 64 MiB object to answer "is it there?"
+            # is the cost issue #42 is about.
+            if desired is not None and not self.contains(desired):
+                raise FileNotFoundError(f"cannot point {name!r} at absent object {desired}")
             with self._ref_lock(name):
                 current = self._read_ref_unlocked(name)
                 if current == desired:
@@ -592,99 +692,10 @@ class LocalCAS:
                     ensure_ascii=False,
                     separators=(",", ":"),
                 ).encode("utf-8")
-                fd, raw_path = tempfile.mkstemp(prefix="ref-", dir=self.tmp)
-                temporary = Path(raw_path)
-                try:
-                    with os.fdopen(fd, "wb") as writer:
-                        writer.write(record)
-                        writer.flush()
-                        os.fsync(writer.fileno())
+                with self._leased_temp("ref", store_locked=True) as (writer, temporary):
+                    writer.write(record)
+                    writer.flush()
+                    os.fsync(writer.fileno())
                     os.replace(temporary, destination)
                     _fsync_dir(self.refs)
-                except BaseException:
-                    temporary.unlink(missing_ok=True)
-                    raise
         return desired
-
-    def _logical_roots_unlocked(self) -> set[CASRef]:
-        roots: set[CASRef] = set()
-        for path in self.refs.iterdir():
-            if not path.is_file():
-                continue
-            if len(path.name) != 64 or any(char not in "0123456789abcdef" for char in path.name):
-                continue
-            raw = json.loads(path.read_bytes())
-            if (
-                not isinstance(raw, dict)
-                or set(raw) != {"format", "name", "target"}
-                or raw.get("format") != 1
-                or not isinstance(raw.get("name"), str)
-                or self._ref_id(raw["name"]) != path.name
-            ):
-                raise ValueError(f"logical ref record {path.name!r} is malformed")
-            roots.add(CASRef.parse(str(raw.get("target", ""))))
-        return roots
-
-    def collect_garbage(
-        self,
-        reachable: Iterable[str | CASRef] = (),
-        *,
-        manifests: Iterable[RepositoryManifest] = (),
-        older_than: float,
-    ) -> GCReport:
-        """Delete unreferenced immutable objects older than a caller cutoff.
-
-        Current logical refs are always roots. Consumers add active byte refs
-        and repository manifests; TensorFS deliberately owns no retention
-        policy. A required age cutoff protects freshly produced bytes during the
-        gap before a consumer installs its logical ref.
-        """
-
-        if older_than <= 0:
-            raise ValueError("garbage collection requires a positive age grace")
-        with self._store_lock(exclusive=True):
-            keep = self._logical_roots_unlocked()
-            keep.update(CASRef.parse(ref) for ref in reachable)
-            for manifest in manifests:
-                for entry in manifest.files:
-                    keep.update(ref for ref, _size in entry.objects())
-
-            # A logical ref commonly targets a stored repository manifest.
-            # Expand valid manifests; arbitrary object bytes simply remain roots.
-            for root in tuple(keep):
-                with self._object_lock(root):
-                    path = self._verify_object_unlocked(root, None)
-                try:
-                    manifest = RepositoryManifest.from_bytes(path.read_bytes())
-                except (OSError, UnicodeDecodeError, ValueError):
-                    continue
-                for entry in manifest.files:
-                    keep.update(ref for ref, _size in entry.objects())
-
-            cutoff = time.time() - older_than
-            examined = deleted = bytes_deleted = 0
-            namespace = self.objects / "sha256"
-            if namespace.exists():
-                for path in namespace.glob("*/*/*"):
-                    if not path.is_file():
-                        continue
-                    try:
-                        ref = CASRef(path.name)
-                    except ValueError:
-                        continue
-                    examined += 1
-                    stat = path.stat()
-                    if ref in keep or stat.st_mtime > cutoff:
-                        continue
-                    with self._object_lock(ref):
-                        try:
-                            current = path.stat()
-                        except FileNotFoundError:
-                            continue
-                        if current.st_mtime > cutoff:
-                            continue
-                        path.unlink()
-                        _fsync_dir(path.parent)
-                        deleted += 1
-                        bytes_deleted += current.st_size
-            return GCReport(examined, len(keep), deleted, bytes_deleted)

--- a/src/gen_worker/_vendor/tensorfs/manifest.py
+++ b/src/gen_worker/_vendor/tensorfs/manifest.py
@@ -7,8 +7,9 @@ from typing import Any
 
 from .refs import CASRef
 
-# Every independently addressed object remains at most 64 MiB. This is a wire
-# bound, not a promise that chunk offsets are fixed multiples of this value.
+# The tensor chunk grid constant: every CHUNKED object is at most 64 MiB.
+# A chunkless file is one whole blob of any size — this is not an admission
+# cap. The bound is a wire fact for chunks, not a fixed-offset promise.
 MAX_CHUNK_SIZE = 64 << 20
 FORMAT = 1
 MAX_SIZE = (1 << 63) - 1
@@ -92,8 +93,8 @@ class FileEntry:
         if not 0 <= self.size_bytes <= MAX_SIZE:
             raise ValueError(f"file size must be in [0, {MAX_SIZE}]")
         if not self.chunks:
-            if self.size_bytes > MAX_CHUNK_SIZE:
-                raise ValueError("files above 64 MiB require chunks")
+            # A chunkless file is one whole blob of ANY size; the 64 MiB
+            # bound is the tensor chunk grid constant, never a blob cap.
             return
         if sum(chunk.length for chunk in self.chunks) != self.size_bytes:
             raise ValueError("chunk lengths must sum exactly to the file size")

--- a/src/gen_worker/_vendor/tensorfs/project.py
+++ b/src/gen_worker/_vendor/tensorfs/project.py
@@ -285,22 +285,26 @@ def project_snapshot(
     if symlinks is None:
         symlinks = _supports_symlinks(parent)
 
-    scratch = parent / f".building-{final.name}-{os.getpid()}-{next(_SCRATCH_SEQUENCE)}"
-    shutil.rmtree(scratch, ignore_errors=True)
-    scratch.mkdir()
-    try:
-        _fill(cas, manifest, scratch, symlinks=symlinks)
-        os.rename(scratch, final)
-    except OSError as error:
-        shutil.rmtree(scratch, ignore_errors=True)
-        # Another projector of the same manifest won the race. Its tree has
-        # the same content by construction.
-        if error.errno in (errno.EEXIST, errno.ENOTEMPTY) and final.exists():
-            return final
-        raise
-    except Exception:
-        shutil.rmtree(scratch, ignore_errors=True)
-        raise
+    # The lease is taken BEFORE the scratch exists and held past the rename,
+    # so `LocalCAS.reap_projection_scratch` can tell a projection that
+    # crashed from one that is merely slow. The token is unique, so nothing
+    # is ever removed by name-guess before it is created.
+    with cas.scratch_lease() as token:
+        scratch = parent / f".building-{token}"
+        scratch.mkdir()
+        try:
+            _fill(cas, manifest, scratch, symlinks=symlinks)
+            os.rename(scratch, final)
+        except OSError as error:
+            shutil.rmtree(scratch, ignore_errors=True)
+            # Another projector of the same manifest won the race. Its tree
+            # has the same content by construction.
+            if error.errno in (errno.EEXIST, errno.ENOTEMPTY) and final.exists():
+                return final
+            raise
+        except Exception:
+            shutil.rmtree(scratch, ignore_errors=True)
+            raise
     return final
 
 

--- a/src/gen_worker/_vendor/tensorfs/tensors.py
+++ b/src/gen_worker/_vendor/tensorfs/tensors.py
@@ -91,7 +91,7 @@ class TensorError(ValueError):
 
 
 class FileTooLarge(TensorError):
-    """A caller tried to extract a file the escape hatch must not carry."""
+    """A caller tried to materialize a file the escape hatch must not carry."""
 
 
 
@@ -250,7 +250,7 @@ class TensorReader(Mapping[str, TensorView]):
         # 310.1 MiB now -- and now flat in the shard's size rather than equal
         # to it. Re-mapping an object a later read wants again is one
         # `mmap(2)`; its digest stays in `_verified`, so it is not re-hashed.
-        self._maps: weakref.WeakValueDictionary[str, MappedObject] = (
+        self._maps: weakref.WeakValueDictionary[str, _MappedObject] = (
             weakref.WeakValueDictionary()
         )
         self._verified: set[str] = set()
@@ -316,19 +316,32 @@ class TensorReader(Mapping[str, TensorView]):
         entry = self._entry(path)
         return self.read_range(path, 0, entry.size_bytes)
 
-    def extract(
+    def materialize(
         self,
         path: str,
         destination: str | Path,
         *,
         limit: int | None = None,
     ) -> Path:
-        """Write ONE non-tensor file to disk, for consumers that need a path.
+        """Write ONE file to disk. The LAST RESORT of the access ladder.
 
-        This is the whole remaining reason to create a file: config JSON a
-        third-party constructor insists on reading from a directory, or any
-        other non-tensor member of a repo. Tensors never come through here --
-        they are read with :class:`TensorView`.
+        Paul's 2026-08-17 ruling fixes the preference order for every
+        consumer, and this method is tier 3 of 3:
+
+        1. symlink snapshot + native tensorfs reads (:class:`TensorView`,
+           :meth:`read_file`) -- all of our own code, all tensors;
+        2. symlink snapshot + FUSE, for third-party code that needs file
+           semantics on a tensor file (the ``tensorfsd`` consumer class) --
+           only where FUSE exists, which is NOT a RunPod pod;
+        3. ``materialize()`` -- a private copy, only when neither works.
+
+        The seam is PERMANENT: some third party will always insist on a real
+        file, and on a FUSE-less pod there is nothing above this tier for it.
+        It is not separately priced or metered; it is simply the
+        least-preferred tier, and the ideal state is that our own code never
+        reaches for it. Tensors especially should never come through here --
+        they are read with :class:`TensorView`, which is tier 1 and cheaper by
+        a whole copy.
 
         There is NO size cap -- ruled by Paul, 2026-08-16: "no hard-cap on
         materialization size; we just want to avoid large non-tensor files
@@ -336,7 +349,7 @@ class TensorReader(Mapping[str, TensorView]):
         ingestion (CAS holds repos only; datasets and compiled-graph artifacts
         never enter it -- DESIGN-RULINGS "CAS scope: repos only"), not a limit
         here. The stream is O(one block) of memory regardless of file size, so
-        extraction itself has no reason to refuse. ``limit`` remains for a
+        the write itself has no reason to refuse. ``limit`` remains for a
         caller that wants to bound ITS OWN request; when given, exceeding it
         raises :class:`FileTooLarge`.
 
@@ -363,7 +376,9 @@ class TensorReader(Mapping[str, TensorView]):
                 sink.flush()
                 os.fsync(sink.fileno())
             if digest.hexdigest() != entry.digest.digest:
-                raise TensorError(f"{path}: extracted bytes do not match the manifest")
+                raise TensorError(
+                    f"{path}: materialized bytes do not match the manifest"
+                )
             os.replace(temporary, target)
             return target
         except BaseException:
@@ -477,7 +492,7 @@ class TensorReader(Mapping[str, TensorView]):
         through the compiled extension's ``tensorfs.native.MappedObject`` and
         says there is no fallback. A source-vendored wheel cannot carry a
         compiled extension, so this snapshot supplies the same object in pure
-        Python: :class:`_MappedObject` below owns an ``mmap`` and exports it
+        Python: :class:`_MappedObject` above owns an ``mmap`` and exports it
         through PEP 688, which is the property upstream needed from the
         extension here -- a weak-referenceable handle whose pages stay alive
         exactly as long as some view of them does.

--- a/src/gen_worker/aot_delivery.py
+++ b/src/gen_worker/aot_delivery.py
@@ -25,6 +25,8 @@ from gen_worker._vendor.tensorfs import (
     Chunk,
     DigestMismatch,
     FileEntry,
+    RepositoryManifest,
+    TensorReader,
 )
 from gen_worker.transfer.grants import TransferGrant, download
 from gen_worker._vendor.torchcg import (
@@ -205,9 +207,10 @@ def _materialize_named_artifact(
         # own compiled graph store. Priced under §9's `tcg artifact export off-store`
         # row: the destination is a different store's file, not a path inside
         # a projected snapshot, so there is nothing here to point a stub at.
-        # The pinned rev spells the single-file hatch `materialize`; §9 and
-        # current upstream spell it `extract`.
-        cas.materialize(file_entry, dest)  # mixed-cas-hatch: tcg-artifact-export
+        # pgw#1575: the hatch is `TensorReader.materialize`, tier 3 of
+        # upstream's access ladder, since the snapshot went to one rev.
+        with TensorReader(cas, RepositoryManifest((file_entry,))) as reader:
+            reader.materialize(file_entry.path, dest)  # mixed-cas-hatch: tcg-artifact-export
     except NamedArtifactUnavailable:
         raise
     except (ValueError, RuntimeError, OSError) as exc:

--- a/src/gen_worker/cas/__init__.py
+++ b/src/gen_worker/cas/__init__.py
@@ -1,0 +1,36 @@
+"""The worker's own half of the content store.
+
+`_vendor/tensorfs` is upstream's bytes at one rev. THIS package is what pgw
+owns and upstream does not implement in Python: the object planner (a port of
+the Rust planner, because pgw#1310 rules a compiled extension out of a
+source-vendored wheel), admission built on top of it, and retention.
+
+pgw#1575 is why the split is here rather than smuggled into the snapshot.
+Before it, `_vendor/tensorfs` pinned its write half to `8bafdfbb` — a rev with
+NO common ancestor with tensorfs master at all — purely to keep
+`LocalCAS.ingest_file`, `ingest_repository` and `collect_garbage` alive, plus a
+`planner.py` that existed at no upstream rev whatsoever. Every one of those is
+this repo's code answering this repo's question, and none of them was ever a
+reason to hold a dead lineage.
+
+Whole-directory admission is NOT here, and that is the same audit's other
+answer: nothing in `src/` has ever called it. It is a fixture, and it lives at
+`tests/cas_fixture.py`.
+"""
+
+from .admission import ingest_file
+from .planner import BLOB_V1, GGUF_V1, SAFETENSORS_V1, Plan, Region, plan, plan_chunks
+from .retention import GCReport, collect_garbage
+
+__all__ = [
+    "BLOB_V1",
+    "GGUF_V1",
+    "GCReport",
+    "Plan",
+    "Region",
+    "SAFETENSORS_V1",
+    "collect_garbage",
+    "ingest_file",
+    "plan",
+    "plan_chunks",
+]

--- a/src/gen_worker/cas/admission.py
+++ b/src/gen_worker/cas/admission.py
@@ -1,0 +1,82 @@
+"""Admission: bytes on disk become CAS objects and a v1 manifest entry.
+
+FIRST-PARTY (pgw#1575), and it is where this always belonged. Upstream ported
+admission to Rust (`ObjectStore.admit_file`, `Plan`/`HashedPlan`/
+`AdmittedObject`) and pgw#1310 rules a compiled extension out of a
+source-vendored wheel, so pgw cannot call it. The argument for holding a dead
+`8bafdfbb` `local.py` was that admission is "the store's identity contract" and
+must not be forked — but the identity contract is the OBJECT GRID, and pgw#1365
+already forked that into `planner.py`, where it is asserted against upstream's
+released `spec/v1/planner-vectors` corpus. What was left in `local.py` was the
+forty lines below: plan, put, hash, and refuse a file that moved underneath us.
+
+They take a `LocalCAS` rather than living on it, because `LocalCAS` is
+upstream's and this is not.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+from .._vendor.tensorfs.local import LocalCAS
+from .._vendor.tensorfs.manifest import Chunk, FileEntry
+from .._vendor.tensorfs.refs import CASRef
+from .planner import plan_chunks
+
+
+def ingest_file(
+    cas: LocalCAS,
+    source: str | Path,
+    *,
+    manifest_path: str | None = None,
+) -> FileEntry:
+    """Admit one file on the planner grid and return its manifest entry.
+
+    The whole-file sha256 is computed over the SAME bytes that were written to
+    objects, in one pass, so a manifest can never describe a reconstruction
+    that differs from what was admitted. The stat comparison around the read is
+    the concurrent-mutation refusal: a file that grew, shrank or was rewritten
+    while it was being read produces no entry at all.
+    """
+
+    path = Path(source)
+    initial = path.stat()
+    whole = hashlib.sha256()
+    chunks: list[Chunk] = []
+    copied = 0
+    with path.open("rb") as handle:
+        before = os.fstat(handle.fileno())
+        chunk_lengths = plan_chunks(handle, initial.st_size)
+        if not chunk_lengths:
+            return FileEntry(
+                manifest_path or path.name,
+                initial.st_size,
+                cas.put_file(path, size=initial.st_size),
+            )
+        handle.seek(0)
+        for length in chunk_lengths:
+            data = handle.read(length)
+            if len(data) != length:
+                raise OSError(f"{path} ended while it was being ingested")
+            copied += len(data)
+            whole.update(data)
+            digest = cas.put_bytes(data)
+            chunks.append(Chunk(digest, len(data)))
+        if handle.read(1):
+            raise OSError(f"{path} grew while it was being ingested")
+        after = os.fstat(handle.fileno())
+    if (
+        copied != initial.st_size
+        or before.st_size != initial.st_size
+        or after.st_size != initial.st_size
+        or after.st_mtime_ns != before.st_mtime_ns
+    ):
+        raise OSError(f"{path} changed while it was being ingested")
+    return FileEntry(
+        manifest_path or path.name,
+        copied,
+        CASRef(whole.hexdigest()),
+        tuple(chunks),
+    )

--- a/src/gen_worker/cas/planner.py
+++ b/src/gen_worker/cas/planner.py
@@ -1,14 +1,15 @@
-"""The canonical object planner, in pure Python.
+"""The canonical object planner, in pure Python. FIRST-PARTY, not vendored.
 
-This module is a DECLARED REWRITE (see `VENDORED.toml`). It replaces
-`chunking.py`, the greedy small-tensor packer upstream deleted at `00c57c1`
-("pgw#1259: one chunker — the legacy Python data plane is gone") because its
-grid disagreed with the Rust planner's: packed tensors own no digest of their
-own and cannot be inherited by `TensorWriter`. Upstream's successor is
-`crates/tensorfs-core/src/planner/{mod,safetensors,gguf}.rs`, reachable from
-Python only through the compiled extension, and pgw#1310 rules a compiled
-extension out of a source-vendored wheel. So the grid is restored here in pure
-Python — the pgw#1344 precedent — and pinned to upstream's own released
+pgw#1575 moved this module out of `_vendor/tensorfs/`, where it had been
+masquerading as a vendored file it never was: it exists at NO upstream rev.
+Upstream deleted the Python chunker (`chunking.py`, the greedy small-tensor
+packer) at `00c57c1` — "pgw#1259: one chunker, the legacy Python data plane is
+gone" — because its grid disagreed with the Rust planner's: packed tensors own
+no digest of their own and cannot be inherited by `TensorWriter`. Upstream's
+successor is `crates/tensorfs-core/src/planner/{mod,safetensors,gguf}.rs`,
+reachable from Python only through the compiled extension, and pgw#1310 rules a
+compiled extension out of a source-vendored wheel. So the grid is restored here
+in pure Python — the pgw#1344 precedent — and pinned to upstream's own released
 conformance corpus (`spec/v1/planner-vectors`), vendored at
 `tests/testdata/planner-vectors/` and asserted object-for-object by
 `tests/test_planner_grid.py`.
@@ -41,8 +42,22 @@ import json
 from dataclasses import dataclass
 from typing import BinaryIO
 
-from . import gguf
-from .manifest import MAX_CHUNK_SIZE
+from .._vendor.tensorfs import gguf
+from .._vendor.tensorfs.manifest import MAX_CHUNK_SIZE
+
+# THE SAFETENSORS HEADER BOUND IS UPSTREAM'S, AND IT IS IMPORTED RATHER THAN
+# RESTATED. pgw#973 says one threat, one number, and it is right — but there
+# are two OWNERS here, not two copies of one number.
+# `models/safetensors_header.MAX_HEADER_BYTES` is 100 MiB (104_857_600) and is
+# a REFUSAL bound for readers. This one is `planner/safetensors.rs`'s
+# `MAX_HEADER_SIZE` (100_000_000, safetensors' own `tensor.rs` limit); it
+# decides a PLAN rather than a refusal — above it a file is `blob-v1`, not an
+# error — and the released `spec/v1/planner-vectors` corpus is keyed on it.
+# Swapping in the reader's number would make this port disagree with the Rust
+# planner for any header between the two, a dedup miss the conformance suite
+# cannot see. So it comes from the vendored snapshot, which states it once for
+# this lineage.
+from .._vendor.tensorfs.tensors import _MAX_HEADER_BYTES as _MAX_SAFETENSORS_HEADER_BYTES
 
 # `planner/mod.rs`: the tensor chunk grid constant. It is NOT a store admission
 # cap — a blob is one object of any size.
@@ -57,10 +72,6 @@ HEADER = "header"
 TENSOR = "tensor"
 BLOB = "blob"
 
-# safetensors 0.8.0's Rust reader refuses header lengths above 100,000,000
-# bytes (MAX_HEADER_SIZE in safetensors/src/tensor.rs). Match that format
-# boundary instead of conflating it with TensorFS's smaller object ceiling.
-_MAX_SAFETENSORS_HEADER_BYTES = 100_000_000
 # TensorFS v1 targets 64-bit Linux/POSIX. Safetensors decodes every shape
 # dimension into Rust usize before it checks tensor byte lengths.
 _MAX_USIZE = (1 << 64) - 1
@@ -176,6 +187,12 @@ def _tensor_spans(source: BinaryIO, size: int) -> tuple[int, tuple[tuple[int, in
         or header_end > size
     ):
         return None
+    # bound-justified: the four-clause refusal directly above caps
+    # `header_length` at `_MAX_SAFETENSORS_HEADER_BYTES` (100 MiB, the
+    # safetensors reference limit) AND at the file's own declared size before
+    # this line can run, so the allocation is bounded by a constant, not by
+    # the header the file claims. Upstream's `safetensors.rs::read_layout`
+    # applies the same two bounds in the same order.
     header_bytes = source.read(header_length)
     if len(header_bytes) != header_length or not header_bytes.startswith(b"{"):
         return None
@@ -361,9 +378,10 @@ def plan_chunks(source: BinaryIO, size: int) -> tuple[int, ...]:
     THE ONE DEVIATION, and it is upstream's counterpart's, not a preference.
     A blob above 64 MiB is still cut on the fixed grid here, because
     tensorhub's publish-v2 lane promotes an object with a SINGLE PUT
-    (`internal/s3/sha256_cas.go`: `verified promote: size %d is outside the
-    HashRepo single-PUT range 0..67108864`) and would refuse the whole-blob
-    entry terminally. Files at or below 64 MiB — every `config.json`, every
+    and would refuse the whole-blob entry terminally. Its refusal, quoted from
+    `internal/s3/sha256_cas.go` so a reader who hits it can grep for it, reads
+    "verified promote: size %d is outside the HashRepo single-PUT range
+    0..67108864". Files at or below 64 MiB — every `config.json`, every
     small non-tensor file — are already exactly blob-v1. The residual is
     tracked as pgw#1366: it closes when publish-v2 grants ride th#2064's
     multipart blob lane, and `test_the_oversized_blob_deviation_is_the_only_one`

--- a/src/gen_worker/cas/retention.py
+++ b/src/gen_worker/cas/retention.py
@@ -1,0 +1,126 @@
+"""Reachability collection over the local store.
+
+FIRST-PARTY (pgw#1575). Upstream never owned this: `LocalCAS.collect_garbage`'s
+own docstring said "TensorFS deliberately owns no retention policy", and the
+policy — what counts as reachable, and how long a freshly produced object is
+protected — has always been `models/disk_gc.py`'s. The reachability WALK was
+the only part that lived upstream, and it walks nothing but the ref record and
+manifest formats, both of which are still upstream's and still vendored.
+
+Master's `LocalCAS` has no successor for it: the Rust `ObjectStore` collects
+abandoned TEMPORARIES (`collect_abandoned_temps`, which is a lease sweep, not a
+reachability pass) and nothing else. So a bumped snapshot deletes this and puts
+nothing in its place — which is exactly why it is here now.
+
+`_store_lock` and `_object_lock` are `LocalCAS` privates. Reaching for them is
+deliberate and is the whole reason this module sits beside the store rather
+than in `models/`: collection has to exclude concurrent admission, and the
+exclusive store lock is the only thing that does.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .._vendor.tensorfs.local import LocalCAS, _fsync_dir
+from .._vendor.tensorfs.manifest import RepositoryManifest
+from .._vendor.tensorfs.refs import CASRef
+
+
+@dataclass(frozen=True, slots=True)
+class GCReport:
+    """One reachability collection pass."""
+
+    examined: int
+    reachable: int
+    deleted: int
+    bytes_deleted: int
+
+
+def _logical_roots(cas: LocalCAS) -> set[CASRef]:
+    """Every current logical ref's target. Call under the store lock."""
+
+    roots: set[CASRef] = set()
+    for path in cas.refs.iterdir():
+        if not path.is_file():
+            continue
+        if len(path.name) != 64 or any(char not in "0123456789abcdef" for char in path.name):
+            continue
+        raw = json.loads(path.read_bytes())
+        if (
+            not isinstance(raw, dict)
+            or set(raw) != {"format", "name", "target"}
+            or raw.get("format") != 1
+            or not isinstance(raw.get("name"), str)
+            or cas._ref_id(raw["name"]) != path.name
+        ):
+            raise ValueError(f"logical ref record {path.name!r} is malformed")
+        roots.add(CASRef.parse(str(raw.get("target", ""))))
+    return roots
+
+
+def collect_garbage(
+    cas: LocalCAS,
+    reachable: Iterable[str | CASRef] = (),
+    *,
+    manifests: Iterable[RepositoryManifest] = (),
+    older_than: float,
+) -> GCReport:
+    """Delete unreferenced immutable objects older than a caller cutoff.
+
+    Current logical refs are always roots. The caller adds active byte refs and
+    repository manifests. The age cutoff is required, and it protects freshly
+    produced bytes during the gap between a writer finishing and its consumer
+    installing the logical ref that makes them reachable.
+    """
+
+    if older_than <= 0:
+        raise ValueError("garbage collection requires a positive age grace")
+    with cas._store_lock(exclusive=True):
+        keep = _logical_roots(cas)
+        keep.update(CASRef.parse(ref) for ref in reachable)
+        for manifest in manifests:
+            for entry in manifest.files:
+                keep.update(ref for ref, _size in entry.objects())
+
+        # A logical ref commonly targets a stored repository manifest. Expand
+        # valid manifests; arbitrary object bytes simply remain roots.
+        for root in tuple(keep):
+            path = cas.object_path(root)
+            try:
+                manifest = RepositoryManifest.from_bytes(path.read_bytes())
+            except (OSError, UnicodeDecodeError, ValueError):
+                continue
+            for entry in manifest.files:
+                keep.update(ref for ref, _size in entry.objects())
+
+        cutoff = time.time() - older_than
+        examined = deleted = bytes_deleted = 0
+        namespace = cas.objects / "sha256"
+        if namespace.exists():
+            for path in namespace.glob("*/*/*"):
+                if not path.is_file():
+                    continue
+                try:
+                    ref = CASRef(path.name)
+                except ValueError:
+                    continue
+                examined += 1
+                stat = path.stat()
+                if ref in keep or stat.st_mtime > cutoff:
+                    continue
+                with cas._object_lock(ref):
+                    try:
+                        current = path.stat()
+                    except FileNotFoundError:
+                        continue
+                    if current.st_mtime > cutoff:
+                        continue
+                    path.unlink()
+                    _fsync_dir(path.parent)
+                    deleted += 1
+                    bytes_deleted += current.st_size
+        return GCReport(examined, len(keep), deleted, bytes_deleted)

--- a/src/gen_worker/hubio/client.py
+++ b/src/gen_worker/hubio/client.py
@@ -33,6 +33,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, cast
 
 import requests
 from gen_worker._vendor.tensorfs import CASRef, RepositoryManifest
+from gen_worker.cas.admission import ingest_file
 from gen_worker.transfer.grants import TransferGrant, upload
 from gen_worker.transfer.journal import TransferJournal, TransferSession
 
@@ -634,7 +635,7 @@ class HubClient:
                     f"publish_v2: {f.path!r} is a by-reference add; v2 declares "
                     "digests computed from local bytes"
                 )
-            entries.append(cas.ingest_file(Path(f.local_path), manifest_path=f.path))
+            entries.append(ingest_file(cas, Path(f.local_path), manifest_path=f.path))
         manifest = RepositoryManifest(tuple(entries))
         manifest_ref = manifest.digest()
 

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, Sequence
 
 from gen_worker._vendor.tensorfs import (
+    MAX_CHUNK_SIZE,
     CASRef,
     Chunk,
     DigestMismatch,
@@ -121,12 +122,30 @@ def _manifest_entry(file: WorkerResolvedRepoFile) -> FileEntry:
         Chunk(CASRef.parse(f"sha256:{chunk.sha256}"), int(chunk.length))
         for chunk in file.chunks
     )
-    return FileEntry(
-        _norm_rel_path(file.path),
-        int(file.size_bytes),
-        digest,
-        chunks,
-    )
+    path = _norm_rel_path(file.path)
+    size = int(file.size_bytes)
+    # pgw#1575: THE 64 MiB CHUNKLESS CEILING IS THIS REPO'S, SO IT IS ENFORCED
+    # HERE. tensorfs's own `manifest.py` dropped it (a chunkless entry is one
+    # blob of ANY size upstream), and the vendored snapshot carries upstream's
+    # bytes. But in THIS fleet an object above 64 MiB cannot exist: tensorhub's
+    # publish-v2 lane promotes with a single PUT and refuses anything larger,
+    # which is why `cas/planner.py::plan_chunks` still cuts an oversized blob on
+    # the fixed grid (pgw#1366). So a hub snapshot describing a large file as
+    # ONE object names an object nothing can ever hold, and accepting it is not
+    # harmless: `store.ensure_pinned` would write a pin for it, and
+    # `announce_resident` would then advertise a tree whose bytes are
+    # unreachable — an eager-bridge `header too large` about an intact
+    # checkpoint. The old, stricter vendored parser refused this by accident;
+    # this refuses it on purpose, at the one place every hub-derived entry is
+    # built. It closes with pgw#1366, together with the planner deviation.
+    if not chunks and size > MAX_CHUNK_SIZE:
+        raise ValueError(
+            f"resolved model file {path}: {size} bytes with no chunks. An "
+            f"object above {MAX_CHUNK_SIZE} bytes cannot be promoted by "
+            f"tensorhub's single-PUT publish lane, so this manifest names an "
+            f"object that can never be resident (pgw#1366)"
+        )
+    return FileEntry(path, size, digest, chunks)
 
 
 def _validate_resolved(ref: TensorhubRef, resolved: WorkerResolvedRepo) -> WorkerResolvedRepo:

--- a/src/gen_worker/models/disk_gc.py
+++ b/src/gen_worker/models/disk_gc.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, Optional, Tuple
 
 from gen_worker._vendor.tensorfs import RefConflict
+from gen_worker.cas.retention import collect_garbage
 
 from .cache_paths import open_worker_cas
 
@@ -316,8 +317,8 @@ def sweep_orphan_blobs(cas_dir: Path) -> int:
     """Collect unpinned tensorfs objects after the writer safety grace."""
 
     return int(
-        open_worker_cas(cas_dir).collect_garbage(
-            older_than=_STALE_WRITER_TEMP_AGE_S
+        collect_garbage(
+            open_worker_cas(cas_dir), older_than=_STALE_WRITER_TEMP_AGE_S
         ).bytes_deleted
     )
 

--- a/src/gen_worker/models/materialized_view.py
+++ b/src/gen_worker/models/materialized_view.py
@@ -58,7 +58,12 @@ import shutil
 from pathlib import Path
 
 
-from gen_worker._vendor.tensorfs import FileEntry, LocalCAS
+from gen_worker._vendor.tensorfs import (
+    FileEntry,
+    LocalCAS,
+    RepositoryManifest,
+    TensorReader,
+)
 
 from . import projection
 
@@ -107,12 +112,13 @@ def view_root_for(snapshot_root: Path | str) -> Path:
 
 def _materialize(cas: LocalCAS, entry: FileEntry, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    # The single-file hatch. It streams, it is atomic, and it verifies the
-    # reconstruction against the manifest's whole-file digest before the
-    # rename — so a view is known-good bytes, not merely copied ones. One
-    # name upstream and here since tensorfs#107 renamed `extract()` to
-    # `materialize()` (Paul's #1303 ruling).
-    cas.materialize(entry, destination)  # mixed-cas-hatch: author-slot-directory
+    # The single-file hatch — tier 3 of upstream's own access ladder. It
+    # streams, it is atomic, and it verifies the reconstruction against the
+    # manifest's whole-file digest before the rename, so a view is known-good
+    # bytes rather than merely copied ones. pgw#1575 moved it from `LocalCAS`
+    # to `TensorReader`, which is where the one-rev snapshot carries it.
+    with TensorReader(cas, RepositoryManifest((entry,))) as reader:
+        reader.materialize(entry.path, destination)  # mixed-cas-hatch: author-slot-directory
 
 
 def third_party_dir(path: Path | str, *, why: str) -> Path:

--- a/tests/cas_fixture.py
+++ b/tests/cas_fixture.py
@@ -1,0 +1,47 @@
+"""Whole-directory admission. A TEST FIXTURE, and it lives here because of it.
+
+`LocalCAS.ingest_repository` used to be production surface — it was one of the
+five methods the pre-genesis `8bafdfbb` snapshot was pinned for. pgw#1575 asked
+what actually calls it and the answer was: nothing in `src/`, ever. Production
+admits bytes one file at a time (`publish_v2` -> `gen_worker.cas.ingest_file`)
+or adopts them from a hub grant with the hub's own manifest
+(`transfer/grants.py`). Admitting a directory tree is what a TEST does to build
+a real store to read back out of.
+
+So it is here rather than in `src/gen_worker/cas/`, where
+`scripts/lint_unreached_surface.py` would be right to call it stranded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gen_worker._vendor.tensorfs.local import LocalCAS
+from gen_worker._vendor.tensorfs.manifest import FileEntry, RepositoryManifest
+from gen_worker.cas import ingest_file
+
+
+def ingest_repository(cas: LocalCAS, source: str | Path) -> RepositoryManifest:
+    """Admit every regular file below a directory into one manifest.
+
+    V1 manifests describe files, not symlinks or empty directories. Refusing
+    those entry types keeps projection portable and prevents a source-tree link
+    from escaping the repository root.
+    """
+
+    root = Path(source)
+    if not root.is_dir():
+        raise NotADirectoryError(root)
+    entries: list[FileEntry] = []
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+        if path.is_symlink():
+            raise ValueError(f"repository contains a symlink: {path.relative_to(root)}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            relative = path.relative_to(root)
+            raise ValueError(f"repository contains a non-regular file: {relative}")
+        entries.append(
+            ingest_file(cas, path, manifest_path=path.relative_to(root).as_posix())
+        )
+    return RepositoryManifest(tuple(entries))

--- a/tests/projection_fixture.py
+++ b/tests/projection_fixture.py
@@ -21,6 +21,7 @@ from gen_worker._vendor.tensorfs import (
     project_snapshot,
     read_entry,
 )
+from cas_fixture import ingest_repository
 from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR
 
 # safetensors dtype -> (itemsize, struct format for one element)
@@ -179,7 +180,7 @@ def build(
     else:
         write_model(source, dtype=dtype)
     cas = LocalCAS(base)
-    manifest = cas.ingest_repository(source)
+    manifest = ingest_repository(cas, source)
     # Exactly what `cozy_snapshot._pin_manifest` does, so `resolve_projection`
     # is exercised against the production pinning and not a test convention.
     cas.compare_and_swap_ref(REF_PREFIX + key, cas.store_manifest(manifest), expected=None)

--- a/tests/test_gguf_native_pgw1344.py
+++ b/tests/test_gguf_native_pgw1344.py
@@ -25,6 +25,7 @@ from typing import cast
 import pytest
 
 from gen_worker._vendor.tensorfs import LocalCAS, RepositoryManifest
+from cas_fixture import ingest_repository
 from gen_worker._vendor.tensorfs.manifest import MAX_CHUNK_SIZE
 from gen_worker.convert.gguf_native import (
     GGUFUnsupported,
@@ -115,7 +116,7 @@ def snapshot(tmp_path_factory: pytest.TempPathFactory) -> tuple[LocalCAS, Reposi
     staged.mkdir()
     (staged / "model.safetensors").write_bytes(_safetensors_bytes(FIXTURE))
     (staged / "config.json").write_text(json.dumps(CONFIG))
-    manifest = cas.ingest_repository(staged)
+    manifest = ingest_repository(cas, staged)
     # The staged tree exists only to be admitted; from here the conversion sees
     # the store and nothing else.
     for path in sorted(staged.rglob("*"), reverse=True):

--- a/tests/test_gguf_serving.py
+++ b/tests/test_gguf_serving.py
@@ -399,6 +399,7 @@ def test_the_store_source_is_one_constructor_from_the_edge_source(
     nothing else.
     """
     from gen_worker._vendor.tensorfs import LocalCAS
+    from cas_fixture import ingest_repository
     from gen_worker._vendor.tensorfs.tensors import open_tensors
 
     # A cross-attention-free UNet, and the reason is a REAL constraint worth
@@ -429,7 +430,7 @@ def test_the_store_source_is_one_constructor_from_the_edge_source(
     assert max(len(k) for k in reference.state_dict()) <= 63
 
     cas = LocalCAS(tmp_path / "cas")
-    manifest = cas.ingest_repository(staged)
+    manifest = ingest_repository(cas, staged)
     with open_tensors(cas, manifest) as reader:
         views = {name: reader[name] for name in reader}
         assert any(v.format == "gguf-v1" and v.block.quantized

--- a/tests/test_gguf_weights.py
+++ b/tests/test_gguf_weights.py
@@ -481,6 +481,7 @@ def test_the_served_path_reads_block_bytes_out_of_the_cas(tmp_path: Path) -> Non
     buffer are the bytes that were ingested.
     """
     from gen_worker._vendor.tensorfs import LocalCAS
+    from cas_fixture import ingest_repository
     from gen_worker._vendor.tensorfs.tensors import open_tensors
 
     raw, qtype, dense = _packed_weight()
@@ -489,7 +490,7 @@ def test_the_served_path_reads_block_bytes_out_of_the_cas(tmp_path: Path) -> Non
     _write_gguf(staged / "model.gguf", raw, qtype)
 
     cas = LocalCAS(tmp_path / "cas")
-    manifest = cas.ingest_repository(staged)
+    manifest = ingest_repository(cas, staged)
     with open_tensors(cas, manifest) as reader:
         view = reader["fc1.weight"]
         assert view.format == "gguf-v1"

--- a/tests/test_key_migration.py
+++ b/tests/test_key_migration.py
@@ -34,6 +34,7 @@ pytest.importorskip("transformers")
 pytest.importorskip("safetensors")
 
 from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from cas_fixture import ingest_repository  # noqa: E402
 from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
 from gen_worker.serving.streaming import StreamingLoader, engine_for  # noqa: E402
 from gen_worker.serving.streaming import keymap  # noqa: E402
@@ -107,7 +108,7 @@ def _legacy_attn_renamer(paths: Tuple[str, ...]) -> Any:
 
 def _project(base: Path, source: Path, key: str) -> Path:
     cas = LocalCAS(base)
-    manifest = cas.ingest_repository(source)
+    manifest = ingest_repository(cas, source)
     cas.compare_and_swap_ref(
         REF_PREFIX + key, cas.store_manifest(manifest), expected=None
     )

--- a/tests/test_lane_contracts.py
+++ b/tests/test_lane_contracts.py
@@ -180,13 +180,13 @@ def test_the_document_property_is_the_canonical_json_string() -> None:
 
 
 def _upstream_blob(path: str) -> bytes | None:
-    """One upstream file AT `contract_plane_rev`, or None if unavailable.
+    """One upstream file AT the pinned `rev`, or None if unavailable.
 
     THE REV, NOT THE SIBLING'S WORKING TREE, and the difference is the whole
     point of pinning one. Both drift checks below used to read
     `UPSTREAM / <path>` — whatever the neighbouring checkout happened to have
     checked out — which asserts that this repo is always at tensorfs TIP. That
-    contradicts `contract_plane_rev` existing at all, and it goes red for
+    contradicts the pin existing at all, and it goes red for
     reasons that have nothing to do with the change under test: while tensorfs
     is under active multi-lane development its master gains a lane document
     every few hours, so every vendor PR inherits an unrelated failure and the
@@ -202,7 +202,7 @@ def _upstream_blob(path: str) -> bytes | None:
     manifest = tomllib.loads(
         (ROOT / "src" / "gen_worker" / "_vendor" / "VENDORED.toml").read_text()
     )
-    rev = manifest["packages"]["tensorfs"]["contract_plane_rev"]
+    rev = manifest["packages"]["tensorfs"]["rev"]
     done = subprocess.run(
         ["git", "-C", str(UPSTREAM), "show", f"{rev}:{path}"],
         capture_output=True,
@@ -218,7 +218,7 @@ def test_the_corpus_matches_the_pinned_upstream_rev() -> None:
 
     theirs = _upstream_blob("spec/v1/contract-vectors/contract-vectors.json")
     if theirs is None:
-        pytest.skip("no sibling tensorfs checkout carrying contract_plane_rev")
+        pytest.skip("no sibling tensorfs checkout carrying the pinned rev")
     ours = (VECTORS / "contract-vectors.json").read_bytes()
     assert hashlib.sha256(theirs).hexdigest() == hashlib.sha256(ours).hexdigest()
 
@@ -228,21 +228,30 @@ def test_the_vendored_documents_match_the_pinned_upstream_rev() -> None:
     for path in DOCUMENTS.glob("*.json"):
         theirs = _upstream_blob(f"spec/v1/contracts/{path.name}")
         if theirs is None:
-            pytest.skip("no sibling tensorfs checkout carrying contract_plane_rev")
+            pytest.skip("no sibling tensorfs checkout carrying the pinned rev")
         assert path.read_bytes() == theirs, f"{path.name} drifted from upstream"
         checked += 1
     # A loop that checked nothing is not a passing drift check.
     assert checked == len(list(DOCUMENTS.glob("*.json"))) >= 14
 
 
-def test_the_contract_plane_rev_is_recorded_in_vendored_toml() -> None:
+def test_the_contract_plane_is_digest_fenced_at_the_one_rev() -> None:
+    """pgw#1575: the contract plane has no rev of its own any more.
+
+    It used to, because the snapshot's `rev` was a lineage that predated
+    contracts entirely. One master-ancestor rev now supplies every plane, so
+    the only thing left to assert is that these files are in the SINGLE digest
+    inventory rather than sitting on disk unfenced — which is the failure that
+    third-document drift actually took.
+    """
+
     manifest = tomllib.loads(
         (ROOT / "src" / "gen_worker" / "_vendor" / "VENDORED.toml").read_text()
     )
     spec = manifest["packages"]["tensorfs"]
-    assert len(spec["contract_plane_rev"]) == 40
-    recorded = set(spec["contract_plane_files"])
-    assert "contracts.py" in recorded
+    assert len(spec["rev"]) == 40
+    recorded = set(spec["files"])
+    assert {"contract.py", "contracts.py"} <= recorded
     assert {f"_contracts/{path.name}" for path in DOCUMENTS.glob("*.json")} <= recorded
 
 

--- a/tests/test_materialized_view_pgw1308.py
+++ b/tests/test_materialized_view_pgw1308.py
@@ -203,4 +203,6 @@ def test_the_seam_is_the_only_way_the_hatch_is_reached(tmp_path: Path) -> None:
 
     source = Path(materialized_view.__file__).read_text()
     assert source.count("# mixed-cas-hatch: author-slot-directory") == 1
-    assert "cas.materialize(" in source
+    # pgw#1575: the hatch is `TensorReader.materialize`, not `LocalCAS`'s —
+    # the one-rev snapshot carries it there.
+    assert "reader.materialize(" in source

--- a/tests/test_planner_grid.py
+++ b/tests/test_planner_grid.py
@@ -38,7 +38,8 @@ import pytest
 from gen_worker._vendor.tensorfs import gguf
 from gen_worker._vendor.tensorfs.local import LocalCAS
 from gen_worker._vendor.tensorfs.manifest import FileEntry
-from gen_worker._vendor.tensorfs.planner import (
+from gen_worker.cas import ingest_file
+from gen_worker.cas.planner import (
     BLOB_V1,
     GGUF_V1,
     MAX_OBJECT_SIZE,
@@ -336,7 +337,7 @@ def test_ingest_file_admits_on_the_planner_grid(tmp_path: Path) -> None:
     source.write_bytes(raw)
 
     cas = LocalCAS(tmp_path / "cas")
-    entry = cas.ingest_file(source, manifest_path="model.safetensors")
+    entry = ingest_file(cas, source, manifest_path="model.safetensors")
     assert tuple(chunk.length for chunk in entry.chunks) == (113, 3, 5)
     for chunk, declared in zip(entry.chunks, case["expected"]["objects"], strict=True):
         assert f"sha256:{chunk.digest.digest}" == declared["digest"]
@@ -366,9 +367,9 @@ def test_a_second_publish_moves_only_the_tensors_that_changed(tmp_path: Path) ->
     b.write_bytes(_assemble(build, _write_safetensors(build, changed, "b.safetensors")))
 
     cas = LocalCAS(tmp_path / "cas")
-    first = cas.ingest_file(a, manifest_path="model.safetensors")
+    first = ingest_file(cas, a, manifest_path="model.safetensors")
     resident = {chunk.digest.digest for chunk in first.chunks}
-    second = cas.ingest_file(b, manifest_path="model.safetensors")
+    second = ingest_file(cas, b, manifest_path="model.safetensors")
 
     new = [chunk for chunk in second.chunks if chunk.digest.digest not in resident]
     assert [chunk.length for chunk in new] == [1024], (

--- a/tests/test_pod_projected_load_pgw1330.py
+++ b/tests/test_pod_projected_load_pgw1330.py
@@ -46,6 +46,7 @@ from gen_worker._vendor.tensorfs import (  # noqa: E402
     read_entry,
     tree_bytes,
 )
+from cas_fixture import ingest_repository  # noqa: E402
 from gen_worker.models import projection  # noqa: E402
 from gen_worker.models import svdq_native as native  # noqa: E402
 from gen_worker.models.loading import (  # noqa: E402
@@ -141,7 +142,7 @@ def pod(tmp_path_factory: pytest.TempPathFactory) -> Dict[str, Any]:
 
     base = root / "store"
     cas = LocalCAS(base)
-    manifest = cas.ingest_repository(source)
+    manifest = ingest_repository(cas, source)
     cas.compare_and_swap_ref(
         REF_PREFIX + KEY, cas.store_manifest(manifest), expected=None
     )

--- a/tests/test_pod_serve_loop_streams.py
+++ b/tests/test_pod_serve_loop_streams.py
@@ -40,6 +40,7 @@ pytest.importorskip("diffusers")
 pytest.importorskip("transformers")
 
 from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from cas_fixture import ingest_repository  # noqa: E402
 from gen_worker.models import projection, store as store_mod  # noqa: E402
 from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
 from gen_worker.models.refs import WireRef  # noqa: E402
@@ -87,7 +88,7 @@ def projected(tmp_path_factory: pytest.TempPathFactory) -> Dict[str, Any]:
     build_source(source)
 
     cas = LocalCAS(base)
-    manifest = cas.ingest_repository(source)
+    manifest = ingest_repository(cas, source)
     # Exactly what `cozy_snapshot._pin_manifest` does, so `resolve_projection`
     # runs against the production pinning and not a test convention.
     cas.compare_and_swap_ref(

--- a/tests/test_projected_tree_pgw1330.py
+++ b/tests/test_projected_tree_pgw1330.py
@@ -256,6 +256,7 @@ def test_adapter_sizes_are_the_LOGICAL_sizes(tmp_path: Path) -> None:
     """
 
     from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot
+    from cas_fixture import ingest_repository
     from gen_worker.models.projection import logical_size
     from gen_worker.utils.lora import find_adapter_file
 
@@ -270,7 +271,7 @@ def test_adapter_sizes_are_the_LOGICAL_sizes(tmp_path: Path) -> None:
     )
 
     cas = LocalCAS(base)
-    manifest = cas.ingest_repository(source)
+    manifest = ingest_repository(cas, source)
     cas.compare_and_swap_ref(
         projection.REF_PREFIX + "e" * 64, cas.store_manifest(manifest), expected=None
     )

--- a/tests/test_snapshot_residency_progress_pgw1289.py
+++ b/tests/test_snapshot_residency_progress_pgw1289.py
@@ -148,7 +148,17 @@ def test_the_scan_yields_the_event_loop_between_grants(
 
     real_contains = LocalCAS.contains
 
+    # pgw#1575: the probe counts the GRANTS, not every `contains` call in the
+    # process. Since the vendored tensorfs went to one master-ancestor rev,
+    # `compare_and_swap_ref` answers "is the target there?" with `contains`
+    # (one `lstat`) instead of rehashing the object, so pinning the manifest
+    # adds a call this probe used to be able to ignore. Keying on the grant
+    # digests measures the scan itself and is immune to the next such change.
+    grant_digests = {str(digest) for digest in digests}
+
     def slow_contains(self: Any, ref: Any, *, size: int | None = None) -> bool:
+        if str(ref) not in grant_digests:
+            return bool(real_contains(self, ref, size=size))
         scanned.append(time.monotonic())
         time.sleep(0.05)
         try:

--- a/tests/test_svdq_native_reads_pgw1330.py
+++ b/tests/test_svdq_native_reads_pgw1330.py
@@ -26,6 +26,7 @@ torch = pytest.importorskip("torch")
 pytest.importorskip("diffusers")
 
 from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from gen_worker.cas import ingest_file  # noqa: E402
 from gen_worker.models import projection  # noqa: E402
 from gen_worker.models import svdq_native as native  # noqa: E402
 from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
@@ -52,7 +53,7 @@ def _project(checkpoint: Path, base: Path, key: str = "c" * 64) -> Path:
     """Ingest ONE checkpoint into a real CAS and project it as a snapshot."""
 
     cas = LocalCAS(base)
-    entry = cas.ingest_file(checkpoint, manifest_path=checkpoint.name)
+    entry = ingest_file(cas, checkpoint, manifest_path=checkpoint.name)
     from gen_worker._vendor.tensorfs import RepositoryManifest
 
     manifest = RepositoryManifest((entry,))

--- a/tests/test_vendored_snapshot_pgw1310.py
+++ b/tests/test_vendored_snapshot_pgw1310.py
@@ -78,60 +78,79 @@ def test_the_vendored_tensorfs_carries_no_transfer_plane() -> None:
         )
 
 
-def test_the_read_plane_is_recorded_at_its_own_rev() -> None:
-    """pgw#1330: the snapshot is SPLIT at two revs, and the split is declared.
+def test_the_tensorfs_snapshot_is_one_rev() -> None:
+    """pgw#1575: ONE rev, and nothing may re-grow a second.
 
-    The consumption plane comes from a rev the storage half is deliberately NOT
-    at: the newer lineage deleted three `LocalCAS` methods this repo still
-    calls (ingest, GC, and the whole-tree copy the chokepoint uses —
-    VENDORED.toml names them). A split that is only in a comment is a split
-    nobody can audit, so the rev is a field and the file list is a field, and
-    the digest fence above covers them like any other vendored file.
+    The snapshot used to carry THREE — a `rev` on a lineage with no common
+    ancestor with upstream master at all, plus a `read_plane_rev` and a
+    `contract_plane_rev` bolted on beside it because the dead rev could not
+    supply either plane. Each was added by a lane that needed one more file,
+    and each was locally reasonable, which is exactly how a snapshot ends up
+    certifying fidelity to a rev nobody would ever fix.
 
-    pgw#1344 widened the plane rather than the split: `writer.py` joins it (the
-    GGUF/safetensors composer a conversion writes through) and `__init__.py`
-    comes from the same rev, verbatim, now that upstream no longer re-exports a
-    Python transfer plane. The membership is spelled out so a file JOINING the
-    plane is a decision somebody makes on purpose.
+    Paul's 2026-08-20 release-policy ruling ended it: "get rid of the vendored
+    copies … Remove the v1's from the codebase fully." This is the torchcg
+    shape (see below), applied here.
+
+    The rev itself is NOT restated here. VENDORED.toml is "the single home of
+    the fact", and a copy of a rev in a test is a second home that drifts.
     """
 
     spec = MANIFEST["packages"]["tensorfs"]
-    assert spec["read_plane_rev"] != spec["rev"]
-    assert set(spec["read_plane_files"]) == {
-        "__init__.py", "gguf.py", "project.py", "tensors.py", "writer.py",
-    }
-    for name in spec["read_plane_files"]:
-        assert name in spec["files"], f"{name} is not digest-fenced"
+    extra = sorted(k for k in spec if k.endswith("_rev") and k != "rev")
+    assert not extra, (
+        f"the tensorfs snapshot grew a second rev ({extra}). One rev, per "
+        f"pgw#1575. If a plane needs a file the pinned rev lacks, bump the "
+        f"rev; if it needs a file NO upstream rev has, it is first-party and "
+        f"belongs in gen_worker/, not under _vendor/."
+    )
+    assert not any(k.endswith("_files") for k in spec), (
+        "a per-plane file list is back. The one inventory is "
+        "[packages.tensorfs.files], enforced as a set above."
+    )
 
 
-def test_the_storage_half_still_provides_what_the_ownership_ruling_keeps() -> None:
-    """pgw#1308 step ⑥: the split is the STEADY STATE, and this says why.
+def test_the_write_plane_is_first_party_and_never_returns() -> None:
+    """pgw#1575: the five `8bafdfbb`-only APIs, and where each of them went.
 
-    The ruling (VENDORED.toml, and the issue's own section) is that admission
-    and GC are TENSORFS'S — upstream ported them to Rust rather than
-    abandoning them, and a source-vendored wheel cannot load Rust (pgw#1310).
-    So they are consumed from the pinned rev indefinitely, and a bump that
-    "finishes the migration" deletes them with no reachable successor.
-
-    A comment saying that goes stale silently. This goes red instead, and it
-    is deliberately NOT a digest check: the digest fence above would refuse
-    the bump too, but only with "a file changed", which is exactly the message
-    that gets a fence regenerated rather than read.
+    `8bafdfbb` was held for exactly these. Upstream's current `LocalCAS` has
+    none of them: ingest and GC went to Rust or to nobody, `materialize` moved
+    to `TensorReader`, and the whole-tree copy died with the chokepoint flip
+    (pgw#1308 step 6). Re-vendoring a `local.py` that has them means the dead
+    lineage is back, so this refuses the SYMBOLS rather than the rev — a
+    digest fence would only say "a file changed", which is the message that
+    gets a fence regenerated instead of read.
     """
 
     from gen_worker._vendor.tensorfs import LocalCAS
 
-    for kept in ("ingest_file", "ingest_repository", "collect_garbage", "materialize"):
-        assert callable(getattr(LocalCAS, kept, None)), (
-            f"LocalCAS.{kept} is gone from the vendored storage snapshot. If "
-            f"this is a `rev` bump: upstream's successor is the compiled Rust "
-            f"extension, which pgw cannot load (pgw#1310). Read the ownership "
-            f"ruling in VENDORED.toml before bumping."
+    for retired in (
+        "ingest_file",
+        "ingest_repository",
+        "collect_garbage",
+        "materialize",
+        "materialize" + "_repository",
+    ):
+        assert not hasattr(LocalCAS, retired), (
+            f"LocalCAS.{retired} is back on the vendored snapshot. It exists "
+            f"at NO tensorfs master ancestor; a `local.py` carrying it came "
+            f"from the pre-genesis `8bafdfbb` lineage. Admission and retention "
+            f"are first-party at gen_worker/cas/; the single-file hatch is "
+            f"`TensorReader.materialize`."
         )
 
-    # And the one that DID die with the chokepoint flip: still defined by the
-    # pinned upstream snapshot, called by nothing here.
-    assert hasattr(LocalCAS, "materialize" + "_repository")
+    # The planner is not upstream's at any rev and must not masquerade as one.
+    assert "planner.py" not in MANIFEST["packages"]["tensorfs"]["files"]
+    assert not (VENDOR / "tensorfs" / "planner.py").exists()
+
+    # And the successors actually exist, so this is a redirection rather than
+    # a deletion: importing them is the proof.
+    from gen_worker._vendor.tensorfs import TensorReader
+    from gen_worker.cas import collect_garbage, ingest_file, plan_chunks
+
+    for successor in (collect_garbage, ingest_file, plan_chunks):
+        assert callable(successor)
+    assert callable(TensorReader.materialize)
 
 
 def test_the_torchcg_snapshot_is_one_rev() -> None:
@@ -269,7 +288,7 @@ def test_the_recipe_vocabulary_runs_against_the_VENDORED_identity_and_ingress() 
 
 
 def test_the_read_plane_runs_without_the_compiled_extension() -> None:
-    """The reason the split is expressible at all: this half is PURE PYTHON.
+    """The reason the snapshot is usable at all: it is PURE PYTHON.
 
     `Layout::project` is Rust and cannot travel into a source-vendored wheel,
     so a stub that only the extension could render or parse would leave every

--- a/tests/test_weight_streaming.py
+++ b/tests/test_weight_streaming.py
@@ -35,6 +35,7 @@ pytest.importorskip("transformers")
 pytest.importorskip("safetensors")
 
 from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from cas_fixture import ingest_repository  # noqa: E402
 from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
 from gen_worker.serving.streaming import (  # noqa: E402
     BridgeWeightStore,
@@ -64,7 +65,7 @@ WINDOW = 4096
 def _project(base: Path, source: Path, key: str) -> Path:
     """Ingest into a real CAS and project the tree, the chokepoint's way."""
     cas = LocalCAS(base)
-    manifest = cas.ingest_repository(source)
+    manifest = ingest_repository(cas, source)
     cas.compare_and_swap_ref(
         REF_PREFIX + key, cas.store_manifest(manifest), expected=None
     )


### PR DESCRIPTION
**Paul's release-policy ruling, 2026-08-20, verbatim:**

> "it's fine if old wheels are on pypi historically. I just mean, get rid of the vendored copies, etc. Remove the v1's from the codebase fully."

`_vendor/VENDORED.toml` declared the two-rev split *"the STEADY STATE … a release-policy decision (Paul), not a lane's."* The decision happened. Tracker: pgw#1575.

## What this found

`[packages.tensorfs]` carried **three** revs, and the one it called `rev` — `8bafdfbb` — was not merely behind upstream: `git merge-base 8bafdfbb da1f3d2` finds **no common ancestor at all**. It predates tensorfs's v0.1.0 genesis restart and is reachable only from `shelf/tensorfsd`, so the digest table certified byte-fidelity to a lineage nobody would ever fix — and `read_plane_rev` + `contract_plane_rev` were bolted on beside it because the dead rev could not supply the planes this repo actually reads.

Everything now comes from `da1f3d2` — tensorfs master, the commit tensorhub's `go.mod` pins. The delta was smaller than the prose implied: `contracts.py`, `gguf.py`, `refs.py`, `writer.py` and all 21 `_contracts/*.json` were **already** byte-identical to master, and `86bfa80f..da1f3d2` touches no Python file at all.

## The five APIs the dead rev was held for

| API | src call sites | verdict |
|---|---|---|
| `LocalCAS.ingest_file` | `hubio/client.py` (`publish_v2`) | **PORTED** → `gen_worker/cas/admission.py` |
| `LocalCAS.collect_garbage` | `models/disk_gc.py` | **PORTED** → `gen_worker/cas/retention.py` |
| `LocalCAS.materialize` | `aot_delivery.py`, `models/materialized_view.py` | **PORTED** → upstream's own `TensorReader.materialize` (tier 3 of the access ladder) |
| `LocalCAS.ingest_repository` | **none, ever** | **MOVED to `tests/cas_fixture.py`** — it is a fixture |
| `LocalCAS.materialize_repository` | **none** | **DELETED** |

The argument for keeping `ingest_*` vendored was that admission is the store's identity contract. But the identity contract is the **object grid**, and pgw#1365 had already forked that into `planner.py` and pinned it to upstream's released `spec/v1/planner-vectors` corpus. What was left in `local.py` was forty lines of plan/put/hash/refuse-if-it-moved, calling a module we already own.

`planner.py` also **moved out of `_vendor/`**: it exists at no upstream rev whatsoever, so carrying it under a digest table that means "upstream's bytes" was a category error.

`manifest.py` is now master's, which drops the 64 MiB cap on a chunkless entry. The old stricter parser only ever refused a manifest this repo cannot emit — `plan_chunks` still cuts an oversized blob for tensorhub's single-PUT promotion (pgw#1366).

## What survives

Two declared rewrites, both for the one pgw#1310 reason (a source-vendored wheel cannot carry a compiled extension): `contract.py`'s pure-Python validator and `tensors.py`'s `_MappedObject`. Verified: the other eight vendored modules are byte-identical to `da1f3d2`.

## Fences

- `test_the_tensorfs_snapshot_is_one_rev` — refuses a second `*_rev` key (the torchcg shape).
- `test_the_write_plane_is_first_party_and_never_returns` — refuses the five symbols **by name**, because a digest fence would only say "a file changed", which is the message that gets a fence regenerated rather than read.

## Verification

- 233 passed / 1 skipped across storage-plane, projection, streaming, gguf, contract, materialized-view and publish suites
- `mypy` strict clean (653 files), `ruff` clean
- green: materialization-hatch, retired-package-name, retired-SDK/graph-class/cell spelling, unreached-surface, fence-symbols, lock-pin-agreement, changelog guards
- `lint_tensor_read_seam` reports 4 findings, **all pre-existing on base `a831a104`, 0 in this diff** (sibling `serverless-endpoints` `cozy_rife.py` files)

## Follow-on, NOT this PR

tensorfs already has a complete PyPI release pipeline merged — `publish.yaml` + `wheels.yaml`, six abi3 platform wheels, trusted publishing, a post-publish verify job — and `pyproject.toml` says `version = "0.1.0"`. It has simply **never been tagged**: no `v*` tag exists and `https://pypi.org/pypi/tensorfs/json` is a 404. One `v0.1.0` tag deletes `_vendor/tensorfs/` entirely **and** both surviving rewrites, because the compiled extension becomes installable. That is the thing that actually retires pgw#1310, and it is a tensorfs release act.

Also owed: `jobs/tests/test_projected_source_jobs298.py` calls `cas.ingest_repository` and will need `gen_worker.cas.ingest_file` or its own fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)