### PR TITLE
pgw#1581: split load_marks_compile out of _calls_ctx_compile — one compile reader, two entry points

### DIFF
--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -266,6 +266,36 @@ def _calls_ctx_compile(fn: Any) -> bool:
     definition = tree.body[0] if tree.body else None
     if not isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return False
+    return load_marks_compile(definition)
+
+
+def load_marks_compile(definition: Any) -> bool:
+    """Whether this ``load`` DEFINITION marks a compile target — the AST half
+    of :func:`_calls_ctx_compile`, taking the parsed node instead of a live
+    function.
+
+    PUBLIC, and split out for exactly one reason (se#809): a reader that can
+    only be reached through :func:`inspect.getsource` can only be used by code
+    that has already IMPORTED the endpoint, and an endpoint module imports
+    torch. Every repo-side gate over the fleet is therefore torch-free and
+    AST-based, so before this split the only way for one to ask "does this
+    model compile?" was to write a SECOND walker — which is how
+    `serverless-endpoints`' AUTHOR-CI gate ended up still counting the v1
+    `@endpoint(compile=...)` spelling and reporting 2 compiling endpoints
+    where the fleet had 13.
+
+    One reader, two entry points: this takes a parsed
+    ``FunctionDef``/``AsyncFunctionDef``, and ``_calls_ctx_compile`` is the
+    thin wrapper that gets there from a live function object.
+
+    Parsed rather than grepped — the string ``ctx.compile`` appears in comments
+    and docstrings that say a model deliberately does NOT compile, and a
+    substring check would refuse exactly the classes that documented
+    themselves best.
+    """
+
+    if not isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return False
     # The ctx parameter: `load(self, ctx)`, the ruled signature (pgw#1382).
     names = {argument.arg for argument in definition.args.args[1:2]}
     for node in ast.walk(definition):
@@ -704,6 +734,7 @@ __all__ = [
     "model_requires",
     "ModelDeclarationError",
     "lane_handle",
+    "load_marks_compile",
     "model_lanes",
     "model_type",
 ]


### PR DESCRIPTION
`_calls_ctx_compile` (`serving/model.py`) answers *"does this `load` mark a compile target?"* and is reachable **only** through `inspect.getsource` — i.e. only by code that has already IMPORTED the endpoint. **An endpoint module imports torch.**

Every repo-side gate over the fleet is therefore torch-free and AST-based, so before this split the only way for one to ask that question was to write a SECOND walker.

One did not, and that is **se#809**: `serverless-endpoints`' AUTHOR-CI gate still counts the v1 `@endpoint(compile=...)` spelling and reports **2** compiling endpoints where the fleet has **13** — leaving the parity/speed obligations of DESIGN-RULINGS §4.32 (a binding Paul ruling) enforced against nobody. The instruction when that fix was approved was explicit: *reuse `_calls_ctx_compile`, one reader, never a second AST walker.* This is what makes that possible.

## What changed

`load_marks_compile(definition)` takes a parsed `FunctionDef`/`AsyncFunctionDef`; `_calls_ctx_compile(fn)` becomes the thin wrapper that gets there from a live function object. **No logic moved or changed** — the walk is the same lines, relocated, and exported in `__all__`.

## Behaviour preserved — measured against master, not asserted

| | master | this branch |
|---|---|---|
| class in a real file | `marks=True` / `no-mark=False` | identical |
| class defined by `exec` | `False` (documented unreadable-source path) | identical |

Six AST cases pass, and three are the ones a substring check gets wrong: a docstring saying the model *deliberately does NOT `ctx.compile`*, a commented-out `# ctx.compile(x)`, and `other.compile(...)` on a different name. Nested and `async def` forms both detected.

No behaviour change for any existing caller; `Model.__init_subclass__`'s `eager_only=` + `ctx.compile` refusal goes through the wrapper exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)