### PR TITLE
pgw#1579/#1580: child_calls, handles and expected_outputs are DECLARED again — the hub was still reading all three

### DIFF
--- a/changelog.d/pgw1579-1580.md
+++ b/changelog.d/pgw1579-1580.md
@@ -1,0 +1,52 @@
+- **`@entrypoint` gets `child_calls=` and `handles=` back, and the manifest carries
+  `expected_outputs` again.** The pgw#1373 v1 hardcut deleted three author-side declarations while
+  the hub kept DECODING them and kept ACTING on them. Nothing failed, so nothing was noticed:
+  each was found later by an endpoint breaking on it.
+
+  - **`child_calls=True` (pgw#1579).** `scheduler_dispatch.go` mints the `invoke_child` capability
+    grant only `if subj.ChildCallsDeclared`, and `manifestFunction.ChildCalls` is where that flag
+    comes from. `@entrypoint` could not say it, so a ported workflow endpoint published fine,
+    deployed fine, and failed at its **first child call** with `child_calls_not_declared` —
+    pointing the author at `@endpoint(child_calls=True)`, a decorator the SDK had deleted. This is
+    what `private-inference-endpoints/dj-pipeline` IS: `make_video` composes the whole DJ pipeline
+    out of child requests. `ctx.call_endpoint` now refuses an undeclared body **before a socket
+    opens**, with the hub's own refusal code, and every remedy string names the successor.
+  - **`handles=("fp8-w8a8-dynamic",)` (pgw#1580).** The lane-body divergence marker. RESTORED, not
+    retired, on the ruling that **capabilities and behavioral divergence are DECLARED in the
+    manifest, never inferred from code shape** — inferring `child_calls` from the presence of
+    `ctx.call_endpoint` would mint the credential for anything that merely imports the surface,
+    and the same logic governs the lane. Tokens are validated at DECORATION against
+    `known_execution_lane_bodies()`, the SDK twin of the table `normalizeManifestHandles` checks,
+    so a bad token names the author's line instead of failing the publish after the image bake.
+    The asymmetry is closed too: `ctx.execution_lane` now raises `LaneNotDeclaredError` for an
+    undeclared reader rather than handing back a plausible `bf16-w16a16+eager` that nobody
+    checked. `ctx.lane` inside `Model.load` is deliberately NOT gated — that lane is the deploy's
+    pick and `ctx.lane.dtype` is how every model loads at all, and it is model scope while
+    `handles=` is function scope.
+  - **`expected_outputs` (pgw#1580), and this one was LIVE IN PRODUCTION.** `ExpectedOutput`
+    survived the hardcut as an exported, documented, still-written annotation whose emission was
+    gone, so every endpoint promoted to v2 silently stopped telling the platform what it was about
+    to produce. Measured on the live hub: `ltx-video-2.3` (v1) 4/4 functions carried it, `musicgen`
+    (v1) 1/1, and `anima`/`sd15`/`sdxl`/`dj-utils`/`music-analysis` (v2) **0 of 10** — `anima`
+    served a real plan before its pointer moved and `null` after. The loss is per-REQUEST:
+    `expectedOutputsForRelease` resolves each plan against the actual input payload and stamps
+    count, type and resolved aspect ratio onto the request row, so a consumer rendering output
+    placeholders gets nothing. The shape is read off the Go `ExpectedOutputPlan` rather than
+    guessed; `duration_s` is validated but **not** emitted, because no hub reader has ever decoded
+    it and a key with no reader is the th#2087 mirror.
+
+  Emission is conditional throughout, so a row that declares nothing is byte-identical and the
+  hub's `omitempty` reading of absent-is-undeclared is unchanged. **Restoring the emission does
+  nothing for anything already released** — the manifest is stamped at publish, so every v2
+  endpoint needs a version bump, a rebuild and a re-promotion before it serves `expected_outputs`
+  again (se#806 carries that wave).
+
+- **The fence is keyed on the SHAPE of the mistake, not on the three fields.** A test per field
+  would have caught none of these, because the fields were gone before anyone wrote the test.
+  `tests/test_manifest_declarations_pgw1579_1580.py` reads `inspect.signature(entrypoint)` and
+  requires every kwarg to appear in a ledger naming the `functions[]` key it owes: a kwarg added
+  without an emission fails there, a kwarg deleted leaves an orphan row and fails there, and a
+  dropped emission fails the pinned key set of a fully-declaring row. The rule it encodes is
+  written into `v1_deleted.py` where the next hardcut author will read it — **a field the platform
+  decodes may only be dropped WITH a tombstone row naming its successor.** Every field that had
+  one was a decision; every field that did not was an accident, and there were four.

--- a/src/gen_worker/api/errors.py
+++ b/src/gen_worker/api/errors.py
@@ -356,7 +356,8 @@ class ChildCallRefusedError(ChildCallError):
     ``call_cycle_detected``, ``tree_budget_exceeded``,
     ``tier_escalation_denied``, ``parent_not_running``, ``budget_not_root``,
     or ``child_calls_not_declared`` (this invocation's function did not
-    declare ``child_calls=True``, so it holds no child-call credential).
+    declare ``@entrypoint(child_calls=True)``, so it holds no child-call
+    credential — pgw#1579).
     """
 
     def __init__(self, code: str, message: str = "") -> None:
@@ -521,6 +522,38 @@ class MediaNotDeclaredError(ValidationError):
             "justifies the hub minting the upload_media grant, so without it "
             "there is nothing to upload against. It is independent of "
             "publishes=: a job may emit media and write no repo."
+        )
+
+
+class LaneNotDeclaredError(ValidationError):
+    """This function read ``ctx.execution_lane`` without declaring
+    ``handles=[...]`` (pgw#1580).
+
+    The third sibling of :class:`PublishNotDeclaredError` /
+    :class:`MediaNotDeclaredError`, on the ruling that BEHAVIORAL DIVERGENCE is
+    declared in the manifest and never inferred from code shape. Reading the
+    executing lane is what "this body branches on the lane" MEANS, and the hub
+    validates the declared tokens against its concrete lane-body table and
+    hydrates them onto ``FunctionMetadata.Handles`` for selection — so an
+    undeclared branch diverges invisibly to everything that plans around it.
+
+    The refusal is what makes the declaration load-bearing rather than
+    decorative: without it, ``ctx.execution_lane`` handed back a plausible
+    default (``bf16-w16a16+eager``) and an undeclared body branched on a value
+    nobody had checked.
+
+    FATAL, not retryable: no retry adds a declaration to a published release.
+    """
+
+    def __init__(self, surface: str = "ctx.execution_lane") -> None:
+        self.surface = str(surface or "ctx.execution_lane")
+        super().__init__(
+            f"{self.surface} refused: this function did not declare "
+            "handles=[...]. Add the concrete lane BODIES this code branches on "
+            "to the decorator (@entrypoint(handles=(\"fp8-w8a8-dynamic\",))) "
+            "and republish — the declaration is what tells the platform the "
+            "body diverges per lane, and reading the lane without it is a "
+            "divergence nothing downstream can see."
         )
 
 

--- a/src/gen_worker/callout.py
+++ b/src/gen_worker/callout.py
@@ -1,7 +1,7 @@
 """Endpoint-to-endpoint call-out client — the workflow primitive.
 
 The SDK half of the platform's call-out primitive: a function declared with
-``@endpoint(child_calls=True)`` receives an ``invoke_child`` grant on its
+``@entrypoint(child_calls=True)`` receives an ``invoke_child`` grant on its
 per-job capability token; this module submits/polls/cancels child requests
 and reads/writes the invocation's workflow checkpoints through the ordinary
 platform HTTP API using that token as the bearer.
@@ -43,7 +43,9 @@ _REFUSAL_CODES = frozenset(
 )
 
 # Route-scope denials for a capability token WITHOUT the invoke_child grant —
-# the function didn't declare child_calls=True.
+# the function didn't declare child_calls=True (pgw#1579: the declaration is
+# `@entrypoint(child_calls=True)`; `ctx._callout_client` refuses an undeclared
+# body before a socket opens, so reaching here means the grant was declined).
 _NOT_DECLARED_CODES = frozenset({"forbidden", "insufficient_scope", "unauthorized"})
 
 DEFAULT_POLL_INTERVAL_S = 2.0
@@ -110,7 +112,7 @@ class CalloutClient:
             raise ChildCallRefusedError(
                 "child_calls_not_declared",
                 "no capability token in this invocation context; declare "
-                "@endpoint(child_calls=True) and run under the platform",
+                "@entrypoint(child_calls=True) and run under the platform",
             )
         return {"Authorization": f"Bearer {token}"}
 
@@ -123,7 +125,7 @@ class CalloutClient:
                 "child_calls_not_declared",
                 message
                 or "the platform refused this credential for child calls; "
-                "declare @endpoint(child_calls=True)",
+                "declare @entrypoint(child_calls=True)",
             )
         raise ChildCallError(
             f"child call failed ({status_code}{', ' + code if code else ''}): "

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -53,6 +53,7 @@ import pkgutil
 import textwrap
 from typing import Any, Dict, List, Set
 
+from .expected_outputs import expected_outputs
 from .moderation import payload_moderation
 from .schema import type_schema_and_hash
 
@@ -533,6 +534,7 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         type_schema_and_hash(delta_type) if delta_type is not None else (None, "")
     )
     moderation = payload_moderation(spec.payload_type)
+    outputs = expected_outputs(spec.payload_type, spec.return_type)
     slots: List[Dict[str, Any]] = []
     for slot in spec.slots:
         slots.append(_model_slot(slot) if slot.kind == "model" else _adapter_slot(slot))
@@ -579,6 +581,16 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         # when the payload declares one, so a text-only row stays byte
         # identical.
         **({"moderation": moderation} if moderation else {}),
+        # pgw#1580: WHAT THIS FUNCTION IS ABOUT TO PRODUCE, read off the return
+        # struct's `ExpectedOutput` annotations. `expectedOutputsForRelease`
+        # resolves each plan against the actual request payload and stamps
+        # `ExpectedOutputsJSON` onto the request row, so a consumer rendering
+        # output placeholders has a count/type/aspect BEFORE generation
+        # finishes; `len(fn.ExpectedOutputs) == 0` returns nil and that whole
+        # path goes quiet. The marker survived the v1 hardcut and this emission
+        # did not, which is why every v2 release served `expected_outputs:
+        # null` — measured live on anima, before and after its pointer moved.
+        **({"expected_outputs": outputs} if outputs else {}),
         "slots": slots,
         # `None` is ABSENT (no model slot, no `resources=`); a dict is
         # PRESENT, and a present-but-empty block is the hub's explicit CPU
@@ -617,6 +629,20 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         # copies verbatim, so there is no second vocabulary to drift.
         **({"publishes": True} if spec.publishes else {}),
         **({"env": list(spec.env)} if spec.env else {}),
+        # pgw#1579: the CHILD-CALL capability declaration.
+        # `scheduler_dispatch.go` mints the `invoke_child` grant only `if
+        # subj.ChildCallsDeclared`, and this key is where that flag comes from
+        # (`manifestFunction.ChildCalls`). Absent means undeclared and the hub
+        # declines the credential, so a workflow endpoint that publishes
+        # without it fails at its FIRST child call rather than at publish.
+        **({"child_calls": True} if spec.child_calls else {}),
+        # pgw#1580: the LANE-BODY divergence declaration.
+        # `normalizeManifestHandles` validates every token against the hub's
+        # concrete lane-body table and folds the result into
+        # `requirement_payload["handles"]`, which the release resolver hydrates
+        # into `FunctionMetadata.Handles` for selection. Tokens are already
+        # validated at decoration against the SDK twin of that table.
+        **({"handles": list(spec.handles)} if spec.handles else {}),
         **(
             {"emits_media": bool(spec.emits_media)}
             if spec.emits_media is not None and _is_job_kind(row_kind)

--- a/src/gen_worker/discovery/expected_outputs.py
+++ b/src/gen_worker/discovery/expected_outputs.py
@@ -1,0 +1,240 @@
+"""The ``expected_outputs`` manifest block: what this function is ABOUT to
+produce, before it produces it (pgw#1580).
+
+Read off the RETURN struct's ``Annotated[..., ExpectedOutput(...)]`` markers —
+not a decorator kwarg, because the fact belongs to the output field it
+describes. ``ExpectedOutput`` is still exported from ``gen_worker`` and
+endpoints still write it; pgw#1373 deleted the v1 collector with the rest of
+``discover.py`` and the v2 row never grew a replacement, so every endpoint
+promoted to v2 silently stopped telling the platform what it would return.
+Measured on the live hub: ``ltx-video-2.3`` (v1) 4/4 functions carried it,
+``anima``/``sd15``/``sdxl``/``dj-utils``/``music-analysis`` (v2) 0/10.
+
+**What is lost is per-REQUEST.** ``expectedOutputsForRelease``
+(``internal/orchestrator/http/expected_outputs.go``) resolves each plan against
+the actual input payload and stamps ``ExpectedOutputsJSON`` onto the request
+row — the count, the type and the resolved aspect ratio of what is coming — so
+a consumer that renders output placeholders before generation finishes has
+something to render. ``len(fn.ExpectedOutputs) == 0`` returns ``nil`` and the
+whole path goes quiet.
+
+THE SHAPE IS THE HUB'S, read off ``release.ExpectedOutputPlan`` /
+``builder.ExpectedOutputPlan`` rather than guessed::
+
+    {"field": str, "type": str, "mime_type"?: str,
+     "count"?: int|str, "width"?: int|str, "height"?: int|str,
+     "aspect_ratio"?: int|str}
+
+``type`` is the hub's five-value vocabulary (``normalizeExpectedOutputType``:
+image | video | audio | file | other — anything else becomes ``other``), which
+is exactly :class:`~gen_worker.api.types.ExpectedOutput`'s ``media_type``
+Literal. Expression values are a positive int literal or an ``input.<field>``
+ref the hub resolves against the request payload.
+
+**``duration_s`` IS DELIBERATELY NOT EMITTED.** v1 emitted it and no hub reader
+has ever decoded it — it is absent from both ``ExpectedOutputPlan`` structs and
+from ``expectedOutputsFromPlans`` — so a key here would be the
+mirror-with-no-reader shape th#2087's fence exists to catch. The marker's own
+docstring already routes settlement at the probed ``VideoAsset.duration_s``
+instead. It is validated like every other expression so a wrong spelling is
+still refused; it just does not travel.
+"""
+
+from __future__ import annotations
+
+import types as py_types
+import typing
+from typing import Any, Dict, List, Set
+
+import msgspec
+
+from ..api.types import (
+    AudioAsset,
+    ExpectedOutput,
+    ImageAsset,
+    MediaAsset,
+    VideoAsset,
+)
+
+
+def _is_msgspec_struct(t: Any) -> bool:
+    return isinstance(t, type) and issubclass(t, msgspec.Struct)
+
+
+def _unwrap_optional(ann: Any) -> Any:
+    origin = typing.get_origin(ann)
+    if origin in (typing.Union, py_types.UnionType):
+        arms = [arm for arm in typing.get_args(ann) if arm is not type(None)]
+        if len(arms) == 1:
+            return arms[0]
+    return ann
+
+
+def _media_kind(ann: Any) -> str:
+    """The hub's ``normalizeExpectedOutputType`` vocabulary, inferred from the
+    annotated field when the author did not name a ``media_type``."""
+    ann = _unwrap_optional(ann)
+    origin = typing.get_origin(ann)
+    if origin in (list, tuple, set, frozenset):
+        args = typing.get_args(ann)
+        ann = _unwrap_optional(args[0]) if args else Any
+    if isinstance(ann, type):
+        if issubclass(ann, ImageAsset):
+            return "image"
+        if issubclass(ann, VideoAsset):
+            return "video"
+        if issubclass(ann, AudioAsset):
+            return "audio"
+        if issubclass(ann, MediaAsset):
+            return "file"
+    return "other"
+
+
+def _hints_or_refuse(struct: type, path: str) -> Any:
+    """Resolved type hints, or a BUILD ERROR naming the struct.
+
+    The v1 collector swallowed a resolution failure and fell back to
+    ``__annotations__`` — which, under ``from __future__ import annotations``
+    (every endpoint module in this repo), is a dict of STRINGS. A string is not
+    a type, so the walk below skips it and the function emits an EMPTY plan:
+    the pgw#1418 silence one field over, and indistinguishable from an endpoint
+    that declared nothing. Refuse instead.
+    """
+    try:
+        return typing.get_type_hints(struct, include_extras=True)
+    except Exception as exc:
+        raise ValueError(
+            f"{path or struct.__name__}: cannot resolve the type hints of "
+            f"{struct.__name__} ({type(exc).__name__}: {exc}) — the "
+            f"expected_outputs plan would be silently EMPTY, which the hub "
+            f"reads as an endpoint that promises nothing"
+        ) from exc
+
+
+def _payload_has_field_path(payload_type: type, ref: str) -> bool:
+    """Does ``input.<path>`` name a real payload field? The hub resolves the
+    ref against the request payload at submit time and silently drops a plan it
+    cannot resolve, so a typo here would cost the whole row, at request time,
+    with no error anywhere."""
+    if not ref.startswith("input."):
+        return True
+    path = ref.removeprefix("input.")
+    if not path:
+        return False
+    current: Any = payload_type
+    for raw_part in path.replace("[]", "").split("."):
+        part = raw_part.strip()
+        if not part:
+            return False
+        current = _unwrap_optional(current)
+        origin = typing.get_origin(current)
+        if origin in (list, tuple, set, frozenset):
+            args = typing.get_args(current)
+            current = _unwrap_optional(args[0]) if args else Any
+        if not _is_msgspec_struct(current):
+            return False
+        hints = _hints_or_refuse(current, part)
+        if part not in hints:
+            return False
+        current = hints[part]
+    return True
+
+
+def _expression(value: Any, *, payload_type: type, field: str, key: str) -> Any:
+    """One plan expression: a positive int literal, an ``input.<field>`` ref,
+    or ``None`` for undeclared. Anything else is a build error."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError(f"{field}: ExpectedOutput.{key} must be int, str, or None")
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError(f"{field}: ExpectedOutput.{key} must be positive")
+        return value
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.startswith("input.") and not _payload_has_field_path(payload_type, raw):
+            raise ValueError(
+                f"{field}: ExpectedOutput.{key} references unknown payload "
+                f"field {raw!r}"
+            )
+        return raw
+    raise TypeError(f"{field}: ExpectedOutput.{key} must be int, str, or None")
+
+
+#: Marker attribute -> manifest key, in the hub's field order. ``duration_s``
+#: is absent on purpose (module docstring); it is still validated below.
+_EXPRESSIONS = (("count", "count"), ("width", "width"), ("height", "height"),
+                ("aspect_ratio", "aspect_ratio"))
+
+
+def expected_outputs(payload_type: type, return_type: type) -> List[Dict[str, Any]]:
+    """The ``expected_outputs`` rows for one entrypoint — an empty list when
+    the return struct carries no marker, and the caller omits the key then."""
+    out: List[Dict[str, Any]] = []
+    seen_structs: Set[type] = set()
+
+    def walk(ann: Any, path: str) -> None:
+        origin = typing.get_origin(ann)
+
+        if origin is typing.Annotated:
+            args = typing.get_args(ann)
+            if not args:
+                return
+            base = args[0]
+            markers = [m for m in args[1:] if isinstance(m, ExpectedOutput)]
+            if not markers:
+                walk(base, path)
+                return
+            marker = markers[-1]
+            item: Dict[str, Any] = {
+                "field": path,
+                "type": marker.media_type or _media_kind(base),
+            }
+            for attribute, key in _EXPRESSIONS:
+                value = _expression(
+                    getattr(marker, attribute),
+                    payload_type=payload_type, field=path, key=attribute,
+                )
+                if value is not None:
+                    item[key] = value
+            # Validated, never emitted — see the module docstring.
+            _expression(
+                marker.duration_s,
+                payload_type=payload_type, field=path, key="duration_s",
+            )
+            mime = (marker.mime_type or "").strip()
+            if mime:
+                item["mime_type"] = mime
+            out.append(item)
+            return
+
+        if origin in (typing.Union, py_types.UnionType):
+            for arg in typing.get_args(ann):
+                if arg is not type(None):
+                    walk(arg, path)
+            return
+
+        if origin in (list, tuple, set, frozenset):
+            args = typing.get_args(ann)
+            if args:
+                walk(args[0], f"{path}[]")
+            return
+
+        if isinstance(ann, type) and _is_msgspec_struct(ann):
+            if ann in seen_structs:
+                return
+            seen_structs.add(ann)
+            hints = _hints_or_refuse(ann, path)
+            for field in getattr(ann, "__struct_fields__", ()) or ():
+                if field in hints:
+                    walk(hints[field], f"{path}.{field}" if path else field)
+            seen_structs.discard(ann)
+
+    walk(return_type, "")
+    return out
+
+
+__all__ = ["expected_outputs"]

--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -645,6 +645,21 @@ class TraceRequestContext:
         return True
 
     @property
+    def child_calls(self) -> bool:
+        """FALSE: a trace calls no child endpoint — there is no request tree to
+        parent one to, and a stub ref is not a child's output (pgw#1579)."""
+        return False
+
+    @property
+    def handles(self) -> tuple[str, ...]:
+        """The lane a trace IS, when it has one. ``handles=`` names the lane
+        BODIES a body branches on, and the derive drives exactly one — so
+        answering the trace's own lane keeps a declared branch on the observed
+        side rather than sending it down the undeclared arm (pgw#1580)."""
+        body = str(getattr(self.lane, "contract", "") or "")
+        return (body,) if body else ()
+
+    @property
     def request_id(self) -> str:
         return "trace"
 

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -270,6 +270,8 @@ class RequestContext(Generic[D]):
         boot_warmup: bool = False,
         publishes: bool = False,
         emits_media: Optional[bool] = None,
+        child_calls: bool = False,
+        handles: Optional[Sequence[str]] = None,
     ) -> None:
         self._request_id = str(request_id or "").strip()
         self._job_id = str(job_id or "").strip() or None
@@ -293,6 +295,13 @@ class RequestContext(Generic[D]):
         # for which the hub minted no `upload_media` grant. Stamped from the
         # spec at dispatch, like `publishes`.
         self._emits_media = emits_media if emits_media is None else bool(emits_media)
+        # pgw#1579/pgw#1580: the two declarations the v1 hardcut dropped while
+        # the hub kept reading them. Same shape as `publishes` above — the
+        # manifest asks the hub for the capability, the spec stamps the same
+        # fact here, and the SDK surface refuses undeclared code at the call
+        # site instead of letting the hub decline a credential mid-request.
+        self._child_calls = bool(child_calls)
+        self._handles: Tuple[str, ...] = tuple(handles or ())
         # Monotonic progress POSITION per phase (pgw#1294). Liveness for a job
         # is position ADVANCE within a phase budget — never pulse, never
         # duration — so a position that goes backwards is a lying instrument
@@ -359,12 +368,54 @@ class RequestContext(Generic[D]):
         return self._boot_warmup
 
     @property
+    def handles(self) -> Tuple[str, ...]:
+        """The lane BODIES this function declared it branches on
+        (``@entrypoint(handles=…)``), stamped from the spec at dispatch."""
+        return self._handles
+
+    @property
+    def child_calls(self) -> bool:
+        """Did this function declare ``@entrypoint(child_calls=True)``? The
+        SDK mirror of the hub's ``invoke_child`` grant decision."""
+        return self._child_calls
+
+    @property
     def execution_lane(self) -> str:
         """The EXECUTING precision lane of this call, a full descriptor id like
         ``"fp8-w8a8-dynamic+compiled"`` — post-degrade truth, the same value
-        JobMetrics.lane reports. Read-only; always available. Handlers that
-        declared ``handles=[...]`` branch on it; everyone else may ignore it."""
+        JobMetrics.lane reports.
+
+        DECLARED READERS ONLY (pgw#1580). Reading the executing lane IS the
+        behavioral divergence ``handles=`` declares, so a function that did not
+        declare one is refused typed rather than handed
+        ``"bf16-w16a16+eager"`` — a plausible default that an undeclared body
+        would branch on and nothing downstream could see. Same
+        one-fact-two-enforcers shape as ``publishes=``: the manifest tells the
+        hub, this refuses the author.
+        """
+        self._require_lane_declaration("ctx.execution_lane")
         return self._execution_lane or "bf16-w16a16+eager"
+
+    def _require_lane_declaration(self, surface: str) -> None:
+        if not self._handles:
+            from ..api.errors import LaneNotDeclaredError
+
+            raise LaneNotDeclaredError(surface)
+
+    def _declare_from_spec(self, spec: Any) -> None:
+        """Worker-internal: stamp an ``EntrypointSpec``'s declarations onto a
+        context built before the function was known.
+
+        The serve loop passes them at construction; the LOCAL host
+        (``EndpointHost.dispatch``, the CLI and the daemon) builds one context
+        per request and only then routes it to a function, so it stamps here.
+        Both ends read the SAME spec fields, which is the point — a declaration
+        that only works under the serverless dispatcher is a declaration an
+        author cannot test."""
+        if spec is None:
+            return
+        self._child_calls = bool(getattr(spec, "child_calls", False))
+        self._handles = tuple(getattr(spec, "handles", ()) or ())
 
     def _set_execution_lane(self, execution_lane: str) -> None:
         self._execution_lane = str(execution_lane or "").strip()
@@ -700,6 +751,21 @@ class RequestContext(Generic[D]):
     # -- call-out primitive --------------------------------------------------
 
     def _callout_client(self) -> "CalloutClient":
+        # pgw#1579, and it must come FIRST: the hub mints `invoke_child` only
+        # for a function whose manifest row declared it, so an undeclared body
+        # would otherwise reach the wire and come back 403 —
+        # `child_calls_not_declared` after the request was already running.
+        # Same refusal CODE as the hub's, so both ends say one word.
+        if not self._child_calls:
+            from ..api.errors import ChildCallRefusedError
+
+            raise ChildCallRefusedError(
+                "child_calls_not_declared",
+                "this function did not declare @entrypoint(child_calls=True), "
+                "so the platform minted no invoke_child grant for it. Add the "
+                "declaration and republish — it is a capability the manifest "
+                "asks for, never one inferred from the body.",
+            )
 
         if not self._file_api_base_url:
             from ..api.errors import ChildCallError
@@ -735,8 +801,10 @@ class RequestContext(Generic[D]):
         an unassigned semver-major is a typed refusal naming the assigned
         ones, and there is no ``latest``.
 
-        The function must be declared ``@endpoint(child_calls=True)`` — the
-        platform then scopes this invocation's credential for child calls.
+        The function must be declared ``@entrypoint(child_calls=True)`` — the
+        platform then scopes this invocation's credential for child calls, and
+        an undeclared function is refused HERE (``child_calls_not_declared``)
+        rather than by the hub mid-request.
         Children bill the parent request's payer, inherit its availability
         tier (``tier=`` may name a CHEAPER class, never escalate), count
         against the tree's depth/budget ceilings, and die with the parent

--- a/src/gen_worker/serving/entrypoints.py
+++ b/src/gen_worker/serving/entrypoints.py
@@ -36,6 +36,10 @@ ruling, 2026-08-17 — one parameter-order rule across the SDK, matching
     def cast_dtype(ctx: RequestContext, payload: CastDtypeInput
                    ) -> PublishResult: ...
 
+    @entrypoint(child_calls=True)     # a WORKFLOW (pgw#1579): this body
+    def make_video(ctx: RequestContext,   # composes OTHER endpoints through
+                   payload: DjInput) -> DjOutput: ...  # ctx.call_endpoint
+
 * first: ``ctx`` annotated :class:`~gen_worker.serving.context.RequestContext`
   — ONE class for inference and producers alike (pgw#1294/pgw#1306: *no kind
   selects a different class, because no kind decides what a body may write —
@@ -63,11 +67,18 @@ beyond import.
 **THE KWARG RULE (pgw#1406).** Decorator kwargs are declarations about
 PLACEMENT AND AUTHORITY; the signature carries MODEL SLOTS. ``resources=``
 (pgw#1396) and ``kind=`` are placement; ``publishes=`` / ``env=`` /
-``emits_media=`` are authority, and together they are the producer plane's
-whole declaration set — pgw#983 deleted ``@job`` and this is where its 27
-conversion producers land (th#2173). The "``resources=`` is the ONE kwarg"
-sentence described the surface on the day it had one; it was never the
-principle.
+``emits_media=`` / ``child_calls=`` / ``handles=`` are authority, and together
+they are the producer plane's whole declaration set — pgw#983 deleted ``@job``
+and this is where its 27 conversion producers land (th#2173). The
+"``resources=`` is the ONE kwarg" sentence described the surface on the day it
+had one; it was never the principle.
+
+**CAPABILITIES AND BEHAVIORAL DIVERGENCE ARE DECLARED, NEVER INFERRED**
+(coordinator ruling, 2026-08-20, on pgw#1579/pgw#1580). ``child_calls=`` and
+``handles=`` are back here rather than sniffed out of the body, because the
+manifest is where a capability is asked for: inferring ``child_calls`` from the
+presence of ``ctx.call_endpoint`` would mint an ``invoke_child`` credential for
+anything that merely imports the surface.
 """
 
 from __future__ import annotations
@@ -155,6 +166,20 @@ class EntrypointSpec:
     #: hub still derives three PLACEMENT facts from it, which is why a producer
     #: cannot leave it at the default. See the decorator docstring.
     kind: str = ""
+    #: pgw#1579: this function makes endpoint-to-endpoint CHILD CALLS. It is
+    #: the hub's ONE justification for minting the ``invoke_child`` capability
+    #: grant (``scheduler_dispatch.go`` mints it only ``if
+    #: subj.ChildCallsDeclared``), so an undeclared function's token cannot
+    #: submit a child request and ``ctx.call_endpoint`` fails at the FIRST
+    #: invoke — not at publish.
+    child_calls: bool = False
+    #: pgw#1580: the concrete execution-lane BODIES this function's code
+    #: branches on (``ctx.execution_lane``) — a BEHAVIORAL-DIVERGENCE marker,
+    #: never inventory and never a request for a lane. Tokens come from
+    #: ``models.execution_lanes.known_execution_lane_bodies()``, the twin of
+    #: the table the hub validates against; the execution axis (eager/compiled)
+    #: is the platform's and is refused here.
+    handles: Tuple[str, ...] = ()
     #: The class the author annotated on ``ctx``. The serve loop constructs
     #: THIS class, so a producer that annotates ``JobContext`` receives the
     #: publisher surface and an inference entrypoint is unchanged.
@@ -349,6 +374,59 @@ def _delta_declaration(
     return annotation, tuple(arms)
 
 
+def _validate_handles_decl(fn: Callable[..., Any], handles: Any) -> Tuple[str, ...]:
+    """The declared lane BODIES, validated at decoration (pgw#1580).
+
+    Every refusal here is one the hub's ``normalizeManifestHandles``
+    (``internal/builder/manifest_contract.go``) would raise instead — after the
+    image bake and the registry push. The vocabulary is not invented: it is
+    ``models.execution_lanes.known_execution_lane_bodies()``, already
+    documented in that module as *"the valid ``handles=`` declaration
+    tokens"*, and the twin of ``precision.KnownExecutionLaneBodies`` the hub
+    checks. The execution axis is refused with its own sentence rather than
+    lumped in with "unknown token", because ``"fp8-w8a8-dynamic+compiled"`` is
+    a legal LANE and an illegal DECLARATION, and the difference is the point.
+    """
+    from ..models.execution_lanes import (
+        known_execution_lane_bodies,
+        valid_execution_lane_body,
+    )
+
+    if handles is None:
+        return ()
+    if isinstance(handles, str) or not isinstance(handles, (list, tuple)):
+        raise _refuse(
+            fn,
+            f"handles= must be a list/tuple of lane BODY tokens, got "
+            f"{type(handles).__name__} — a bare string would iterate into "
+            "characters, so it is refused rather than accepted",
+        )
+    known = ", ".join(known_execution_lane_bodies())
+    out: list[str] = []
+    for raw in handles:
+        token = str(raw or "").strip().lower()
+        if not token:
+            raise _refuse(fn, "handles= carries an empty token")
+        if "+" in token:
+            raise _refuse(
+                fn,
+                f"handles= token {raw!r} carries an execution axis; declare "
+                "the lane BODY — eager/compiled is platform-managed and is "
+                "not something a body can branch on",
+            )
+        if not valid_execution_lane_body(token):
+            raise _refuse(
+                fn,
+                f"handles= token {raw!r} is not a known lane body "
+                f"(known: {known}) — the hub validates this against the same "
+                "table AFTER the image bake, so it is refused here instead",
+            )
+        if token in out:
+            raise _refuse(fn, f"handles= repeats {raw!r}")
+        out.append(token)
+    return tuple(out)
+
+
 @overload
 def entrypoint(fn: F) -> F: ...
 @overload
@@ -360,6 +438,8 @@ def entrypoint(
     env: Any = ...,
     emits_media: bool | None = ...,
     streams: Any = ...,
+    child_calls: bool = ...,
+    handles: Any = ...,
 ) -> Callable[[F], F]: ...
 
 
@@ -372,6 +452,8 @@ def entrypoint(
     env: Any = None,
     emits_media: bool | None = None,
     streams: Any = None,
+    child_calls: bool = False,
+    handles: Any = None,
 ) -> F | Callable[[F], F]:
     """Mark a module-level function as an entrypoint (contract above).
 
@@ -512,6 +594,35 @@ def entrypoint(
     blessed types) or smuggled in as a special last frame. Both are weaker than
     a plain ``return``, so the generator shape is refused at import naming
     ``streams=`` + ``ctx.emit`` as the successor.
+
+    ``child_calls=`` / ``handles=`` are the other two AUTHORITY kwargs, restored
+    by pgw#1579/pgw#1580 after the v1 hardcut deleted them while all three
+    other layers kept speaking them. Both are DECLARATIONS, on the ruling that
+    capabilities and behavioral divergence are never inferred from code shape:
+
+    * ``child_calls=True`` — this function calls OTHER endpoints
+      (``ctx.call_endpoint``). ``scheduler_dispatch.go`` mints the
+      ``invoke_child`` capability grant only ``if subj.ChildCallsDeclared``,
+      and ``manifestFunction.ChildCalls`` is where that flag comes from, so an
+      undeclared workflow endpoint publishes fine, deploys fine, and then fails
+      at its FIRST child call with ``child_calls_not_declared``. It is what
+      ``private-inference-endpoints/dj-pipeline`` IS: ``make_video`` is
+      ordinary CPU code that composes the DJ pipeline out of child requests.
+      Inference from the body is refused BY DESIGN — it would mint the
+      credential for anything that merely imports the surface.
+    * ``handles=("fp8-w8a8-dynamic",)`` — the concrete lane BODIES this
+      function's code BRANCHES ON, read back at runtime as
+      ``ctx.execution_lane``. A behavioral-divergence marker and nothing else:
+      it is not a request for a lane, not inventory, and it never narrows what
+      the platform may serve. The hub validates the tokens against its
+      concrete lane-body table; this decorator validates them against the SDK
+      twin first, so the refusal names your line instead of arriving after the
+      image bake. Undeclared is the norm — and ``ctx.execution_lane`` then
+      REFUSES typed rather than handing back a default nobody checked, the same
+      one-fact-two-enforcers shape as ``publishes=``. ``ctx.lane`` inside
+      ``Model.load`` is deliberately NOT gated by this: that lane is the
+      deploy's pick and ``ctx.lane.dtype`` is how every model loads at all,
+      which is the ordinary path rather than a divergence.
     """
 
     if fn is None:
@@ -524,6 +635,8 @@ def entrypoint(
                 env=env,
                 emits_media=emits_media,
                 streams=streams,
+                child_calls=child_calls,
+                handles=handles,
             )
         return bind
 
@@ -532,8 +645,9 @@ def entrypoint(
     if not inspect.isfunction(fn):
         raise EntrypointDeclarationError(
             f"@entrypoint marks module-level functions, got "
-            f"{type(fn).__name__} — the kwargs are resources= (pgw#1396) and "
-            "publishes=/env=/emits_media= (pgw#1406); the Model class header "
+            f"{type(fn).__name__} — the kwargs are resources= (pgw#1396), "
+            "publishes=/env=/emits_media= (pgw#1406) and "
+            "child_calls=/handles= (pgw#1579/pgw#1580); the Model class header "
             "carries lanes="
         )
     if not isinstance(publishes, bool):
@@ -542,6 +656,14 @@ def entrypoint(
             f"publishes= is a bool DECLARATION, got "
             f"{type(publishes).__name__} — it says this function MAY write to "
             "the hub; the request still says where",
+        )
+    if not isinstance(child_calls, bool):
+        raise _refuse(
+            fn,
+            f"child_calls= is a bool DECLARATION, got "
+            f"{type(child_calls).__name__} — it says this function calls OTHER "
+            "endpoints, and it is what the hub mints the invoke_child grant "
+            "against",
         )
     if emits_media is not None and not isinstance(emits_media, bool):
         raise _refuse(
@@ -559,6 +681,7 @@ def entrypoint(
         )
     declared_env = _validate_env_decl(fn, env)
     delta_type, delta_arms = _delta_declaration(fn, streams)
+    declared_handles = _validate_handles_decl(fn, handles)
     if resources is not None:
         from ..api.resources import Resources
 
@@ -679,6 +802,8 @@ def entrypoint(
         publishes=bool(publishes),
         env=declared_env,
         emits_media=emits_media,
+        child_calls=bool(child_calls),
+        handles=declared_handles,
         ctx_type=ctx_type,
         delta_type=delta_type,
         delta_arms=delta_arms,

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -545,6 +545,13 @@ class EndpointHost:
         decoded = self._decode(spec, payload)
         if ctx is None:
             ctx = self.make_context(request_id)
+        # pgw#1579/pgw#1580: the local host builds a context BEFORE it knows
+        # the function, so the spec's declarations are stamped here instead of
+        # at construction. Without this the CLI and the daemon refuse
+        # `ctx.execution_lane` and `ctx.call_endpoint` on an endpoint that
+        # declared both — a declaration only the serverless dispatcher honours
+        # is one an author cannot test.
+        ctx._declare_from_spec(spec)
         arguments = [
             self.instances[slot.annotation].model if slot.kind == "model"
             else list(loras) if slot.kind == "adapters"

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -607,6 +607,11 @@ class ServeLoop:
             declared_media = getattr(spec, "emits_media", None)
             if declared_media is not None:
                 kwargs["emits_media"] = bool(declared_media)
+            # pgw#1579/pgw#1580, the same wire for the two declarations the
+            # hardcut dropped. Unstamped they read as undeclared, which is the
+            # fail-closed answer the hub's own grant minter uses.
+            kwargs["child_calls"] = bool(getattr(spec, "child_calls", False))
+            kwargs["handles"] = tuple(getattr(spec, "handles", ()) or ())
         return RequestContext(
             request_id,
             binding=binding

--- a/src/gen_worker/v1_deleted.py
+++ b/src/gen_worker/v1_deleted.py
@@ -15,6 +15,31 @@ rule). A bare ``ImportError: cannot import name 'endpoint'`` across 27
 unmigrated endpoint packages says nothing about what happened or where to go,
 so every deleted name raises :class:`V1SdkDeleted` NAMING the migration —
 here, at import, at the exact spelling the author wrote.
+
+THE RULE THIS TABLE ENFORCES, and it is a rule about MANIFEST FIELDS too
+(pgw#1580's enumeration audit). Every field the hub DECODES may only be dropped
+from the author surface together with a row here naming its successor. The
+audit checked ``manifestFunction`` field by field against what
+``discovery/entrypoints_v2.py`` emits and the partition was exact:
+
+* every field with a row here — ``compile``/``compile_axes``, ``variant_of``,
+  ``objectives``, ``runtime_formula``, ``config_params``,
+  ``accepts_references`` — was a DECISION, and the successor holds;
+* every field WITHOUT one was an ACCIDENT. There were three, all P0, all found
+  by an endpoint breaking on them rather than by anything failing at publish:
+  ``child_calls`` (pgw#1579 — the hub mints ``invoke_child`` only when it is
+  set, so a workflow endpoint failed at its FIRST child call),
+  ``incremental_output``/``delta_output_schema`` (pgw#1576 — emitted, but
+  hardcoded ``False``), and ``expected_outputs`` (pgw#1580 — LIVE in
+  production: every endpoint promoted to v2 silently stopped telling the
+  platform what it was about to produce). ``handles`` was the fourth, ruled
+  RESTORED rather than retired on the principle that capabilities and
+  behavioral divergence are DECLARED, never inferred from code shape.
+
+So: a hardcut that removes an author-side spelling owes either a row in
+:data:`REPLACEMENTS` or a hub change that stops reading the field. Silence is
+the one option that is not available, and
+``tests/test_manifest_declarations_pgw1579_1580.py`` is the fence that says so.
 """
 
 from __future__ import annotations

--- a/tests/release_fixtures/declaring_endpoint.py
+++ b/tests/release_fixtures/declaring_endpoint.py
@@ -1,0 +1,117 @@
+"""THE FULLY-DECLARING ENDPOINT — every author-side declaration at once.
+
+The control for ``tests/test_manifest_declarations_pgw1579_1580.py``. Its job is
+to be the row that carries EVERYTHING, so a fence can pin the emitted key set
+and fail the moment a hardcut drops one of them again. ``producer_endpoint.py``
+is its opposite number and pins the row that declares NOTHING.
+
+* ``make_video`` — ``child_calls=True`` (pgw#1579). The
+  ``private-inference-endpoints/dj-pipeline`` shape, verbatim in structure: an
+  ordinary CPU body whose whole purpose is composing OTHER endpoints out of
+  child requests. Weightless, so it also proves the declaration does not depend
+  on a model slot.
+* ``render`` — ``handles=`` (pgw#1580) plus the ``ExpectedOutput`` annotations
+  on its return struct, in both shapes the fleet writes: a single asset with a
+  payload-ref aspect (``anima``'s exact annotation) and a list whose count is a
+  payload ref (``sdxl``'s shape).
+* ``everything`` — every declaration at once, including pgw#1576's
+  ``streams=``. Nothing in the fleet looks like this; it exists so ONE row can
+  pin the complete emitted key set.
+* ``describe`` — declares NOTHING and returns an un-annotated struct.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import msgspec
+
+from gen_worker import (
+    ExpectedOutput,
+    ImageAsset,
+    RequestContext,
+    Resources,
+    TokenDelta,
+    VideoAsset,
+    entrypoint,
+)
+
+
+class DjInput(msgspec.Struct, forbid_unknown_fields=True):
+    track_url: str
+    duration_s: int = 30
+
+
+class DjOutput(msgspec.Struct):
+    video: Annotated[
+        VideoAsset,
+        ExpectedOutput(media_type="video", mime_type="video/mp4",
+                       duration_s="input.duration_s"),
+    ]
+
+
+class RenderInput(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    num_images: int = 1
+    aspect_ratio: str = "1:1"
+    width: int = 1024
+    height: int = 1024
+
+
+class RenderOutput(msgspec.Struct):
+    #: `anima`'s annotation, character for character — the row measured on the
+    #: live hub as `{"type":"image","count":1,"field":"image",
+    #: "aspect_ratio":"input.aspect_ratio"}` before its pointer moved to v2,
+    #: and as `null` after.
+    image: Annotated[ImageAsset, ExpectedOutput(aspect_ratio="input.aspect_ratio")]
+    #: The multi-output shape: count and dimensions are payload refs.
+    thumbnails: Annotated[
+        list[ImageAsset],
+        ExpectedOutput(count="input.num_images", width="input.width",
+                       height="input.height", mime_type="image/webp"),
+    ]
+    model: str
+
+
+class DescribeInput(msgspec.Struct, forbid_unknown_fields=True):
+    ref: str
+
+
+class DescribeResult(msgspec.Struct):
+    summary: str
+
+
+@entrypoint(child_calls=True)
+def make_video(ctx: RequestContext, payload: DjInput) -> DjOutput:
+    """`dj-pipeline/main.py:498`, re-decorated: composes the pipeline out of
+    child requests to music-analysis / ltx-video-2.3 / dj-utils."""
+    raise NotImplementedError
+
+
+@entrypoint(handles=("fp8-w8a8-dynamic", "bf16-w16a16"))
+def render(ctx: RequestContext, payload: RenderInput) -> RenderOutput:
+    """Branches on the executing lane, and says so."""
+    raise NotImplementedError
+
+
+@entrypoint(
+    kind="conversion",
+    resources=Resources(vcpus=8),
+    publishes=True,
+    env=("HF_TOKEN",),
+    emits_media=True,
+    child_calls=True,
+    handles=("fp8-w8a8-dynamic",),
+    streams=TokenDelta,
+)
+def everything(ctx: RequestContext, payload: RenderInput) -> RenderOutput:
+    """EVERY declaration at once. Nothing in the fleet looks like this; it
+    exists so one row can pin the complete emitted key set, and so dropping any
+    single emission fails a fence instead of a production request."""
+    raise NotImplementedError
+
+
+@entrypoint
+def describe(ctx: RequestContext, payload: DescribeInput) -> DescribeResult:
+    """Declares nothing — the undeclared control."""
+    return DescribeResult(summary=payload.ref)

--- a/tests/test_call_endpoint_semver_major_pgw1293.py
+++ b/tests/test_call_endpoint_semver_major_pgw1293.py
@@ -158,6 +158,12 @@ def test_ctx_call_endpoint_addresses_a_non_zero_major_over_the_real_client() -> 
         ctx._request_id = "req-parent"  # type: ignore[attr-defined]
         ctx._worker_capability_token = "tok"  # type: ignore[attr-defined]
         ctx._file_api_base_url = rec.base_url  # type: ignore[attr-defined]
+        # pgw#1579: child calls are a DECLARED capability again, and a
+        # hand-built context must state it — `_callout_client` refuses an
+        # undeclared body with the hub's own `child_calls_not_declared` before
+        # a socket opens. Left absent it is an AttributeError, which is the
+        # right answer for a fixture that skipped a load-bearing field.
+        ctx._child_calls = True  # type: ignore[attr-defined]
 
         handle = ctx.call_endpoint(
             "acme/child", "generate", {}, semver_major=7, wait=False

--- a/tests/test_manifest_declarations_pgw1579_1580.py
+++ b/tests/test_manifest_declarations_pgw1579_1580.py
@@ -1,0 +1,516 @@
+"""THE DECLARATION LEDGER FENCE — every author-side declaration, and the
+manifest key it owes (pgw#1579 / pgw#1580).
+
+WHY THIS FILE EXISTS AND WHY IT IS GENERAL. The pgw#1373 v1 hardcut deleted
+four author-side declarations while the hub kept decoding and ACTING on them,
+and not one test failed. Each was found later by an endpoint breaking on it:
+``child_calls`` at a workflow endpoint's first child call (pgw#1579),
+``incremental_output`` at a streaming port (pgw#1576), ``expected_outputs``
+LIVE IN PRODUCTION on five promoted endpoints (pgw#1580), and ``handles`` by
+the enumeration audit that went looking for the third.
+
+A test per field would have caught none of them, because the fields were gone
+before anyone wrote the test. So the fences below are keyed on the SHAPE of the
+mistake rather than on the field:
+
+* :func:`test_every_entrypoint_kwarg_is_classified` reads
+  ``inspect.signature(entrypoint)`` and requires every kwarg to appear in
+  :data:`KWARG_DECLARATIONS`. A kwarg ADDED without wiring an emission fails
+  here; a kwarg DELETED leaves an orphan row and fails here too.
+* :func:`test_the_fully_declaring_row_carries_every_declaration` requires each
+  ledger entry with a manifest key to appear on a row that declared it.
+  Deleting an emission while keeping the kwarg fails here — the exact pgw#1579
+  shape.
+* :func:`test_the_declared_row_key_set_is_pinned` and its undeclared twin pin
+  both ends of the manifest row, so a key that appears or vanishes must be
+  argued for in this file.
+
+The rule they encode is written down in ``gen_worker/v1_deleted.py``: a field
+the platform decodes may only be dropped WITH a tombstone row naming its
+successor. Every field that had one was a decision; every field that did not
+was an accident.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator
+
+import pytest
+
+from gen_worker.api.errors import ChildCallRefusedError, LaneNotDeclaredError
+from gen_worker.discovery.entrypoints_v2 import discover_entrypoints
+from gen_worker.models.execution_lanes import known_execution_lane_bodies
+from gen_worker.serving.context import RequestContext
+from gen_worker.serving.entrypoints import (
+    ENTRYPOINT_ATTR,
+    EntrypointDeclarationError,
+    EntrypointSpec,
+    entrypoint,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+MODULE = "declaring_endpoint"
+
+
+#: THE LEDGER: every ``@entrypoint`` kwarg -> the ``functions[]`` key it must
+#: produce on a row that declares it, or ``None`` for one deliberately kept
+#: SDK-side. Adding a kwarg without a row here fails
+#: :func:`test_every_entrypoint_kwarg_is_classified`; a ``None`` must carry its
+#: reason in the comment beside it, because "the hub does not read it" is a
+#: measurement, not an assumption.
+KWARG_DECLARATIONS: dict[str, str | None] = {
+    "resources": "resources",
+    "kind": "kind",
+    "publishes": "publishes",
+    "env": "env",
+    # TRI-STATE and JOB-KIND ONLY (th#2177): on the REQUEST path the hub grants
+    # `upload_media` unconditionally and has no column to store it in, so an
+    # inference row emits nothing. Keyed here because a JOB-kind row does carry
+    # it — `test_producer_declarations.py` owns that pair.
+    "emits_media": "emits_media",
+    # pgw#1579: `scheduler_dispatch.go` mints the `invoke_child` grant only
+    # `if subj.ChildCallsDeclared`.
+    "child_calls": "child_calls",
+    # pgw#1580: `normalizeManifestHandles` validates it and the resolver
+    # hydrates `FunctionMetadata.Handles` for selection.
+    "handles": "handles",
+    # pgw#1576: `manifestFunction.DeltaOutputSchema`, emitted off
+    # `EntrypointSpec.delta_type`. It also flips `incremental_output`, which is
+    # emitted UNCONDITIONALLY (the cardinality fact is stated, never omitted),
+    # so the droppable-channel key is the one that proves the declaration
+    # travelled. `tests/test_streaming_entrypoints.py` owns its
+    # semantics; this row is here so the LEDGER stays complete — an
+    # unclassified kwarg is the whole failure mode.
+    "streams": "delta_output_schema",
+}
+
+#: Declarations that are NOT kwargs — read off the author's TYPES instead.
+#: They need the same fence for the same reason: `ExpectedOutput` survived the
+#: hardcut as an exported, documented, still-written annotation whose emission
+#: was gone, which is why nothing complained for five promoted endpoints.
+ANNOTATION_DECLARATIONS: dict[str, str] = {
+    # `Annotated[..., ExpectedOutput(...)]` on the RETURN struct.
+    "ExpectedOutput": "expected_outputs",
+    # `Annotated[str, PromptRole(...)]` / typed Asset fields on the PAYLOAD.
+    "PromptRole": "moderation",
+}
+
+#: ``release.ExpectedOutputPlan`` / ``builder.ExpectedOutputPlan``, field for
+#: field. Read off the Go structs, not guessed. Anything outside this set is a
+#: key the hub silently drops — a mirror with no reader, which is what th#2087
+#: fences against and why ``duration_s`` is validated but never emitted.
+EXPECTED_OUTPUT_PLAN_KEYS = frozenset(
+    {"field", "type", "mime_type", "count", "width", "height", "aspect_ratio"}
+)
+
+#: ``normalizeExpectedOutputType``'s whole vocabulary; anything else becomes
+#: ``other`` hub-side, so emitting a sixth word would be a silent downgrade.
+EXPECTED_OUTPUT_TYPES = frozenset({"image", "video", "audio", "file", "other"})
+
+
+@pytest.fixture(scope="module")
+def declaring() -> Iterator[ModuleType]:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        yield importlib.import_module(MODULE)
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+
+@pytest.fixture(scope="module")
+def rows(declaring: ModuleType) -> dict[str, dict]:
+    return {row["name"]: row for row in discover_entrypoints(MODULE)}
+
+
+def spec(fn: object) -> EntrypointSpec:
+    stamped: EntrypointSpec = getattr(fn, ENTRYPOINT_ATTR)
+    return stamped
+
+
+def _probe(source: str, name: str) -> None:
+    module = type(sys)(name)
+    module.__dict__["__name__"] = name
+    sys.modules[name] = module
+    try:
+        exec(compile(source, name, "exec"), module.__dict__)
+    finally:
+        sys.modules.pop(name, None)
+
+
+# -- the general fences ------------------------------------------------------
+
+
+def test_every_entrypoint_kwarg_is_classified() -> None:
+    """THE FENCE THAT WOULD HAVE CAUGHT ALL FOUR.
+
+    Read off the decorator's own signature, so it cannot go stale: every kwarg
+    must be classified in :data:`KWARG_DECLARATIONS` as either producing a
+    manifest key or deliberately not. A hardcut that deletes a kwarg orphans a
+    row here; a lane that adds one without wiring the emission has nowhere to
+    put it. Either way the next reader is stopped in this file, next to the
+    rule, instead of by a pod nine months later.
+    """
+    parameters = set(inspect.signature(entrypoint).parameters) - {"fn"}
+    missing = sorted(parameters - set(KWARG_DECLARATIONS))
+    orphaned = sorted(set(KWARG_DECLARATIONS) - parameters)
+    assert not missing, (
+        f"@entrypoint grew {missing} with no ledger row. Add it to "
+        "KWARG_DECLARATIONS naming the functions[] key it emits — or None with "
+        "the MEASUREMENT showing the hub does not read it."
+    )
+    assert not orphaned, (
+        f"KWARG_DECLARATIONS names {orphaned}, which @entrypoint no longer "
+        "takes. If the deletion was deliberate it owes a v1_deleted.py row "
+        "naming the successor; if it was not, this is the pgw#1579 shape again."
+    )
+
+
+def test_the_fully_declaring_row_carries_every_declaration(
+    rows: dict[str, dict],
+) -> None:
+    """Every ledger entry with a manifest key reaches a row that declared it.
+
+    This is the assertion the three P0s failed. It is written over the LEDGER
+    rather than over a list of fields, so a future field is covered by adding
+    one line above rather than by remembering to write a test.
+    """
+    row = rows["everything"]
+    for declaration, key in KWARG_DECLARATIONS.items():
+        if key is None:
+            continue
+        assert key in row, (
+            f"@entrypoint({declaration}=…) was declared and the manifest row "
+            f"carries no {key!r}. The hub decodes it; an absent key is the "
+            "fail-closed reading, so this endpoint would be declined the "
+            "capability at RUNTIME with nothing failing at publish."
+        )
+    for marker, key in ANNOTATION_DECLARATIONS.items():
+        if marker == "PromptRole":
+            continue  # `everything`'s payload declares no prompt/media field
+        assert key in row, f"{marker} annotations reached no {key!r} key"
+
+
+def test_the_declared_row_key_set_is_pinned(rows: dict[str, dict]) -> None:
+    """Both directions. A DROPPED emission fails here even if someone deletes
+    the ledger row with it; a NEW key has to be argued for in this file."""
+    assert set(rows["everything"]) == {
+        "name", "python_name", "module", "declared_module", "class_name",
+        "kind", "input_schema", "payload_schema_sha256", "output_schema",
+        "output_schema_sha256", "incremental_output", "delta_output_schema",
+        "delta_output_schema_sha256", "expected_outputs",
+        "slots", "resources", "publishes", "env", "emits_media",
+        "child_calls", "handles",
+    }
+
+
+def test_the_undeclared_row_stays_byte_identical(rows: dict[str, dict]) -> None:
+    """The other end of the pin: conditional emission, so a row that declares
+    nothing is unchanged by any of this. The hub's own struct tags are
+    ``omitempty`` and absent IS undeclared."""
+    assert set(rows["describe"]) == {
+        "name", "python_name", "module", "declared_module", "class_name",
+        "kind", "input_schema", "payload_schema_sha256", "output_schema",
+        "output_schema_sha256", "incremental_output", "slots",
+    }
+
+
+# -- child_calls (pgw#1579) --------------------------------------------------
+
+
+def test_child_calls_reaches_the_spec_and_the_row(
+    declaring: ModuleType, rows: dict[str, dict]
+) -> None:
+    """The dj-pipeline blocker. Weightless and slotless, because a workflow
+    endpoint has no weights — the declaration must not depend on a model."""
+    assert spec(declaring.make_video).child_calls is True
+    assert rows["make_video"]["child_calls"] is True
+    assert rows["make_video"]["slots"] == []
+    assert "child_calls" not in rows["describe"]
+    assert spec(declaring.describe).child_calls is False
+
+
+def test_child_calls_must_be_a_bool() -> None:
+    with pytest.raises(EntrypointDeclarationError, match="child_calls= is a bool"):
+        _probe(
+            "import msgspec\n"
+            "from gen_worker import RequestContext, entrypoint\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct): pass\n"
+            "@entrypoint(child_calls='yes')\n"
+            "def f(ctx: RequestContext, payload: I) -> O: ...\n",
+            "pgw1579_child_calls_str",
+        )
+
+
+def test_an_undeclared_body_is_refused_the_child_call_surface() -> None:
+    """The SDK half of one-fact-two-enforcers, and the CODE is the hub's own.
+
+    Without this the refusal arrived from the hub as a 403 mid-request, after
+    the child request had already been attempted, quoting a decorator the SDK
+    had deleted."""
+    ctx: RequestContext = RequestContext("req-undeclared")
+    with pytest.raises(ChildCallRefusedError) as excinfo:
+        ctx._callout_client()
+    assert excinfo.value.code == "child_calls_not_declared"
+
+
+def test_a_declared_body_reaches_the_child_call_surface() -> None:
+    """Past the declaration gate it fails on the PLATFORM fact instead — proof
+    the gate is the declaration and not the environment."""
+    from gen_worker.api.errors import ChildCallError
+
+    ctx: RequestContext = RequestContext("req-declared", child_calls=True)
+    with pytest.raises(ChildCallError, match="no platform base URL"):
+        ctx._callout_client()
+
+
+def test_the_callout_refusals_name_the_successor_decorator() -> None:
+    """pgw#1579's third layer: the remedy text pointed at ``@endpoint``, which
+    the hardcut deleted. An unfollowable remedy is worse than none."""
+    from gen_worker import callout
+
+    source = Path(callout.__file__).read_text()
+    assert "@endpoint(" not in source
+
+
+# -- handles (pgw#1580) ------------------------------------------------------
+
+
+def test_handles_reaches_the_spec_and_the_row(
+    declaring: ModuleType, rows: dict[str, dict]
+) -> None:
+    assert spec(declaring.render).handles == ("fp8-w8a8-dynamic", "bf16-w16a16")
+    assert rows["render"]["handles"] == ["fp8-w8a8-dynamic", "bf16-w16a16"]
+    assert "handles" not in rows["describe"]
+
+
+def test_handles_tokens_come_from_the_hubs_own_table(rows: dict[str, dict]) -> None:
+    """Not a second vocabulary: ``known_execution_lane_bodies`` is the SDK twin
+    of ``precision.KnownExecutionLaneBodies``, which is what
+    ``normalizeManifestHandles`` validates against."""
+    known = set(known_execution_lane_bodies())
+    for name in ("render", "everything"):
+        assert set(rows[name]["handles"]) <= known
+
+
+@pytest.mark.parametrize(
+    "declared, match",
+    [
+        ("'fp8-w8a8-dynamic'", "iterate into"),
+        ("('fp8-w8a8-dynamic+compiled',)", "carries an execution axis"),
+        ("('fp8',)", "not a known lane body"),
+        ("('bf16-w16a16', 'bf16-w16a16')", "repeats"),
+    ],
+)
+def test_a_bad_handles_declaration_is_refused(declared: str, match: str) -> None:
+    """Every one of these is a refusal the HUB would raise instead — after the
+    image bake and the registry push. Raising at decoration names the author's
+    own line."""
+    with pytest.raises(EntrypointDeclarationError, match=match):
+        _probe(
+            "import msgspec\n"
+            "from gen_worker import RequestContext, entrypoint\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct): pass\n"
+            f"@entrypoint(handles={declared})\n"
+            "def f(ctx: RequestContext, payload: I) -> O: ...\n",
+            f"pgw1580_handles_{abs(hash(declared))}",
+        )
+
+
+def test_an_undeclared_body_is_refused_the_executing_lane() -> None:
+    """The asymmetry pgw#1580 asked about, CLOSED: reading the lane IS the
+    divergence, so an undeclared read is refused rather than handed a plausible
+    default nobody checked."""
+    ctx: RequestContext = RequestContext("req-undeclared")
+    with pytest.raises(LaneNotDeclaredError):
+        ctx.execution_lane
+
+
+def test_a_declared_body_reads_the_executing_lane() -> None:
+    ctx: RequestContext = RequestContext("req-declared", handles=("bf16-w16a16",))
+    assert ctx.execution_lane == "bf16-w16a16+eager"
+    ctx._set_execution_lane("fp8-w8a8-dynamic+compiled")
+    assert ctx.execution_lane == "fp8-w8a8-dynamic+compiled"
+
+
+def test_ctx_lane_inside_load_is_not_gated() -> None:
+    """The scope line, stated as a test so it is not re-litigated by guess.
+
+    ``LoadContext.lane`` is the deploy's PICK and ``ctx.lane.dtype`` is how
+    every model loads at all — the ordinary path, not a divergence — and it is
+    MODEL scope while ``handles=`` is FUNCTION scope, so one model serving two
+    entrypoints could not be gated coherently. Only the request-time read is
+    the declared branch."""
+    from gen_worker.serving.context import LoadContext
+
+    assert not hasattr(LoadContext, "_require_lane_declaration")
+    assert "handles" not in inspect.signature(LoadContext.__init__).parameters
+
+
+# -- expected_outputs (pgw#1580) ---------------------------------------------
+
+
+def test_expected_outputs_reproduces_the_measured_anima_row(
+    rows: dict[str, dict],
+) -> None:
+    """THE PRODUCTION REGRESSION, pinned to the bytes that were measured.
+
+    ``GET /api/v1/endpoints/tensorhub/anima`` served
+    ``[{"type":"image","count":1,"field":"image",
+    "aspect_ratio":"input.aspect_ratio"}]`` on v1 ``0.3.28`` and ``null`` on v2
+    ``0.4.3``. The fixture's ``image`` field carries anima's annotation
+    character for character, so this asserts the v1 row is back."""
+    plan = rows["render"]["expected_outputs"]
+    assert plan[0] == {
+        "field": "image",
+        "type": "image",
+        "count": 1,
+        "aspect_ratio": "input.aspect_ratio",
+    }
+
+
+def test_expected_outputs_carries_refs_and_lists(rows: dict[str, dict]) -> None:
+    """The multi-output shape: the hub resolves each expression against the
+    real request payload, so a ref must survive as a ref.
+
+    The marker sits on the LIST, and the path is the annotated field's own —
+    ``thumbnails``, not ``thumbnails[]``. v1's walk stopped at the ``Annotated``
+    node without descending, and the cardinality is ``count`` rather than the
+    container anyway."""
+    plan = {item["field"]: item for item in rows["render"]["expected_outputs"]}
+    assert plan["thumbnails"] == {
+        "field": "thumbnails",
+        "type": "image",
+        "count": "input.num_images",
+        "width": "input.width",
+        "height": "input.height",
+        "mime_type": "image/webp",
+    }
+
+
+def test_expected_outputs_matches_the_hubs_plan_struct(rows: dict[str, dict]) -> None:
+    """Shape parity with ``ExpectedOutputPlan``, both directions. A key outside
+    the struct is silently dropped by the hub's decoder — a mirror with no
+    reader — and a ``type`` outside the vocabulary becomes ``other``."""
+    for name in ("make_video", "render", "everything"):
+        for item in rows[name]["expected_outputs"]:
+            assert set(item) <= EXPECTED_OUTPUT_PLAN_KEYS, set(item)
+            assert {"field", "type"} <= set(item)
+            assert item["type"] in EXPECTED_OUTPUT_TYPES
+
+
+def test_duration_s_is_validated_but_never_emitted(rows: dict[str, dict]) -> None:
+    """v1 emitted it and no hub reader has ever decoded it — it is absent from
+    both ``ExpectedOutputPlan`` structs and from ``expectedOutputsFromPlans``.
+    So it is checked (a wrong ref still fails the build) and dropped. The
+    marker's own docstring already routes settlement at the probed
+    ``VideoAsset.duration_s``."""
+    plan = rows["make_video"]["expected_outputs"]
+    assert plan == [{
+        "field": "video",
+        "type": "video",
+        "count": 1,
+        "mime_type": "video/mp4",
+    }]
+
+    with pytest.raises(ValueError, match="unknown payload field"):
+        _probe(
+            "from typing import Annotated\n"
+            "import msgspec\n"
+            "from gen_worker import ExpectedOutput, RequestContext, VideoAsset\n"
+            "from gen_worker import entrypoint\n"
+            "from gen_worker.discovery.entrypoints_v2 import _entrypoint_row\n"
+            "from gen_worker.serving.entrypoints import ENTRYPOINT_ATTR\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct):\n"
+            "    v: Annotated[VideoAsset, ExpectedOutput("
+            "media_type='video', duration_s='input.seconds')]\n"
+            "@entrypoint\n"
+            "def f(ctx: RequestContext, payload: I) -> O: ...\n"
+            "_entrypoint_row(getattr(f, ENTRYPOINT_ATTR))\n",
+            "pgw1580_bad_duration_ref",
+        )
+
+
+def test_an_unresolvable_output_struct_refuses_instead_of_emptying() -> None:
+    """The pgw#1418 lesson, one field over. v1 swallowed a hint-resolution
+    failure and fell back to ``__annotations__`` — strings, under ``from
+    __future__ import annotations`` — so the walk found no markers and the plan
+    came out EMPTY, indistinguishable from an endpoint that declared none."""
+    from gen_worker.discovery.expected_outputs import expected_outputs
+
+    module = type(sys)("pgw1580_unresolvable")
+    module.__dict__["__name__"] = "pgw1580_unresolvable"
+    sys.modules["pgw1580_unresolvable"] = module
+    try:
+        exec(compile(
+            "from __future__ import annotations\n"
+            "import msgspec\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct):\n"
+            "    v: NeverImported\n",
+            "pgw1580_unresolvable", "exec"), module.__dict__)
+        with pytest.raises(ValueError, match="silently EMPTY"):
+            expected_outputs(module.__dict__["I"], module.__dict__["O"])
+    finally:
+        sys.modules.pop("pgw1580_unresolvable", None)
+
+
+def test_a_row_with_no_markers_omits_the_key(rows: dict[str, dict]) -> None:
+    assert "expected_outputs" not in rows["describe"]
+
+
+# -- the declarations reach the RUNNING body ---------------------------------
+
+
+def test_the_serve_loop_stamps_both_declarations(declaring: ModuleType) -> None:
+    """A declaration the running body never sees is a declaration that does
+    nothing. This is the wire from the spec to ``ctx``, and it is the same wire
+    ``publishes`` already had."""
+    from gen_worker.serving.serve_loop import ServeLoop
+
+    host = object.__new__(ServeLoop)
+    host._context_kwargs = {}
+    host._output_dir = None
+    host._hf_token = ""
+
+    workflow = host._make_context("r1", None, spec(declaring.make_video))
+    assert workflow.child_calls is True
+    assert workflow.handles == ()
+
+    brancher = host._make_context("r2", None, spec(declaring.render))
+    assert brancher.child_calls is False
+    assert brancher.handles == ("fp8-w8a8-dynamic", "bf16-w16a16")
+    assert brancher.execution_lane  # does not raise
+
+    plain = host._make_context("r3", None, spec(declaring.describe))
+    assert plain.child_calls is False
+    with pytest.raises(LaneNotDeclaredError):
+        plain.execution_lane
+
+
+def test_the_local_host_stamps_them_too(declaring: ModuleType) -> None:
+    """The CLI and the daemon build a context BEFORE they know the function, so
+    they stamp at dispatch. A declaration only the serverless dispatcher
+    honours is one an author cannot test."""
+    ctx: RequestContext = RequestContext("req-local")
+    ctx._declare_from_spec(spec(declaring.everything))
+    assert ctx.child_calls is True
+    assert ctx.handles == ("fp8-w8a8-dynamic",)
+
+
+# -- the row is still publishable -------------------------------------------
+
+
+def test_every_fixture_row_survives_discovery(rows: dict[str, dict]) -> None:
+    """``discover_entrypoints`` runs the pipeline-class refusal and the
+    duplicate-name check over these rows, so reaching here at all is the
+    publish path accepting every declaration above."""
+    assert set(rows) == {"describe", "everything", "make_video", "render"}
+    assert all(row["module"] == MODULE for row in rows.values())


### PR DESCRIPTION
Closes pgw#1579 and pgw#1580.

## What was wrong

The pgw#1373 v1 hardcut deleted three author-side declarations while the hub kept **decoding** them and kept **acting** on them. Nothing failed at publish, so nothing was noticed — each was found later by an endpoint breaking on it.

| field | hub reader at HEAD | how it surfaced |
|---|---|---|
| `child_calls` | `scheduler_dispatch.go:1449` mints `invoke_child` only `if subj.ChildCallsDeclared` | a ported workflow endpoint fails at its **first child call** |
| `handles` | `normalizeManifestHandles` → `FunctionMetadata.Handles` | a body branches on the lane with no way to say so |
| `expected_outputs` | `expectedOutputsForRelease` stamps `ExpectedOutputsJSON` per REQUEST | **live in production**: v2 releases served `null` |

`expected_outputs` is the serious one. `ExpectedOutput` survived the hardcut as an exported, documented, still-written annotation whose emission was gone. Measured on the live hub: `ltx-video-2.3` (v1) 4/4 functions carried it, `musicgen` (v1) 1/1, and `anima`/`sd15`/`sdxl`/`dj-utils`/`music-analysis` (v2) **0 of 10** — `anima` served a real plan before its pointer moved to v2 and `null` after.

## What this does

- **`@entrypoint(child_calls=True)`** and **`@entrypoint(handles=("fp8-w8a8-dynamic",))`** join the AUTHORITY kwarg set beside `publishes=` / `env=` / `emits_media=`. Both are DECLARATIONS, on the ruling that **capabilities and behavioral divergence are declared in the manifest, never inferred from code shape** — inferring `child_calls` from the presence of `ctx.call_endpoint` would mint the credential for anything that merely imports the surface.
- **`expected_outputs` is emitted off the return struct's `ExpectedOutput` annotations**, in the shape read off the Go `ExpectedOutputPlan` rather than guessed. `duration_s` is validated but **not** emitted: no hub reader has ever decoded it (absent from both `ExpectedOutputPlan` structs and from `expectedOutputsFromPlans`), and a key with no reader is the th#2087 mirror.
- **Emission is conditional throughout**, matching the house style, so a row that declares nothing is byte-identical and the hub's `omitempty` absent-is-undeclared reading is unchanged.
- **`handles=` tokens are validated at DECORATION** against `known_execution_lane_bodies()` — the SDK twin of the table `normalizeManifestHandles` checks — so a bad token names the author's line instead of failing the publish after the image bake and registry push.
- **The SDK half of one-fact-two-enforcers.** `ctx.call_endpoint` refuses an undeclared body before a socket opens, with the hub's own `child_calls_not_declared` code. `ctx.execution_lane` raises `LaneNotDeclaredError` for an undeclared reader rather than handing back a plausible `bf16-w16a16+eager` nobody checked. Both are stamped from the spec by the serve loop AND by the local host, so a declaration works under the CLI too.
- **`ctx.lane` inside `Model.load` is deliberately NOT gated** — that lane is the deploy's pick and `ctx.lane.dtype` is how every model loads at all (the ordinary path, not a divergence), and it is model scope while `handles=` is function scope, so one model serving two entrypoints could not be gated coherently. There is a test that states this rather than leaving it to be re-litigated.
- Every refusal string that named the deleted `@endpoint` now names `@entrypoint`.

## The fence, and why it is not three tests

A test per field would have caught **none** of these, because the fields were gone before anyone wrote the test. Four have now been found this way (`child_calls`, `incremental_output`, `expected_outputs`, and the never-wired progress emitter) and not one was caught by CI.

So `tests/test_manifest_declarations_pgw1579_1580.py` is keyed on the SHAPE of the mistake:

- **`test_every_entrypoint_kwarg_is_classified`** reads `inspect.signature(entrypoint)` and requires every kwarg to appear in a ledger naming the `functions[]` key it owes. A kwarg **added** without wiring an emission fails there; a kwarg **deleted** leaves an orphan row and fails there. (It already earned its keep on this branch: rebasing onto pgw#1576 made it red until `streams=` was classified.)
- **`test_the_fully_declaring_row_carries_every_declaration`** iterates the ledger, so a future field is covered by adding one line rather than by remembering to write a test.
- **The pinned key sets** for the fully-declaring and the declares-nothing rows catch a dropped emission from the other direction.
- `test_expected_outputs_reproduces_the_measured_anima_row` pins the exact bytes measured on the live hub.

The rule is written into `v1_deleted.py` where the next hardcut author will read it: **a field the platform decodes may only be dropped WITH a tombstone row naming its successor.** Every field that had one was a decision; every field that did not was an accident.

## Sequencing

Rebased onto `master` at `4c0a8d16` (pgw#1576), per the coordinator's ruling that whichever lane was closer to merge went first. The overlap in `serving/entrypoints.py` and `_entrypoint_row` was resolved by keeping both sides; `streams=`'s generator refusal is untouched.

## Not closed by this

Restoring the emission does nothing for anything already released — the manifest is stamped at publish, so every v2 endpoint needs a version bump, a rebuild and a re-promotion before it serves `expected_outputs` again. se#806 carries that wave.

## Tests

`test_manifest_declarations_pgw1579_1580.py` (27 new), plus `test_streaming_entrypoints.py`, `test_producer_declarations.py`, `test_call_endpoint_semver_major_pgw1293.py`, `test_weightless_entrypoints.py`, `test_endpoint_discovery.py`, `test_serve_path_wires.py`, `test_staffing_envelope.py`, `test_pod_serve_loop_streams.py` — 131 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)