### PR TITLE
pgw#1577: keep the denoiser resident — free the bytes you need, and PROVE the plan on the card

### DIFF
--- a/changelog.d/pgw1577.md
+++ b/changelog.d/pgw1577.md
@@ -1,0 +1,26 @@
+- **pgw#1577: a new `partial_resident` rung — offload the minimum BYTES, not every
+  component.** `model_offload` is all-or-nothing: it evicts the whole pipeline after every
+  request and re-onloads it before the next. Measured on an RTX 4070 Laptop, SDXL: **13 GiB
+  of PCIe per request** — 6.5 GiB out, 6.5 GiB back, at ~2.7 GB/s effective — to reclaim the
+  **1.2 GiB** the pipeline was actually over budget by, which is ~4.8 s of a ~7.0 s fixed
+  per-request cost against ComfyUI's 2.61 s on the same card. Nothing about the placement
+  decision required that. The new rung asks which SUBSET of components clears the budget,
+  takes the one that moves the fewest bytes (fewest bytes, not fewest components — a single
+  1.5 GiB encoder costs more per request than two 0.6 GiB ones), and keeps the denoiser on
+  the card between requests. On SDXL at 7.3 GiB free it evicts the two text encoders and
+  holds UNet+VAE resident: **1.64 GiB per request instead of 13.**
+- **pgw#1577: an evicted component is mirrored in PINNED host RAM, so there is no copy
+  back.** Weights are read-only during inference, so the host mirror never goes stale and
+  `park()` is a pointer swap rather than a device-to-host copy. That deletes half the traffic
+  outright, and the half that remains is a pinned H2D rather than accelerate's pageable one.
+- **pgw#1577: admission-first, never reactive.** The resident set is computed once at load
+  from free VRAM and measured component sizes — budget, and a transient ceiling for the
+  onload of the largest evicted component — and never changes at runtime. There is no
+  eviction loop for pgw#1560's non-raising allocator thrash to live in, and no except-OOM
+  retry: an OOM inside a compiled graph is process death. A plan that does not fit REFUSES
+  and names why, and the load falls to `model_offload` exactly as before.
+- **pgw#1577: `unhookable_components` is now enforced for real on this rung.**
+  `_pin_unhookable_components` sets diffusers' `_exclude_from_cpu_offload`, but diffusers
+  consults that list ONLY for components absent from `model_cpu_offload_seq` — and SDXL's
+  `force_upcast` VAE, the one gw#441/gw#469 requires to stay resident, is in that sequence.
+  The rung keeps forced-resident components out of its own eviction candidates.

--- a/src/gen_worker/measured_posture.py
+++ b/src/gen_worker/measured_posture.py
@@ -134,6 +134,7 @@ PLACEMENT_DISK = "disk"
 #: Technique names — the SDK's OWN rungs (`models/rung.py`) plus the levers that
 #: had no wire representation at all.
 TECHNIQUE_FP8_STORAGE = "fp8_storage"
+TECHNIQUE_PARTIAL_RESIDENT = "partial_resident"
 TECHNIQUE_MODEL_OFFLOAD = "model_offload"
 TECHNIQUE_GROUP_OFFLOAD = "group_offload"
 TECHNIQUE_SEQUENTIAL = "sequential"
@@ -378,6 +379,7 @@ _PLACEMENT_RESIDENCY: Dict[str, str] = {
     "": "",
     "off": RESIDENCY_ALL_RESIDENT,
     "vae_only": RESIDENCY_ALL_RESIDENT,
+    "partial_resident": TECHNIQUE_PARTIAL_RESIDENT,
     "model_offload": TECHNIQUE_MODEL_OFFLOAD,
     "group_offload": TECHNIQUE_GROUP_OFFLOAD,
     "sequential": TECHNIQUE_SEQUENTIAL,
@@ -388,6 +390,7 @@ _PLACEMENT_RESIDENCY: Dict[str, str] = {
 #: the worker's estimate OF the lever, not a property of the run, and two SDK
 #: versions estimating it differently must not fork one posture's identity.
 _TECHNIQUE_SLOWDOWN: Dict[str, float] = {
+    TECHNIQUE_PARTIAL_RESIDENT: 1.3,
     TECHNIQUE_MODEL_OFFLOAD: 2.5,
     TECHNIQUE_GROUP_OFFLOAD: 3.0,
     TECHNIQUE_SEQUENTIAL: 4.0,

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -41,6 +41,7 @@ from .. import measured_posture as posture_mod
 from . import machine_fit
 from ..api.errors import HostRamMoveRefusedError
 from ..component_vocab import component_vocabulary
+from .partial_resident import PARTIAL_RESIDENT_DEVICE_ATTR
 from .structure_only import STAMP as _STRUCTURE_ONLY
 import asyncio
 from ..hostfacts import cuda_ready
@@ -53,8 +54,8 @@ _GIB = 1024 ** 3
 Mode = str  # "auto" | "off" | "vae_only" | "model_offload" | "group_offload" | "sequential" | "cpu"
 
 _VALID_MODES: tuple[str, ...] = (
-    "auto", "off", "vae_only", "partial_stream", "model_offload",
-    "group_offload", "sequential", "cpu",
+    "auto", "off", "vae_only", "partial_resident", "partial_stream",
+    "model_offload", "group_offload", "sequential", "cpu",
 )
 
 _DEFAULT_MODEL_OFFLOAD_THRESHOLD_GB = 8.0
@@ -1481,6 +1482,55 @@ def _pin_unhookable_components(
         )
 
 
+def _execution_device() -> Any:
+    """The device an offload rung onloads TO. Index 0, like every other rung
+    here (``enable_model_cpu_offload(gpu_id=0)``)."""
+    return "cuda:0"
+
+
+def _plan_partial_resident(pipeline: Any, log: logging.Logger) -> Any:
+    """The pgw#1577 component-residency plan, or None to keep ``model_offload``.
+
+    None is the answer whenever the subset search cannot beat the coarse rung —
+    the denoiser alone over budget, an unmeasurable tree, no CUDA. It is never
+    an exception: this sits on the load path of every offloaded pipeline, and a
+    planner that raises would take out placements that work today.
+    """
+    try:
+        from .partial_resident import (
+            PARTIAL_RESIDENT_RESERVE_GB,
+            plan_for_pipeline,
+        )
+
+        free_gb = get_available_vram_gb()
+        if free_gb <= 0.0:
+            return None
+        plan = plan_for_pipeline(
+            pipeline,
+            budget_bytes=int(max(0.0, free_gb - PARTIAL_RESIDENT_RESERVE_GB) * _GIB),
+            free_bytes=int(free_gb * _GIB),
+            sizer=lambda m: module_storage_bytes(m),
+            forced_resident=unhookable_components(pipeline),
+        )
+    except Exception as exc:
+        log.warning(
+            "low_vram: could not plan component residency (%s: %s); keeping "
+            "model_offload", type(exc).__name__, exc,
+        )
+        return None
+    if not plan.fits:
+        log.info("low_vram: partial_resident declined — %s", plan.refusal)
+        return None
+    if not plan.offloaded:
+        # Nothing to evict means the pipeline fits resident, which is a fit
+        # decision `select_auto_mode` already made against a different margin.
+        # Do not overrule it from here.
+        return None
+    log.info("low_vram: upgrading model_offload -> partial_resident: %s",
+             plan.summary())
+    return plan
+
+
 #: The typed phase a `partial_stream` arming FAILURE confesses under. A rung
 #: that could not arm and fell through to a coarser one is a placement the
 #: operator asked for and did not get — pgw#1497 measured that exact silence on
@@ -2135,6 +2185,35 @@ def attention_kernel_census(pipeline: Any) -> str:
     )
 
 
+def component_placement_census(pipeline: Any) -> str:
+    """Where each weight-bearing component's tensors actually LIVE, read off
+    the objects.
+
+    pgw#1577, and the same lesson pgw#1570 learned about attention: the rung a
+    log names is the decision, not the outcome. ``_pin_unhookable_components``
+    has been setting ``_exclude_from_cpu_offload`` and reporting
+    ``vae_resident`` since gw#441 — and diffusers consults that list ONLY for
+    components absent from ``model_cpu_offload_seq``, where SDXL's ``vae`` is
+    not, so the claim was decorative and nothing could see that. A census can.
+    """
+    parts: List[str] = []
+    for name, comp in _named_components(pipeline):
+        if not hasattr(comp, "parameters"):
+            continue
+        devices: Dict[str, int] = {}
+        try:
+            for t in comp.parameters(recurse=True):
+                key = str(t.device)
+                devices[key] = devices.get(key, 0) + 1
+        except Exception:  # noqa: BLE001 - a census must not fail a placement
+            continue
+        if not devices:
+            continue
+        where = "/".join(sorted(devices, key=lambda d: -devices[d]))
+        parts.append(f"{name}@{where}")
+    return "placement=" + (",".join(parts) if parts else "unreadable")
+
+
 def _report_offload_engaged(
     pipeline: Any, rung: str, applied: Dict[str, Any], log: logging.Logger,
 ) -> None:
@@ -2163,7 +2242,8 @@ def _report_offload_engaged(
             needed_gb=needed_gb, free_gb=free_gb,
             detail=f"CPU offload ENGAGED ({_applied_summary(applied)}); every "
                    f"forward on this pipeline now moves weights over PCIe; "
-                   f"{attention_kernel_census(pipeline)}",
+                   f"{attention_kernel_census(pipeline)}; "
+                   f"{component_placement_census(pipeline)}",
         ),
         detail=(
             f"pipeline={type(pipeline).__name__}: CPU offload ENGAGED at rung "
@@ -2235,6 +2315,14 @@ def install_execution_device_fallback() -> bool:
         armed_device = getattr(armed, "device", None) if armed is not None else None
         if armed_device is not None and getattr(armed, "plan", None) is not None:
             return armed_device
+        # pgw#1577. The SAME repair for `partial_resident`, which breaks the
+        # same public answer for the same reason: an evicted text encoder is
+        # parked on the host and the original getter answers with whichever
+        # component it reaches first. The rung records the device its resident
+        # set actually executes on, and that is the honest answer.
+        resident_device = getattr(self, PARTIAL_RESIDENT_DEVICE_ATTR, None)
+        if resident_device is not None:
+            return resident_device
         if getattr(got, "type", None) != "meta":
             return got
         if getattr(reentry, "active", False):
@@ -2380,12 +2468,34 @@ def apply_low_vram_config(
                 effective_mode, int(stream_budget_bytes) / _GIB,
             )
 
+    # pgw#1577. `model_offload` evicts EVERY component after EVERY request and
+    # re-onloads the lot before the next one. Measured on the campaign card,
+    # SDXL: 13 GiB of PCIe per request — 6.5 GiB out, 6.5 GiB back — to reclaim
+    # the 1.2 GiB the pipeline was over budget by. Nothing about the placement
+    # decision required that; the rung is simply all-or-nothing. So before
+    # taking it, ask whether a SUBSET of components clears the budget, and keep
+    # the denoiser on the card if one does. Paul, 2026-08-20: *"if the space is
+    # available, and it helps us run faster, why wouldn't varena take it?"*
+    #
+    # ADMISSION-FIRST, and that is the whole safety argument (pgw#1560): the
+    # plan is computed ONCE, here, from free VRAM and measured component sizes,
+    # and the resident set never changes again. There is no eviction loop for a
+    # non-raising allocator to thrash inside, and no except-OOM retry — an OOM
+    # in a compiled graph is process death, so before the weights land is the
+    # only honest place to decide.
+    partial_resident_plan = None
+    if effective_mode == "model_offload":
+        partial_resident_plan = _plan_partial_resident(pipeline, log)
+        if partial_resident_plan is not None:
+            effective_mode = "partial_resident"
+
     applied: Dict[str, Any] = {
         "mode": effective_mode,
         "vae_slicing": False,
         "vae_tiling": False,
         "attention_slicing": False,
         "partial_stream": False,
+        "partial_resident": False,
         "model_offload": False,
         "group_offload": False,
         "sequential_offload": False,
@@ -2480,6 +2590,32 @@ def apply_low_vram_config(
             "low_vram: partial_stream did not arm; descending to model_offload"
         )
         applied["partial_stream"] = False
+        effective_mode = "model_offload"
+        applied["mode"] = effective_mode
+
+    if effective_mode == "partial_resident" and partial_resident_plan is not None:
+        from .partial_resident import (
+            PARTIAL_RESIDENT_UNARMED_PHASE,
+            apply_component_residency,
+        )
+
+        if apply_component_residency(
+            pipeline, partial_resident_plan, device=_execution_device(), log=log,
+        ):
+            applied["partial_resident"] = True
+            applied["partial_resident_offloaded"] = list(
+                partial_resident_plan.offloaded
+            )
+            applied["partial_resident_bytes"] = partial_resident_plan.offloaded_bytes
+            setattr(pipeline, _COZY_MODE_ATTR, "partial_resident")
+            _report_offload_engaged(pipeline, "partial_resident", applied, log)
+            return applied
+        # Same discipline as `partial_stream`: a rung the operator was told
+        # about and did not get is a placement lie. Confess and descend.
+        log.warning(
+            "low_vram: partial_resident did not arm; descending to "
+            "model_offload (%s)", PARTIAL_RESIDENT_UNARMED_PHASE,
+        )
         effective_mode = "model_offload"
         applied["mode"] = effective_mode
 

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -1488,7 +1488,9 @@ def _execution_device() -> Any:
     return "cuda:0"
 
 
-def _plan_partial_resident(pipeline: Any, log: logging.Logger) -> Any:
+def _plan_partial_resident(
+    pipeline: Any, log: logging.Logger, *, min_moved_bytes: int = 0,
+) -> Any:
     """The pgw#1577 component-residency plan, or None to keep ``model_offload``.
 
     None is the answer whenever the subset search cannot beat the coarse rung —
@@ -1511,6 +1513,7 @@ def _plan_partial_resident(pipeline: Any, log: logging.Logger) -> Any:
             free_bytes=int(free_gb * _GIB),
             sizer=lambda m: module_storage_bytes(m),
             forced_resident=unhookable_components(pipeline),
+            min_moved_bytes=min_moved_bytes,
         )
     except Exception as exc:
         log.warning(
@@ -2595,18 +2598,39 @@ def apply_low_vram_config(
 
     if effective_mode == "partial_resident" and partial_resident_plan is not None:
         from .partial_resident import (
+            _MAX_PROBE_ATTEMPTS,
             PARTIAL_RESIDENT_UNARMED_PHASE,
             apply_component_residency,
         )
 
-        if apply_component_residency(
-            pipeline, partial_resident_plan, device=_execution_device(), log=log,
-        ):
-            applied["partial_resident"] = True
-            applied["partial_resident_offloaded"] = list(
-                partial_resident_plan.offloaded
+        # THE PROBE LOOP, and it is why this rung is admission-first WITHOUT
+        # being estimate-first (pgw#1577). The planner's transient ceiling is
+        # arithmetic over the two numbers it can read — component sizes and free
+        # VRAM — and on the campaign card that arithmetic admitted a plan whose
+        # onload then died 5 MiB short, because allocator fragmentation and a
+        # co-tenant's share are in neither. So each plan is DONE once before it
+        # is trusted, and a plan the card refuses is followed by the
+        # next-cheapest one rather than by giving up on the rung. Bounded, and
+        # every attempt is at load: no OOM can reach a request from here.
+        plan = partial_resident_plan
+        armed = False
+        for _ in range(_MAX_PROBE_ATTEMPTS):
+            armed = apply_component_residency(
+                pipeline, plan, device=_execution_device(), log=log,
+                free_bytes_now=lambda: int(get_available_vram_gb() * _GIB),
             )
-            applied["partial_resident_bytes"] = partial_resident_plan.offloaded_bytes
+            if armed:
+                break
+            nxt = _plan_partial_resident(
+                pipeline, log, min_moved_bytes=plan.offloaded_bytes
+            )
+            if nxt is None:
+                break
+            plan = nxt
+        if armed:
+            applied["partial_resident"] = True
+            applied["partial_resident_offloaded"] = list(plan.offloaded)
+            applied["partial_resident_bytes"] = plan.offloaded_bytes
             setattr(pipeline, _COZY_MODE_ATTR, "partial_resident")
             _report_offload_engaged(pipeline, "partial_resident", applied, log)
             return applied

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -1,0 +1,512 @@
+"""Component-granular residency — offload the MINIMUM bytes, keep the rest.
+
+``model_offload`` is all-or-nothing: every component leaves the card after every
+request and comes back over PCIe before the next one. Measured on an RTX 4070
+with SDXL (pgw#1577) that is **13 GiB of traffic per request** — 6.5 GiB in,
+6.5 GiB out, ~4.8 s at the card's ~2.7 GB/s effective rate — to reclaim the
+**1.2 GiB** the pipeline was actually over budget by. ComfyUI's
+``free_memory(memory_required)`` frees only what it must; this rung is that
+policy at component granularity.
+
+The plan is computed ONCE, before any weight lands, from free VRAM and measured
+component sizes. The resident set never changes at runtime, so there is no
+eviction loop for pgw#1560's non-raising allocator thrash to live in, and no
+except-OOM retry: an OOM inside a compiled graph is process death, so admission
+is the only honest place to decide.
+
+The mechanism is a PINNED HOST MIRROR per evicted component, not accelerate's
+``CpuOffload``. Weights are read-only during inference, so the host copy never
+goes stale and eviction is a pointer swap rather than a device-to-host copy —
+which deletes half of ``model_offload``'s bill outright, and leaves the other
+half as a pinned H2D instead of a pageable one. Three rules hold the arithmetic
+the plan admitted:
+
+* an evicted component's forward-pre-hook onloads it and parks every other one,
+  so at most one is ever on the card;
+* the first RESIDENT module after the chain parks them all, so the encoders are
+  gone BEFORE the denoise loop rather than at the end of the call;
+* ``maybe_free_model_hooks`` is replaced, because the stock one re-runs
+  ``enable_model_cpu_offload``, whose first statement is ``self.to("cpu")`` —
+  that would bounce the resident denoiser off the card and back on every single
+  call, which is strictly worse than the rung it replaces.
+
+It also honors ``unhookable_components`` for real. ``_exclude_from_cpu_offload``
+does not: diffusers consults it only for components ABSENT from
+``model_cpu_offload_seq``, and SDXL's ``vae`` — the ``force_upcast`` one
+gw#441/gw#469 requires to stay resident — is in that sequence.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Any, Collection, Dict, List, Mapping, Optional, Sequence, Tuple
+
+_GIB = 1 << 30
+
+#: Set on a pipeline this rung armed: the :class:`ResidencyPlan` it armed, so a
+#: later reader can state the resident set without re-deriving it.
+COMPONENT_RESIDENCY_ATTR = "_cozy_component_residency"
+
+#: Set on a pipeline this rung armed: ``{name: ParkedComponent}``, so a later
+#: reader can state where each evicted component actually is.
+PARKED_COMPONENTS_ATTR = "_cozy_parked_components"
+
+#: The device this rung's resident set actually executes on. ``DiffusionPipeline.device``
+#: answers with the FIRST component's device, and an evicted encoder parked on
+#: the host makes that ``cpu`` for a pipeline whose denoiser is on the card —
+#: the same public-answer break pgw#1497 measured for ``partial_stream``, where
+#: the endpoint then builds ``input_ids`` on the host and the first embedding
+#: dies with *"index is on cpu, different from other tensors on cuda:0"*.
+#: ``memory.install_execution_device_fallback`` reads this.
+PARTIAL_RESIDENT_DEVICE_ATTR = "_cozy_partial_resident_device"
+
+#: The typed phase an arming FAILURE confesses under, mirroring
+#: ``PARTIAL_STREAM_UNARMED_PHASE``: a rung that could not arm and fell through
+#: to a coarser one is a placement the operator asked for and did not get.
+PARTIAL_RESIDENT_UNARMED_PHASE = "partial_resident_unarmed"
+
+#: Headroom held back for the transient onload of an offloaded component. Text
+#: encoding runs at 77 tokens and its activations are noise next to the weights
+#: being moved; this covers the allocator's own slack and fragmentation during
+#: the copy. On the campaign card it is also what decides between two admissible
+#: SDXL plans — evicting `text_encoder_2` alone peaks at 6.95 GiB of 7.3 free
+#: (96%), evicting both encoders peaks at 6.70 (92%) for 0.25 GiB more traffic.
+#: The second is the trade this number buys, and it buys it by ARITHMETIC.
+_TRANSIENT_RESERVE_BYTES = 512 * (1 << 20)
+
+#: The activation headroom this rung reserves, and it is NOT
+#: ``memory._DEFAULT_SAFETY_MARGIN_GB``. That 2.0 GiB is a PLACEMENT heuristic
+#: for the resident-vs-offload decision, deliberately pessimistic because it
+#: guards a rung with no offload at all. Here the measurement exists: pgw#1570
+#: recorded SDXL 1024^2 batch-2 CFG at a 5956 MiB peak with 5437 MiB of weights
+#: resident — **519 MiB of activations**. 1.25 GiB is 2.4x that, and holding
+#: back 2.0 would refuse the plan that keeps the denoiser resident, which is
+#: Paul's ruling inverted: *"if the space is available, and it helps us run
+#: faster, why wouldn't varena take it?"*
+PARTIAL_RESIDENT_RESERVE_GB = 1.25
+
+
+@dataclass(frozen=True)
+class ResidencyPlan:
+    """Which components stay on the card, which commute, and the arithmetic.
+
+    ``fits`` is the only verdict. ``refusal`` names why not, and is "" exactly
+    when ``fits`` — a plan that does not fit must say what beat it, because the
+    caller's next move (fall to ``model_offload``) erases the evidence.
+    """
+
+    resident: Tuple[str, ...]
+    offloaded: Tuple[str, ...]
+    resident_bytes: int
+    offloaded_bytes: int
+    budget_bytes: int
+    transient_peak_bytes: int
+    free_bytes: int
+    fits: bool
+    refusal: str = ""
+
+    def summary(self) -> str:
+        return (
+            f"resident={','.join(self.resident) or '-'} "
+            f"({self.resident_bytes / _GIB:.2f} GiB) "
+            f"offloaded={','.join(self.offloaded) or '-'} "
+            f"({self.offloaded_bytes / _GIB:.2f} GiB/request, H2D only) "
+            f"budget={self.budget_bytes / _GIB:.2f} GiB "
+            f"transient_peak={self.transient_peak_bytes / _GIB:.2f} GiB "
+            f"free={self.free_bytes / _GIB:.2f} GiB"
+        )
+
+
+def plan_component_residency(
+    *,
+    sizes: Mapping[str, int],
+    order: Sequence[str],
+    denoiser: str,
+    forced_resident: Collection[str] = (),
+    budget_bytes: int,
+    free_bytes: int,
+    transient_reserve_bytes: int = _TRANSIENT_RESERVE_BYTES,
+) -> ResidencyPlan:
+    """The minimum-BYTES subset of components to evict, or a refusal.
+
+    Minimum bytes, not minimum count: every evicted byte is paid twice per
+    request (out and back), so the cheapest plan that fits is the one that moves
+    the least — which is usually neither the largest component nor the smallest
+    number of them. ``order`` is the pipeline's own execution order and is what
+    makes the transient peak a single component rather than a sum: an offloaded
+    component is released by the next one's pre-forward, so at most one of them
+    is on the card at a time.
+
+    The denoiser is never a candidate. It is the component the rung exists to
+    keep — evicting it reproduces ``model_offload`` at a higher complexity.
+    """
+    known = [n for n in order if n in sizes]
+    known += sorted(n for n in sizes if n not in known)
+    total = sum(int(sizes[n]) for n in known)
+    forced = {str(n) for n in forced_resident}
+    forced.add(str(denoiser))
+
+    if denoiser not in sizes:
+        return ResidencyPlan(
+            (), (), total, 0, budget_bytes, total, free_bytes, False,
+            f"no denoiser named {denoiser!r} among {known}",
+        )
+
+    pinned_bytes = sum(int(sizes[n]) for n in known if n in forced)
+    if pinned_bytes > budget_bytes:
+        return ResidencyPlan(
+            (), (), total, 0, budget_bytes, total, free_bytes, False,
+            f"the forced-resident set alone is {pinned_bytes / _GIB:.2f} GiB "
+            f"against a {budget_bytes / _GIB:.2f} GiB budget",
+        )
+
+    candidates = [n for n in known if n not in forced and int(sizes[n]) > 0]
+    best: Optional[Tuple[int, int, Tuple[str, ...]]] = None
+    # Few components (<= 8 in every shipped family), so the EXACT answer is
+    # cheap. It is also the only correct one: fewest components and fewest bytes
+    # are different plans — evicting one 1.5 GiB encoder to free 1.0 GiB moves
+    # more per request than evicting two 0.6 GiB ones — and bytes is what PCIe
+    # charges for. Every subset is enumerated for that reason.
+    for k in range(0, len(candidates) + 1):
+        for subset in combinations(candidates, k):
+            moved = sum(int(sizes[n]) for n in subset)
+            resident_bytes = total - moved
+            if resident_bytes > budget_bytes:
+                continue
+            # One at a time: each offloaded component is released by the next
+            # one's pre-forward (or by the release hook on the first resident
+            # module after the chain), so the transient ceiling sees the largest
+            # of them, never their sum. An empty subset has no transient at all.
+            peak = resident_bytes + max(
+                (int(sizes[n]) for n in subset), default=0
+            )
+            ceiling = max(0, free_bytes - transient_reserve_bytes)
+            if subset and peak > ceiling:
+                continue
+            key = (moved, len(subset), subset)
+            if best is None or key < best:
+                best = key
+
+    if best is None:
+        return ResidencyPlan(
+            (), (), total, 0, budget_bytes, total, free_bytes, False,
+            f"no subset of {candidates or ['(nothing evictable)']} brings "
+            f"{total / _GIB:.2f} GiB under the {budget_bytes / _GIB:.2f} GiB "
+            f"budget without breaking the transient ceiling",
+        )
+
+    moved, _, subset = best
+    offloaded = tuple(n for n in known if n in set(subset))
+    resident = tuple(n for n in known if n not in set(subset))
+    resident_bytes = total - moved
+    peak = resident_bytes + max((int(sizes[n]) for n in offloaded), default=0)
+    return ResidencyPlan(
+        resident, offloaded, resident_bytes, moved, budget_bytes, peak,
+        free_bytes, True, "",
+    )
+
+
+def _component_sizes(
+    pipeline: Any, names: Sequence[str], sizer: Any
+) -> Dict[str, int]:
+    sizes: Dict[str, int] = {}
+    for name in names:
+        comp = getattr(pipeline, name, None)
+        if comp is None or not hasattr(comp, "parameters"):
+            continue
+        try:
+            n = int(sizer(comp))
+        except Exception:
+            continue
+        if n > 0:
+            sizes[name] = n
+    return sizes
+
+
+def _pipeline_component_names(pipeline: Any) -> List[str]:
+    names: List[str] = []
+    seq = str(getattr(pipeline, "model_cpu_offload_seq", "") or "")
+    for part in seq.split("->"):
+        part = part.strip()
+        if part and part not in names:
+            names.append(part)
+    try:
+        components = dict(getattr(pipeline, "components", {}) or {})
+    except Exception:
+        components = {}
+    for name in components:
+        if name not in names:
+            names.append(str(name))
+    return names
+
+
+def _denoiser_name(pipeline: Any, names: Sequence[str]) -> str:
+    """The component whose residency is the point. Named by attribute, in the
+    order diffusers itself uses across families."""
+    for candidate in ("unet", "transformer", "prior", "decoder"):
+        if candidate in names and getattr(pipeline, candidate, None) is not None:
+            return candidate
+    return ""
+
+
+def plan_for_pipeline(
+    pipeline: Any,
+    *,
+    budget_bytes: int,
+    free_bytes: int,
+    sizer: Any,
+    forced_resident: Collection[str] = (),
+    transient_reserve_bytes: int = _TRANSIENT_RESERVE_BYTES,
+) -> ResidencyPlan:
+    """:func:`plan_component_residency` against a live pipeline's own tree."""
+    names = _pipeline_component_names(pipeline)
+    sizes = _component_sizes(pipeline, names, sizer)
+    denoiser = _denoiser_name(pipeline, list(sizes))
+    return plan_component_residency(
+        sizes=sizes,
+        order=names,
+        denoiser=denoiser,
+        forced_resident=forced_resident,
+        budget_bytes=budget_bytes,
+        free_bytes=free_bytes,
+        transient_reserve_bytes=transient_reserve_bytes,
+    )
+
+
+class ParkedComponent:
+    """One offloaded component, mirrored in PINNED host RAM.
+
+    **Weights are read-only during inference**, so the host mirror never goes
+    stale — and that single fact is what lets ``park`` be a pointer swap rather
+    than a device-to-host copy. Half of ``model_offload``'s PCIe bill is that
+    copy, paid on every component on every request for data the host already
+    had. The half that remains is a PINNED H2D, which the card takes at roughly
+    4x the pageable rate accelerate's ``CpuOffload`` gets.
+
+    The invariant has a cost: anything that MUTATES weights in place after
+    arming (a fused LoRA, a dtype cast) invalidates the mirror. Arming happens
+    once at load, before serving, like every other rung, and re-arming is how a
+    mutation is absorbed.
+    """
+
+    __slots__ = ("name", "module", "_slots", "_torch", "_device", "on_device", "bytes")
+
+    def __init__(self, name: str, module: Any, slots: List[Any], torch_mod: Any,
+                 device: Any, nbytes: int) -> None:
+        self.name = name
+        self.module = module
+        self._slots = slots
+        self._torch = torch_mod
+        self._device = device
+        self.on_device = False
+        self.bytes = nbytes
+
+    @classmethod
+    def mirror(
+        cls, name: str, module: Any, *, device: Any, torch_mod: Any,
+        log: logging.Logger,
+    ) -> Optional["ParkedComponent"]:
+        """Snapshot ``module``'s weights into pinned host RAM and park it.
+
+        Returns None — having changed nothing — when any tensor cannot be
+        represented (meta, or an alias into a larger storage). A half-moved
+        component is the one outcome worse than not arming.
+        """
+        from .staging import alloc_pinned_like
+        from .stream_residency import own_tensors, tensor_bytes
+
+        pending: List[Any] = []
+        total = 0
+        for sub in module.modules():
+            for attr, is_param, tensor in own_tensors(sub):
+                if tensor.is_meta or tensor.storage_offset() != 0:
+                    log.warning(
+                        "partial_resident: %s.%s is meta or a partial-view "
+                        "alias; the component cannot be mirrored", name, attr,
+                    )
+                    return None
+                host = alloc_pinned_like(torch_mod, tensor)
+                if host is None:
+                    host = torch_mod.empty_like(tensor, device="cpu")
+                host.copy_(tensor)
+                total += tensor_bytes(host)
+                pending.append((sub, attr, is_param, host))
+        if not pending:
+            return None
+        parked = cls(name, module, pending, torch_mod, device, total)
+        parked._bind_host()
+        return parked
+
+    def _bind_host(self) -> None:
+        from .stream_residency import bind_tensor
+
+        with self._torch.no_grad():
+            for sub, attr, is_param, host in self._slots:
+                bind_tensor(sub, attr, host, is_param)
+        self.on_device = False
+
+    def park(self) -> None:
+        """Drop the device copy. No copy back — the mirror is authoritative."""
+        if not self.on_device:
+            return
+        self._bind_host()
+
+    def onload(self) -> None:
+        """Pinned, non-blocking H2D."""
+        if self.on_device:
+            return
+        from .stream_residency import bind_tensor
+
+        with self._torch.no_grad():
+            for sub, attr, is_param, host in self._slots:
+                try:
+                    pinned = bool(host.is_pinned())
+                except Exception:  # noqa: BLE001
+                    pinned = False
+                bind_tensor(
+                    sub, attr, host.to(self._device, non_blocking=pinned), is_param
+                )
+        self.on_device = True
+
+
+def _install_residency_hooks(
+    pipeline: Any, parked: Dict[str, ParkedComponent], order: Sequence[str],
+    log: logging.Logger,
+) -> None:
+    """One rule, applied everywhere: **at most one parked component is on the
+    card at a time.** Each parked component's pre-forward onloads itself and
+    parks the others; the first RESIDENT module after the chain parks them all,
+    which is what puts the encoders off the card BEFORE the denoise loop rather
+    than at the end of the call. Both are the arithmetic
+    :func:`plan_component_residency` admitted, enforced rather than assumed."""
+
+    def _park_all_but(keep: str = "") -> None:
+        for name, comp in parked.items():
+            if name != keep:
+                comp.park()
+
+    for name, comp in parked.items():
+        def _pre(_m: Any, _a: Any, _n: str = name, _c: ParkedComponent = comp) -> None:
+            _park_all_but(_n)
+            _c.onload()
+
+        comp.module.register_forward_pre_hook(_pre)
+
+    seen_parked = False
+    for name in order:
+        if name in parked:
+            seen_parked = True
+            continue
+        if not seen_parked:
+            continue
+        module = getattr(pipeline, name, None)
+        if module is None or not hasattr(module, "register_forward_pre_hook"):
+            continue
+
+        def _release(_m: Any, _a: Any) -> None:
+            _park_all_but()
+
+        module.register_forward_pre_hook(_release)
+        break
+
+    def maybe_free_model_hooks(_self: Any = pipeline) -> None:
+        """THE TRAP THIS OVERRIDE EXISTS FOR (pgw#1577):
+        ``DiffusionPipeline.maybe_free_model_hooks`` ends by calling
+        ``enable_model_cpu_offload``, whose FIRST statement is
+        ``self.to("cpu")``. Left in place it drags the resident denoiser to the
+        host and back on every call — the exact cost this rung deletes,
+        reintroduced at the end of the request instead of the start."""
+        for component in dict(getattr(_self, "components", {}) or {}).values():
+            reset = getattr(component, "_reset_stateful_cache", None)
+            if callable(reset):
+                reset()
+        _park_all_but()
+
+    pipeline.maybe_free_model_hooks = maybe_free_model_hooks
+    # The stock method returns early on an empty `_all_hooks`, so anything that
+    # still reaches the base implementation is a no-op rather than a re-arm.
+    pipeline._all_hooks = []
+    log.debug("partial_resident: hooks installed for %s", ",".join(parked))
+
+
+def apply_component_residency(
+    pipeline: Any,
+    plan: ResidencyPlan,
+    *,
+    device: Any,
+    log: logging.Logger,
+) -> bool:
+    """Arm ``plan`` on ``pipeline``. Returns whether it armed.
+
+    A False return means nothing was armed and the caller must fall to the next
+    rung — never that a partial arrangement was left behind.
+    """
+    if not plan.fits:
+        return False
+    try:
+        import torch
+    except Exception as exc:
+        log.warning("partial_resident: unavailable (%s: %s)", type(exc).__name__, exc)
+        return False
+
+    dev = torch.device(device)
+    parked: Dict[str, ParkedComponent] = {}
+    try:
+        remove = getattr(pipeline, "remove_all_hooks", None)
+        if callable(remove):
+            remove()
+        for name in plan.resident:
+            comp = getattr(pipeline, name, None)
+            if comp is not None and hasattr(comp, "to"):
+                comp.to(dev)
+        for name in plan.offloaded:
+            comp = getattr(pipeline, name, None)
+            if comp is None:
+                continue
+            mirrored = ParkedComponent.mirror(
+                name, comp, device=dev, torch_mod=torch, log=log
+            )
+            if mirrored is None:
+                log.warning(
+                    "partial_resident: %s could not be mirrored; the caller "
+                    "falls to the next rung", name,
+                )
+                return False
+            parked[name] = mirrored
+        if not parked:
+            log.warning(
+                "partial_resident: the plan named %d component(s) to offload "
+                "and none could be parked", len(plan.offloaded),
+            )
+            return False
+        _install_residency_hooks(
+            pipeline, parked, _pipeline_component_names(pipeline), log
+        )
+    except Exception as exc:
+        log.warning(
+            "partial_resident: arming failed (%s: %s); the caller falls to the "
+            "next rung", type(exc).__name__, exc,
+        )
+        return False
+
+    setattr(pipeline, COMPONENT_RESIDENCY_ATTR, plan)
+    setattr(pipeline, PARKED_COMPONENTS_ATTR, parked)
+    setattr(pipeline, PARTIAL_RESIDENT_DEVICE_ATTR, dev)
+    log.info("partial_resident: armed — %s", plan.summary())
+    return True
+
+
+__all__ = [
+    "COMPONENT_RESIDENCY_ATTR",
+    "PARKED_COMPONENTS_ATTR",
+    "PARTIAL_RESIDENT_DEVICE_ATTR",
+    "PARTIAL_RESIDENT_RESERVE_GB",
+    "PARTIAL_RESIDENT_UNARMED_PHASE",
+    "ParkedComponent",
+    "ResidencyPlan",
+    "apply_component_residency",
+    "plan_component_residency",
+    "plan_for_pipeline",
+]

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -106,6 +106,18 @@ _TRANSIENT_RESERVE_BYTES = 512 * (1 << 20)
 #: faster, why wouldn't varena take it?"*
 PARTIAL_RESIDENT_RESERVE_GB = 1.25
 
+#: What the ON-CARD PROBE demands still be free with the largest evicted
+#: component onloaded. The arithmetic above is an ESTIMATE — measured on the
+#: campaign card it admitted a plan that then OOMed by 5 MiB — and no constant
+#: fitted to one card fixes that, because the allocator's fragmentation and the
+#: co-tenants' share are not in any of the numbers the planner can read. So the
+#: plan is checked by DOING it once, at load, before a request can hit it.
+_PROBE_FLOOR_BYTES = 256 * (1 << 20)
+
+#: How many progressively more expensive plans the probe may reject before the
+#: rung gives up and lets the load fall to `model_offload`.
+_MAX_PROBE_ATTEMPTS = 4
+
 
 @dataclass(frozen=True)
 class ResidencyPlan:
@@ -147,8 +159,15 @@ def plan_component_residency(
     budget_bytes: int,
     free_bytes: int,
     transient_reserve_bytes: int = _TRANSIENT_RESERVE_BYTES,
+    min_moved_bytes: int = 0,
 ) -> ResidencyPlan:
     """The minimum-BYTES subset of components to evict, or a refusal.
+
+    ``min_moved_bytes`` asks for the next plan STRICTLY more expensive than a
+    given one. It exists because the arithmetic here is an estimate and the
+    allocator is not: :func:`apply_component_residency` probes the plan it was
+    given on the real card, and when the probe says no the caller comes back for
+    the next-cheapest one rather than giving up on the rung.
 
     Minimum bytes, not minimum count: every evicted byte is paid twice per
     request (out and back), so the cheapest plan that fits is the one that moves
@@ -203,6 +222,8 @@ def plan_component_residency(
             )
             ceiling = max(0, free_bytes - transient_reserve_bytes)
             if subset and peak > ceiling:
+                continue
+            if moved <= min_moved_bytes:
                 continue
             key = (moved, len(subset), subset)
             if best is None or key < best:
@@ -278,6 +299,7 @@ def plan_for_pipeline(
     sizer: Any,
     forced_resident: Collection[str] = (),
     transient_reserve_bytes: int = _TRANSIENT_RESERVE_BYTES,
+    min_moved_bytes: int = 0,
 ) -> ResidencyPlan:
     """:func:`plan_component_residency` against a live pipeline's own tree."""
     names = _pipeline_component_names(pipeline)
@@ -291,6 +313,7 @@ def plan_for_pipeline(
         budget_bytes=budget_bytes,
         free_bytes=free_bytes,
         transient_reserve_bytes=transient_reserve_bytes,
+        min_moved_bytes=min_moved_bytes,
     )
 
 
@@ -450,17 +473,42 @@ def _install_residency_hooks(
     log.debug("partial_resident: hooks installed for %s", ",".join(parked))
 
 
+def probe_plan(
+    parked: Dict[str, ParkedComponent], *, free_bytes_now: Any,
+    floor_bytes: int = _PROBE_FLOOR_BYTES,
+) -> tuple[bool, int]:
+    """DO the worst onload once and read what is left. Returns (ok, free_bytes).
+
+    The planner's transient ceiling is arithmetic over numbers it can read, and
+    on the campaign card that arithmetic admitted a plan whose onload then died
+    5 MiB short — because allocator fragmentation and a co-tenant's share are in
+    neither the component sizes nor the free-VRAM probe. This is the same
+    question asked of the card instead of of a constant, and it costs one copy
+    at load.
+    """
+    if not parked:
+        return True, int(free_bytes_now())
+    worst = max(parked.values(), key=lambda c: c.bytes)
+    worst.onload()
+    free = int(free_bytes_now())
+    worst.park()
+    return free >= floor_bytes, free
+
+
 def apply_component_residency(
     pipeline: Any,
     plan: ResidencyPlan,
     *,
     device: Any,
     log: logging.Logger,
+    free_bytes_now: Any = None,
 ) -> bool:
-    """Arm ``plan`` on ``pipeline``. Returns whether it armed.
+    """Arm ``plan`` on ``pipeline``, PROBING it on the card first. Returns
+    whether it armed.
 
-    A False return means nothing was armed and the caller must fall to the next
-    rung — never that a partial arrangement was left behind.
+    A False return means nothing was armed and the caller either asks for a
+    more expensive plan or falls to the next rung — never that a partial
+    arrangement was left behind.
     """
     if not plan.fits:
         return False
@@ -500,6 +548,23 @@ def apply_component_residency(
                 "and none could be parked", len(plan.offloaded),
             )
             return False
+        if free_bytes_now is not None:
+            ok, free = probe_plan(parked, free_bytes_now=free_bytes_now)
+            if not ok:
+                log.warning(
+                    "partial_resident: PROBE REFUSED %s — onloading the largest "
+                    "evicted component left %.2f GiB free, under the %.2f GiB "
+                    "floor. The plan's arithmetic said %.2f GiB peak of %.2f "
+                    "free; the card disagrees, and the card is right.",
+                    ",".join(plan.offloaded), free / _GIB,
+                    _PROBE_FLOOR_BYTES / _GIB,
+                    plan.transient_peak_bytes / _GIB, plan.free_bytes / _GIB,
+                )
+                return False
+            log.info(
+                "partial_resident: probe OK — %.2f GiB still free with %s "
+                "onloaded", free / _GIB, ",".join(plan.offloaded),
+            )
         _install_residency_hooks(
             pipeline, parked, _pipeline_component_names(pipeline), log
         )
@@ -528,4 +593,5 @@ __all__ = [
     "apply_component_residency",
     "plan_component_residency",
     "plan_for_pipeline",
+    "probe_plan",
 ]

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -67,14 +67,19 @@ PARTIAL_RESIDENT_DEVICE_ATTR = "_cozy_partial_resident_device"
 #: to a coarser one is a placement the operator asked for and did not get.
 PARTIAL_RESIDENT_UNARMED_PHASE = "partial_resident_unarmed"
 
-#: Headroom held back for the transient onload of an offloaded component. Text
-#: encoding runs at 77 tokens and its activations are noise next to the weights
-#: being moved; this covers the allocator's own slack and fragmentation during
-#: the copy. On the campaign card it is also what decides between two admissible
-#: SDXL plans — evicting `text_encoder_2` alone peaks at 6.95 GiB of 7.3 free
-#: (96%), evicting both encoders peaks at 6.70 (92%) for 0.25 GiB more traffic.
-#: The second is the trade this number buys, and it buys it by ARITHMETIC.
-_TRANSIENT_RESERVE_BYTES = 512 * (1 << 20)
+#: Allocator slack for the ONLOAD COPY itself — and nothing else. It is NOT an
+#: activation estimate: the only phase in which an evicted component is on the
+#: card is the one that runs it (text encoding, 77 tokens), whose activations are
+#: noise next to the weights being moved. The activation estimate is the BUDGET's
+#: `PARTIAL_RESIDENT_RESERVE_GB`, and it guards the denoise phase, where
+#: activations actually exist.
+#:
+#: MEASURED CLIFF, found on the card and recorded because the number looks
+#: arbitrary otherwise: at 512 MiB this check REFUSED the whole rung once free
+#: VRAM dropped from 7.3 to 7.1 GiB — a 200 MiB shift by a co-tenant silently
+#: reverting SDXL to the 13 GiB-per-request rung. Charging a denoise-sized
+#: reserve against an encode-sized phase is what produced that cliff.
+_TRANSIENT_RESERVE_BYTES = 256 * (1 << 20)
 
 #: The activation headroom this rung reserves, and it is NOT
 #: ``memory._DEFAULT_SAFETY_MARGIN_GB``. That 2.0 GiB is a PLACEMENT heuristic

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -67,19 +67,33 @@ PARTIAL_RESIDENT_DEVICE_ATTR = "_cozy_partial_resident_device"
 #: to a coarser one is a placement the operator asked for and did not get.
 PARTIAL_RESIDENT_UNARMED_PHASE = "partial_resident_unarmed"
 
-#: Allocator slack for the ONLOAD COPY itself — and nothing else. It is NOT an
-#: activation estimate: the only phase in which an evicted component is on the
-#: card is the one that runs it (text encoding, 77 tokens), whose activations are
-#: noise next to the weights being moved. The activation estimate is the BUDGET's
-#: `PARTIAL_RESIDENT_RESERVE_GB`, and it guards the denoise phase, where
-#: activations actually exist.
+#: Headroom held back for the transient onload of an evicted component.
 #:
-#: MEASURED CLIFF, found on the card and recorded because the number looks
-#: arbitrary otherwise: at 512 MiB this check REFUSED the whole rung once free
-#: VRAM dropped from 7.3 to 7.1 GiB — a 200 MiB shift by a co-tenant silently
-#: reverting SDXL to the 13 GiB-per-request rung. Charging a denoise-sized
-#: reserve against an encode-sized phase is what produced that cliff.
-_TRANSIENT_RESERVE_BYTES = 256 * (1 << 20)
+#: MEASURED TWICE ON THE CARD, and both numbers are in the record because the
+#: first one was mine and it was wrong:
+#:
+#: * At **512 MiB** the check refused the whole rung once free VRAM fell from
+#:   7.3 to 7.1 GiB — a co-tenant taking 200 MiB reverting SDXL to
+#:   `model_offload`. A performance cliff.
+#: * At **256 MiB** the rung admitted the single-encoder plan (6.95 GiB peak of
+#:   7.3 free, 96%) and the onload **OOMed in `ParkedComponent.onload`**:
+#:   *"Tried to allocate 20.00 MiB … 14.94 MiB is free … this process has
+#:   6.96 GiB in use."* A failed request.
+#:
+#: The 256 MiB reasoning — "the encode phase has no activations to reserve for"
+#: — is wrong about the mechanism. The caching allocator does not return the
+#: DENOISE phase's blocks between requests, so the next request's encode does
+#: not start on a clean card: it starts on a pool that still holds them, next to
+#: whatever co-tenants took. The reserve must cover both, and it is therefore an
+#: activation-sized number after all.
+#:
+#: The two failures are not symmetric. 512 MiB's cliff falls back to today's
+#: rung — slow, correct, loud. 256 MiB's failure is an OOM on a paid request.
+#: That asymmetry picks the number, not the arithmetic.
+#:
+#: OWED: the cliff is real and should be closed by a ceiling that scales with
+#: the card rather than a constant subtracted from it. Filed with the rung.
+_TRANSIENT_RESERVE_BYTES = 512 * (1 << 20)
 
 #: The activation headroom this rung reserves, and it is NOT
 #: ``memory._DEFAULT_SAFETY_MARGIN_GB``. That 2.0 GiB is a PLACEMENT heuristic

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -217,7 +217,7 @@ def _default_free_vram_bytes(group: Optional[DeviceGroup] = None) -> int:
 def _obj_manages_own_device(obj: Any) -> bool:
     """diffusers offload hooks own placement; manual .to() would break them."""
     return getattr(obj, "_cozy_low_vram_mode", None) in (
-        "model_offload", "group_offload", "sequential",
+        "partial_resident", "model_offload", "group_offload", "sequential",
     )
 
 

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -66,6 +66,25 @@ RUN_CPU = "cpu"
 
 NATIVE = Rung("native", "", "", RUN_NATIVE, 1.0, False)
 FP8_STORAGE = Rung("fp8_storage", "", "fp8", RUN_FP8_STORAGE, 1.05, False)
+# pgw#1577 — COMPONENT-granular residency: evict the minimum-BYTE subset of
+# components that clears the budget and keep everything else, denoiser first,
+# on the card between requests. It sits ABOVE `model_offload` because it is
+# strictly cheaper on the same placement decision: same fit test, a subset of
+# the traffic. Measured cause on the campaign card (SDXL, RTX 4070 Laptop):
+# `model_offload` moves 13 GiB per request — the whole pipeline out and back —
+# to reclaim 1.2 GiB, at ~2.7 GB/s effective, which is ~4.8 s of the ~7.0 s
+# fixed per-request cost. This rung moves 1.64 GiB, one way, from pinned host
+# RAM, because a weight the host still holds needs no copy back.
+#
+# ADMISSION-ONLY, for the same reason `partial_stream` is: the resident set is
+# chosen from free VRAM and component sizes at LOAD, and the reactive OOM
+# descent has neither in hand when it fires. `_walk` therefore sends any
+# resident token to `model_offload`, exactly as before, and `price(RUN_OFFLOAD)`
+# keeps answering with `model_offload`'s coarse number rather than this rung's.
+PARTIAL_RESIDENT = Rung(
+    "partial_resident", "partial_resident", "", RUN_OFFLOAD, 1.3, True,
+    admission_only=True,
+)
 MODEL_OFFLOAD = Rung("model_offload", "model_offload", "", RUN_OFFLOAD, 2.5, True)
 # pgw#1497 — per-LEAF-MODULE budgeted residency, the tail cast per forward from
 # pinned host RAM (`models.stream_residency`). The only rung with a BUDGET: the
@@ -132,8 +151,8 @@ CPU = Rung("cpu", "cpu", "", RUN_CPU, 40.0, True)
 
 #: The ONE ordering, best first. ``descend`` walks it; nothing else may.
 LADDER: tuple[Rung, ...] = (
-    NATIVE, FP8_STORAGE, MODEL_OFFLOAD, PARTIAL_STREAM, GROUP_OFFLOAD, SEQUENTIAL,
-    CPU,
+    NATIVE, FP8_STORAGE, PARTIAL_RESIDENT, MODEL_OFFLOAD, PARTIAL_STREAM,
+    GROUP_OFFLOAD, SEQUENTIAL, CPU,
 )
 
 #: The reactive placement tail, shallowest first (gw#463): a load-time CUDA

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -1,0 +1,396 @@
+"""Component-granular residency: the admission arithmetic and the mechanism.
+
+Lineage: pgw#1577. The mechanism tests drive a REAL ``diffusers.DiffusionPipeline``
+through ``diffusers``' own offload code with ``torch.nn.Module.to`` counted — the
+same instrument the issue's decomposition used, just on the CPU execution device
+so it runs without a card. The counter is what makes the defect visible: the
+stock rung moves every component every request, and the first test here asserts
+that it does. If that test ever goes green without the second changing, the
+instrument has gone blind.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, cast
+
+import pytest
+
+torch = pytest.importorskip("torch")
+diffusers = pytest.importorskip("diffusers")
+
+from diffusers import DiffusionPipeline, ModelMixin  # noqa: E402
+from diffusers.configuration_utils import ConfigMixin, register_to_config  # noqa: E402
+
+from gen_worker.models.partial_resident import (  # noqa: E402
+    PARKED_COMPONENTS_ATTR,
+    PARTIAL_RESIDENT_RESERVE_GB,
+    apply_component_residency,
+    plan_component_residency,
+    COMPONENT_RESIDENCY_ATTR,
+    plan_for_pipeline,
+)
+
+_MIB = 1 << 20
+_GIB = 1 << 30
+
+# SDXL bf16, measured on the campaign card (pgw#1577).
+_SDXL = {
+    "text_encoder": int(0.25 * _GIB),
+    "text_encoder_2": int(1.39 * _GIB),
+    "unet": int(5.14 * _GIB),
+    "vae": int(0.17 * _GIB),
+}
+_SDXL_ORDER = ("text_encoder", "text_encoder_2", "unet", "vae")
+
+
+def _plan(sizes, *, free_gb, budget_gb=None, forced=(), denoiser="unet", order=None):
+    if budget_gb is None:
+        budget_gb = free_gb - PARTIAL_RESIDENT_RESERVE_GB
+    return plan_component_residency(
+        sizes=sizes,
+        order=order or tuple(sizes),
+        denoiser=denoiser,
+        forced_resident=forced,
+        budget_bytes=int(budget_gb * _GIB),
+        free_bytes=int(free_gb * _GIB),
+    )
+
+
+# --------------------------------------------------------------------------
+# Admission arithmetic
+# --------------------------------------------------------------------------
+
+
+def test_sdxl_on_a_7_3_gib_card_keeps_the_denoiser_and_evicts_the_encoders():
+    # free 7.3, reserve 1.25 -> budget 6.05. Weights 6.95; must free 0.90.
+    # {text_encoder_2} alone (1.39) clears the budget and is the fewest bytes,
+    # but its transient peak is 6.95 of 7.3 free — 96% — so the reserve rejects
+    # it. `vae` is forced resident on this family — it is the `force_upcast`
+    # one — so the arithmetic takes both encoders at 1.64 and a 6.70 peak.
+    plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
+    assert plan.fits, plan.refusal
+    assert plan.offloaded == ("text_encoder", "text_encoder_2")
+    assert plan.resident == ("unet", "vae")
+    # The whole point: per-request traffic collapses from the pipeline's full
+    # weight set, twice over, to the encoders once.
+    assert plan.offloaded_bytes < sum(_SDXL.values()) / 4
+
+
+def test_a_roomier_card_evicts_only_the_one_component_it_has_to():
+    # Same pipeline, 7.6 GiB free: the tighter plan the reserve rejected above is
+    # admissible here, and the search takes it. The policy is the arithmetic,
+    # not a hardcoded component list.
+    plan = _plan(_SDXL, free_gb=7.6, order=_SDXL_ORDER)
+    assert plan.fits, plan.refusal
+    assert plan.offloaded == ("text_encoder_2",)
+
+
+def test_fewest_bytes_wins_over_fewest_components():
+    # Freeing 1.0 GiB: one 1.5 GiB component fits and so do two 0.6 GiB ones.
+    # PCIe charges bytes, so the pair is the cheaper plan, and a search that
+    # stopped at the first admitting subset size would pick the single.
+    sizes = {"unet": 4 * _GIB, "big": int(1.5 * _GIB), "a": int(0.6 * _GIB),
+             "b": int(0.6 * _GIB)}
+    plan = _plan(sizes, budget_gb=5.7, free_gb=16.0)
+    assert plan.fits, plan.refusal
+    assert plan.offloaded == ("a", "b")
+    assert plan.offloaded_bytes == int(1.2 * _GIB)
+
+
+def test_the_denoiser_is_never_a_candidate_for_eviction():
+    plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
+    assert "unet" not in plan.offloaded
+
+
+def test_a_denoiser_larger_than_the_budget_refuses_rather_than_evicting_it():
+    # This is where `model_offload` remains the right rung, and the plan must
+    # say so instead of quietly producing one that reproduces it.
+    plan = _plan(_SDXL, budget_gb=4.0, free_gb=6.0, order=_SDXL_ORDER)
+    assert not plan.fits
+    assert "forced-resident set" in plan.refusal
+
+
+def test_forced_resident_components_are_never_evicted():
+    # SDXL's force_upcast VAE (gw#441/gw#469) must stay on the card. Diffusers'
+    # own `_exclude_from_cpu_offload` does NOT achieve this — it is consulted
+    # only for components absent from `model_cpu_offload_seq`, and `vae` is in
+    # SDXL's — so this rung enforces it itself.
+    plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
+    assert plan.fits, plan.refusal
+    assert "vae" not in plan.offloaded
+
+
+def test_the_transient_ceiling_rejects_a_plan_the_budget_alone_admits():
+    # Budget says the resident set fits; onloading the evicted component during
+    # the request would still exceed free VRAM. Admission has to see both, or
+    # the rung OOMs mid-encode on a plan that looked fine at load.
+    sizes = {"unet": 5 * _GIB, "encoder": 3 * _GIB}
+    roomy = _plan(sizes, budget_gb=5.0, free_gb=9.0)
+    assert roomy.fits and roomy.offloaded == ("encoder",)
+    tight = _plan(sizes, budget_gb=5.0, free_gb=8.4)
+    assert not tight.fits
+    assert "transient ceiling" in tight.refusal
+
+
+def test_a_plan_that_fits_reports_the_arithmetic_it_used():
+    plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
+    assert plan.resident_bytes + plan.offloaded_bytes == sum(_SDXL.values())
+    assert plan.resident_bytes <= plan.budget_bytes
+    assert plan.transient_peak_bytes == plan.resident_bytes + _SDXL["text_encoder_2"]
+    assert plan.refusal == ""
+    assert "text_encoder_2" in plan.summary()
+
+
+def test_a_refusal_always_names_a_reason():
+    plan = _plan({"vae": _GIB}, budget_gb=8.0, free_gb=12.0, denoiser="unet")
+    assert not plan.fits
+    assert plan.refusal
+
+
+# --------------------------------------------------------------------------
+# Mechanism, against real diffusers code
+# --------------------------------------------------------------------------
+
+
+class _Block(ModelMixin, ConfigMixin):
+    @register_to_config
+    def __init__(self, width: int = 8):
+        super().__init__()
+        self.lin = torch.nn.Linear(width, width)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+class _ThreeStagePipeline(DiffusionPipeline):
+    """A real ``DiffusionPipeline``: diffusers' own offload code runs on it.
+
+    The component attributes are created by ``register_modules`` at runtime and
+    carry no annotations upstream, so they are declared here rather than
+    silenced per line."""
+
+    model_cpu_offload_seq = "text_encoder->unet->vae"
+    text_encoder: Any
+    unet: Any
+    vae: Any
+
+    def __init__(self, text_encoder: Any, unet: Any, vae: Any) -> None:
+        super().__init__()
+        cast(Any, self).register_modules(
+            text_encoder=text_encoder, unet=unet, vae=vae
+        )
+
+    def run_once(self) -> None:
+        self.text_encoder(torch.randn(2, 8))
+        for _ in range(3):  # a denoise loop, in miniature
+            self.unet(torch.randn(2, 16))
+        self.vae(torch.randn(2, 4))
+        cast(Any, self).maybe_free_model_hooks()
+
+
+def _pipeline():
+    return _ThreeStagePipeline(_Block(8), _Block(16), _Block(4))
+
+
+class _MoveCounter:
+    """Counts ``Module.to`` by component. This is the PCIe bill, on a device
+    where the copies are free — the count is the fact under test."""
+
+    def __init__(self, pipe):
+        self.moved: List[str] = []
+        self._names = {
+            id(m): n for n, m in pipe.components.items()
+            if isinstance(m, torch.nn.Module)
+        }
+        self._orig = torch.nn.Module.to
+
+    def __enter__(self):
+        names, moved, orig = self._names, self.moved, self._orig
+
+        def counted(module, *args, **kwargs):
+            name = names.get(id(module))
+            if name is not None:
+                moved.append(name)
+            return orig(module, *args, **kwargs)
+
+        torch.nn.Module.to = counted
+        return self
+
+    def __exit__(self, *exc):
+        torch.nn.Module.to = self._orig
+        return False
+
+
+def test_stock_model_offload_moves_every_component_every_request():
+    """THE DEFECT, stated as a passing test. `model_offload` evicts the whole
+    pipeline after each call and re-onloads it before the next — on SDXL that
+    is 13 GiB of PCIe per request to reclaim 1.2 GiB (pgw#1577)."""
+    pipe = _pipeline()
+    pipe.enable_model_cpu_offload(device="cpu")
+    with _MoveCounter(pipe) as counter:
+        pipe.run_once()
+    assert "unet" in counter.moved, (
+        "the stock rung is supposed to move the denoiser every request; if it "
+        "no longer does, this counter is measuring the wrong thing"
+    )
+    assert set(counter.moved) == {"text_encoder", "unet", "vae"}
+
+
+def _arm(pipe, **kw):
+    plan = plan_for_pipeline(
+        pipe,
+        budget_bytes=kw.pop("budget_bytes", 1200),
+        free_bytes=kw.pop("free_bytes", 64 * _MIB),
+        transient_reserve_bytes=kw.pop("transient_reserve_bytes", 0),
+        sizer=lambda m: sum(p.numel() * p.element_size() for p in m.parameters()),
+        **kw,
+    )
+    armed = apply_component_residency(
+        pipe, plan, device="cpu", log=logging.getLogger("t")
+    )
+    return plan, armed
+
+
+def test_partial_residency_never_moves_the_components_it_kept():
+    pipe = _pipeline()
+    plan, armed = _arm(pipe, forced_resident=("vae",))
+    assert plan.fits, plan.refusal
+    assert plan.offloaded == ("text_encoder",)
+    assert armed
+    with _MoveCounter(pipe) as counter:
+        pipe.run_once()
+        pipe.run_once()
+    assert "unet" not in counter.moved, (
+        "the denoiser left the card — that is the whole cost this rung deletes"
+    )
+    assert "vae" not in counter.moved
+    assert getattr(pipe, COMPONENT_RESIDENCY_ATTR) is plan
+
+
+def test_an_evicted_component_lives_in_its_host_mirror_between_requests():
+    pipe = _pipeline()
+    _, armed = _arm(pipe)
+    assert armed
+    parked = getattr(pipe, PARKED_COMPONENTS_ATTR)["text_encoder"]
+    assert not parked.on_device
+    pipe.text_encoder(torch.randn(2, 8))
+    assert parked.on_device
+    pipe.maybe_free_model_hooks()
+    assert not parked.on_device, (
+        "the request ended with an evicted component still holding VRAM"
+    )
+
+
+def test_at_most_one_evicted_component_holds_the_card_at_a_time():
+    """The transient ceiling the plan admitted assumes exactly this. If two can
+    be resident together the admission arithmetic is a fiction."""
+    pipe = _pipeline()
+    plan = plan_component_residency(
+        sizes={"text_encoder": 400, "unet": 1000, "vae": 300},
+        order=("text_encoder", "unet", "vae"),
+        denoiser="unet",
+        budget_bytes=1000,
+        free_bytes=2000,
+        transient_reserve_bytes=0,
+    )
+    assert plan.fits and set(plan.offloaded) == {"text_encoder", "vae"}
+    assert apply_component_residency(
+        pipe, plan, device="cpu", log=logging.getLogger("t")
+    )
+    parked = getattr(pipe, PARKED_COMPONENTS_ATTR)
+    pipe.text_encoder(torch.randn(2, 8))
+    pipe.vae(torch.randn(2, 4))
+    assert sum(p.on_device for p in parked.values()) == 1
+
+
+def test_the_evicted_component_is_released_before_the_denoiser_runs():
+    """It must be off the card BEFORE the denoise loop, not at the end of the
+    call — otherwise the peak the plan admitted is a floor the request never
+    comes back under."""
+    pipe = _pipeline()
+    _, armed = _arm(pipe)
+    assert armed
+    parked = getattr(pipe, PARKED_COMPONENTS_ATTR)["text_encoder"]
+    pipe.text_encoder(torch.randn(2, 8))
+    assert parked.on_device
+    pipe.unet(torch.randn(2, 16))
+    assert not parked.on_device, (
+        "the encoder was still holding VRAM during the denoise loop"
+    )
+
+
+def test_arming_does_not_change_what_the_pipeline_computes():
+    pipe = _pipeline()
+    torch.manual_seed(0)
+    probe = torch.randn(2, 8)
+    before = pipe.text_encoder(probe).detach().clone()
+    _, armed = _arm(pipe)
+    assert armed
+    after = pipe.text_encoder(probe)
+    assert torch.equal(before, after)
+    pipe.maybe_free_model_hooks()
+    assert torch.equal(before, pipe.text_encoder(probe))
+
+
+def test_the_free_hooks_override_does_not_re_arm_the_stock_rung():
+    """RED ARM for the trap that makes this rung worse than useless without it.
+
+    ``DiffusionPipeline.maybe_free_model_hooks`` ends by calling
+    ``enable_model_cpu_offload``, whose FIRST statement is ``self.to("cpu")``.
+    Left in place it drags the resident denoiser to the host and back on every
+    call. Delete the override in ``_install_residency_hooks`` and this fails.
+    """
+    pipe = _pipeline()
+    _arm(pipe)
+
+    rearmed: List[str] = []
+    stock = type(pipe).enable_model_cpu_offload
+
+    def watched(self, *args, **kwargs):
+        rearmed.append("re-armed")
+        return stock(self, *args, **kwargs)
+
+    type(pipe).enable_model_cpu_offload = watched
+    try:
+        pipe.maybe_free_model_hooks()
+    finally:
+        type(pipe).enable_model_cpu_offload = stock
+    assert rearmed == [], (
+        "the stock maybe_free_model_hooks re-ran enable_model_cpu_offload, "
+        "which starts with self.to('cpu') — the resident set is gone"
+    )
+
+
+def test_arming_refuses_a_plan_that_does_not_fit_rather_than_half_applying_it():
+    pipe = _pipeline()
+    plan = plan_for_pipeline(
+        pipe, budget_bytes=1, free_bytes=1,
+        sizer=lambda m: sum(p.numel() * p.element_size() for p in m.parameters()),
+    )
+    assert not plan.fits
+    assert not apply_component_residency(
+        pipe, plan, device="cpu", log=logging.getLogger("t")
+    )
+    assert getattr(pipe, COMPONENT_RESIDENCY_ATTR, None) is None
+
+
+def test_the_placement_census_reads_live_devices_not_the_flag_that_set_them():
+    """pgw#1577's red arm for the confession itself. `_pin_unhookable_components`
+    has reported `vae_resident` since gw#441 by setting diffusers'
+    `_exclude_from_cpu_offload` — a list diffusers consults ONLY for components
+    absent from `model_cpu_offload_seq`, where SDXL's `vae` is not. The claim
+    was decorative and nothing could see that. A census can, because it reads
+    the tensors."""
+    from gen_worker.models.memory import component_placement_census
+
+    pipe = _pipeline()
+    census = component_placement_census(pipe)
+    assert "unet@cpu" in census and "vae@cpu" in census
+    pipe.unet.to("meta")
+    moved = component_placement_census(pipe)
+    assert "unet@meta" in moved, (
+        "the census reported a device the component is not on — it is reading "
+        "a flag, not the tensors"
+    )
+    assert "vae@cpu" in moved

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -62,30 +62,31 @@ def _plan(sizes, *, free_gb, budget_gb=None, forced=(), denoiser="unet", order=N
 # --------------------------------------------------------------------------
 
 
-def test_sdxl_on_a_7_3_gib_card_keeps_the_denoiser_and_evicts_an_encoder():
+def test_sdxl_on_a_7_3_gib_card_keeps_the_denoiser_and_evicts_the_encoders():
     # free 7.3, reserve 1.25 -> budget 6.05. Weights 6.95; must free 0.90, and
     # `vae` is forced resident on this family (the `force_upcast` one), so the
-    # fewest bytes that clear it is {text_encoder_2} at 1.39.
+    # fewest bytes that clear the BUDGET is {text_encoder_2} at 1.39 — whose
+    # transient peak is 6.95 of 7.3, 96%. MEASURED: that plan OOMs in the
+    # onload. The transient ceiling rejects it and the search takes both
+    # encoders at 1.64 for a 6.70 peak.
     plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
     assert plan.fits, plan.refusal
-    assert plan.offloaded == ("text_encoder_2",)
-    assert plan.resident == ("text_encoder", "unet", "vae")
+    assert plan.offloaded == ("text_encoder", "text_encoder_2")
+    assert plan.resident == ("unet", "vae")
     # The whole point: per-request traffic collapses from the pipeline's full
     # weight set, twice over, to one encoder once.
     assert plan.offloaded_bytes < sum(_SDXL.values()) / 4
 
 
-def test_a_busier_card_evicts_more_rather_than_refusing_the_rung():
-    # 7.1 GiB free — a co-tenant took 200 MiB. The single-encoder plan's 6.95
-    # transient peak no longer clears the ceiling, so the search takes BOTH
-    # encoders at a 6.70 peak for 0.25 GiB more traffic. It must NOT refuse:
-    # refusing here reverts SDXL to model_offload's 13 GiB per request over a
-    # 200 MiB shift, which is the cliff a 512 MiB reserve actually produced on
-    # the card.
+def test_a_busier_card_refuses_the_rung_rather_than_admitting_a_plan_that_ooms():
+    # 7.1 GiB free — a co-tenant took 200 MiB. Nothing clears the transient
+    # ceiling any more, and the honest answer is to REFUSE and let the load fall
+    # to `model_offload`: slow, correct, loud. This IS a performance cliff and it
+    # is owed work (see `_TRANSIENT_RESERVE_BYTES`) — but the alternative was
+    # measured on this card and it is an OOM inside `ParkedComponent.onload`.
     plan = _plan(_SDXL, free_gb=7.1, forced=("vae",), order=_SDXL_ORDER)
-    assert plan.fits, plan.refusal
-    assert plan.offloaded == ("text_encoder", "text_encoder_2")
-    assert plan.resident == ("unet", "vae")
+    assert not plan.fits
+    assert "transient ceiling" in plan.refusal
 
 
 def test_fewest_bytes_wins_over_fewest_components():
@@ -130,7 +131,7 @@ def test_the_transient_ceiling_rejects_a_plan_the_budget_alone_admits():
     sizes = {"unet": 5 * _GIB, "encoder": 3 * _GIB}
     roomy = _plan(sizes, budget_gb=5.0, free_gb=9.0)
     assert roomy.fits and roomy.offloaded == ("encoder",)
-    tight = _plan(sizes, budget_gb=5.0, free_gb=8.2)
+    tight = _plan(sizes, budget_gb=5.0, free_gb=8.4)
     assert not tight.fits
     assert "transient ceiling" in tight.refusal
 

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -62,28 +62,30 @@ def _plan(sizes, *, free_gb, budget_gb=None, forced=(), denoiser="unet", order=N
 # --------------------------------------------------------------------------
 
 
-def test_sdxl_on_a_7_3_gib_card_keeps_the_denoiser_and_evicts_the_encoders():
-    # free 7.3, reserve 1.25 -> budget 6.05. Weights 6.95; must free 0.90.
-    # {text_encoder_2} alone (1.39) clears the budget and is the fewest bytes,
-    # but its transient peak is 6.95 of 7.3 free — 96% — so the reserve rejects
-    # it. `vae` is forced resident on this family — it is the `force_upcast`
-    # one — so the arithmetic takes both encoders at 1.64 and a 6.70 peak.
+def test_sdxl_on_a_7_3_gib_card_keeps_the_denoiser_and_evicts_an_encoder():
+    # free 7.3, reserve 1.25 -> budget 6.05. Weights 6.95; must free 0.90, and
+    # `vae` is forced resident on this family (the `force_upcast` one), so the
+    # fewest bytes that clear it is {text_encoder_2} at 1.39.
     plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
     assert plan.fits, plan.refusal
-    assert plan.offloaded == ("text_encoder", "text_encoder_2")
-    assert plan.resident == ("unet", "vae")
+    assert plan.offloaded == ("text_encoder_2",)
+    assert plan.resident == ("text_encoder", "unet", "vae")
     # The whole point: per-request traffic collapses from the pipeline's full
-    # weight set, twice over, to the encoders once.
+    # weight set, twice over, to one encoder once.
     assert plan.offloaded_bytes < sum(_SDXL.values()) / 4
 
 
-def test_a_roomier_card_evicts_only_the_one_component_it_has_to():
-    # Same pipeline, 7.6 GiB free: the tighter plan the reserve rejected above is
-    # admissible here, and the search takes it. The policy is the arithmetic,
-    # not a hardcoded component list.
-    plan = _plan(_SDXL, free_gb=7.6, order=_SDXL_ORDER)
+def test_a_busier_card_evicts_more_rather_than_refusing_the_rung():
+    # 7.1 GiB free — a co-tenant took 200 MiB. The single-encoder plan's 6.95
+    # transient peak no longer clears the ceiling, so the search takes BOTH
+    # encoders at a 6.70 peak for 0.25 GiB more traffic. It must NOT refuse:
+    # refusing here reverts SDXL to model_offload's 13 GiB per request over a
+    # 200 MiB shift, which is the cliff a 512 MiB reserve actually produced on
+    # the card.
+    plan = _plan(_SDXL, free_gb=7.1, forced=("vae",), order=_SDXL_ORDER)
     assert plan.fits, plan.refusal
-    assert plan.offloaded == ("text_encoder_2",)
+    assert plan.offloaded == ("text_encoder", "text_encoder_2")
+    assert plan.resident == ("unet", "vae")
 
 
 def test_fewest_bytes_wins_over_fewest_components():
@@ -128,7 +130,7 @@ def test_the_transient_ceiling_rejects_a_plan_the_budget_alone_admits():
     sizes = {"unet": 5 * _GIB, "encoder": 3 * _GIB}
     roomy = _plan(sizes, budget_gb=5.0, free_gb=9.0)
     assert roomy.fits and roomy.offloaded == ("encoder",)
-    tight = _plan(sizes, budget_gb=5.0, free_gb=8.4)
+    tight = _plan(sizes, budget_gb=5.0, free_gb=8.2)
     assert not tight.fits
     assert "transient ceiling" in tight.refusal
 


### PR DESCRIPTION
Closes the fixed-per-request half of the SDXL gap. pgw#1570 fixed the per-step half and its own commit hands this over: *"the fixed per-request cost is still ~5.6 s against ComfyUI's 2.61 s, which is `model_offload` re-onloading a 5.1 GB UNet over PCIe every request."*

## THE MERGE JUSTIFICATION IS A COUNT, NOT A WALL — read this first

Under `rung=resident->partial_resident` the confession carries, read off the live tensors:

```
placement=vae@cuda:0,text_encoder@cuda:0,text_encoder_2@cpu,unet@cuda:0
```

**The UNet stayed on the card between requests.** That is the entire thesis and it is proven. RED's line, from the same instrument on the same card, reads `rung=resident->model_offload` and carries no census at all.

The safety case is likewise made of counts: the probe **refused a real plan on the card** and the load fell to `model_offload` and served five requests without incident; the falsifier registered before the window **fired** and was answered with a design change rather than a third fitted constant; non-regression for sd15 and anima is **structural** (neither has ever engaged an offload rung, and this rung is reachable only from `model_offload`).

## ⚠️ THE WALL NUMBER IS UNSETTLED

| arm | rung | warm RT median | peak PID VRAM | 1m load |
|---|---|---|---|---|
| RED-1 (master) | `model_offload` | 27.68 s | 5956 MiB | 37.7 |
| GREEN | `partial_resident` | 21.85 s *(directional only)* | 7416 MiB | 41.9 |
| RED-2 (master) | `model_offload` | 34.45 s | 5956 MiB | 56.2 |

**21.85 s is DIRECTIONAL, not a result.** Three reasons, all disqualifying on their own: the two reference arms drifted **24.4 %** against a 15 % bar agreed before the window; the box's load climbed monotonically 37.7 → 41.9 → 56.2 across the three arms; and **that arm ran the PRE-PROBE code, arming a plan the shipping code now rejects.** A quiet-slot RED/GREEN/RED re-run on the shipping code is owed and tracked. Do not quote 21.85 s as this change's number.

## The cost this rung attacks

`model_offload` evicts every component after every request — diffusers' `maybe_free_model_hooks` re-runs `enable_model_cpu_offload`, whose first statement is `self.to("cpu")`, so it is unconditional by construction. On SDXL: **6.5 GiB out + 6.5 GiB back = 13 GiB of PCIe per request, ~4.8 s at ~2.7 GB/s — to reclaim the 1.2 GiB the pipeline was over budget by.**

## The rung

`partial_resident` asks which SUBSET of components clears the budget and takes the one that moves the **fewest bytes** (not fewest components — PCIe charges bytes). The denoiser is never a candidate. The mover is a **pinned host mirror**, not accelerate's `CpuOffload`: weights are read-only during inference, so the host copy never goes stale, eviction is a pointer swap, the D2H half of the bill disappears and the H2D half becomes pinned.

## The falsifier fired — and that is why this PR contains a probe

Registered before the window: *peak >7.2 GiB or any `oom_ladder` confession = the ceiling is wrong.* GREEN peaked at 7.24 GiB, and an earlier arm OOMed inside `ParkedComponent.onload` (`Tried to allocate 20.00 MiB … 14.94 MiB is free`). Two transient-reserve constants were fitted to this card and the card falsified both: 256 MiB OOMs a paid request, 512 MiB refuses the rung over a 200 MiB co-tenant shift.

**The reason is not the number.** The planner reads component sizes and free VRAM; allocator fragmentation carried over from the previous request's denoise blocks, and the share co-tenant processes hold, are in neither. So the plan is now **DONE once before it is trusted** — `probe_plan` onloads the largest evicted component at load, reads free VRAM, parks it, and REFUSES a plan leaving under 256 MiB, printing both the arithmetic it claimed and the number the card gave; the ladder then walks to the next-cheapest plan (`min_moved_bytes`). Bounded at four attempts, all at load, so no OOM from this path can reach a request. Still admission-first for #1560: resident set fixed before any request, no eviction loop, no except-OOM retry.

**The probe went red on the card in the same window**, which is the evidence that it is not decorative:

```
partial_resident: PROBE REFUSED text_encoder,text_encoder_2 — onloading the largest evicted
component left 0.17 GiB free, under the 0.25 GiB floor. The plan's arithmetic said 6.23 GiB
peak of 6.77 free; the card disagrees, and the card is right.
```

## A standing correctness argument found to be decorative

The fallback line reads `CPU offload ENGAGED (…,vae_resident) … placement=vae@cpu,…` — **both in one line.** `_pin_unhookable_components` has claimed since gw#441 that the `force_upcast` VAE stays resident by setting `_exclude_from_cpu_offload`; diffusers consults that list ONLY for components absent from `model_cpu_offload_seq`, and SDXL's `vae` is in it. The claim has been decorative for the life of the code and nothing could see it. The new `placement=<component>@<device>` census is read off the tensors, so the next such claim is falsifiable. Same lesson #1570 learned about attention kernels. Filed separately — it outlives this issue.

Also repaired: `DiffusionPipeline.device` answers with whichever component it reaches first, so a parked encoder makes it `cpu` for a pipeline executing on the card — the break #1497 fixed for `partial_stream`, same fix.

## Owed (tracked in `#1577`)

1. Quiet-slot re-measure of the shipping code — pre-approved by the coordinator.
2. The 512 MiB cliff — the ceiling should scale with the card rather than be a constant subtracted from it. The probe makes the cliff safe, not absent.

## Local state

18 tests (arithmetic + the mechanism driven through a REAL `DiffusionPipeline`), 134 green across every ladder-touching file, mypy clean, ruff clean, three lint scripts pass. The red arm is deliberate: `test_stock_model_offload_moves_every_component_every_request` asserts the defect still exists, so the green test cannot go quietly blind; delete the `maybe_free_model_hooks` override and `test_the_free_hooks_override_does_not_re_arm_the_stock_rung` fails.
