### PR TITLE
pgw#1576: incremental output — @entrypoint(streams=…) + ctx.emit, and the terminal is still RETURNED

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,11 @@ Full reference: [docs/endpoint-authoring.md](docs/endpoint-authoring.md).
   context — every `@job` body and every producer-kind `@endpoint` handler gets
   it, and what it may write comes from the declaration, not the kind
 - Errors: `ValidationError`, `RetryableError`, `CanceledError`, `FatalError`
-- Streaming: `BatchItemDelta`, `IncrementalTokenDelta`, `Done`, `Error`
+- Incremental output (pgw#1576): `@entrypoint(streams=TokenDelta)` +
+  `ctx.emit(...)`; chunk types `TokenDelta`, `ItemDelta`, `Delta`, and
+  `iter_transformers_text_deltas`. A streaming entrypoint still RETURNS its
+  terminal struct — deltas are the droppable live lane, the return is the
+  authoritative result
 - Value types: `Asset`, `ImageAsset`, `AudioAsset`, `VideoAsset`
 - I/O codecs: `gen_worker.io`
 

--- a/changelog.d/pgw1576-incremental-output.md
+++ b/changelog.d/pgw1576-incremental-output.md
@@ -1,0 +1,20 @@
+- **pgw#1576 (feature): incremental output — `@entrypoint(streams=…)` +
+  `ctx.emit`, and the ctx-event lane that was dead is alive.** The v1 hardcut
+  deleted token streaming with no successor, so `qwen3.6-35b-a3b`,
+  `qwen3.6-27b-mtp-gguf` and `joycaption` could not be ported at all. A
+  streaming entrypoint now DECLARES its chunk type (one, or a discriminated
+  union for a handler that streams several shapes), emits chunks with
+  `ctx.emit(TokenDelta(text=…))` from sync or async bodies and any thread, and
+  still RETURNS its terminal struct: the wire has a droppable ordered
+  `JobProgress` lane and exactly one authoritative `JobResult`, and the
+  declaration names both — publish reports `incremental_output` and
+  `delta_output_schema` off the spec without executing author code, and no hub
+  change was needed. The v1 async-generator shape is refused at import with the
+  migration line, because Python forbids `return <value>` inside a generator and
+  that shape can therefore express only the droppable half. Found and fixed
+  alongside: the v2 worker wired NO emitter at all, so `ctx.progress`,
+  `ctx.log`, `ctx.warning` and `ctx.checkpoint` were silently discarded on every
+  v2 pod — one JobProgress emitter with one per-(request, attempt) `seq` now
+  carries both lanes — and the send queue's two progress-drop sites, silent
+  since they were written, each confess a `serve_degrade` row that the hub folds
+  into `occurrences`.

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -135,6 +135,12 @@ if TYPE_CHECKING:  # pragma: no cover - the eager spelling, for type checkers on
         LlamaServer,
         VllmServer,
     )
+    from .serving.deltas import (
+        Delta,
+        ItemDelta,
+        TokenDelta,
+        iter_transformers_text_deltas,
+    )
     from .serving.entrypoints import entrypoint
     from .api.resources import Resources
     from .serving.model import Model
@@ -190,6 +196,14 @@ _EXPORTS: Final[dict[str, str]] = {
     "VllmServer": "serving.engine_runtime",
     "Resources": "api.resources",
     "DistillationAdapter": "serving.context",
+    # pgw#1576: INCREMENTAL OUTPUT. `@entrypoint(streams=<type>)` declares the
+    # chunk type, `ctx.emit(chunk)` puts one on the droppable JobProgress lane,
+    # and the entrypoint still RETURNS its terminal struct on the authoritative
+    # one — two wire channels, and the declaration names both.
+    "Delta": "serving.deltas",
+    "ItemDelta": "serving.deltas",
+    "TokenDelta": "serving.deltas",
+    "iter_transformers_text_deltas": "serving.deltas",
     "ExpectedOutput": "api.types",
     "FamilyGeometry": "geometry",
     "FatalError": "api.errors",
@@ -279,6 +293,12 @@ __all__ = [
     "Model",
     "Resources",
     "entrypoint",
+    # pgw#1576: incremental output — the declared chunk types + the
+    # transformers text-delta helper.
+    "Delta",
+    "ItemDelta",
+    "TokenDelta",
+    "iter_transformers_text_deltas",
     # pgw#1421: the engine-hosted tier (external binaries only).
     "EngineBootError",
     "EngineHandle",

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -528,6 +528,10 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
     row_kind = getattr(spec, "kind", "") or ENTRYPOINT_KIND
     input_schema, input_sha = type_schema_and_hash(spec.payload_type)
     output_schema, output_sha = type_schema_and_hash(spec.return_type)
+    delta_type = getattr(spec, "delta_type", None)
+    delta_schema, delta_sha = (
+        type_schema_and_hash(delta_type) if delta_type is not None else (None, "")
+    )
     moderation = payload_moderation(spec.payload_type)
     slots: List[Dict[str, Any]] = []
     for slot in spec.slots:
@@ -550,9 +554,23 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         "payload_schema_sha256": input_sha,
         "output_schema": output_schema,
         "output_schema_sha256": output_sha,
-        # A v2 entrypoint returns one struct; streaming is not part of the
-        # ratified surface, so the cardinality fact is stated, never omitted.
-        "incremental_output": False,
+        # pgw#1576: a v2 entrypoint ALWAYS returns one struct — that is
+        # `output_schema` above, and it is what a non-streaming caller and the
+        # request record read. `streams=` adds the second, droppable channel,
+        # and the hub already decodes both keys on a function row
+        # (`manifestFunction.IncrementalOutput` / `.DeltaOutputSchema`, and
+        # `entrypoints[]` IS `[]manifestFunction`), so this reaches
+        # `endpoint_function_schemas` with no hub change. Read off the SPEC:
+        # publish never executes author code.
+        "incremental_output": bool(delta_schema is not None),
+        **(
+            {
+                "delta_output_schema": delta_schema,
+                "delta_output_schema_sha256": delta_sha,
+            }
+            if delta_schema is not None
+            else {}
+        ),
         # pgw#1418: WHICH payload paths are media, and which are prompts. The
         # hub decodes exactly this key to recognize typed media inputs — it
         # deliberately will not sniff URL-shaped strings — so without it no

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -46,6 +46,7 @@ import msgspec
 from ..families.base import GenerationDefaults
 from ..request_context import RequestContext as _BaseRequestContext
 from ..request_context import _PublisherMixin
+from .deltas import frame_of
 
 if TYPE_CHECKING:
     from ..models.defaults_decode import CarriesDefaults
@@ -1055,11 +1056,68 @@ class RequestContext(_PublisherMixin, _BaseRequestContext[D]):
         request_id: str,
         *,
         binding: Optional[DeployBinding] = None,
+        streams: Optional[Tuple[type, ...] | type] = None,
+        chunk_sink: Optional[Callable[[bytes, str], None]] = None,
         **base_kwargs: Any,
     ) -> None:
         super().__init__(request_id, **base_kwargs)
         self._serve_binding = binding
         self._mktemp_root: Optional[Path] = None
+        #: pgw#1576: the ``@entrypoint(streams=…)`` chunk type(s), stamped from
+        #: the spec exactly like ``publishes`` — the SDK half of the declaration
+        #: the manifest reports as ``incremental_output``. A tuple because one
+        #: handler may declare several shapes.
+        self._delta_types: Tuple[type, ...] = (
+            () if streams is None
+            else (tuple(streams) if isinstance(streams, tuple) else (streams,))
+        )
+        #: Where a chunk goes: ``(data, content_type) -> None``, the dispatch's
+        #: ``JobProgress`` emitter. Absent on a local run, where a chunk is
+        #: logged and dropped rather than refused — the wire says deltas are
+        #: droppable, and `gen-worker run` has no wire at all.
+        self._chunk_sink = chunk_sink
+
+    def emit(self, chunk: Any) -> None:
+        """Put one incremental-output chunk on the wire (pgw#1576).
+
+        Ordered per request, live, never persisted, and DROPPABLE by contract —
+        the worker's send queue sheds progress under pressure and says so with
+        a ``serve_degrade`` row. What a caller is owed is the struct this
+        entrypoint RETURNS; a delta is how they see it arriving.
+
+        Refuses unless the function declared ``@entrypoint(streams=<type>)``,
+        and refuses a chunk that is not that type: an undeclared emitter would
+        publish ``incremental_output: false`` and stream anyway, which is a
+        manifest that lies to every client that reads it.
+
+        Sync and thread-safe on purpose — the body runs on a worker thread
+        (``asyncio.to_thread``) and a plain ``def`` entrypoint streams with the
+        identical call.
+        """
+        declared = self._delta_types
+        if not declared:
+            raise RuntimeError(
+                "ctx.emit: this entrypoint declared no chunk type, so the hub "
+                "publishes incremental_output=false for it and no client will "
+                "subscribe. Declare @entrypoint(streams=<msgspec.Struct>) "
+                "(pgw#1576)"
+            )
+        if not isinstance(chunk, declared):
+            names = " | ".join(arm.__name__ for arm in declared)
+            raise TypeError(
+                f"ctx.emit: this entrypoint declared streams={names} and "
+                f"delta_output_schema was published from it; got "
+                f"{type(chunk).__name__}"
+            )
+        sink = self._chunk_sink
+        if sink is None:
+            logger.debug(
+                "ctx.emit dropped for %s: no chunk sink (local run)",
+                self.request_id,
+            )
+            return
+        data, content_type = frame_of(chunk)
+        sink(data, content_type)
 
     def mktemp(self) -> Path:
         """A request-scoped scratch directory. Contents are NOT persisted.

--- a/src/gen_worker/serving/deltas.py
+++ b/src/gen_worker/serving/deltas.py
@@ -1,0 +1,242 @@
+"""The streamed-chunk vocabulary (pgw#1576) — what ``ctx.emit`` puts on the wire.
+
+An entrypoint declares its chunk type once, on the decorator, and emits chunks
+of that type while it works::
+
+    @entrypoint(streams=TokenDelta)
+    async def complete(ctx: RequestContext, payload: CompletionInput,
+                       model: QwenModel) -> Completion:
+        parts: list[str] = []
+        async for token in engine.stream(payload.prompt):
+            ctx.raise_if_cancelled()
+            parts.append(token)
+            ctx.emit(TokenDelta(text=token))
+        return Completion(text="".join(parts))
+
+The function is an ORDINARY ``async def`` (or ``def``) returning a
+``msgspec.Struct``, because the wire has two channels and they carry different
+promises: ``JobProgress`` deltas are ordered, live, never persisted and
+DROPPABLE by contract, while the returned struct is the single authoritative
+``JobResult``. An async-generator entrypoint could express only the first —
+Python forbids ``return <value>`` inside one — so it is refused at declaration
+with the migration line, and the terminal is a real ``return``.
+
+**TWO delta types, because they answer two different questions.**
+
+* :class:`TokenDelta` — MORE OF ONE OUTPUT. One completion, growing. Frames as
+  raw UTF-8 ``text/plain``, so an SSE subscriber concatenates
+  ``payload.delta`` and has the answer.
+* :class:`ItemDelta` — WHICH OF N OUTPUTS ADVANCED. A batch, item by item, each
+  with its own index, terminal flag and per-item error. Frames as
+  ``application/json``.
+
+Collapsing them into one struct would hand every token five fields it must
+leave at zero. An author who needs a third shape subclasses :class:`Delta`
+(default framing: ``application/json``) or overrides :meth:`Delta.frame`.
+
+**One handler may declare several shapes** — ``@entrypoint(streams=(TokenDelta,
+ItemDelta))`` — and the manifest publishes a discriminated ``anyOf`` over them.
+Note before reaching for it: per-token progress WITHIN one batch item is
+``ItemDelta(index=…, text=…, finished=False)``, which is one shape and what
+joycaption's own v1 body did (it wrapped every ``iter_transformers_text_deltas``
+piece in a ``BatchItemDelta``, never mixing the two). The union is for a stream
+that genuinely carries both. A consumer tells them apart by ``content_type``
+(``text/plain`` is token text) or by the ``type`` tag inside a JSON frame.
+
+**Framing is UTF-8 text, and that is a wire constraint rather than a
+preference.** The hub renders every non-``audio/*`` chunk as
+``payload["delta"] = string(data)`` inside a JSON SSE envelope
+(``internal/orchestrator/http/requests.go``), so binary framing arrives as
+replacement-character mojibake. v1's ``BatchItemDelta.chunk: bytes`` +
+``application/x-batch-item+msgpack`` was undeliverable for exactly that reason
+and is not restored: binary rides the ``audio/*`` arm (base64'd by the hub as
+``audio_chunk``) or the terminal result.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any, Tuple
+
+import msgspec
+
+#: What a chunk frames to when its type states nothing else.
+JSON_CONTENT_TYPE = "application/json"
+#: The concatenable token stream every SSE consumer already reads.
+TEXT_CONTENT_TYPE = "text/plain"
+
+
+class Delta(msgspec.Struct, frozen=True, kw_only=True, tag_field="type", tag=True):
+    """Base for a streamed chunk. Frames as JSON unless a subclass says else.
+
+    TAGGED on ``type`` (each subclass's own class name), for two reasons and
+    neither is decoding: a JSON frame tells a consumer WHICH shape it is
+    without a second channel, and ``streams=(A, B)`` — one handler, two shapes,
+    which joycaption needs — can only be published as a discriminated
+    ``anyOf`` if the arms carry a tag. An untagged multi-arm declaration is
+    refused at import rather than published as an ambiguous schema.
+    """
+
+    def frame(self) -> Tuple[bytes, str]:
+        """This chunk on the wire: ``(data, content_type)``."""
+        return msgspec.json.encode(self), JSON_CONTENT_TYPE
+
+
+class TokenDelta(Delta, frozen=True, kw_only=True):
+    """More of ONE output — the successor to v1's ``IncrementalTokenDelta``.
+
+    ``text`` is the increment, never the accumulation: the caller concatenates.
+    The complete text belongs in the entrypoint's returned struct, which is what
+    a non-streaming caller (and the persisted request record) reads.
+    """
+
+    text: str = ""
+
+    def frame(self) -> Tuple[bytes, str]:
+        return self.text.encode("utf-8"), TEXT_CONTENT_TYPE
+
+
+class ItemDelta(Delta, frozen=True, kw_only=True):
+    """WHICH of N outputs advanced — the successor to v1's ``BatchItemDelta``.
+
+    ``finished`` marks an item's terminal delta and ``error`` (non-empty) fails
+    that ITEM without failing the request; the entrypoint still returns a
+    terminal struct describing the whole batch.
+    """
+
+    index: int = 0
+    total: int = 0
+    item_id: str = ""
+    text: str = ""
+    finished: bool = False
+    error: str = ""
+
+
+def frame_of(chunk: Any) -> Tuple[bytes, str]:
+    """``(data, content_type)`` for any chunk — the one encoder.
+
+    A chunk that defines ``frame()`` frames itself; anything else is JSON. Kept
+    a free function so the emitter never has to care which it holds.
+    """
+    framer = getattr(chunk, "frame", None)
+    if callable(framer):
+        data, content_type = framer()
+        return bytes(data), str(content_type)
+    return msgspec.json.encode(chunk), JSON_CONTENT_TYPE
+
+
+def iter_transformers_text_deltas(
+    *,
+    model: Any,
+    tokenizer: Any,
+    generation_kwargs: Mapping[str, Any],
+    cancel_checker: Callable[[], bool] | None = None,
+    skip_prompt: bool = True,
+    timeout: float | None = 0.5,
+    join_timeout: float = 2.0,
+    streamer_cls: type[Any] | None = None,
+    decode_kwargs: Mapping[str, Any] | None = None,
+) -> Iterator[str]:
+    """Stream text chunks out of a ``transformers`` ``model.generate`` call.
+
+    Wraps ``TextIteratorStreamer`` and runs ``generate`` on a background thread,
+    yielding progressive text. ``cancel_checker`` is wired into the generation's
+    stopping criteria when transformers exposes them, so a cancelled request
+    stops the decode rather than draining it. An exception raised inside the
+    generate thread is re-raised here.
+
+    Chunks are text SEGMENTS, not guaranteed single tokens.
+    """
+    if model is None:
+        raise ValueError("model is required")
+    if tokenizer is None:
+        raise ValueError("tokenizer is required")
+    if generation_kwargs is None:
+        raise ValueError("generation_kwargs is required")
+
+    local_decode_kwargs = dict(decode_kwargs or {})
+    local_generation_kwargs = dict(generation_kwargs)
+
+    if streamer_cls is None:
+        try:
+            from transformers import TextIteratorStreamer
+        except Exception as exc:  # pragma: no cover - guarded by endpoint deps
+            raise RuntimeError(
+                "transformers TextIteratorStreamer is unavailable"
+            ) from exc
+        streamer_cls = TextIteratorStreamer
+
+    if cancel_checker is not None:
+        _checker = cancel_checker
+        try:
+            from transformers import StoppingCriteria, StoppingCriteriaList
+
+            class _CancelStopCriteria(StoppingCriteria):
+                def __call__(self, _ids: Any, _scores: Any, **_kw: Any) -> bool:
+                    try:
+                        return bool(_checker())
+                    except Exception:
+                        return False
+
+            existing = local_generation_kwargs.get("stopping_criteria")
+            cancel_criteria = _CancelStopCriteria()
+            if existing is None:
+                local_generation_kwargs["stopping_criteria"] = StoppingCriteriaList(
+                    [cancel_criteria]
+                )
+            elif isinstance(existing, StoppingCriteriaList):
+                existing.append(cancel_criteria)
+            else:
+                local_generation_kwargs["stopping_criteria"] = StoppingCriteriaList(
+                    list(existing) + [cancel_criteria]
+                )
+        except Exception:
+            # Streaming still works without cooperative stopping criteria.
+            pass
+
+    streamer = streamer_cls(
+        tokenizer, skip_prompt=bool(skip_prompt), timeout=timeout,
+        **local_decode_kwargs,
+    )
+    local_generation_kwargs["streamer"] = streamer
+
+    errq: "queue.Queue[BaseException]" = queue.Queue(maxsize=1)
+
+    def _run_generate() -> None:
+        try:
+            model.generate(**local_generation_kwargs)
+        except BaseException as exc:
+            try:
+                errq.put_nowait(exc)
+            except Exception:
+                pass
+
+    thread = threading.Thread(
+        target=_run_generate, daemon=True, name="hf-generate-stream"
+    )
+    thread.start()
+    try:
+        for chunk in streamer:
+            if cancel_checker is not None and cancel_checker():
+                break
+            text = str(chunk or "")
+            if text:
+                yield text
+    finally:
+        thread.join(timeout=max(0.0, float(join_timeout)))
+
+    if not errq.empty():
+        raise errq.get()
+
+
+__all__ = [
+    "JSON_CONTENT_TYPE",
+    "TEXT_CONTENT_TYPE",
+    "Delta",
+    "ItemDelta",
+    "TokenDelta",
+    "frame_of",
+    "iter_transformers_text_deltas",
+]

--- a/src/gen_worker/serving/entrypoints.py
+++ b/src/gen_worker/serving/entrypoints.py
@@ -26,6 +26,11 @@ ruling, 2026-08-17 — one parameter-order rule across the SDK, matching
     def generate(ctx: RequestContext, payload: GenerateInput,
                  video: H3Model) -> GenerateOutput: ...
 
+    @entrypoint(streams=TokenDelta)   # INCREMENTAL OUTPUT (pgw#1576): the
+    async def complete(ctx: RequestContext,   # chunk type is declared, the
+                       payload: CompletionInput,   # terminal struct is still
+                       model: QwenModel) -> Completion: ...  # RETURNED
+
     @entrypoint(kind="conversion",    # a PRODUCER (pgw#1406)
                 publishes=True, env=("HF_TOKEN", "CIVITAI_API_KEY"))
     def cast_dtype(ctx: RequestContext, payload: CastDtypeInput
@@ -67,6 +72,7 @@ principle.
 
 from __future__ import annotations
 
+import collections.abc
 import inspect
 import types
 import typing
@@ -153,6 +159,15 @@ class EntrypointSpec:
     #: THIS class, so a producer that annotates ``JobContext`` receives the
     #: publisher surface and an inference entrypoint is unchanged.
     ctx_type: type | None = None
+    #: pgw#1576: the declared ``streams=`` chunk ANNOTATION, or ``None``. One
+    #: struct type, or a discriminated union when a handler streams several
+    #: shapes. Present means this function emits incremental output: publish
+    #: reports ``incremental_output`` + ``delta_output_schema`` off THIS field
+    #: without executing author code.
+    delta_type: Any = None
+    #: The same declaration as an isinstance-able tuple — what ``ctx.emit``
+    #: refuses a foreign chunk against.
+    delta_arms: Tuple[Type[msgspec.Struct], ...] = ()
 
     @property
     def model_params(self) -> Tuple[Tuple[str, type], ...]:
@@ -278,6 +293,62 @@ def _validate_env_decl(fn: Callable[..., Any], env: Any) -> Tuple[str, ...]:
     return tuple(out)
 
 
+def _delta_declaration(
+    fn: Callable[..., Any], streams: Any
+) -> Tuple[Any, Tuple[Type[msgspec.Struct], ...]]:
+    """``streams=`` normalized: ``(annotation, arms)``.
+
+    Accepts one ``msgspec.Struct`` type, a tuple/list of them, or ``A | B`` —
+    one handler legitimately streams more than one shape. The ANNOTATION is
+    what publish turns into ``delta_output_schema`` (a union becomes a
+    discriminated ``anyOf``); the ARMS are what ``ctx.emit`` type-checks
+    against.
+    """
+    if streams is None:
+        return None, ()
+    if isinstance(streams, (tuple, list)):
+        candidates = tuple(streams)
+    elif typing.get_origin(streams) in (typing.Union, types.UnionType):
+        candidates = typing.get_args(streams)
+    else:
+        candidates = (streams,)
+    arms: list[Type[msgspec.Struct]] = []
+    for candidate in candidates:
+        concrete = _annotation_class(candidate)
+        if concrete is None or not issubclass(concrete, msgspec.Struct):
+            raise _refuse(
+                fn,
+                f"streams= takes the msgspec.Struct chunk type(s) this "
+                f"function emits (gen_worker.TokenDelta, gen_worker.ItemDelta, "
+                f"your own Delta subclass, or a tuple/union of them), got "
+                f"{candidate!r} — the type is what publish reports as "
+                f"delta_output_schema",
+            )
+        arms.append(concrete)
+    if not arms:
+        raise _refuse(fn, "streams= declares no chunk type")
+    if len(arms) == 1:
+        return arms[0], (arms[0],)
+    # `Union[tuple(...)]` at runtime — the arms are only known here, so mypy
+    # cannot read it as a type alias and is told so.
+    annotation: Any = typing.Union[tuple(arms)]
+    untagged = [
+        arm.__name__
+        for arm in arms
+        if getattr(arm, "__struct_config__", None) is None
+        or getattr(arm.__struct_config__, "tag", None) is None
+    ]
+    if untagged:
+        raise _refuse(
+            fn,
+            f"streams= declares several chunk types and {untagged} carry no "
+            "msgspec tag, so the published delta_output_schema could not tell "
+            "them apart. Subclass gen_worker.Delta (tagged on `type`), or "
+            "declare tag=True on your struct",
+        )
+    return annotation, tuple(arms)
+
+
 @overload
 def entrypoint(fn: F) -> F: ...
 @overload
@@ -288,6 +359,7 @@ def entrypoint(
     publishes: bool = ...,
     env: Any = ...,
     emits_media: bool | None = ...,
+    streams: Any = ...,
 ) -> Callable[[F], F]: ...
 
 
@@ -299,6 +371,7 @@ def entrypoint(
     publishes: bool = False,
     env: Any = None,
     emits_media: bool | None = None,
+    streams: Any = None,
 ) -> F | Callable[[F], F]:
     """Mark a module-level function as an entrypoint (contract above).
 
@@ -400,6 +473,45 @@ def entrypoint(
       it would silently downgrade every producer that declared media. An
       INFERENCE row still emits nothing, because nothing there can store or
       read it; that half of th#2087's fence stays.
+
+    ``streams=`` is the INCREMENTAL-OUTPUT declaration (pgw#1576): the
+    ``msgspec.Struct`` type this function emits through :meth:`ctx.emit
+    <gen_worker.serving.context.RequestContext.emit>` while it works. It does
+    NOT change the return contract — a streaming entrypoint still returns one
+    struct, because the wire carries two things and they promise different
+    amounts::
+
+        @entrypoint(streams=TokenDelta)
+        async def complete(ctx: RequestContext, payload: CompletionInput,
+                           model: QwenModel) -> Completion:
+            parts = []
+            async for token in engine.stream(payload.prompt):
+                ctx.raise_if_cancelled()
+                parts.append(token)
+                ctx.emit(TokenDelta(text=token))
+            return Completion(text="".join(parts))
+
+    One handler may stream several shapes — ``streams=(TokenDelta, ItemDelta)``
+    or ``streams=TokenDelta | ItemDelta`` — and the manifest publishes a
+    DISCRIMINATED ``anyOf`` over them, which is why every arm must carry a
+    msgspec tag (``gen_worker.Delta`` subclasses do).
+
+    ``JobProgress`` deltas are ordered, live, never persisted and DROPPABLE by
+    contract; ``JobResult`` is the single authoritative output every
+    non-streaming caller and the request record read. The declaration is read
+    statically at publish — ``incremental_output`` and ``delta_output_schema``
+    come off ``EntrypointSpec.delta_type``, no author code executed — and
+    ``ctx.emit`` refuses both an undeclared function and a chunk of another
+    type, the same one-fact-two-enforcers shape as ``publishes=``.
+
+    **An async-generator entrypoint is refused, and the refusal is the design.**
+    Python forbids ``return <value>`` inside an async generator, so
+    ``-> AsyncIterator[Delta]`` can express the droppable half of the wire and
+    nothing else: the authoritative result would have to be folded out of the
+    deltas by the platform (v1's accumulator, magic field-peeling over three
+    blessed types) or smuggled in as a special last frame. Both are weaker than
+    a plain ``return``, so the generator shape is refused at import naming
+    ``streams=`` + ``ctx.emit`` as the successor.
     """
 
     if fn is None:
@@ -411,6 +523,7 @@ def entrypoint(
                 publishes=publishes,
                 env=env,
                 emits_media=emits_media,
+                streams=streams,
             )
         return bind
 
@@ -445,6 +558,7 @@ def entrypoint(
             "normalize would silently become 'inference'",
         )
     declared_env = _validate_env_decl(fn, env)
+    delta_type, delta_arms = _delta_declaration(fn, streams)
     if resources is not None:
         from ..api.resources import Resources
 
@@ -525,6 +639,28 @@ def entrypoint(
     # JUNK slots are not — `_slot_of` above still refuses every parameter
     # that is neither a Model subclass nor an adapter form.
 
+    # pgw#1576: name the STREAMING migration before the generic refusal does.
+    # An async-generator body (or an `AsyncIterator[...]`/`Iterator[...]`
+    # return) is the v1 streaming shape, and "must be a msgspec.Struct" sends
+    # its author looking for a schema defect that is not there.
+    returns_iterator = _annotation_class(hints.get("return")) in (
+        collections.abc.AsyncIterator, collections.abc.AsyncGenerator,
+        collections.abc.Iterator, collections.abc.Generator,
+    )
+    if inspect.isasyncgenfunction(fn) or inspect.isgeneratorfunction(fn) or (
+        returns_iterator
+    ):
+        raise _refuse(
+            fn,
+            "a generator entrypoint cannot produce the request's authoritative "
+            "result — Python forbids `return <value>` inside a generator, and "
+            "JobResult is a separate wire channel from the droppable "
+            "JobProgress deltas. Declare the chunk type instead and return the "
+            "terminal struct: `@entrypoint(streams=TokenDelta)` + "
+            "`ctx.emit(TokenDelta(text=...))` in the loop + "
+            "`return <YourOutput>(...)` at the end (pgw#1576)",
+        )
+
     return_type = _annotation_class(hints.get("return"))
     if return_type is None or not issubclass(return_type, msgspec.Struct):
         raise _refuse(
@@ -544,6 +680,8 @@ def entrypoint(
         env=declared_env,
         emits_media=emits_media,
         ctx_type=ctx_type,
+        delta_type=delta_type,
+        delta_arms=delta_arms,
     )
     setattr(fn, ENTRYPOINT_ATTR, spec)
     return fn

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -600,6 +600,10 @@ class ServeLoop:
             # media is the product of a request, and behaviour is unchanged for
             # every endpoint that never says the word.
             kwargs["publishes"] = bool(getattr(spec, "publishes", False))
+            # pgw#1576: the SAME stamp for the streaming declaration. `emit`
+            # refuses without it, so an undeclared function cannot stream past
+            # a manifest that says `incremental_output: false`.
+            kwargs["streams"] = getattr(spec, "delta_arms", ()) or None
             declared_media = getattr(spec, "emits_media", None)
             if declared_media is not None:
                 kwargs["emits_media"] = bool(declared_media)

--- a/src/gen_worker/transport.py
+++ b/src/gen_worker/transport.py
@@ -192,6 +192,35 @@ def _backoff_ceiling(base: float, cap: float, attempt: int) -> float:
     return ceiling
 
 
+def _confess_dropped_chunk(msg: pb.WorkerMessage) -> None:
+    """One ``serve_degrade`` row for a JobProgress frame this queue destroyed.
+
+    pgw#1576. Shedding progress under pressure is the queue's CONTRACT — a
+    dropped chunk never fails a request, because ``JobResult`` carries the
+    authoritative output. But a dropped chunk IS missing live text in a
+    completion the caller is watching, and both drop sites were silent, so the
+    loss was unobservable at any altitude.
+
+    The detail is stable per (request_id, attempt) and carries no seq on
+    purpose: the hub's activity upsert folds identical rows on
+    ``(worker_id, kind, phase, state, payload_digest)`` with ``occurrences+1``,
+    so a shedding storm becomes ONE row with a count instead of one row per
+    lost token.
+    """
+    progress = msg.job_progress
+    try:
+        activity_mod.emit_event(
+            activity_mod.KIND_SERVE_DEGRADE,
+            f"request_id={progress.request_id} attempt={progress.attempt}: "
+            f"streamed output chunk dropped — the send queue is over its bound "
+            f"and progress is shed by contract; the terminal JobResult still "
+            f"carries the whole output",
+            phase="stream_chunk_dropped",
+        )
+    except Exception:  # noqa: BLE001 — a confession never breaks the queue
+        logger.debug("serve_degrade row for a dropped chunk failed", exc_info=True)
+
+
 def _msg_kind(msg: pb.WorkerMessage) -> str:
     which = msg.WhichOneof("msg")
     if which == "job_result":
@@ -413,9 +442,10 @@ class SendQueue:
         return list(self._pending_results.keys())
 
     def _drop_oldest_progress(self) -> bool:
-        for i, (kind, _m) in enumerate(self._items):
+        for i, (kind, msg) in enumerate(self._items):
             if kind == _PROGRESS:
                 del self._items[i]
+                _confess_dropped_chunk(msg)
                 return True
         return False
 
@@ -686,6 +716,7 @@ class SendQueue:
                 if self._drop_oldest_progress():
                     continue
                 if kind == _PROGRESS:
+                    _confess_dropped_chunk(msg)
                     return                            # drop this progress chunk
                 await self._cond.wait()               # backpressure: block the producer
             if (

--- a/src/gen_worker/v1_deleted.py
+++ b/src/gen_worker/v1_deleted.py
@@ -80,6 +80,39 @@ REPLACEMENTS: Final[dict[str, str]] = {
     "class_set_delta": "the publish-time instrumented derive",
     "contract_delta": "the publish-time instrumented derive",
     "override_delta": "the publish-time instrumented derive",
+    # pgw#1576: these three were deleted BY OMISSION — no successor line, so an
+    # author hit a bare ImportError and the gap read as an oversight rather
+    # than a ruling. It was an oversight, and the successor exists now. The
+    # third name is NOT here: `iter_transformers_text_deltas` came back
+    # verbatim, same spelling, so it imports instead of refusing.
+    "IncrementalTokenDelta": (
+        "gen_worker.TokenDelta with @entrypoint(streams=TokenDelta) and "
+        "ctx.emit(...) — the entrypoint still RETURNS its terminal struct "
+        "(pgw#1576)"
+    ),
+    "BatchItemDelta": (
+        "gen_worker.ItemDelta with @entrypoint(streams=ItemDelta) and "
+        "ctx.emit(...); the binary `chunk` field is gone (msgpack framing "
+        "could not survive the hub's JSON SSE surface) — text rides `text`, "
+        "and the whole batch rides the returned struct (pgw#1576)"
+    ),
+    "TokenUsage": (
+        "typed fields on the entrypoint's own returned struct — the terminal "
+        "is the author's, so the platform folds nothing (pgw#1576)"
+    ),
+    "StreamResult": (
+        "the entrypoint's own returned struct: a streaming entrypoint returns "
+        "its terminal exactly like every other one (pgw#1576)"
+    ),
+    "StreamItem": "a field on the entrypoint's own returned struct (pgw#1576)",
+    "Done": (
+        "no successor — the stream ends when the body returns, and JobResult "
+        "is the terminal (pgw#1576)"
+    ),
+    "Error": (
+        "raise a typed gen_worker error; a failed ITEM in a batch is "
+        "ItemDelta(error=...) plus the terminal struct (pgw#1576)"
+    ),
     "GenerationDefaults": "gen_worker.models — the model type's Defaults struct",
     "StringEnum": "stdlib enum.StrEnum",
     "arm_compile": "ctx.compile inside Model.load",

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -24,6 +24,7 @@ import asyncio
 import contextvars
 import functools
 import importlib
+import itertools
 import json
 import logging
 import os
@@ -32,7 +33,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 import msgspec
 
@@ -96,6 +97,12 @@ _SIGNAL_DRAIN_DEADLINE_MS = 30_000
 #: The same estimate ``python -m gen_worker.serving`` reserves locally; the
 #: exact per-(model type, resolution class) number rides the pgw#1380 sizer.
 _HEADROOM_DIVISOR = 4
+
+#: pgw#1576: the content type that marks a ``JobProgress`` chunk as a typed
+#: ctx-event envelope rather than streamed output. Verbatim from the hub's own
+#: ``runtimestore.RequestEventContentType``; a chunk carrying anything else is
+#: fanned out to SSE subscribers as ``output.delta``.
+EVENT_CONTENT_TYPE = "application/x-request-event+json"
 
 #: v1 decorator stamps. A module still carrying one is a build failure with a
 #: name attached, never an empty manifest.
@@ -1067,13 +1074,97 @@ class Worker:
         if run.media_bytes == pb.MEDIA_BYTES_INLINE:
             # The client asked for bytes back in the result rather than a link.
             hints["output_format"] = "inline"
+        emitter, chunk_sink = self._progress_channel(run)
         return {
             "owner": str(run.org or "") or None,
             "invoker_id": str(run.invoker_id or "") or None,
             "file_api_base_url": self.file_base_url or None,
             "worker_capability_token": str(run.capability_token or "") or None,
             "execution_hints": hints or None,
+            # pgw#1576: THIS REQUEST'S JobProgress LANE, both halves. Per
+            # request because `seq` is per (request_id, attempt) — it can never
+            # ride `ServeLoop`'s construction-time context_kwargs, which is
+            # exactly the reason the v2 rewrite ended up wiring neither.
+            "emitter": emitter,
+            "chunk_sink": chunk_sink,
         }
+
+    def _progress_channel(
+        self, run: pb.RunJob
+    ) -> Tuple[
+        Callable[[Dict[str, Any]], None], Callable[[bytes, str], None]
+    ]:
+        """This request's ``JobProgress`` lane: ``(ctx event emitter, chunk sink)``.
+
+        ONE seam and ONE ``seq`` counter for both, because they are one wire
+        message. ``JobProgress.seq`` is "strictly increasing per (request_id,
+        attempt)" and it is stamped ON THE LOOP, so send order and seq order
+        cannot disagree no matter which thread produced the frame.
+
+        * the CTX EVENT lane — ``ctx.progress``/``log``/``warning``/
+          ``checkpoint`` as a JSON envelope under
+          ``application/x-request-event+json``, which the hub parses into
+          request-progress positions and `request_events` rows.
+          **pgw#1576: the v2 rewrite wired NO emitter at all**, so
+          ``_emit_event`` hit its `no emitter configured` branch on every pod
+          and the hub's liveness sweep read positions nobody was sending.
+        * the OUTPUT DELTA lane — ``ctx.emit(chunk)`` frames, content-typed by
+          the chunk itself, fanned out live to SSE subscribers.
+
+        Both are best-effort by contract: the send queue sheds progress under
+        pressure (and confesses a ``serve_degrade`` row where it does), and a
+        producer never fails a request over a chunk that did not fit.
+        """
+        loop = asyncio.get_running_loop()
+        seq = itertools.count(1)
+        request_id, attempt = str(run.request_id), int(run.attempt)
+
+        async def _send_progress(data: bytes, content_type: str) -> None:
+            await self._send(
+                pb.WorkerMessage(
+                    job_progress=pb.JobProgress(
+                        request_id=request_id,
+                        attempt=attempt,
+                        seq=next(seq),
+                        data=data,
+                        content_type=content_type,
+                    )
+                )
+            )
+
+        def _put(data: bytes, content_type: str) -> None:
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    _send_progress(data, content_type), loop
+                )
+            except RuntimeError:
+                return  # loop closed: the worker is shutting down
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                # Called ON the loop (a sync entrypoint invoked in-process, a
+                # test). Waiting here would deadlock the very loop that has to
+                # do the send, so the frame is scheduled and not awaited.
+                return
+            # WAIT, deliberately: it orders this thread's frames and applies
+            # whatever backpressure the send path has. It cannot hang on queue
+            # capacity — the send queue's policy for a full queue is to DROP
+            # progress, never to block its producer (transport.py).
+            future.result()
+
+        def _emit_event(event: Dict[str, Any]) -> None:
+            try:
+                data = msgspec.json.encode(event)
+            except Exception:
+                logger.debug(
+                    "unencodable ctx event dropped for %s", request_id
+                )
+                return
+            _put(data, EVENT_CONTENT_TYPE)
+
+        return _emit_event, _put
 
     def _check_lane(self, run: pb.RunJob) -> None:
         lane = str(run.lane or "").strip()

--- a/tests/release_fixtures/streaming_endpoint.py
+++ b/tests/release_fixtures/streaming_endpoint.py
@@ -1,0 +1,92 @@
+"""A STREAMING module (pgw#1576): declared chunk types, returned terminals.
+
+The qwen/joycaption shape, weightless so the whole path runs on CPU: an async
+entrypoint streaming tokens, a plain `def` one streaming per-item batch
+progress, and an undeclared one that must be refused when it tries to emit.
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from gen_worker import ItemDelta, RequestContext, TokenDelta, entrypoint
+
+
+class CompletionInput(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    max_tokens: int = 4
+
+
+class Completion(msgspec.Struct):
+    text: str
+    tokens: int
+
+
+class CaptionInput(msgspec.Struct, forbid_unknown_fields=True):
+    items: list[str]
+
+
+class CaptionOutput(msgspec.Struct):
+    captions: list[str]
+    failed: int
+
+
+class SilentOutput(msgspec.Struct):
+    ok: bool
+
+
+@entrypoint(streams=TokenDelta)
+async def complete(ctx: RequestContext, payload: CompletionInput) -> Completion:
+    """Tokens live, the whole completion returned — both, from one body."""
+    parts: list[str] = []
+    for index in range(int(payload.max_tokens)):
+        ctx.raise_if_cancelled()
+        token = f"{payload.prompt}-{index} "
+        parts.append(token)
+        ctx.emit(TokenDelta(text=token))
+        ctx.progress((index + 1) / payload.max_tokens, "decode", step=index + 1,
+                     total=int(payload.max_tokens))
+    return Completion(text="".join(parts), tokens=len(parts))
+
+
+@entrypoint(streams=ItemDelta)
+def caption(ctx: RequestContext, payload: CaptionInput) -> CaptionOutput:
+    """A SYNC body streams with the identical call — no async anywhere."""
+    total = len(payload.items)
+    captions: list[str] = []
+    failed = 0
+    for index, item in enumerate(payload.items):
+        if not item:
+            failed += 1
+            ctx.emit(ItemDelta(index=index, total=total, item_id=f"item-{index}",
+                               error="blank item", finished=True))
+            captions.append("")
+            continue
+        caption_text = f"a photo of {item}"
+        ctx.emit(ItemDelta(index=index, total=total, item_id=f"item-{index}",
+                           text=caption_text, finished=True))
+        captions.append(caption_text)
+    return CaptionOutput(captions=captions, failed=failed)
+
+
+@entrypoint(streams=(TokenDelta, ItemDelta))
+def narrate(ctx: RequestContext, payload: CaptionInput) -> CaptionOutput:
+    """ONE handler, BOTH shapes: tokens while an item decodes, an item frame
+    when it finishes."""
+    total = len(payload.items)
+    captions: list[str] = []
+    for index, item in enumerate(payload.items):
+        for word in item.split():
+            ctx.emit(TokenDelta(text=word + " "))
+        ctx.emit(ItemDelta(index=index, total=total, item_id=f"item-{index}",
+                           text=item, finished=True))
+        captions.append(item)
+    return CaptionOutput(captions=captions, failed=0)
+
+
+@entrypoint
+def silent(ctx: RequestContext, payload: CaptionInput) -> SilentOutput:
+    """Declares no chunk type; `emit` here must refuse rather than stream past
+    a manifest that says `incremental_output: false`."""
+    ctx.emit(TokenDelta(text="never"))
+    return SilentOutput(ok=True)

--- a/tests/test_streaming_entrypoints.py
+++ b/tests/test_streaming_entrypoints.py
@@ -1,0 +1,423 @@
+"""Incremental output, end to end (pgw#1576).
+
+The v1 hardcut deleted token streaming and shipped no successor: three
+endpoints (`qwen3.6-35b-a3b`, `qwen3.6-27b-mtp-gguf`, `joycaption`) could not
+be ported at all. The successor is NOT the v1 async generator — Python forbids
+`return <value>` inside one, so that shape can express only the DROPPABLE half
+of the wire. A streaming entrypoint declares its chunk type, emits chunks, and
+still RETURNS its terminal struct.
+
+This drives the real path on CPU with no weights and no GPU:
+
+1. the declaration — `streams=` lands on the spec; a generator is refused with
+   the migration line;
+2. the serve loop — chunks reach a sink in order, the terminal is the return;
+3. **the worker** — `Worker._run_one` with a capturing transport: N ordered
+   `JobProgress` frames (including the ctx-event lane that was dead) followed
+   by exactly one `JobResult` carrying the whole output;
+4. the manifest — `incremental_output` + `delta_output_schema`, read off the
+   spec without executing author code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator, List, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.serving.deltas import ItemDelta, TokenDelta, frame_of
+from gen_worker.serving.entrypoints import (
+    ENTRYPOINT_ATTR,
+    EntrypointDeclarationError,
+)
+from gen_worker.serving.loader import load_endpoint_module
+from gen_worker.serving.residency import ResidencyManager
+from gen_worker.serving.serve_loop import ServeLoop
+from gen_worker.worker import EVENT_CONTENT_TYPE, Worker
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+MODULE = "streaming_endpoint"
+
+
+@pytest.fixture(scope="module")
+def streaming() -> Iterator[ModuleType]:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        yield importlib.import_module(MODULE)
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+
+# -- 1. the declaration ------------------------------------------------------
+
+
+def test_the_chunk_type_lands_on_the_spec(streaming: ModuleType) -> None:
+    """`streams=` is a STATIC fact: publish reads it, no body runs."""
+    spec = getattr(streaming.complete, ENTRYPOINT_ATTR)
+    assert spec.delta_type is TokenDelta and spec.delta_arms == (TokenDelta,)
+    # ...and the return contract is UNCHANGED — the terminal is still a struct.
+    assert spec.return_type is streaming.Completion
+
+    assert getattr(streaming.caption, ENTRYPOINT_ATTR).delta_type is ItemDelta
+    assert getattr(streaming.silent, ENTRYPOINT_ATTR).delta_type is None
+
+
+def _declare(source: str) -> None:
+    """A REAL module-level declaration — @entrypoint refuses nested functions
+    first, so an in-function probe would measure the wrong wall."""
+    preamble = (
+        "import msgspec\n"
+        "from typing import AsyncIterator, Iterator\n"
+        "from gen_worker import RequestContext, TokenDelta, entrypoint\n"
+        "class In(msgspec.Struct): text: str\n"
+        "class Out(msgspec.Struct): text: str\n"
+    )
+    module = types.ModuleType("pgw1576_probe")
+    sys.modules["pgw1576_probe"] = module
+    try:
+        exec(preamble + source, module.__dict__)  # noqa: S102
+    finally:
+        del sys.modules["pgw1576_probe"]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # the v1 shape, verbatim (qwen3.6-35b-a3b's `complete`)
+        "@entrypoint\n"
+        "async def f(ctx: RequestContext, payload: In) -> AsyncIterator[TokenDelta]:\n"
+        "    yield TokenDelta(text='x')\n",
+        # ...and the sync one (joycaption's `caption_images`)
+        "@entrypoint\n"
+        "def f(ctx: RequestContext, payload: In) -> Iterator[TokenDelta]:\n"
+        "    yield TokenDelta(text='x')\n",
+        # a generator BODY whose annotation lies about it
+        "@entrypoint\n"
+        "def f(ctx: RequestContext, payload: In) -> Out:\n"
+        "    yield Out(text='x')\n",
+    ],
+)
+def test_a_generator_entrypoint_is_refused_with_the_migration(source: str) -> None:
+    """The refusal IS the design, so it has to say what to write instead —
+    'return type must be a msgspec.Struct' would send the author hunting for a
+    schema defect that is not there."""
+    with pytest.raises(EntrypointDeclarationError) as excinfo:
+        _declare(source)
+    message = str(excinfo.value)
+    assert "streams=TokenDelta" in message
+    assert "ctx.emit" in message
+    assert "return" in message
+
+
+def test_streams_takes_a_struct_type_and_says_so() -> None:
+    with pytest.raises(EntrypointDeclarationError, match="streams= takes the"):
+        _declare(
+            "@entrypoint(streams='TokenDelta')\n"
+            "def f(ctx: RequestContext, payload: In) -> Out: ...\n"
+        )
+
+
+def test_a_multi_shape_declaration_must_be_discriminable() -> None:
+    """Several untagged arms cannot be told apart in ONE published schema, so
+    the ambiguity is refused at import rather than shipped to clients."""
+    with pytest.raises(EntrypointDeclarationError, match="carry no msgspec tag"):
+        _declare(
+            "class D1(msgspec.Struct): a: str = ''\n"
+            "class D2(msgspec.Struct): b: str = ''\n"
+            "@entrypoint(streams=(D1, D2))\n"
+            "def f(ctx: RequestContext, payload: In) -> Out: ...\n"
+        )
+
+
+# -- 2. framing --------------------------------------------------------------
+
+
+def test_a_token_delta_frames_as_concatenable_text() -> None:
+    """The hub renders every non-audio chunk as `payload["delta"] = string(data)`
+    inside a JSON SSE envelope, so a token stream must BE text on the wire."""
+    assert frame_of(TokenDelta(text="hello ")) == (b"hello ", "text/plain")
+
+
+def test_an_item_delta_frames_as_json_because_its_metadata_is_the_point() -> None:
+    data, content_type = frame_of(ItemDelta(index=2, total=5, text="a cat"))
+    assert content_type == "application/json"
+    assert msgspec.json.decode(data)["index"] == 2
+
+
+# -- 3. the serve loop -------------------------------------------------------
+
+
+class _NoModels:
+    def resolve(self, model_cls: type, checkpoint_ref: str) -> Any:
+        raise AssertionError("a weightless request resolved a binding")
+
+    def default_pick(self, model_cls: type, slot_name: str) -> str:
+        raise AssertionError("a weightless request asked for a default pick")
+
+    def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        raise AssertionError("a weightless request sized a residency slot")
+
+    def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        raise AssertionError("a weightless request reserved activation bytes")
+
+
+def _loop() -> ServeLoop:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        loaded = load_endpoint_module(MODULE)
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return ServeLoop(
+        loaded,
+        residency=ResidencyManager(1 << 30, _NoModels()),
+        resolver=_NoModels(),
+    )
+
+
+def test_the_serve_loop_streams_the_chunks_and_returns_the_terminal(
+    streaming: ModuleType,
+) -> None:
+    chunks: List[Tuple[bytes, str]] = []
+    outcome = _loop().invoke(
+        "complete",
+        {"input": {"prompt": "hi", "max_tokens": 3}},
+        request_id="pgw1576-loop",
+        context={"chunk_sink": lambda data, ct: chunks.append((data, ct))},
+    )
+
+    # The DROPPABLE half: three ordered text frames.
+    assert [data for data, _ in chunks] == [b"hi-0 ", b"hi-1 ", b"hi-2 "]
+    assert {ct for _, ct in chunks} == {"text/plain"}
+    # The AUTHORITATIVE half: the whole completion, typed, as the return value.
+    assert isinstance(outcome.result, streaming.Completion)
+    assert outcome.result.text == "hi-0 hi-1 hi-2 "
+    assert outcome.result.tokens == 3
+
+
+def test_a_sync_entrypoint_streams_with_the_identical_call(
+    streaming: ModuleType,
+) -> None:
+    """joycaption's handler is a plain `def`; it must not need an async rewrite."""
+    chunks: List[Tuple[bytes, str]] = []
+    outcome = _loop().invoke(
+        "caption",
+        {"input": {"items": ["a cat", "", "a dog"]}},
+        request_id="pgw1576-sync",
+        context={"chunk_sink": lambda data, ct: chunks.append((data, ct))},
+    )
+
+    rows = [msgspec.json.decode(data) for data, _ in chunks]
+    assert [row["index"] for row in rows] == [0, 1, 2]
+    assert rows[1]["error"] == "blank item"          # one ITEM failed...
+    assert outcome.result.failed == 1                # ...and the request did not
+    assert outcome.result.captions[2] == "a photo of a dog"
+
+
+def test_one_handler_streams_two_shapes(streaming: ModuleType) -> None:
+    """joycaption's case: tokens WHILE an item decodes, an item frame when it
+    finishes. Both arms are declared, so both are publishable and emittable."""
+    chunks: List[Tuple[bytes, str]] = []
+    _loop().invoke(
+        "narrate",
+        {"input": {"items": ["a cat"]}},
+        request_id="pgw1576-union",
+        context={"chunk_sink": lambda data, ct: chunks.append((data, ct))},
+    )
+
+    assert [(data, ct) for data, ct in chunks[:2]] == [
+        (b"a ", "text/plain"), (b"cat ", "text/plain"),
+    ]
+    terminal = msgspec.json.decode(chunks[-1][0])
+    # The JSON arm carries its own discriminator, so a consumer reading one
+    # stream of mixed frames never has to guess which shape it holds.
+    assert terminal["type"] == "ItemDelta" and terminal["finished"] is True
+
+
+def test_emit_refuses_a_function_that_declared_no_chunk_type() -> None:
+    """An undeclared emitter would stream past a manifest saying
+    `incremental_output: false` — one fact, two enforcers."""
+    with pytest.raises(RuntimeError, match="declared no chunk type"):
+        _loop().invoke(
+            "silent",
+            {"input": {"items": []}},
+            request_id="pgw1576-undeclared",
+            context={"chunk_sink": lambda data, ct: None},
+        )
+
+
+def test_emit_refuses_a_chunk_of_another_type() -> None:
+    from gen_worker.serving.context import RequestContext
+
+    ctx: RequestContext[Any] = RequestContext(
+        "pgw1576-type", streams=(TokenDelta,), chunk_sink=lambda *_: None
+    )
+    with pytest.raises(TypeError, match="streams=TokenDelta"):
+        ctx.emit(ItemDelta(index=0))
+
+
+# -- 4. the worker: the actual wire -----------------------------------------
+
+
+class _CapturedWorker:
+    """`Worker._run_one` over a REAL `ServeLoop`, with only the socket faked.
+
+    The dispatch, the `to_thread` hop the body really runs on, the per-request
+    JobProgress channel, the seq counter and the terminal `JobResult` are all
+    the production ones; `_send` collects instead of writing to gRPC.
+    """
+
+    def __init__(self) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        worker = object.__new__(Worker)
+        worker._jobs = {}
+        worker._canceled = set()
+        worker.draining = False
+        worker.lanes = frozenset()
+        worker.file_base_url = ""
+        worker.serve = _loop()
+        worker.loaded = worker.serve.loaded
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        worker._send = _send  # type: ignore[method-assign]
+        self.worker = worker
+
+    def run(self, function: str, payload: Any, job_id: str = "pgw1576") -> None:
+        run = pb.RunJob(
+            request_id=job_id,
+            attempt=1,
+            function_name=function,
+            input_payload=msgspec.msgpack.encode(payload),
+        )
+        asyncio.run(self.worker._run_one(run, (job_id, 1)))
+
+    @property
+    def progress(self) -> List[pb.JobProgress]:
+        return [m.job_progress for m in self.sent if m.HasField("job_progress")]
+
+    @property
+    def result(self) -> pb.JobResult:
+        results = [m.job_result for m in self.sent if m.HasField("job_result")]
+        assert len(results) == 1, self.sent
+        return results[0]
+
+
+def test_the_wire_carries_ordered_chunks_then_one_terminal_result(
+    streaming: ModuleType,
+) -> None:
+    captured = _CapturedWorker()
+    captured.run("complete", {"prompt": "tok", "max_tokens": 3})
+
+    frames = captured.progress
+    # `seq` is "strictly increasing per (request_id, attempt)" and is stamped on
+    # the loop, so send order and seq order cannot disagree.
+    assert [f.seq for f in frames] == list(range(1, len(frames) + 1))
+    assert {f.request_id for f in frames} == {"pgw1576"}
+
+    deltas = [f for f in frames if f.content_type == "text/plain"]
+    assert [f.data for f in deltas] == [b"tok-0 ", b"tok-1 ", b"tok-2 "]
+
+    result = captured.result
+    assert result.status == pb.JOB_STATUS_OK
+    decoded = msgspec.msgpack.decode(result.inline, type=streaming.Completion)
+    assert decoded.text == "tok-0 tok-1 tok-2 " and decoded.tokens == 3
+
+
+def test_the_ctx_event_lane_is_alive_on_the_same_seam(streaming: ModuleType) -> None:
+    """The adjacent pgw#1576 finding: the v2 worker wired NO emitter, so
+    `ctx.progress` hit `_emit_event`'s "no emitter configured" branch on every
+    pod and the hub's liveness sweep read positions nobody sent."""
+    captured = _CapturedWorker()
+    captured.run("complete", {"prompt": "p", "max_tokens": 2})
+
+    events = [
+        msgspec.json.decode(f.data)
+        for f in captured.progress
+        if f.content_type == EVENT_CONTENT_TYPE
+    ]
+    progress = [e for e in events if e["type"] == "request.progress"]
+    assert [e["payload"]["step"] for e in progress] == [1, 2]
+    assert progress[-1]["payload"]["stage"] == "decode"
+    assert progress[-1]["payload"]["progress"] == 1.0
+
+
+# -- 5. the manifest ---------------------------------------------------------
+
+
+def _rows() -> dict:
+    from gen_worker.discovery.entrypoints_v2 import discover_entrypoints
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        return {row["name"]: row for row in discover_entrypoints(MODULE)}
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+
+def test_publish_reports_the_stream_without_running_the_body() -> None:
+    rows = _rows()
+
+    streamed = rows["complete"]
+    assert streamed["incremental_output"] is True
+    # The hub decodes `delta_output_schema` on the SAME `manifestFunction` an
+    # `entrypoints[]` row lands in, so this reaches
+    # `endpoint_function_schemas.delta_output_schema` with no hub change.
+    delta = streamed["delta_output_schema"]
+    assert delta["$ref"] == "#/$defs/TokenDelta"
+    assert delta["$defs"]["TokenDelta"]["properties"]["text"]["type"] == "string"
+    # ...and the terminal schema is untouched: a non-streaming caller still
+    # reads one struct.
+    assert set(
+        streamed["output_schema"]["$defs"]["Completion"]["properties"]
+    ) == {"text", "tokens"}
+
+    caption_delta = rows["caption"]["delta_output_schema"]
+    assert "finished" in caption_delta["$defs"]["ItemDelta"]["properties"]
+
+    # Two shapes, one handler: a DISCRIMINATED anyOf, so a client reading the
+    # manifest knows both frames and how to tell them apart.
+    union = rows["narrate"]["delta_output_schema"]
+    assert union["discriminator"]["propertyName"] == "type"
+    assert set(union["discriminator"]["mapping"]) == {"TokenDelta", "ItemDelta"}
+
+    plain = rows["silent"]
+    assert plain["incremental_output"] is False
+    assert "delta_output_schema" not in plain
+
+
+# -- 6. the tombstone --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name, successor",
+    [
+        ("IncrementalTokenDelta", "gen_worker.TokenDelta"),
+        ("BatchItemDelta", "gen_worker.ItemDelta"),
+    ],
+)
+def test_the_deleted_names_now_name_their_successor(name: str, successor: str) -> None:
+    """They were deleted BY OMISSION — no successor line, so an author got a
+    bare ImportError and the gap read as an oversight instead of a ruling."""
+    import gen_worker
+    from gen_worker.v1_deleted import V1SdkDeleted
+
+    with pytest.raises(V1SdkDeleted) as excinfo:
+        getattr(gen_worker, name)
+    assert successor in str(excinfo.value)
+
+
+def test_the_transformers_helper_imports_instead_of_refusing() -> None:
+    """`iter_transformers_text_deltas` came back verbatim — same name, same
+    signature — so joycaption's call site ports unchanged."""
+    import gen_worker
+
+    assert callable(gen_worker.iter_transformers_text_deltas)


### PR DESCRIPTION
Closes the P0 that blocked three endpoint ports (`qwen3.6-35b-a3b`, `qwen3.6-27b-mtp-gguf`, `joycaption`). Tracker: pgw#1576, design section under the checklist.

## The ruling in one line

**The async generator is refused, and the refusal is the design.**

The wire carries two things that promise different amounts: `JobProgress` deltas are ordered, live, never persisted and **droppable by contract**; `JobResult` is the single authoritative output every non-streaming caller and the request record read. Python forbids `return <value>` inside an async generator, so `-> AsyncIterator[Delta]` can express the droppable half and *nothing else* — the terminal would have to be folded out of the deltas by the platform (v1's `StreamAccumulator`: magic field-peeling over three blessed types, `Any`-typed content) or smuggled in as a special last frame. And the hub asks for **two** schemas, not one: `manifestFunction` decodes `delta_output_schema` **and** `incremental_output`, and `entrypoints[]` *is* `[]manifestFunction`.

```python
@entrypoint(streams=TokenDelta)                          # the DELTA type
async def complete(ctx: RequestContext, payload: CompletionInput,
                   model: QwenModel) -> Completion:      # the TERMINAL type
    parts = []
    async for token in engine.stream(payload.prompt):
        ctx.raise_if_cancelled()
        parts.append(token)
        ctx.emit(TokenDelta(text=token))
    return Completion(text="".join(parts))
```

* the body stays an ordinary `async def` (or `def`) returning a struct, so `serve_loop`'s existing `asyncio.run` drive is untouched — there is no `isasyncgen` branch because there is no async generator;
* `ctx.emit` is **sync and thread-safe**, so joycaption's plain `def` handler streams with the identical call;
* it refuses an undeclared function and a foreign chunk — the `publishes=` shape verbatim, one fact two enforcers;
* publish reads `streams=` off the spec: `incremental_output` + `delta_output_schema`, **no author code executed**, **no hub change**;
* a generator entrypoint refuses at import naming `streams=` + `ctx.emit`, instead of the generic "return type must be a msgspec.Struct" that would send its author hunting for a schema defect that is not there.

## The delta vocabulary

`TokenDelta` (more of ONE output → concatenable `text/plain`) and `ItemDelta` (WHICH of N outputs advanced → tagged JSON) — two types because they answer two questions; collapsing them hands every token five fields it must leave at zero. `Delta` is the base for author types, tagged on `type` so `streams=(TokenDelta, ItemDelta)` — one handler, two shapes — publishes a discriminated `anyOf`.

⚠️ v1's binary `BatchItemDelta.chunk` + `application/x-batch-item+msgpack` is **not** restored: the hub renders every non-`audio/*` chunk as `payload["delta"] = string(d.Data)` inside a JSON SSE envelope, so it was undeliverable. `iter_transformers_text_deltas` comes back verbatim; the two struct names get real tombstone rows (they had none — deleted by omission).

## Adjacent finding, fixed on the same seam

**`ctx.progress` was dead on every v2 pod.** `worker.py` built its `ServeLoop` with no emitter at all, so `_emit_event` hit its "no emitter configured" branch and `ctx.progress` / `log` / `warning` / `checkpoint` were silently discarded — while the hub's liveness sweep reads `request.progress` positions. Same defect shape as pgw#1418/#1475. The ctx-event lane and the delta lane are ONE `JobProgress` emitter with ONE per-`(request, attempt)` `seq`, stamped on the loop so send order and seq order cannot disagree.

And the v1 observable: the send queue's two progress-drop sites were silent since they were written. Each now emits one `serve_degrade` row whose detail is stable per `(request, attempt)`, so the hub's upsert conflict key folds a shedding storm into `occurrences+1` rather than a row per lost token.

## Tests

`tests/test_streaming_entrypoints.py` — 19, CPU, no weights, no GPU: declaration + the generator refusal, framing, the **real `ServeLoop`** (async body, sync body, two-shapes body, both refusals), and **`Worker._run_one` with a capturing transport**: N ordered `JobProgress` frames — deltas plus the revived ctx-event lane — followed by exactly one `JobResult` carrying the whole output. Manifest assertions read the real `discover_entrypoints` rows.

Neighbouring suites green (`test_endpoint_discovery`, `test_serve_path_wires`, `test_weightless_entrypoints`, `test_failure_traceback`, `test_reserved_repo_contract`, `test_serve_loop_envelope` — one pre-existing failure there, `test_the_envelope_serves_end_to_end_with_fake_tensors`, reproduced identically on master: it asserts `0.0 GiB` on a box that has a GPU). mypy strict clean over 652 files; ruff, changelog, unreached-surface and fence guards green.