### PR TITLE
pgw#1567 + pgw#1548: the trace is keyed by the LANE, and a shape fan can collapse into one graph

### DIFF
--- a/benchmarks/dynamic_dims_pgw1548.py
+++ b/benchmarks/dynamic_dims_pgw1548.py
@@ -1,0 +1,627 @@
+"""pgw#1548 acceptance: dynamic dims vs the static bucket fan, per shape.
+
+Paul's gate, verbatim in shape: *"For SDXL, Anima, and SD1.5, do 'aspect ratio
+is dynamic dim' versus 'static dim, with many graph specializations' and then
+compile them and test inference time"*, plus a SEPARATE cost for the CFG axis
+(*"I doubt CFG can be a dynamic dim, but it's worth investigating how much time
+we lose if it is"*). Adoption is per axis and per model, and only where the
+regression is within a few percent.
+
+**The production serve path, not a rig.** Every number is a round-trip through
+`gen-worker up` + `gen-worker run` — the same two commands a cozy-local user
+types — because a hand-built pipeline measures a codepath nobody serves. The
+harness never imports diffusers itself.
+
+**Reported per shape, never averaged.** An average over aspect buckets is the
+one summary that can hide the exact thing this gate is looking for: dynamic
+dims cost differently at different sizes, and a mean of a win and a loss reads
+as "no change".
+
+## The arms
+
+| arm | `--dynamic-axes` | what it is |
+|---|---|---|
+| `static` | `off` | the control — one graph per observed shape, today's fleet |
+| `aspect` | `aspect` | Paul's headline question |
+| `batch` | `batch` | the CFG axis, costed on its own |
+| `all` | `all` | both, the best case for mint cost |
+
+## Discipline
+
+* `VARENA_GPU_WINDOW=1` gates every card-touching step. Set it ONLY on a
+  granted window.
+* `--self-test` is CPU-ONLY, needs no window and no card. It red-arms the
+  window gate, the per-shape table (a table that cannot show a regression is
+  not an instrument) and the arm plan.
+* Compile is bounded: the static arm builds ONLY the specializations this run
+  actually benchmarks (`--first <selector> --fill none`), never all 14/18.
+  Compiling buckets nobody measures spends the card on nothing.
+* `nice -n 19` on every child; one heavy child at a time.
+
+    .venv/bin/python benchmarks/dynamic_dims_pgw1548.py --self-test
+    VARENA_GPU_WINDOW=1 .venv/bin/python benchmarks/dynamic_dims_pgw1548.py \
+        --endpoint ~/cozy/serverless-endpoints/sd15 --checkpoint <tree> \
+        --arms static,aspect --reps 5 --out benchmarks/pgw1548/sd15
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ARMS = ("static", "aspect", "batch", "all")
+AXES = {"static": "off", "aspect": "aspect", "batch": "batch", "all": "all"}
+
+
+class WindowRequired(SystemExit):
+    """The card is gated by a granted window, not by an env var we set."""
+
+
+def require_window() -> None:
+    if os.environ.get("VARENA_GPU_WINDOW") != "1":
+        raise WindowRequired(
+            "REFUSING: VARENA_GPU_WINDOW=1 is not set. This box runs several "
+            "agent sessions and one GPU lane at a time; the window is GRANTED "
+            "by the coordinator and set only then. `--self-test` runs without "
+            "one."
+        )
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None, env: dict | None = None,
+         timeout: float | None = None) -> subprocess.CompletedProcess:
+    full = ["nice", "-n", "19", *cmd]
+    return subprocess.run(
+        full, cwd=cwd, env={**os.environ, **(env or {})}, timeout=timeout,
+        capture_output=True, text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The measurement
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Sample:
+    """One request's round-trip, stamped with WHEN and under WHAT load.
+
+    The load stamp is not decoration: this box runs several agent sessions and
+    a peer's CPU job moves a wall by more than a dynamic dim ever will. A
+    number without the load it was taken under cannot be compared to one taken
+    an hour later, and `round` is what makes two arms comparable at all.
+    """
+
+    arm: str
+    aspect: str
+    cfg: str
+    seconds: float
+    round: int = 0
+    load1: float = 0.0
+    served: str = ""
+
+
+@dataclass
+class Table:
+    """Per-shape round-trips, and the comparison the gate is decided on.
+
+    The unit of judgement is one (aspect, cfg) CELL: `static` is the control
+    and every other arm is a percentage against it, IN THAT CELL. Nothing here
+    ever averages across cells — see the module docstring.
+    """
+
+    samples: list[Sample] = field(default_factory=list)
+
+    def add(self, sample: Sample) -> None:
+        self.samples.append(sample)
+
+    def cell(self, arm: str, aspect: str, cfg: str) -> list[float]:
+        return [
+            s.seconds for s in self.samples
+            if s.arm == arm and s.aspect == aspect and s.cfg == cfg
+        ]
+
+    def median(self, arm: str, aspect: str, cfg: str) -> float | None:
+        values = self.cell(arm, aspect, cfg)
+        return statistics.median(values) if values else None
+
+    def shapes(self) -> list[tuple[str, str]]:
+        seen: list[tuple[str, str]] = []
+        for sample in self.samples:
+            key = (sample.aspect, sample.cfg)
+            if key not in seen:
+                seen.append(key)
+        return seen
+
+    def arms(self) -> list[str]:
+        return [arm for arm in ARMS if any(s.arm == arm for s in self.samples)]
+
+    def rounds(self) -> list[int]:
+        return sorted({s.round for s in self.samples})
+
+    def spread(self, arm: str, aspect: str, cfg: str) -> float | None:
+        """The CONTROL's own round-to-round spread, as a percentage.
+
+        The decidability test the coordinator set (2026-08-20): a cell whose
+        reference arm cannot reproduce itself across rounds within 15% is
+        measuring the box, not the graph, and no verdict may be read from it.
+        """
+
+        per_round = []
+        for index in self.rounds():
+            values = [
+                s.seconds for s in self.samples
+                if s.arm == arm and s.aspect == aspect and s.cfg == cfg
+                and s.round == index
+            ]
+            if values:
+                per_round.append(statistics.median(values))
+        if len(per_round) < 2:
+            return None
+        low, high = min(per_round), max(per_round)
+        return (high - low) / low * 100.0 if low else None
+
+    def undecidable(self, aspect: str, cfg: str, limit: float = 15.0) -> bool:
+        spread = self.spread("static", aspect, cfg)
+        return spread is not None and spread > limit
+
+    def regression(self, arm: str, aspect: str, cfg: str) -> float | None:
+        """Percent SLOWER than the static control in this cell. Negative = faster."""
+
+        control = self.median("static", aspect, cfg)
+        measured = self.median(arm, aspect, cfg)
+        if not control or measured is None:
+            return None
+        return (measured - control) / control * 100.0
+
+    def render(self) -> str:
+        arms = self.arms()
+        lines = [
+            "| shape | cfg | " + " | ".join(
+                f"{arm} (s)" + ("" if arm == "static" else " / vs static")
+                for arm in arms
+            ) + " |",
+            "|" + "---|" * (2 + len(arms)),
+        ]
+        for aspect, cfg in self.shapes():
+            cells = []
+            for arm in arms:
+                median = self.median(arm, aspect, cfg)
+                if median is None:
+                    cells.append("—")
+                    continue
+                if arm == "static":
+                    cells.append(f"{median:.3f}")
+                    continue
+                delta = self.regression(arm, aspect, cfg)
+                cells.append(
+                    f"{median:.3f} / {delta:+.1f}%" if delta is not None
+                    else f"{median:.3f}"
+                )
+            lines.append(f"| {aspect} | {cfg} | " + " | ".join(cells) + " |")
+        return "\n".join(lines)
+
+    def verdict(self, arm: str, tolerance: float) -> tuple[bool, list[str]]:
+        """Adopt this axis? Only if EVERY decidable cell is inside tolerance.
+
+        One bad bucket is a reason not to adopt an axis, not a number to
+        average away — a request that lands in it pays the regression every
+        time, forever. An UNDECIDABLE cell blocks adoption too: it is not a
+        pass, it is a measurement that has to be re-run on a quiet box.
+        """
+
+        offenders = []
+        for aspect, cfg in self.shapes():
+            if self.undecidable(aspect, cfg):
+                spread = self.spread("static", aspect, cfg)
+                offenders.append(
+                    f"{aspect}/{cfg}: UNDECIDABLE (control spread "
+                    f"{spread:.1f}% > 15%; re-run on a quiet slot)"
+                )
+                continue
+            delta = self.regression(arm, aspect, cfg)
+            if delta is None:
+                offenders.append(f"{aspect}/{cfg}: NOT MEASURED")
+            elif delta > tolerance:
+                offenders.append(f"{aspect}/{cfg}: {delta:+.1f}%")
+        return (not offenders), offenders
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "samples": [vars(s) for s in self.samples],
+            "rounds": self.rounds(),
+            "control_spread_pct": {
+                f"{aspect}/{cfg}": self.spread("static", aspect, cfg)
+                for aspect, cfg in self.shapes()
+            },
+            "undecidable": [
+                f"{aspect}/{cfg}" for aspect, cfg in self.shapes()
+                if self.undecidable(aspect, cfg)
+            ],
+            "cells": {
+                f"{aspect}/{cfg}": {
+                    arm: {
+                        "median_s": self.median(arm, aspect, cfg),
+                        "runs_s": self.cell(arm, aspect, cfg),
+                        "vs_static_pct": self.regression(arm, aspect, cfg),
+                    }
+                    for arm in self.arms()
+                }
+                for aspect, cfg in self.shapes()
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# The arms, on the card
+# ---------------------------------------------------------------------------
+
+
+class Bench:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.endpoint = Path(args.endpoint).expanduser().resolve()
+        self.out = Path(args.out).expanduser().resolve()
+        self.out.mkdir(parents=True, exist_ok=True)
+        self.table = Table()
+        self.mint: dict[str, dict[str, Any]] = {}
+
+    # -- the endpoint copy: never mutate a shared checkout ------------------
+    def _workspace(self, arm: str) -> Path:
+        """A per-arm COPY of the endpoint.
+
+        `gen-worker up` reads the endpoint's own `endpoint.lock`, so an arm has
+        to write one — and `~/cozy/serverless-endpoints` is a shared checkout
+        with a sibling lane working in it. The copy is the isolation; the
+        `.venv` is symlinked because it is the environment, not the source.
+        """
+
+        room = self.out / f"arm-{arm}"
+        if room.exists():
+            shutil.rmtree(room)
+        room.mkdir(parents=True)
+        for name in ("src", "endpoint.toml", "pyproject.toml", "uv.lock",
+                     "endpoint.lock", "cozy.toml"):
+            source = self.endpoint / name
+            if not source.exists():
+                continue
+            if source.is_dir():
+                shutil.copytree(source, room / name)
+            else:
+                shutil.copy2(source, room / name)
+        venv = self.endpoint / ".venv"
+        if venv.exists():
+            (room / ".venv").symlink_to(venv)
+        return room
+
+    def _python(self) -> str:
+        venv = self.endpoint / ".venv" / "bin" / "python"
+        return str(venv) if venv.exists() else sys.executable
+
+    def _gen_worker(self, room: Path, argv: list[str], timeout: float) -> subprocess.CompletedProcess:
+        """The CLI, running THIS branch's source (PYTHONPATH wins over the pin)."""
+
+        return _run(
+            [self._python(), "-m", "gen_worker.cli", *argv],
+            cwd=room,
+            env={"PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src")},
+            timeout=timeout,
+        )
+
+    # -- one arm ------------------------------------------------------------
+    def lock(self, room: Path, arm: str) -> float:
+        started = time.monotonic()
+        result = self._gen_worker(
+            room,
+            ["lock", str(room), "--force", "--dynamic-axes", AXES[arm],
+             "--checkpoint", str(self.args.checkpoint)],
+            timeout=self.args.lock_timeout,
+        )
+        if result.returncode != 0:
+            raise SystemExit(f"[{arm}] lock failed:\n{result.stdout}\n{result.stderr}")
+        return time.monotonic() - started
+
+    def specializations(self, room: Path) -> list[dict[str, Any]]:
+        from gen_worker.cli import endpoint_lock as el
+
+        block = el.read_lock(room / el.LOCK_FILENAME)
+        document = json.loads(block.document) if isinstance(block.document, (str, bytes)) else block.document
+        return [
+            record
+            for lane in document["graphs"]["lanes"]
+            for record in lane["graphs"]
+        ]
+
+    def compile(self, room: Path, arm: str, selectors: list[str]) -> float:
+        """Build ONLY what this run benchmarks. One selector per child."""
+
+        require_window()
+        started = time.monotonic()
+        for selector in selectors:
+            result = self._gen_worker(
+                room,
+                ["compile", str(room), "--first", selector, "--fill", "none"],
+                timeout=self.args.compile_timeout,
+            )
+            if result.returncode != 0:
+                raise SystemExit(
+                    f"[{arm}] compile {selector!r} failed:\n"
+                    f"{result.stdout}\n{result.stderr}"
+                )
+        return time.monotonic() - started
+
+    def serve(self, room: Path, arm: str) -> None:
+        require_window()
+        up = self._gen_worker(
+            room,
+            ["up", str(room), "-d", "--checkpoint", str(self.args.checkpoint),
+             "--idle-timeout", str(self.args.idle_timeout)],
+            timeout=self.args.boot_timeout,
+        )
+        if up.returncode != 0:
+            raise SystemExit(f"[{arm}] up failed:\n{up.stdout}\n{up.stderr}")
+
+    def down(self, room: Path) -> None:
+        self._gen_worker(room, ["down"], timeout=120)
+
+    def request(self, room: Path, arm: str, aspect: str, cfg: str,
+                round_index: int = 0) -> Sample:
+        payload = {
+            "prompt": self.args.prompt,
+            "aspect_ratio": aspect,
+            "num_inference_steps": self.args.steps,
+            "seed": self.args.seed,
+        }
+        if cfg == "on":
+            payload["guidance_scale"] = self.args.guidance
+        started = time.monotonic()
+        result = self._gen_worker(
+            room,
+            ["run", "-C", str(room), "--payload", json.dumps(payload), "--json"],
+            timeout=self.args.request_timeout,
+        )
+        elapsed = time.monotonic() - started
+        if result.returncode != 0:
+            raise SystemExit(
+                f"[{arm}] request {aspect}/{cfg} failed:\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+        return Sample(
+            arm=arm, aspect=aspect, cfg=cfg, seconds=elapsed,
+            round=round_index, load1=os.getloadavg()[0],
+        )
+
+    def prepare(self, name: str) -> Path:
+        """Lock + compile ONE arm. The card cost, paid once per arm."""
+
+        room = self._workspace(name)
+        lock_s = self.lock(room, name)
+        records = self.specializations(room)
+        selectors = self.args.selectors or [r["graph"][-16:] for r in records]
+        compile_s = self.compile(room, name, selectors)
+        self.mint[name] = {
+            "lock_s": lock_s,
+            "compile_s": compile_s,
+            "specializations": len(records),
+            "built": len(selectors),
+            "load1_at_compile": os.getloadavg()[0],
+        }
+        return room
+
+    def measure(self, room: Path, name: str, round_index: int) -> None:
+        """One arm's turn in ONE round.
+
+        Boot, one warm-up per cell (the first call through a fresh graph pays
+        load and allocator costs no later request pays — reporting it would
+        measure the boot), `--reps` measured calls, tear down. Rounds are the
+        interleave: a peer's CPU job that lands mid-run then falls on every
+        arm rather than on whichever one happened to be running, and the
+        control's round-to-round spread is what says whether the cell is
+        decidable at all.
+        """
+
+        self.serve(room, name)
+        try:
+            for aspect in self.args.aspects:
+                for cfg in self.args.cfg:
+                    self.request(room, name, aspect, cfg, round_index)
+                    for _ in range(self.args.reps):
+                        self.table.add(
+                            self.request(room, name, aspect, cfg, round_index)
+                        )
+        finally:
+            self.down(room)
+
+    def report(self) -> dict[str, Any]:
+        adoption = {}
+        for arm in self.table.arms():
+            if arm == "static":
+                continue
+            ok, offenders = self.table.verdict(arm, self.args.tolerance)
+            adoption[arm] = {"adopt": ok, "outside_tolerance": offenders}
+        return {
+            "endpoint": str(self.endpoint),
+            "tolerance_pct": self.args.tolerance,
+            "mint": self.mint,
+            "table_markdown": self.table.render(),
+            "adoption": adoption,
+            **self.table.as_dict(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# The CPU-only self-test: every instrument proven able to go red
+# ---------------------------------------------------------------------------
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(name: str, condition: bool) -> None:
+        print(f"  {'ok  ' if condition else 'RED '} {name}")
+        if not condition:
+            failures.append(name)
+
+    print("[self-test] the window gate")
+    saved = os.environ.pop("VARENA_GPU_WINDOW", None)
+    try:
+        require_window()
+        check("an ungranted window REFUSES", False)
+    except WindowRequired:
+        check("an ungranted window REFUSES", True)
+    os.environ["VARENA_GPU_WINDOW"] = "1"
+    try:
+        require_window()
+        check("a granted window proceeds", True)
+    except WindowRequired:
+        check("a granted window proceeds", False)
+    finally:
+        os.environ.pop("VARENA_GPU_WINDOW")
+        if saved is not None:
+            os.environ["VARENA_GPU_WINDOW"] = saved
+
+    print("[self-test] the per-shape table CAN show a regression")
+    table = Table()
+    for _ in range(3):
+        table.add(Sample("static", "1:1", "on", 1.000))
+        table.add(Sample("aspect", "1:1", "on", 1.010))
+        table.add(Sample("static", "3:4", "on", 2.000))
+        table.add(Sample("aspect", "3:4", "on", 2.600))
+    check("a 1% cell reads +1.0%", round(table.regression("aspect", "1:1", "on"), 1) == 1.0)
+    check("a 30% cell reads +30.0%", round(table.regression("aspect", "3:4", "on"), 1) == 30.0)
+    ok, offenders = table.verdict("aspect", tolerance=5.0)
+    check("ONE bad bucket refuses the whole axis", not ok and len(offenders) == 1)
+    check("the offender is NAMED", offenders and offenders[0].startswith("3:4/on"))
+    ok, _ = table.verdict("aspect", tolerance=50.0)
+    check("a tolerance that covers it adopts", ok)
+
+    print("[self-test] the >15% control spread makes a cell UNDECIDABLE")
+    noisy = Table()
+    for r, (control, measured) in enumerate(((1.00, 1.00), (1.40, 1.40))):
+        noisy.add(Sample("static", "1:1", "on", control, round=r))
+        noisy.add(Sample("aspect", "1:1", "on", measured, round=r))
+    check("a 40% control spread is measured", round(noisy.spread("static", "1:1", "on")) == 40)
+    check("and the cell is UNDECIDABLE", noisy.undecidable("1:1", "on"))
+    ok, offenders = noisy.verdict("aspect", tolerance=5.0)
+    check("an undecidable cell blocks adoption", not ok)
+    check("and says re-run, not fail", any("UNDECIDABLE" in o for o in offenders))
+    steady = Table()
+    for r, value in enumerate((1.00, 1.05)):
+        steady.add(Sample("static", "1:1", "on", value, round=r))
+        steady.add(Sample("aspect", "1:1", "on", value, round=r))
+    check("a 5% control spread stays decidable", not steady.undecidable("1:1", "on"))
+    check("and adopts", steady.verdict("aspect", tolerance=3.0)[0])
+
+    print("[self-test] an unmeasured cell is NOT silently adopted")
+    thin = Table()
+    thin.add(Sample("static", "1:1", "on", 1.0))
+    thin.add(Sample("aspect", "1:1", "on", 1.0))
+    thin.add(Sample("static", "16:9", "on", 1.0))
+    ok, offenders = thin.verdict("aspect", tolerance=5.0)
+    check("a missing cell refuses", not ok and any("NOT MEASURED" in o for o in offenders))
+
+    print("[self-test] the table never averages across shapes")
+    rendered = table.render()
+    # header + separator + one row per shape, and render() joins without a
+    # trailing newline, so the count is one less than the line count.
+    check(
+        "every shape has its own row",
+        len(rendered.splitlines()) == 2 + len(table.shapes()),
+    )
+    check("the control column carries no percentage", "static (s) / vs static" not in rendered)
+
+    print("[self-test] the arm plan is exhaustive over the axes")
+    check("every arm names an axis policy", set(ARMS) == set(AXES))
+    check("static is the OFF control", AXES["static"] == "off")
+
+    print()
+    if failures:
+        print(f"SELF-TEST RED: {len(failures)} check(s) failed: {failures}")
+        return 1
+    print("SELF-TEST GREEN — every instrument above was shown able to go red.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true",
+                        help="CPU-only; needs no card and no window")
+    parser.add_argument("--endpoint", default="")
+    parser.add_argument("--checkpoint", default="")
+    parser.add_argument("--out", default="benchmarks/pgw1548")
+    parser.add_argument("--arms", default="static,aspect")
+    parser.add_argument("--aspects", default="1:1,3:4,16:9")
+    parser.add_argument("--cfg", default="on")
+    parser.add_argument("--reps", type=int, default=5,
+                        help="measured requests per cell per round")
+    parser.add_argument("--rounds", type=int, default=3,
+                        help="interleave: every arm is measured once per "
+                             "round, so box load falls on all of them. The "
+                             "control's round-to-round spread decides whether "
+                             "a cell is decidable (>15%% is not).")
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--guidance", type=float, default=7.5)
+    parser.add_argument("--seed", type=int, default=1548)
+    parser.add_argument("--prompt", default="a fisherman at dawn")
+    parser.add_argument("--tolerance", type=float, default=3.0,
+                        help="percent slower than static that still adopts")
+    parser.add_argument("--selectors", default="",
+                        help="comma-separated `gen-worker compile --first` "
+                             "selectors; default: every specialization in the "
+                             "arm's lock")
+    parser.add_argument("--lock-timeout", type=float, default=1800)
+    parser.add_argument("--compile-timeout", type=float, default=3600)
+    parser.add_argument("--boot-timeout", type=float, default=900)
+    parser.add_argument("--request-timeout", type=float, default=600)
+    parser.add_argument("--idle-timeout", type=int, default=1800)
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.endpoint or not args.checkpoint:
+        parser.error("--endpoint and --checkpoint are required for a real run")
+    require_window()
+
+    args.aspects = [a for a in args.aspects.split(",") if a]
+    args.cfg = [c for c in args.cfg.split(",") if c]
+    args.selectors = [s for s in args.selectors.split(",") if s]
+
+    arms = args.arms.split(",")
+    for arm in arms:
+        if arm not in ARMS:
+            parser.error(f"unknown arm {arm!r}; one of {list(ARMS)}")
+    if "static" not in arms:
+        parser.error("the static arm is the control; every run needs it")
+
+    bench = Bench(args)
+    rooms = {}
+    for arm in arms:
+        print(f"[prepare] {arm} (--dynamic-axes {AXES[arm]})")
+        rooms[arm] = bench.prepare(arm)
+    for round_index in range(args.rounds):
+        for arm in arms:
+            print(f"[round {round_index}] {arm} (load {os.getloadavg()[0]:.1f})")
+            bench.measure(rooms[arm], arm, round_index)
+
+    report = bench.report()
+    (bench.out / "verdict.json").write_text(json.dumps(report, indent=2))
+    print()
+    print(report["table_markdown"])
+    print()
+    for arm, verdict in report["adoption"].items():
+        state = "ADOPT" if verdict["adopt"] else "KEEP STATIC"
+        print(f"{arm}: {state} {verdict['outside_tolerance'] or ''}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/changelog.d/pgw1548-dynamic-dims.md
+++ b/changelog.d/pgw1548-dynamic-dims.md
@@ -1,0 +1,17 @@
+- **pgw#1567: the derive's trace dtype comes from the LANE DECLARATION, never
+  the mounted checkpoint.** `TraceLoadContext.component_dtype` led its ladder
+  with the tree's own safetensors headers, so a derive against a stock fp16
+  tree traced fp16 graphs under `sd15.diffusers-bf16@1` and armed 14 graphs a
+  bf16 pod could never enter — silently. The lane now answers first for every
+  component of the tree it governs; the checkpoint speaks only for a DERIVED
+  lane, which has no contract to read a dtype from. That is the serve path's
+  own order: the loader is dtype PASSTHROUGH and the STORE converts a tree
+  through the layout contract before a pod mounts it. A mounted tree that
+  disagrees is NAMED once per component instead of followed.
+
+- **pgw#1548: `--dynamic-axes off|batch|aspect|all`** on `gen-worker lock` and
+  `gen-worker release derive` exports the axes that VARY across the observed
+  calls as `torch.export.Dim`s, collapsing the shape fan. Measured on a fixture
+  with sd15's structure (3 aspect buckets x 2 CFG modes): 6 specializations
+  off, 3 with `batch`, 2 with `aspect`, **1** with `all`. `off` is the default
+  and stays it until the per-model serve benchmark says otherwise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -531,7 +531,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "748115fc90e3c2d4cad6e7e521b06fac2d204bab" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -302,7 +302,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "748115fc90e3c2d4cad6e7e521b06fac2d204bab"
+rev = "14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -505,11 +505,11 @@ rewrites = [
 "writer.py" = "f44e74d983d2f642e8479f85a3682bb737dd76ffbd62c3fe7d684ae5c0c71ca1"
 
 [packages.torchcg.files]
-"__init__.py" = "14bbdb65947b78fff1a6a1e1230e8aac7173609d536bc0827750d054cc82eda9"
+"__init__.py" = "a1734b7d8218f7f9e97765a505460e77b7332f495c8cf52b3dbd76b7d99fce2f"
 "__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
 "_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
 "_wrapper_split.py" = "1d5a3bc1ccabadeaa2b8b54f1492cba10723e53074a0022b8c7453565a86a4ce"
-"adopt.py" = "7b0b9c25a0132f3e822a3a04216db2b24c03d8e06e9adb1adc8f26ccb43f2cee"
+"adopt.py" = "c4960aa2c4405438f1e870d1c9afd10ffb338210207e37cf26c8128107222bdb"
 "artifact.py" = "5b61f1b0d06d01b733d55ac123190da5e6a33ea2ec8663402a49e80bfb567a62"
 "cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
 "compiler.py" = "6ee54b26286b215eef8867dffb133d023a6808379574ac69f8007a64c477045a"
@@ -523,14 +523,15 @@ rewrites = [
 "contracts/recipe_v1.json" = "d319b5f2e4a3d5c13587da2b7d7cdc25c83b92e0b5b22311c317948c3e610d1a"
 "contracts/toolchain_identity_v1.json" = "f4114c38ae373f62ddcb2aae5498ffbee30630e80adf11fee99e68bcbdb24282"
 "declaration.py" = "8b42bae864a4127cc5e418915f8395d980b8a439a51fd4d6f5ecbb42ba613b21"
-"discovery.py" = "57050c017eba40e0caca94d2df798c149b988764d2eaef2d84fb1e60dc04aad5"
+"discovery.py" = "7b294cab60126763cc634f536e3b94f8df36523b42b94bf2ef66deec676de4ec"
 "document.py" = "a70f4e53d75dd4cdc5fb6f52be4c8c105e49efee168ab6c295094a09f779d0ad"
+"dynamic.py" = "8466c4a7330513e9ebd381fe89e53ba72e276bfc0dcf8499e004bf0f92961b6d"
 "engine.py" = "577ae142365a67947625df738a10ebc9565ab205c8d470e068a7eccd946a3de2"
 "graph_identity.py" = "88c731a681eb1e0b878f30bc33fcaa4efdbfc16bdc612fd6d406a088e299e567"
 "hollow.py" = "d9a0b57b01036588b9182d737ea925c34885b14a4bf88e76c8bb38d6d4ae97f9"
 "host_isa.py" = "679aa81547be2d60ae6593b6e8f75dd29dcd56ab85d8e858e219b5af5d0eadc4"
 "identity.py" = "a460a24836cbd46cc9e65bd684b9f6258f6718e5c56102f26a7071f01574a99e"
-"ingress.py" = "fa9b814dbfcd43e2a7cfdd2ed48299a7fa5a570aa73d3e2269448c974074d558"
+"ingress.py" = "d680f8724fe28eda7ae5f47b8e1a880d33bfce681e2acc68edef76c385b9df69"
 "introspection.py" = "99310298249ee2ada91544bcdbd91f06e33a44f136c525cb268ca8d7125aa9e5"
 "lane.py" = "bdbc92c07f7eb7dbe56e98f02496774f257ad30f400b7c25b4a9c39ed0814aee"
 "py.typed" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -538,7 +539,7 @@ rewrites = [
 "recipe.py" = "cc6fe9007a7f459ede5ced2cfd5d072e3c807552329d0e1920ade88de8b829a6"
 "requirements.py" = "19b4e0e0203f0cc93052de2cc63deb2ceb3ca3b094b9885b87e7cf87f9bb6c6e"
 "runner.py" = "5293d1f296485963e400dd57332c44ba890a5df6bb0a92fc251e3977a1d9fb2f"
-"selection.py" = "1addd68533008d32b9d36c7877ac4c5fe43fce5f2c8737dda976f681f9145738"
+"selection.py" = "e58c39467fa9e31ccfa1a86f2dbdf2e5f4263ce4f4e5ceda303c78e3c51a2402"
 "serve.py" = "a1f3b6fe5e46305bc9aea9848ac5935537b7bb37e2586ae3f0393f66cead2ade"
 "spans.py" = "4776fac2006967b1f17ffcbec03e50147d511120fd50cf085ac3b6b4702e5539"
 "storage.py" = "6e1e94523ee9c1449538aa57dbfaf8e20e24997d09297b3fd09cc88d17d02354"

--- a/src/gen_worker/_vendor/torchcg/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/__init__.py
@@ -30,6 +30,7 @@ from .document import (
     GraphSetDocument,
     LaneGraphs,
 )
+from .dynamic import DimPolicy
 from .engine import (
     AdmissionError,
     Engine,
@@ -205,6 +206,7 @@ __all__ = [
     "CompileError",
     "COMPILED_GRAPH_FORMAT",
     "DOCUMENT_FORMAT",
+    "DimPolicy",
     "DiscoveryError",
     "DocumentError",
     "ENV_SCHEME",

--- a/src/gen_worker/_vendor/torchcg/adopt.py
+++ b/src/gen_worker/_vendor/torchcg/adopt.py
@@ -28,10 +28,12 @@ import inspect
 import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from .artifact import ArtifactError
 from .document import GraphRecord, GraphSetDocument, LaneGraphs
+from .ingress import symbol_terms
 from .requirements import assert_exact_env
 from .runner import ConstantBindingError
 from .store import GraphStore, StoreError
@@ -171,13 +173,29 @@ def _structure_key(record: GraphRecord) -> tuple[Any, ...]:
     )
 
 
-def _row_mismatch(row: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str | None:
+def _row_mismatch(
+    row: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    bounds: Mapping[str, tuple[int, int]] = MappingProxyType({}),
+    symbols: dict[str, tuple[int, str]] | None = None,
+) -> str | None:
     """Why this ONE ingress row refuses this call, or ``None`` when it passes.
 
     THE single source for both the match decision and the diagnosis (tcg#76):
     ``_matches`` is ``every row answers None``, and the first-mismatch trace
     prints exactly what this function refused on — one predicate, so the guard
     and its explanation cannot drift into telling two stories.
+
+    tcg#77: a SYMBOLIC dim is not a wildcard. ``bounds`` is the record's own
+    ``ingress.symbol_bounds`` and ``symbols`` is the binding table the caller
+    carries ACROSS the record's rows, so a dynamic record guards exactly what
+    it was exported for: the value is inside the exported range, and one
+    symbol takes one value everywhere it appears (a batch symbol shared by
+    ``sample`` and ``encoder_hidden_states`` refuses a call that disagrees
+    with itself). Without the table each row would answer alone and the
+    dispatcher would enter a graph whose shape env refuses the call —
+    a wrong answer, not a slow one.
     """
     import torch
 
@@ -207,19 +225,75 @@ def _row_mismatch(row: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> st
             f"{tuple(value.shape)}) != expected rank {len(row.shape)} (shape "
             f"{tuple(row.shape)})"
         )
-    for got, want in zip(value.shape, row.shape, strict=True):
-        if isinstance(want, int) and int(got) != want:
+    for axis, (got, want) in enumerate(zip(value.shape, row.shape, strict=True)):
+        got = int(got)
+        if isinstance(want, int):
+            if got != want:
+                return (
+                    f"input {row.param!r}: shape {tuple(value.shape)} != expected "
+                    f"{tuple(row.shape)}"
+                )
+            continue
+        span = bounds.get(want)
+        if span is None:
+            # A record whose shape names a symbol its ingress does not bound
+            # cannot be dispatched at all; `CallIngress` refuses to construct
+            # one, so reaching here means a hand-built record.
             return (
-                f"input {row.param!r}: shape {tuple(value.shape)} != expected "
-                f"{tuple(row.shape)}"
+                f"input {row.param!r}: dim {axis} names symbol {want!r}, which "
+                f"this record declares no range for"
             )
+        low, high = span
+        if not low <= got <= high:
+            return (
+                f"input {row.param!r}: dim {axis} (symbol {want!r}) = {got} "
+                f"outside the exported range [{low}, {high}] "
+                f"(received shape {tuple(value.shape)})"
+            )
+        stride, root = symbol_terms(want)
+        if got % stride:
+            return (
+                f"input {row.param!r}: dim {axis} (symbol {want!r}) = {got} is "
+                f"not a multiple of {stride}, which this graph's shape guards "
+                f"require (received shape {tuple(value.shape)})"
+            )
+        if symbols is not None:
+            bound = got // stride
+            prior = symbols.get(root)
+            if prior is not None and prior[0] != bound:
+                return (
+                    f"input {row.param!r}: dim {axis} (symbol {want!r}) = {got} "
+                    f"puts {root} at {bound}, but input {prior[1]!r} put it at "
+                    f"{prior[0]}"
+                )
+            symbols.setdefault(root, (bound, row.name))
+    return None
+
+
+def _record_mismatch(
+    record: GraphRecord, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> tuple[int, str] | None:
+    """(rows passed, the first failure's sentence), or ``None`` when it matches.
+
+    ONE walk answers both questions (tcg#76's property, kept): the match
+    decision is "this returned None" and the diagnosis is what it returned.
+    The symbol table lives here rather than in a row because symbol
+    consistency is a RECORD-level fact (tcg#77).
+    """
+
+    bounds = record.ingress.symbol_bounds
+    symbols: dict[str, tuple[int, str]] = {}
+    passed = 0
+    for row in record.ingress.inputs:
+        sentence = _row_mismatch(row, args, kwargs, bounds, symbols)
+        if sentence is not None:
+            return passed, sentence
+        passed += 1
     return None
 
 
 def _matches(record: GraphRecord, args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
-    return all(
-        _row_mismatch(row, args, kwargs) is None for row in record.ingress.inputs
-    )
+    return _record_mismatch(record, args, kwargs) is None
 
 
 def _first_mismatch(
@@ -230,13 +304,13 @@ def _first_mismatch(
     A record with no failing row never reaches here — ``_matches`` would have
     dispatched it.
     """
-    passed = 0
-    for row in record.ingress.inputs:
-        sentence = _row_mismatch(row, args, kwargs)
-        if sentence is not None:
-            return passed, sentence
-        passed += 1
-    return passed, "every enumerated row matched (a non-row guard refused?)"
+    outcome = _record_mismatch(record, args, kwargs)
+    if outcome is None:
+        return (
+            len(record.ingress.inputs),
+            "every enumerated row matched (a non-row guard refused?)",
+        )
+    return outcome
 
 
 class _ForwardDispatcher:

--- a/src/gen_worker/_vendor/torchcg/discovery.py
+++ b/src/gen_worker/_vendor/torchcg/discovery.py
@@ -26,14 +26,18 @@ from __future__ import annotations
 
 import contextlib
 import inspect
+import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from .document import GraphRecord, LaneGraphs
+from .dynamic import DimPolicy, alias_ingress, plan_exports, resolve_policy
 from .graph_identity import GraphIdentityError, graph_hash
 from .ingress import IngressError, build_call_ingress
 from .lane import LaneError, LaneRef, require_targets, resolve_target
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # torch-free import closure: transform.py is torch-shaped
     from .hollow import HollowSession
@@ -175,6 +179,7 @@ def discover_lane(
     program_sink: Callable[[str, Any], object] | None = None,
     transforms: TransformSet | None = None,
     session: HollowSession | None = None,
+    dynamic_dims: DimPolicy | bool | None = None,
 ) -> LaneGraphs:
     """Run the author's code once, derive every observed graph, state the rest.
 
@@ -210,6 +215,7 @@ def discover_lane(
         program_sink=program_sink,
         transforms=transforms,
         session=session,
+        dynamic_dims=dynamic_dims,
     )
 
 
@@ -269,6 +275,7 @@ def discover_modules(
     program_sink: Callable[[str, Any], object] | None = None,
     transforms: TransformSet | None = None,
     session: HollowSession | None = None,
+    dynamic_dims: DimPolicy | bool | None = None,
 ) -> LaneGraphs:
     """Discovery over MARKED modules (the imperative ``ctx.compile`` surface).
 
@@ -296,6 +303,14 @@ def discover_modules(
     it. A program whose lifted constants are FAKE is still refused by name --
     a silently zeroed literal digest is exactly the class of defect this pass
     exists to delete -- but under tcg#64 no session can produce one.
+
+    ``dynamic_dims`` (tcg#77) decides how many EXPORTS the observed set costs.
+    ``None`` (the default) is one export per observed call — the shape fan.
+    ``True``, or a ``(target, input name, axis) -> bool`` predicate, marks the
+    axes that VARY across the observed calls as ``torch.export.Dim``s, so the
+    calls they distinguish collapse into one graph whose ingress states the
+    axis as a RANGE. A refused dynamic export falls back to that group's own
+    static exports, loudly. See :mod:`torchcg.dynamic`.
 
     ``transforms`` (tcg#52) is the SEALED :class:`~torchcg.transform.
     TransformSet` of the lane's PASS phase. Passing it is what makes PASS ->
@@ -367,19 +382,48 @@ def discover_modules(
 
     records: list[GraphRecord] = []
     seen_graphs: set[str] = set()
+    dims = resolve_policy(dynamic_dims)
     for path, calls in observed.items():
         module = modules[path]
         fake_mode = _fake_mode_of(module)
         device = _trace_device_of(module)
         synthesis = fake_mode if fake_mode is not None else contextlib.nullcontext()
+        synthesized: list[tuple[tuple[Any, ...], dict[str, Any], list[str]]] = []
         for call in calls.values():
             with synthesis:
                 args = tuple(_synthesize(value, device) for value in call.args)
                 kwargs = {name: _synthesize(value, device) for name, value in call.kwargs}
+            synthesized.append((args, kwargs, _param_names(module, args, kwargs)))
+        with synthesis:
+            pending = plan_exports(path, synthesized, dims)
+        while pending:
+            plan = pending.pop(0)
+            args, kwargs = plan.args, plan.kwargs
             try:
                 with synthesis:
-                    program = torch.export.export(module, args, kwargs, strict=strict)
+                    program = torch.export.export(
+                        module,
+                        args,
+                        kwargs,
+                        dynamic_shapes=plan.dynamic_shapes,
+                        strict=strict,
+                    )
             except Exception as exc:
+                if plan.dynamic:
+                    # tcg#77: a refused dynamic export is a MEASUREMENT, not a
+                    # failure — this model cannot carry that axis symbolically,
+                    # and the static fan it replaces is still exactly right.
+                    # Loud, because a silent fallback is how a lane believes it
+                    # collapsed a fan it did not.
+                    logger.warning(
+                        "lane %s target %s: dynamic export over %s was REFUSED "
+                        "(%s: %s); falling back to one static export per "
+                        "observed shape for this group",
+                        contract, path, sorted(plan.symbols),
+                        type(exc).__name__, exc,
+                    )
+                    pending = plan.static_fallback() + pending
+                    continue
                 raise DiscoveryError(
                     f"lane {contract!r} target {path!r}: torch.export"
                     f"(strict={strict}) failed for the observed call: "
@@ -393,9 +437,11 @@ def discover_modules(
                 session.restate(program)
             _assert_literal_values_are_real(contract, path, program)
             _demote_example_inputs(program)
-            names = _param_names(module, args, kwargs)
+            names = list(plan.param_names)
             try:
-                ingress = build_call_ingress(program, names, args, kwargs)
+                ingress = alias_ingress(
+                    build_call_ingress(program, names, args, kwargs), plan
+                )
                 graph = graph_hash(program, ingress, passes=passes)
             except (IngressError, GraphIdentityError) as exc:
                 raise DiscoveryError(

--- a/src/gen_worker/_vendor/torchcg/dynamic.py
+++ b/src/gen_worker/_vendor/torchcg/dynamic.py
@@ -1,0 +1,453 @@
+"""Dynamic export dims: one graph where the fan was a bucket per shape (tcg#77).
+
+The observed set is still the truth (``discovery``'s doctrine is unchanged) —
+this module only decides how many EXPORTS that set costs. A denoiser observed
+at seven aspect buckets x two CFG batches is fourteen calls that differ in
+nothing but four integers; exported one-per-call that is fourteen graph
+specializations, fourteen AOTI compiles, and fourteen artifacts to mint, adopt
+and match. Exported with those four integers marked ``torch.export.Dim`` it is
+ONE, and the shapes it serves are stated as ranges the dispatcher guards
+(``ingress.symbols``, ``adopt._row_mismatch``) instead of as equalities.
+
+The mechanism, in the order it runs:
+
+1. **Group** observed calls by everything a graph cannot vary over: structure,
+   non-tensor leaf values, dtypes and ranks. Two calls in different groups can
+   never be one export.
+2. **Classify** each (leaf, axis) inside a group by the TUPLE of values it
+   takes across that group's calls. Axes with one value are static. Axes whose
+   value tuples are IDENTICAL move together and must therefore be one symbol —
+   a batch axis on ``sample`` and on ``encoder_hidden_states`` is one Dim, and
+   exporting them as two would earn a constraint violation naming the equality
+   we already knew.
+3. **Filter** by the caller's policy. An axis the policy refuses stays an
+   integer, so the caller can adopt dynamic dims one axis at a time — which is
+   what a benchmark that must justify each axis needs (pgw#1548).
+4. **Re-group** on the axes that stayed static. Whatever the policy refused is
+   still a fan; it is simply a smaller one.
+
+Nothing here promises a shape it did not observe: a symbol's range is the
+observed min..max. A live call outside it misses every armed record and serves
+eager, which is the same answer an unobserved bucket has always gotten.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping, Sequence
+from math import gcd
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: ``(target, input name, axis) -> may this axis be exported dynamic?``
+#:
+#: The input name is the ingress spelling (``sample``,
+#: ``added_cond_kwargs.text_embeds``), so a caller that knows its own model
+#: can name an axis exactly. torchcg deliberately holds no opinion about
+#: which axis is "batch" or "spatial": that is the endpoint's vocabulary.
+DimPolicy = Callable[[str, str, int], bool]
+
+
+def all_dims(_target: str, _name: str, _axis: int) -> bool:
+    """Every axis that varies across the observed set becomes a Dim."""
+
+    return True
+
+
+def resolve_policy(policy: DimPolicy | bool | None) -> DimPolicy | None:
+    """``None``/``False`` -> static exports; ``True`` -> :func:`all_dims`."""
+
+    if policy is None or policy is False:
+        return None
+    if policy is True:
+        return all_dims
+    if not callable(policy):
+        raise TypeError(
+            f"dynamic_dims takes a bool or a (target, name, axis) predicate; "
+            f"got {type(policy).__name__}"
+        )
+    return policy
+
+
+def _leaves(value: Any, path: tuple[Any, ...] = ()) -> list[tuple[tuple[Any, ...], Any]]:
+    if isinstance(value, Mapping):
+        return [
+            leaf
+            for key, item in value.items()
+            for leaf in _leaves(item, path + (key,))
+        ]
+    if isinstance(value, (list, tuple)):
+        return [
+            leaf
+            for index, item in enumerate(value)
+            for leaf in _leaves(item, path + (index,))
+        ]
+    return [(path, value)]
+
+
+def _name(param: str, path: Sequence[Any]) -> str:
+    name = param
+    for step in path:
+        name = step if isinstance(step, str) else f"{name}.{step}"
+    return name
+
+
+def _flat(
+    param_names: Sequence[str], args: Sequence[Any], kwargs: Mapping[str, Any]
+) -> list[tuple[str, tuple[Any, ...], Any]]:
+    """``[(param, path, value)]`` in the ingress's own flattening order."""
+
+    values = list(args) + [kwargs[name] for name in param_names[len(args):]]
+    return [
+        (param, path, leaf)
+        for param, value in zip(param_names, values, strict=True)
+        for path, leaf in _leaves(value)
+    ]
+
+
+def _shape_free_key(flat: Sequence[tuple[str, tuple[Any, ...], Any]]) -> str:
+    """Everything about a call one export cannot vary over."""
+
+    import torch
+
+    parts = []
+    for param, path, value in flat:
+        if isinstance(value, torch.Tensor):
+            parts.append(f"{param}{path!r}=t({value.dtype}|rank{value.dim()})")
+        else:
+            parts.append(f"{param}{path!r}={value!r}")
+    return "|".join(parts)
+
+
+def _dims(flat: Sequence[tuple[str, tuple[Any, ...], Any]]) -> list[tuple[int, int]]:
+    import torch
+
+    return [
+        (index, axis)
+        for index, (_param, _path, value) in enumerate(flat)
+        if isinstance(value, torch.Tensor)
+        for axis in range(value.dim())
+    ]
+
+
+Call = tuple[tuple[Any, ...], dict[str, Any], Sequence[str]]
+
+
+class DynamicPlan:
+    """One export: its representative call and the Dims it is exported under."""
+
+    __slots__ = (
+        "args", "kwargs", "param_names", "dynamic_shapes", "symbols", "covers",
+        "classes",
+    )
+
+    def __init__(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        param_names: Sequence[str],
+        dynamic_shapes: dict[str, Any] | None,
+        symbols: dict[str, tuple[int, int]],
+        covers: Sequence[Call] = (),
+        classes: Sequence[Sequence[tuple[int, int]]] = (),
+    ) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.param_names = tuple(param_names)
+        self.dynamic_shapes = dynamic_shapes
+        self.symbols = symbols
+        #: Every observed call this ONE export stands for. A dynamic plan that
+        #: the exporter refuses is replaced by exactly these, exported the way
+        #: they always were — the fan comes back, nothing is dropped.
+        self.covers = tuple(covers) or ((args, dict(kwargs), tuple(param_names)),)
+        #: The ``(flat position, axis)`` groups that were exported as ONE Dim.
+        #: torch may still hand each occurrence its own symbol and tie them
+        #: with a runtime guard — measured: a batch-2 sample against a batch-1
+        #: conditioning fails `Guard failed: …` inside the graph — so the
+        #: record has to say the tie itself or the dispatcher would enter a
+        #: graph that refuses the call. :func:`alias_ingress` does that.
+        self.classes = tuple(tuple(group) for group in classes)
+
+    @property
+    def dynamic(self) -> bool:
+        return self.dynamic_shapes is not None
+
+    def static_fallback(self) -> list[DynamicPlan]:
+        return [
+            DynamicPlan(args, kwargs, names, None, {})
+            for args, kwargs, names in self.covers
+        ]
+
+
+def _dim(name: str, low: int, high: int, step: int) -> Any:
+    """The Dim for one axis, expressed in the units the model can actually take.
+
+    An axis is rarely free over the integers: a UNet with three downsamples
+    accepts a latent side only in multiples of eight, and ``torch.export``
+    says so as a guard (``(size % 2) == 0``) that refuses a plain ``Dim``.
+    The observed values' GCD is that stride, measured rather than assumed, so
+    the exported dim is ``stride * root`` — a DERIVED dim, which is torch's
+    own spelling for exactly this and the one it suggests in the refusal.
+    """
+
+    import torch
+
+    if step <= 1:
+        return torch.export.Dim(name, min=low, max=high)
+    root = torch.export.Dim(f"{name}_root", min=low // step, max=high // step)
+    return step * root
+
+
+def _spec_for(
+    value: Any, index: int, axes: Mapping[tuple[int, int], Any]
+) -> Any:
+    """The ``dynamic_shapes`` spec for ONE flat leaf."""
+
+    import torch
+
+    if not isinstance(value, torch.Tensor):
+        return None
+    marked = {
+        axis: axes[(index, axis)]
+        for axis in range(value.dim())
+        if (index, axis) in axes
+    }
+    return marked or None
+
+
+def _rebuild(value: Any, counter: list[int], axes: Mapping[tuple[int, int], Any]) -> Any:
+    """Mirror one argument's container structure with per-leaf specs."""
+
+    if isinstance(value, Mapping):
+        return {key: _rebuild(item, counter, axes) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_rebuild(item, counter, axes) for item in value)
+    index = counter[0]
+    counter[0] += 1
+    return _spec_for(value, index, axes)
+
+
+def plan_exports(
+    target: str,
+    calls: Sequence[tuple[tuple[Any, ...], dict[str, Any], Sequence[str]]],
+    policy: DimPolicy | None,
+) -> list[DynamicPlan]:
+    """Turn one target's observed calls into the exports they actually need.
+
+    Every call is covered exactly once. With no policy (or nothing varying)
+    this is the identity: one static plan per call, which is what discovery
+    did before this module existed.
+    """
+
+    plans: list[DynamicPlan] = []
+    if policy is None:
+        return [
+            DynamicPlan(args, kwargs, names, None, {})
+            for args, kwargs, names in calls
+        ]
+
+    groups: dict[str, list[int]] = {}
+    flats = [_flat(names, args, kwargs) for args, kwargs, names in calls]
+    for index, flat in enumerate(flats):
+        groups.setdefault(_shape_free_key(flat), []).append(index)
+
+    for members in groups.values():
+        plans.extend(_plan_group(target, calls, flats, members, policy))
+    return plans
+
+
+def _plan_group(
+    target: str,
+    calls: Sequence[tuple[tuple[Any, ...], dict[str, Any], Sequence[str]]],
+    flats: Sequence[Sequence[tuple[str, tuple[Any, ...], Any]]],
+    members: Sequence[int],
+    policy: DimPolicy,
+) -> list[DynamicPlan]:
+    if len(members) == 1:
+        args, kwargs, names = calls[members[0]]
+        return [DynamicPlan(args, kwargs, names, None, {})]
+
+    reference = flats[members[0]]
+    positions = _dims(reference)
+    # The value each axis takes across the group, in member order.
+    tracks: dict[tuple[int, int], tuple[int, ...]] = {
+        position: tuple(
+            int(flats[member][position[0]][2].shape[position[1]]) for member in members
+        )
+        for position in positions
+    }
+    allowed = {
+        position: track
+        for position, track in tracks.items()
+        if len(set(track)) > 1
+        and policy(
+            target,
+            _name(reference[position[0]][0], reference[position[0]][1]),
+            position[1],
+        )
+    }
+    if not allowed:
+        return [
+            DynamicPlan(calls[member][0], calls[member][1], calls[member][2], None, {})
+            for member in members
+        ]
+
+    # Axes whose value tracks are identical MOVE TOGETHER and are one symbol.
+    classes: dict[tuple[int, ...], list[tuple[int, int]]] = {}
+    for position, track in sorted(allowed.items()):
+        classes.setdefault(track, []).append(position)
+
+    # Whatever stayed static still fans out; re-group on exactly that.
+    static = [
+        position
+        for position in positions
+        if position not in allowed and len(set(tracks[position])) > 1
+    ]
+    buckets: dict[tuple[int, ...], list[int]] = {}
+    for offset, member in enumerate(members):
+        key = tuple(tracks[position][offset] for position in static)
+        buckets.setdefault(key, []).append(member)
+
+    plans: list[DynamicPlan] = []
+    for bucket in buckets.values():
+        plans.append(_plan_bucket(target, calls, flats, members, bucket, classes))
+    return plans
+
+
+def _plan_bucket(
+    target: str,
+    calls: Sequence[tuple[tuple[Any, ...], dict[str, Any], Sequence[str]]],
+    flats: Sequence[Sequence[tuple[str, tuple[Any, ...], Any]]],
+    members: Sequence[int],
+    bucket: Sequence[int],
+    classes: Mapping[tuple[int, ...], list[tuple[int, int]]],
+) -> DynamicPlan:
+    offsets = {member: offset for offset, member in enumerate(members)}
+    live: dict[tuple[int, ...], tuple[int, int]] = {}
+    for track in classes:
+        seen = {track[offsets[member]] for member in bucket}
+        if len(seen) > 1:
+            live[track] = (min(seen), max(seen))
+
+    # The representative: the LARGEST observed shape, so the compiler's
+    # example is the one that has to fit, and a min-sized example cannot
+    # tempt inductor into specializing the axis away. Ties break on the
+    # member order, which is the observation order — deterministic.
+    def extent(member: int) -> tuple[int, int]:
+        product = 1
+        for track in live:
+            product *= track[offsets[member]]
+        return (-product, member)
+
+    chosen = sorted(bucket, key=extent)[0]
+    args, kwargs, names = calls[chosen]
+    if not live:
+        return DynamicPlan(args, kwargs, names, None, {})
+
+    axes: dict[tuple[int, int], Any] = {}
+    symbols: dict[str, tuple[int, int]] = {}
+    reference = flats[members[0]]
+    for order, (track, span) in enumerate(sorted(live.items())):
+        first = sorted(classes[track])[0]
+        name = f"{_name(reference[first[0]][0], reference[first[0]][1])}_{first[1]}"
+        name = "".join(char if char.isalnum() else "_" for char in name)
+        if not name[:1].isalpha():
+            name = f"d{order}_{name}"
+        step = 0
+        for member in bucket:
+            step = gcd(step, track[offsets[member]])
+        dim = _dim(name, span[0], span[1], step)
+        symbols[name] = span
+        for position in classes[track]:
+            axes[position] = dim
+
+    counter = [0]
+    presented = list(args) + [kwargs[name] for name in names[len(args):]]
+    shapes = {
+        name: _rebuild(value, counter, axes)
+        for name, value in zip(names, presented, strict=True)
+    }
+    return DynamicPlan(
+        args,
+        kwargs,
+        names,
+        shapes,
+        symbols,
+        [calls[member] for member in bucket],
+        [classes[track] for track in sorted(live)],
+    )
+
+
+def alias_ingress(ingress: Any, plan: DynamicPlan) -> Any:
+    """Restate one ingress so axes exported as ONE Dim carry ONE symbol name.
+
+    ``torch.export`` gives each occurrence of a shared Dim its own symbol and
+    ties them with an in-graph guard. A guard inside the graph is invisible to
+    the dispatcher, which would then admit a call the compiled artifact
+    refuses — so the tie is moved OUT to the ingress, where every guard we own
+    can see it (``adopt`` binds one value per symbol per call).
+    """
+
+    from .ingress import CallIngress, CallInput
+
+    if not plan.classes:
+        return ingress
+    rows = {row.position: row for row in ingress.inputs}
+    rename: dict[str, str] = {}
+    for group in plan.classes:
+        names = []
+        for position, axis in group:
+            row = rows.get(position)
+            if row is None or axis >= len(row.shape):
+                continue
+            dimension = row.shape[axis]
+            if isinstance(dimension, str):
+                names.append(dimension)
+        for name in names[1:]:
+            if name != names[0]:
+                rename[name] = names[0]
+    if not rename:
+        return ingress
+    inputs = tuple(
+        CallInput(
+            name=row.name,
+            position=row.position,
+            param=row.param,
+            param_position=row.param_position,
+            path=row.path,
+            exported_name=row.exported_name,
+            dtype=row.dtype,
+            shape=tuple(
+                rename.get(dimension, dimension) if isinstance(dimension, str)
+                else dimension
+                for dimension in row.shape
+            ),
+        )
+        for row in ingress.inputs
+    )
+    kept = {
+        dimension
+        for row in inputs
+        for dimension in row.shape
+        if isinstance(dimension, str)
+    }
+    return CallIngress(
+        parameters=ingress.parameters,
+        flat_arity=ingress.flat_arity,
+        inputs=inputs,
+        symbols=tuple(
+            (name, bounds) for name, bounds in ingress.symbols if name in kept
+        ),
+        excluded_inputs=ingress.excluded_inputs,
+    )
+
+
+__all__ = [
+    "DimPolicy",
+    "DynamicPlan",
+    "alias_ingress",
+    "all_dims",
+    "plan_exports",
+    "resolve_policy",
+]

--- a/src/gen_worker/_vendor/torchcg/ingress.py
+++ b/src/gen_worker/_vendor/torchcg/ingress.py
@@ -402,6 +402,24 @@ def _symbol_ranges(program: object) -> dict[str, tuple[int, int]]:
     return ranges
 
 
+def symbol_terms(name: str) -> tuple[int, str]:
+    """``'8*s1'`` -> ``(8, 's1')``; ``'s1'`` -> ``(1, 's1')``.
+
+    A dynamic axis is often a DERIVED dim -- a latent side a UNet accepts only
+    in multiples of eight is exported as ``8*s1``, and torch spells the
+    placeholder's dim with that expression. The coefficient is therefore
+    carried by the symbol's own NAME rather than by a second schema field, and
+    every guard reads it from here: the stride a value must satisfy, and the
+    ROOT two axes must agree on when they share one (``8*s1`` and ``16*s1``
+    are one degree of freedom, not two).
+    """
+
+    head, _, tail = name.partition("*")
+    if tail and head.lstrip("-").isdigit():
+        return int(head), tail
+    return 1, name
+
+
 def _placeholder_values(program: object) -> dict[str, object]:
     values: dict[str, object] = {}
     graph = getattr(getattr(program, "graph_module", None), "graph", None)
@@ -465,6 +483,18 @@ def build_call_ingress(
                 continue
             bounds = ranges.get(text)
             if bounds is None:
+                # A derived dim: torch bounds the ROOT and spells the axis as
+                # the expression, so the axis's own range is the root's,
+                # scaled. Recorded in the units the CALL presents, which is
+                # what every guard compares against.
+                coefficient, root = symbol_terms(text)
+                root_bounds = ranges.get(root) if coefficient > 1 else None
+                if root_bounds is not None:
+                    bounds = (
+                        coefficient * root_bounds[0],
+                        coefficient * root_bounds[1],
+                    )
+            if bounds is None:
                 raise IngressError(
                     "range_invalid", f"input {leaf.name!r} symbol {text!r} has no finite range"
                 )
@@ -498,4 +528,5 @@ __all__ = [
     "PathStep",
     "build_call_ingress",
     "exported_input_name",
+    "symbol_terms",
 ]

--- a/src/gen_worker/_vendor/torchcg/selection.py
+++ b/src/gen_worker/_vendor/torchcg/selection.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Final
 
-from .ingress import CallIngress, CallInput
+from .ingress import CallIngress, CallInput, symbol_terms
 
 #: The corpus schema this module reads and writes. A corpus stamping any other
 #: value is refused, never best-effort decoded: a host that silently accepted a
@@ -757,19 +757,35 @@ def class_report(
                     )
                 )
                 continue
-            prior = symbols.get(declared)
-            if prior is not None and prior != got:
+            # tcg#77: a DERIVED dim (`8*s1`) is a range AND a stride. An
+            # in-range value that is not a multiple of it is refused by the
+            # graph's own shape guards, so it is refused here -- same rung,
+            # because "this axis does not admit that value" is one family.
+            stride, root = symbol_terms(declared)
+            if got % stride:
+                misses.append(
+                    IngressMiss(
+                        MissReason.RANGE_VIOLATION,
+                        spec.name,
+                        f"input {spec.name!r} dim {position} (symbol {declared!r}) = {got} "
+                        f"is not a multiple of {stride}",
+                    )
+                )
+                continue
+            bound = got // stride
+            prior = symbols.get(root)
+            if prior is not None and prior != bound:
                 misses.append(
                     IngressMiss(
                         MissReason.SYMBOL_INCONSISTENT,
                         spec.name,
-                        f"symbol {declared!r} = {got} on input {spec.name!r} dim {position} "
-                        f"but {prior} on input {owner[declared]!r}",
+                        f"symbol {root!r} = {bound} on input {spec.name!r} dim {position} "
+                        f"but {prior} on input {owner[root]!r}",
                     )
                 )
                 continue
-            symbols[declared] = got
-            owner.setdefault(declared, spec.name)
+            symbols[root] = bound
+            owner.setdefault(root, spec.name)
     return SpecializationReport(
         name=name,
         misses=tuple(misses[:1]) if first_only else tuple(misses),

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -26,6 +26,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+from ..release.derive import DYNAMIC_AXES
 from . import endpoint_lock as el
 from . import workspace as ws
 
@@ -76,6 +77,19 @@ def add_subparser(sub: Any) -> None:
         "--force",
         action="store_true",
         help="re-trace even when the saved trace is reusable",
+    )
+    # pgw#1548. OFF is the default and stays the default until a measurement
+    # says otherwise per model: a dynamic axis collapses a fan of graph
+    # specializations into one, and whether that costs serving time is an
+    # empirical question inductor answers differently per architecture.
+    parser.add_argument(
+        "--dynamic-axes",
+        choices=list(DYNAMIC_AXES),
+        default="off",
+        help="export these axes as torch.export Dims instead of one graph "
+             "per observed shape: `batch` collapses the CFG axis, `aspect` "
+             "collapses the aspect-ratio buckets, `all` both "
+             "(default: off — one graph per observed shape)",
     )
     parser.add_argument(
         "--discovery-only",
@@ -294,7 +308,7 @@ def run_lock(args: argparse.Namespace) -> int:
              "document moved with them")
         return _check_by_rederive(
             config, root, out, existing, tree, graph_cas_root, device, lockfile,
-            slot_trees,
+            slot_trees, dynamic_axes=getattr(args, "dynamic_axes", "off"),
         )
 
     store = ws.local_graph_store(graph_cas_root)
@@ -340,6 +354,7 @@ def run_lock(args: argparse.Namespace) -> int:
 
     traced = _trace(
         config, root, tree, graph_cas_root, device, lockfile, slot_trees,
+        dynamic_axes=getattr(args, "dynamic_axes", "off"),
     )
     if traced is None:
         return 1
@@ -456,6 +471,7 @@ def _trace(
     device: str,
     lockfile: Optional[Path] = None,
     slot_trees: Optional[dict[str, Path]] = None,
+    dynamic_axes: str = "off",
 ) -> Optional[tuple[Any, float]]:
     """Import the author's module and derive it. ``None`` = said why, failed.
 
@@ -486,6 +502,7 @@ def _trace(
             lockfile=lockfile if lockfile is not None else lockfile_beside(root),
             graph_cas=graph_cas_root,
             slot_checkpoints=slot_trees or {},
+            dynamic_axes=dynamic_axes,
         )
     except DeriveError as exc:
         _say(f"error: derive: {exc}")
@@ -506,6 +523,7 @@ def _check_by_rederive(
     device: str,
     lockfile: Optional[Path] = None,
     slot_trees: Optional[dict[str, Path]] = None,
+    dynamic_axes: str = "off",
 ) -> int:
     """``--check``'s expensive arm: does the committed DOCUMENT still hold?
 
@@ -517,6 +535,7 @@ def _check_by_rederive(
 
     traced = _trace(
         config, root, tree, graph_cas_root, device, lockfile, slot_trees,
+        dynamic_axes=dynamic_axes,
     )
     if traced is None:
         return 1

--- a/src/gen_worker/cli/release.py
+++ b/src/gen_worker/cli/release.py
@@ -14,6 +14,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from ..release.derive import DYNAMIC_AXES
+
 
 def add_subparser(sub: Any) -> None:
     parser = sub.add_parser(
@@ -73,6 +75,17 @@ def add_subparser(sub: Any) -> None:
         default=None,
         help="write the document bytes here (default: stdout)",
     )
+    # pgw#1548: see `release.derive.DYNAMIC_AXES`. OFF by default — a dynamic
+    # axis re-keys every graph in the lane, and whether it is free is measured
+    # per model, not assumed.
+    derive.add_argument(
+        "--dynamic-axes",
+        choices=list(DYNAMIC_AXES),
+        default="off",
+        help="export these axes as torch.export Dims instead of one graph per "
+        "observed shape: `batch` collapses the CFG axis, `aspect` collapses "
+        "the aspect-ratio buckets, `all` both (default: off)",
+    )
     derive.set_defaults(_handler=_run_derive)
 
 
@@ -127,6 +140,7 @@ def _run_derive(args: argparse.Namespace) -> int:
             lockfile=lockfile,
             graph_cas=Path(args.graph_cas).resolve() if args.graph_cas else None,
             slot_checkpoints=trees,
+            dynamic_axes=args.dynamic_axes,
         )
     except DeriveError as exc:
         print(f"derive error: {exc}", file=sys.stderr)

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -105,9 +105,53 @@ ENUM_CAP = 64
 #: modules like a marked VAE decoder). None = the author's own step count.
 TRACE_STEP_BUDGET: Optional[int] = 1
 
+#: The axes a derive may export DYNAMIC, by name (pgw#1548).
+#:
+#: torchcg takes a ``(target, input name, axis) -> bool`` predicate and holds
+#: no opinion about what an axis MEANS; naming them is the endpoint layer's
+#: job, and these two names are the ones Paul's ruling is written in:
+#:
+#: * ``batch`` — axis 0 of any feed. Classifier-free guidance is the whole
+#:   axis: batch 2 is cond+uncond concatenated, batch 1 is the guidance-free
+#:   path, and every shipped lock carries both.
+#: * ``aspect`` — axes 2.. of a rank-4+ feed, i.e. a latent's spatial sides.
+#:   sd15 carries 7 of these and sdxl 9, one graph each.
+#:
+#: ``all`` is both; ``off`` (the default) is the static fan every lock in the
+#: fleet was derived under. The default is deliberately OFF: which axis is
+#: worth collapsing is a MEASURED question per model (pgw#1548's acceptance),
+#: and a flag that silently re-keys every graph in the fleet is not a default.
+DYNAMIC_AXES = ("off", "batch", "aspect", "all")
+
 
 class DeriveError(RuntimeError):
     """The release derive cannot state this endpoint's graph set."""
+
+
+def dynamic_dim_policy(axes: str) -> Any:
+    """Turn an axis NAME into the predicate torchcg dispatches on."""
+
+    if axes not in DYNAMIC_AXES:
+        raise DeriveError(
+            f"dynamic dims are declared by axis name, one of "
+            f"{list(DYNAMIC_AXES)!r}; got {axes!r}"
+        )
+    if axes == "off":
+        return None
+    batch = axes in ("batch", "all")
+    aspect = axes in ("aspect", "all")
+
+    def policy(_target: str, _name: str, axis: int) -> bool:
+        if axis == 0:
+            return batch
+        # Rank is not handed to the predicate, so "axis 2 or beyond" is the
+        # spelling of spatial here. Axis 1 is a channel or a sequence length
+        # and is never offered: neither varies across an aspect fan, so
+        # admitting it would widen a graph over an axis no observation
+        # supports.
+        return aspect and axis >= 2
+
+    return policy
 
 
 class PayloadEnumerationRefused(DeriveError):
@@ -1384,6 +1428,7 @@ def _derive_lane(
     slot_checkpoints: Mapping[str, Path] = MappingProxyType({}),
     endpoint_root: Optional[Path] = None,
     unservable: Optional[list[dict[str, Any]]] = None,
+    dynamic_dims: Any = None,
 ) -> Optional[Any]:
     """One lane's instrumented runs, merged across defaults variants.
 
@@ -1589,7 +1634,7 @@ def _derive_lane(
             try:
                 lane_graphs = torchcg.discover_modules(
                     handle, modules, drive, program_sink=program_sink,
-                    session=session,
+                    session=session, dynamic_dims=dynamic_dims,
                 )
                 if set(lane_graphs.targets) - {
                     record.target for record in lane_graphs.graphs
@@ -1600,7 +1645,7 @@ def _derive_lane(
                     request_ctx.step_budget = None
                     lane_graphs = torchcg.discover_modules(
                         handle, modules, drive, program_sink=program_sink,
-                        session=session,
+                        session=session, dynamic_dims=dynamic_dims,
                     )
             except DeriveError:
                 raise
@@ -1642,6 +1687,7 @@ def derive_release(
     lockfile: Optional[Path] = None,
     graph_cas: Optional[Path] = None,
     slot_checkpoints: Mapping[str, Path] = MappingProxyType({}),
+    dynamic_axes: str = "off",
 ) -> ReleaseDeriveResult:
     """Derive the release metadata document for one endpoint module.
 
@@ -1750,6 +1796,7 @@ def derive_release(
                 slot_checkpoints=slot_checkpoints,
                 endpoint_root=endpoint_source_root(module),
                 unservable=unservable_payloads,
+                dynamic_dims=dynamic_dim_policy(dynamic_axes),
             )
             if lane_graphs is None:
                 # Traced, nothing marked (pgw#1488). No lane row: an empty one

--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -63,6 +63,10 @@ class TraceLoadContext:
         #: Modules the author marked via ctx.compile() -- discovery hooks
         #: exactly these during the payload drives.
         self.marked_modules: list[Any] = []
+        #: Component directories already reported as disagreeing with the
+        #: lane, so the pgw#1567 warning is one line per component and not
+        #: one per parameter.
+        self._dtype_said: set[str] = set()
 
     def load(self, loader: Any) -> Any:
         """Hollow-materialize the CONFIG-ONLY tree through the author's loader.
@@ -95,12 +99,12 @@ class TraceLoadContext:
         # bf16 landed on the VAE beside it — a bf16 bias meeting an fp32
         # activation in a decode block that is fine on a pod.
         #
-        # Precision is now decided PER COMPONENT, by `component_dtype` below,
-        # through the session policy torchcg asks (tcg#68). The lane still
-        # governs the component its contract describes, so the marked
-        # denoiser's precision — which IS graph identity (pgw#1458) — still
-        # comes from the contract, and pgw#1448's "real dtype, never the
-        # spelling" rule still applies to it.
+        # Precision is asked PER COMPONENT, by `component_dtype` below,
+        # through the session policy torchcg installs (tcg#68) — and every
+        # component of a tree a DECLARED lane governs answers with that lane's
+        # dtype (pgw#1567, Paul). Precision IS graph identity (pgw#1458), the
+        # lane is where that identity is declared, and pgw#1448's "real dtype,
+        # never the spelling" rule applies to it.
         loaded = from_pretrained(self.checkpoint_dir)
         # Adapter application mutates WEIGHTS (or injects adapter layers);
         # at trace every parameter is fake and no adapter bytes exist, so the
@@ -114,34 +118,55 @@ class TraceLoadContext:
         return loaded
 
     def component_dtype(self, tree: Any, subfolder: Any, module: Any = None) -> Any:
-        """The precision ONE component loads at (pgw#1512, Paul's ruling).
+        """The precision ONE component loads at — **from the LANE DECLARATION**.
+
+        ⚖️ **Paul, 2026-08-20 (pgw#1567), ratifying and generalizing:** *"do one
+        trace per tensor-layout-contract-template… the tensor-layout contract
+        says, essentially 'this is a lane you can use'."* The trace dtype and
+        the trace identity come from the lane the endpoint DECLARES, never from
+        whatever checkpoint happens to be mounted at derive time. Within a lane
+        the checkpoint is irrelevant by construction: the artifact is
+        weight-free and runtime constant folding binds any conforming
+        fine-tune's weights at load.
+
+        **THE BUG THIS DELETES, and it was in the ORDER, not the sources.**
+        This ladder used to read the mounted tree's safetensors headers FIRST.
+        A dev-box derive against a stock fp16 dreamshaper tree therefore traced
+        every graph fp16 while the lane was ``sd15.diffusers-bf16@1`` and the
+        pod served bf16 — 14 graphs armed, 0 entered, silently, for a night.
+        tcg#76's instrument named it in one line::
+
+            input 'sample': dtype bfloat16 != expected float16
+
+        **Why the lane is the right source and the checkpoint is not.** The
+        serve path does not convert anything: ``streaming.engine`` is dtype
+        PASSTHROUGH and the STORE converts the tree through the lane's layout
+        contract before a pod ever mounts it (``engine._warn_on_lane`` is that
+        rule stated from the other side). So on the tree that actually serves,
+        every container IS the lane's dtype — the lane declaration is a
+        complete and correct statement of it, and the header read only ever
+        agreed by luck. At derive time the mounted tree is usually NOT the
+        converted one, which is exactly when the two answers differ and exactly
+        when following the checkpoint is wrong.
+
+        The ladder, in order:
+
+        1. **The lane's declared dtype**, for every component of the tree the
+           lane governs. Precision is graph identity (pgw#1458) and the lane is
+           the one place that identity is declared.
+        2. **A lane that declares none** is a DERIVED lane (pgw#1488) — no
+           contract, so no contract dtype. Only then does the checkpoint speak,
+           through the same stub-aware reader the serve path uses: the
+           component's own bytes, then its config.
+        3. **Nothing may default.** A quiet fp32 is the defect pgw#1448
+           deleted, and at trace it would silently re-key a graph.
 
         ``module`` is tcg#71's third argument — the component just built on
-        meta, handed over so a policy CAN match by the module's own parameter
-        names. This policy still decides by contract-segment + container
-        (below); adopting name-matching is pgw#1530's owner's call, and until
-        then the argument is accepted so the vendored torchcg tip can call the
-        policy at all.
-
-        Installed as torchcg's session policy, so it is asked once per
-        component instead of once per tree.
-
-        1. **The lane governs the component its CONTRACT DESCRIBES.** A layout
-           contract names the tensors it covers, and a pattern's first segment
-           is the component that owns them (``unet.conv_out.weight`` ->
-           ``unet``). For h3 that set is the DiT and nothing else, which is the
-           whole ruling: a denoiser contract says nothing about the VAE beside
-           it. This branch is where precision-is-identity lives (pgw#1458), so
-           it keeps pgw#1448's real-dtype-never-the-spelling read.
-        2. **Otherwise the component's own container answers**, through the
-           SAME stub-aware reader the serve path uses
-           (``serving.checkpoint_dtype``): its config's declared dtype first,
-           then the safetensors headers. On a projected tree those headers are
-           128-byte stubs, and that reader is the one that knows it -- a naive
-           open here would read a stub as truth.
-        3. **Nothing may default.** If neither the contract nor the container
-           can say, this REFUSES by name. A quiet fp32 is the defect pgw#1448
-           deleted, and at trace it would silently re-key a graph.
+        meta. This policy does not need it: the lane governs the tree, not a
+        matched subset (pgw#1538 measured that match-scoping leaves sd15's text
+        encoder at fp32 beside a bf16 denoiser, which is the same defect
+        arriving from the other side). It is accepted so the vendored torchcg
+        tip can call the policy at all.
         """
 
         from ..serving.checkpoint_dtype import (
@@ -169,35 +194,29 @@ class TraceLoadContext:
             if relative is not None and str(relative) not in (".", ""):
                 name = str(relative).strip("/")
 
-        # 1. THE COMPONENT'S OWN BYTES, when it has any. A serving tree has
-        #    been CONVERTED through the lane contract by the store, so its
-        #    safetensors headers are the precision the pod actually runs —
-        #    read through the stub-aware reader, which knows a 128-byte
-        #    projection stub from a real file.
+        # 1. THE LANE, for every component of the tree it governs. A contract's
+        #    `tensors` list enumerates the DENOISER's own parameter names —
+        #    `conv_in.weight` for sd15, `transformer_blocks.…` for h3 — but its
+        #    `dtype` states the precision of the TREE the store converts to
+        #    that contract, which is the tree that serves.
+        # No `checkpoint_dir=`: this read asks the CONTRACT and nothing else.
+        # Passing the tree is what would reintroduce the checkpoint as a
+        # silent second answer.
+        declared = _lane_torch_dtype(self.lane)
+        if declared is not None:
+            self._say_checkpoint_disagrees(directory, name, declared)
+            return declared
+
+        # 2. A DERIVED LANE (pgw#1488) declares no dtype, so there is no
+        #    contract to read one from and the checkpoint is the only source
+        #    left. Its own BYTES first, through the stub-aware reader that
+        #    knows a 128-byte projection stub from a real file; its config
+        #    last, because on a converted tree a component config is the
+        #    PUBLISHER's (sd15's `text_encoder/config.json` still says
+        #    `float32` in a tree whose bytes are bf16).
         own = _header_dtype(directory)
         if own is not None:
             return own
-
-        # 2. OTHERWISE THE LANE. pgw#1530: this is the half pgw#1512 got
-        #    wrong. A contract's `tensors` list enumerates the DENOISER's own
-        #    parameter names — every shipped contract does, `conv_in.weight`
-        #    for sd15, `transformer_blocks.…` for h3, never a `unet.`/
-        #    `transformer.` prefix — but its `dtype` states the precision of
-        #    the TREE the store converts to that contract. Treating the
-        #    tensor list as a component roster made the governed set match
-        #    nothing on every endpoint in the fleet, so the lane's dtype was
-        #    never applied anywhere and a config-only derive silently traced
-        #    fp32 graphs under a bf16 lane.
-        declared = _lane_torch_dtype(self.lane, checkpoint_dir=self.checkpoint_dir)
-        if declared is not None:
-            return declared
-
-        # 3. THE COMPONENT'S CONFIG, LAST and only when nothing above spoke.
-        #    On a converted tree a component config is the PUBLISHER's, not
-        #    the store's: sd15's `text_encoder/config.json` still says
-        #    `float32` in a tree whose bytes are bf16. Preferring it is what
-        #    put an fp32 encoder beside a bf16 denoiser and produced
-        #    `Input type (float) and bias type (c10::BFloat16)` on payload 0.
         config = _config_dtype(directory)
         if config is not None:
             return config
@@ -206,6 +225,45 @@ class TraceLoadContext:
         # which is what the streaming loader does with bytes it was given no
         # contract for.
         return None
+
+    def _say_checkpoint_disagrees(
+        self, directory: Path, name: str, declared: Any
+    ) -> None:
+        """Name a mounted tree whose bytes are not the lane's, once per component.
+
+        The trace follows the LANE regardless — that is the fix. But a
+        derive run against an unconverted tree is worth saying out loud,
+        because it is the state in which the old order silently produced a
+        whole fleet of graphs no runtime could enter (pgw#1567). Same fact the
+        serve-side loader reports from the other side
+        (``streaming.engine._warn_on_lane``): conversion is the store's job,
+        and a tree that skipped it is a store defect, never a trace decision.
+        """
+
+        from ..serving.checkpoint_dtype import _tensor_dtype
+
+        key = str(directory)
+        if key in self._dtype_said:
+            return
+        try:
+            own = _tensor_dtype(directory)
+        except Exception:  # noqa: BLE001 — a diagnostic never fails a derive
+            return
+        if own is None or own == declared:
+            return
+        self._dtype_said.add(key)
+        self._log.warning(
+            "derive: lane %s declares dtype %s and the mounted checkpoint's "
+            "%s containers carry %s. The TRACE FOLLOWS THE LANE (pgw#1567): "
+            "the store converts a tree through the layout contract before a "
+            "pod mounts it, so the lane is what serves. This tree was not "
+            "converted — the graphs are still right, but nothing here has "
+            "verified the checkpoint against the contract it is keyed under.",
+            getattr(self.lane, "contract", self.lane),
+            declared,
+            name or "root",
+            own,
+        )
 
     def compile(self, target: Any) -> Any:
         """torch.compile-style marking, trace half (pgw#1370/#1372 contract).

--- a/tests/release_fixtures/dynamic_axes_endpoint.py
+++ b/tests/release_fixtures/dynamic_axes_endpoint.py
@@ -1,0 +1,82 @@
+"""sd15's SHAPE FAN, in miniature: three aspects x two CFG modes (pgw#1548).
+
+The real sd15 endpoint derives 14 graph specializations — 2 (CFG) x 7 (aspect
+bucket) — and sdxl 18. Nothing about that count is declared anywhere; it falls
+out of the payload enumeration driving the marked UNet at a different shape
+each pass. This fixture reproduces exactly that structure at fixture scale so
+the collapse can be measured through the REAL derive, not a stand-in.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint
+from gen_worker.models import SDXL
+from gen_worker.models.model_types import SD15_DIFFUSERS_BF16
+
+class Aspect(StrEnum):
+    """The aspect axis, spelled the way sd15's own `AspectRatio` is.
+
+    A shape-bearing string axis is a StrEnum, never a string Literal: the
+    derive enumerates enums and NUMERIC literals, and deliberately refuses to
+    cross-product string literals (they name host-side policy, not shape).
+    """
+
+    SQUARE = "square"
+    TALL = "tall"
+    WIDE = "wide"
+
+
+#: latent side = pixel side here (the fixture VAE has one block), so these are
+#: the three aspect buckets the UNet actually sees.
+SHAPES: dict[str, tuple[int, int]] = {
+    Aspect.SQUARE: (64, 64),
+    Aspect.TALL: (80, 48),
+    Aspect.WIDE: (48, 80),
+}
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str = "a cat"
+    #: The aspect axis. Each value is one bucket, and the enumeration drives
+    #: the marked module once per value.
+    aspect: Aspect = Aspect.SQUARE
+    #: The CFG axis: guided runs concatenate cond+uncond (batch 2), the
+    #: guidance-free path does not (batch 1). Spelled as an int enum because
+    #: msgspec refuses a bool Literal.
+    guided: Literal[1, 0] = 1
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class FanShaped(Model[SDXL], lanes=(SD15_DIFFUSERS_BF16,)):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In, model: FanShaped) -> Out:
+    ctx.raise_if_cancelled()
+    height, width = SHAPES[payload.aspect]
+    with torch.inference_mode():
+        model.pipe(
+            prompt=payload.prompt,
+            num_inference_steps=1,
+            guidance_scale=7.5 if payload.guided else 1.0,
+            width=width,
+            height=height,
+            callback_on_step_end=ctx.step_callback(1),
+            output_type="latent",
+        )
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_release_derive_component_dtype.py
+++ b/tests/test_release_derive_component_dtype.py
@@ -19,10 +19,14 @@ two things followed:
     activation into a bf16 denoiser: `Input type (float) and bias type
     (c10::BFloat16)` on payload 0.
 
-The rule is now about WHERE the answer comes from, in order of how directly
-the source knows: the component's own BYTES, then the LANE, then the
-component's config — with the config last precisely because it is the one
-source a conversion does not rewrite.
+**pgw#1567 (Paul, 2026-08-20) then settled the ORDER, which is what was still
+wrong.** The ladder led with the component's own BYTES, so a derive against a
+tree the store had not converted — a stock fp16 dreamshaper on a dev box —
+traced fp16 graphs under a bf16 lane and armed a fleet no runtime could enter.
+The lane declaration now answers FIRST for every component of the tree it
+governs; the checkpoint speaks only for a DERIVED lane, which has no contract
+to read a dtype from. The trace dtype is a property of the contract-template,
+never of the bytes that happen to be mounted.
 
 These tests use the REAL library contracts on purpose. pgw#1512's fixture
 invented `unet.conv_out.weight`, and that invention is what let every check
@@ -162,26 +166,100 @@ def test_the_WHOLE_sd15_pipeline_agrees_so_no_activation_crosses_a_boundary(
     assert set(seen.values()) == {torch.bfloat16}, seen
 
 
-def test_a_components_own_BYTES_outrank_the_lane(tmp_path: Path) -> None:
-    """A converted tree's headers are what the pod actually runs.
-
-    Built with real safetensors so the stub-aware reader is the thing under
-    test, not a stand-in.
-    """
+def _tree_at(root: Path, dtype: Any) -> Path:
+    """A tiny two-component tree whose safetensors headers carry ``dtype``."""
 
     safetensors = pytest.importorskip("safetensors.torch")
 
-    tree = tmp_path / "tree"
-    (tree / "vae").mkdir(parents=True)
-    (tree / "vae" / "config.json").write_text(json.dumps({"_class_name": "AutoencoderKL"}))
-    safetensors.save_file(
-        {"decoder.conv_out.weight": torch.zeros(2, 2, dtype=torch.float16)},
-        str(tree / "vae" / "diffusion_pytorch_model.safetensors"),
-    )
+    root.mkdir(parents=True, exist_ok=True)
+    for component, weight in (
+        ("unet", "conv_in.weight"),
+        ("vae", "decoder.conv_out.weight"),
+    ):
+        (root / component).mkdir(parents=True, exist_ok=True)
+        (root / component / "config.json").write_text(json.dumps({"_class_name": "X"}))
+        safetensors.save_file(
+            {weight: torch.zeros(2, 2, dtype=dtype)},
+            str(root / component / "diffusion_pytorch_model.safetensors"),
+        )
+    return root
 
+
+def test_the_LANE_outranks_the_mounted_checkpoints_own_bytes(tmp_path: Path) -> None:
+    """pgw#1567, Paul's ruling: the checkpoint is IRRELEVANT to the trace.
+
+    Built with real safetensors so the stub-aware reader is the thing under
+    test, not a stand-in. These bytes say float16 and the lane says bfloat16;
+    under the old order the bytes won, and a dev-box derive against a stock
+    fp16 tree keyed a whole fleet of fp16 graphs that a bf16 pod could never
+    enter (14 armed, 0 entered).
+    """
+
+    tree = _tree_at(tmp_path / "tree", torch.float16)
     ctx = _ctx(tree, _contract("sd15.diffusers-bf16.v1.json"))
-    # The lane says bfloat16; these bytes say float16, and the bytes win.
-    assert ctx.component_dtype(tree, "vae") is torch.float16
+    assert ctx.component_dtype(tree, "vae") is torch.bfloat16
+    assert ctx.component_dtype(tree, "unet") is torch.bfloat16
+
+
+def test_FLIPPING_the_checkpoints_dtype_does_not_move_the_traced_precision(
+    tmp_path: Path,
+) -> None:
+    """The deliverable, stated as a property: same lane, two checkpoints.
+
+    Two trees identical but for the dtype their containers carry. Precision is
+    graph identity (pgw#1458), so if the checkpoint could move it, the two
+    would derive DIFFERENT graph sets under one contract-template — which is
+    exactly the fleet of unenterable graphs pgw#1567 measured. A weight-free
+    artifact plus runtime constant folding means any conforming checkpoint
+    folds in at load; nothing about the trace may depend on which one is
+    mounted.
+    """
+
+    lane = _contract("sd15.diffusers-bf16.v1.json")
+    answers = []
+    for name, dtype in (("fp16", torch.float16), ("fp32", torch.float32)):
+        tree = _tree_at(tmp_path / name, dtype)
+        ctx = _ctx(tree, lane)
+        answers.append(
+            tuple(ctx.component_dtype(tree, part) for part in ("unet", "vae"))
+        )
+    assert answers[0] == answers[1] == (torch.bfloat16, torch.bfloat16)
+
+
+def test_a_checkpoint_that_disagrees_with_the_lane_is_NAMED(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Following the lane silently would hide an unconverted tree.
+
+    The trace still follows the lane — that is the fix — but a tree the store
+    never converted is a store defect worth one line, the same fact
+    `streaming.engine._warn_on_lane` reports from the serve side.
+    """
+
+    import logging
+
+    tree = _tree_at(tmp_path / "tree", torch.float16)
+    ctx = _ctx(tree, _contract("sd15.diffusers-bf16.v1.json"))
+    with caplog.at_level(logging.WARNING, logger="gen_worker.release.trace"):
+        assert ctx.component_dtype(tree, "unet") is torch.bfloat16
+        assert ctx.component_dtype(tree, "unet") is torch.bfloat16
+    said = [r for r in caplog.records if "TRACE FOLLOWS THE LANE" in r.getMessage()]
+    assert len(said) == 1, "named once per component, not once per ask"
+    assert "float16" in said[0].getMessage()
+
+
+def test_a_checkpoint_that_AGREES_with_the_lane_says_nothing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The red arm's other half: no warning when there is nothing to warn about."""
+
+    import logging
+
+    tree = _tree_at(tmp_path / "tree", torch.bfloat16)
+    ctx = _ctx(tree, _contract("sd15.diffusers-bf16.v1.json"))
+    with caplog.at_level(logging.WARNING, logger="gen_worker.release.trace"):
+        assert ctx.component_dtype(tree, "unet") is torch.bfloat16
+    assert not [r for r in caplog.records if "TRACE FOLLOWS THE LANE" in r.getMessage()]
 
 
 def test_a_stale_component_CONFIG_does_not_outrank_the_lane(

--- a/tests/test_release_derive_dynamic_axes_pgw1548.py
+++ b/tests/test_release_derive_dynamic_axes_pgw1548.py
@@ -1,0 +1,201 @@
+"""pgw#1548: `--dynamic-axes` collapses the shape fan, one axis at a time.
+
+Through the REAL `gen-worker release derive` codepath, over a fixture endpoint
+whose payload enumeration reproduces sd15's actual structure — three aspect
+buckets x two CFG modes. sd15 ships 14 specializations (2 x 7) and sdxl 18
+(2 x 9); nothing declares those counts, they fall out of the enumeration
+driving the marked UNet at a different shape each pass.
+
+The static arm is the control and it stays exactly as it was: the default is
+`off`, and a lock derived without the flag is the lock the fleet has today.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+import torch  # noqa: E402
+
+from gen_worker.release.derive import DeriveError, dynamic_dim_policy  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+LOCK = (
+    'version = 1\n'
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+
+@pytest.fixture(scope="module")
+def config_only_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    import sys
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    tree: Path = tiny_tree.save_config_only(tmp_path_factory.mktemp("fan-tree"))
+    return tree
+
+
+def _lane(tree: Path, out: Path, axes: str) -> dict:
+    from gen_worker.cli import main
+
+    lockfile = out.parent / f"{axes}-uv.lock"
+    lockfile.write_text(LOCK)
+    code = main(
+        [
+            "release", "derive",
+            "--dir", str(FIXTURES),
+            "--module", "dynamic_axes_endpoint",
+            "--checkpoint", str(tree),
+            "--lockfile", str(lockfile),
+            "--dynamic-axes", axes,
+            "--out", str(out),
+        ]
+    )
+    assert code == 0, f"derive --dynamic-axes {axes} failed"
+    document = json.loads(out.read_bytes())
+    (lane,) = document["graphs"]["lanes"]
+    return dict(lane)
+
+
+@pytest.fixture(scope="module")
+def lanes(config_only_tree: Path, tmp_path_factory: pytest.TempPathFactory) -> dict:
+    room = tmp_path_factory.mktemp("fan-derives")
+    return {
+        axes: _lane(config_only_tree, room / f"{axes}.json", axes)
+        for axes in ("off", "batch", "aspect", "all")
+    }
+
+
+def test_the_static_fan_is_the_default_and_is_unchanged(lanes: dict) -> None:
+    """The control: 3 aspects x 2 CFG modes = six concrete specializations."""
+
+    graphs = lanes["off"]["graphs"]
+    assert len(graphs) == 6
+    for record in graphs:
+        assert record["ingress"]["symbols"] == {}
+        for row in record["ingress"]["inputs"]:
+            assert all(isinstance(dim, int) for dim in row["shape"])
+
+
+def test_every_axis_dynamic_is_ONE_graph_for_the_whole_fan(lanes: dict) -> None:
+    (record,) = lanes["all"]["graphs"]
+    sample = next(
+        row for row in record["ingress"]["inputs"] if row["name"] == "sample"
+    )
+    batch, channels, height, width = sample["shape"]
+    assert channels == 4
+    symbols = record["ingress"]["symbols"]
+    assert symbols[batch] == [1, 2], "the CFG axis, as a range"
+    assert symbols[height] == [48, 80] and symbols[width] == [48, 80]
+    assert height != width, "H and W are two degrees of freedom"
+
+
+def test_ONE_axis_at_a_time_is_the_acceptance_gates_shape(lanes: dict) -> None:
+    """Paul's gate adopts per axis, so the derive must be able to do that.
+
+    `batch` collapses the CFG pair and leaves the three aspect buckets
+    concrete (6 -> 3); `aspect` collapses the three buckets and leaves the two
+    CFG batches concrete (6 -> 2). WHICH axis moved is visible in the record.
+    """
+
+    assert len(lanes["batch"]["graphs"]) == 3
+    assert len(lanes["aspect"]["graphs"]) == 2
+
+    for record in lanes["batch"]["graphs"]:
+        shape = record["ingress"]["inputs"][0]["shape"]
+        assert isinstance(shape[0], str), "batch is a symbol"
+        assert isinstance(shape[2], int) and isinstance(shape[3], int)
+
+    for record in lanes["aspect"]["graphs"]:
+        shape = record["ingress"]["inputs"][0]["shape"]
+        assert shape[0] in (1, 2), "batch stays concrete"
+        assert isinstance(shape[2], str) and isinstance(shape[3], str)
+
+
+def test_the_dynamic_records_still_dispatch_every_observed_shape(
+    lanes: dict,
+) -> None:
+    """A collapsed record must ADMIT what the fan it replaced admitted.
+
+    Through the serving dispatcher's own predicate, not a re-implementation.
+    """
+
+    from gen_worker._vendor.torchcg.adopt import _matches
+    from gen_worker._vendor.torchcg.document import GraphRecord
+    from gen_worker._vendor.torchcg.ingress import CallIngress
+
+    raw = lanes["all"]["graphs"][0]
+    record = GraphRecord(
+        graph=raw["graph"],
+        target=raw["target"],
+        ingress=CallIngress.decode(raw["ingress"]),
+    )
+    rows = {row.name: row for row in record.ingress.inputs}
+    text = rows["encoder_hidden_states"]
+
+    def call(batch: int, height: int, width: int) -> bool:
+        return _matches(
+            record,
+            (),
+            {
+                "sample": torch.zeros(
+                    (batch, 4, height, width),
+                    dtype=getattr(torch, rows["sample"].dtype),
+                ),
+                "timestep": torch.zeros(
+                    (), dtype=getattr(torch, rows["timestep"].dtype)
+                ),
+                "encoder_hidden_states": torch.zeros(
+                    (batch, int(text.shape[1]), int(text.shape[2])),
+                    dtype=getattr(torch, text.dtype),
+                ),
+            },
+        )
+
+    for height, width in ((64, 64), (80, 48), (48, 80)):
+        for batch in (1, 2):
+            assert call(batch, height, width), f"{batch}x{height}x{width}"
+    # And refuses what it was never exported for — a dynamic record is a
+    # range, so an unobserved shape still falls to eager.
+    assert not call(4, 64, 64)
+    assert not call(2, 96, 96)
+
+
+def test_the_collapsed_record_is_keyed_at_the_LANES_dtype(lanes: dict) -> None:
+    """pgw#1567 holds through the collapse: bf16 lane, bf16 ingress."""
+
+    for record in lanes["all"]["graphs"]:
+        for row in record["ingress"]["inputs"]:
+            if row["name"] in ("sample", "encoder_hidden_states"):
+                assert row["dtype"] == "bfloat16"
+
+
+def test_an_unknown_axis_name_REFUSES_rather_than_defaulting() -> None:
+    with pytest.raises(DeriveError, match="axis name"):
+        dynamic_dim_policy("spatial")
+
+
+def test_off_is_the_absence_of_a_policy_and_not_an_empty_one() -> None:
+    """`off` must be `None`, so torchcg takes the untouched static path."""
+
+    assert dynamic_dim_policy("off") is None
+    assert dynamic_dim_policy("all")("unet", "sample", 0) is True
+    assert dynamic_dim_policy("batch")("unet", "sample", 2) is False
+    assert dynamic_dim_policy("aspect")("unet", "sample", 0) is False
+    assert dynamic_dim_policy("aspect")("unet", "sample", 3) is True
+    # Axis 1 is a channel or a sequence length: never offered.
+    assert dynamic_dim_policy("all")("unet", "sample", 1) is False

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=748115fc90e3c2d4cad6e7e521b06fac2d204bab" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=748115fc90e3c2d4cad6e7e521b06fac2d204bab#748115fc90e3c2d4cad6e7e521b06fac2d204bab" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f#14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
## pgw#1567 — the derive's dtype comes from the lane declaration, never the mounted checkpoint

`TraceLoadContext.component_dtype` led its ladder with the mounted tree's own
safetensors headers. A derive against a stock fp16 dreamshaper tree therefore
traced fp16 graphs under `sd15.diffusers-bf16@1` and armed 14 graphs a bf16 pod
could never enter — silently, for a night, until tcg#76's instrument named it:

```
input 'sample': dtype bfloat16 != expected float16
```

The lane now answers **first** for every component of the tree it governs; the
checkpoint speaks only for a DERIVED lane (pgw#1488), which has no contract to
read a dtype from.

**That order is the serve path's, not a new opinion.** `streaming.engine` is
dtype PASSTHROUGH and the STORE converts a tree through the layout contract
before a pod mounts it (`engine._warn_on_lane` states the same rule from the
other side), so on the tree that actually serves, every container IS the lane's
dtype. A mounted tree that disagrees is now **named** once per component
instead of followed.

Paul, 2026-08-20: *"one trace per tensor-layout-contract-template."* Within a
lane the checkpoint is irrelevant by construction — the artifact is weight-free
and runtime constant folding binds any conforming fine-tune's weights at load.

Proven as a property rather than a case: two trees identical but for their
container dtype derive the same precision. **Red-armed** — all three new
assertions fail against `origin/master`'s source and pass here.

## pgw#1548 — `--dynamic-axes off|batch|aspect|all`

On `gen-worker lock` and `gen-worker release derive`, over torchcg
[tcg#77](https://github.com/cozy-creator/torchcg/pull/76) (vendored at
`14e8b4df`). Measured through the real derive on a fixture with sd15's exact
structure (3 aspect buckets x 2 CFG modes):

| `--dynamic-axes` | graph specializations |
|---|---|
| `off` (default, unchanged) | 6 |
| `batch` (the CFG axis) | 3 |
| `aspect` (the buckets) | 2 |
| `all` | **1** |

Axis naming is the endpoint layer's job — torchcg takes a
`(target, input, axis)` predicate and holds no opinion about what an axis
means — so `batch` is axis 0 and `aspect` is axes 2.. of a rank-4 feed. Axis 1
is never offered: a channel or a sequence length bears no aspect.

**`off` is the default and stays the default** until the GPU acceptance gate
says otherwise per model. A dynamic axis re-keys every graph in the lane, and
whether it costs serving time is empirical. The gate (sd15/sdxl/anima,
per-shape round-trip on the production serve path, CFG axis costed separately)
is still owed and nothing here adopts anything.

## Tests

* 7 new (`test_release_derive_dynamic_axes_pgw1548.py`) through the real CLI
  derive: the static control, the collapse, one-axis-at-a-time, the collapsed
  record dispatching every observed shape and refusing what it was not exported
  for, and the lane-dtype keying holding through the collapse.
* 4 new/rewritten in `test_release_derive_component_dtype.py`, including the
  checkpoint-flip property and the disagreement warning (with its silent arm).
* Adjacent seams re-run green on this branch: `test_lora_fold.py`,
  `test_adopt_flow.py` (pgw#1571's peft guard + `rearm_constants` tripwire),
  `test_serving_adopt_first.py`, `test_adoption_verdict.py`,
  `test_release_derive*.py`, `test_vendored_snapshot_pgw1310.py`.
* `ruff check src/gen_worker` and mypy clean.