### PR TITLE
pgw#1573: close pgw#1571's LoRA P0 on the path that runs — the v2 dispatcher

### DIFF
--- a/changelog.d/pgw1573-adapter-guard.md
+++ b/changelog.d/pgw1573-adapter-guard.md
@@ -1,0 +1,30 @@
+- **pgw#1573: a LoRA on a compiled-armed module serves EAGER and says so —
+  on the path that actually runs.** pgw#1571 measured the defect exactly (peft
+  wraps a denoiser's SUBMODULES; an armed graph replaces the PARENT's forward
+  and never enters them, so an adapter attached after arming does not execute
+  and the base model is served bit-identically with no refusal and no log —
+  eager `max|delta| = 2.2e-02` against armed `0.0` with 32 wrappers attached)
+  and fixed it inside `aot_serve.wrap_module`. That function has **zero
+  non-test callers**: the production arm is `torchcg.adopt.AdoptSession` →
+  `torchcg.serve.aoti_loader`, which none of `PEFT_MARKER_ATTR`,
+  `_say_adapter_ops_once`, `rearm_constants` or the `wrap_module` guard
+  touches. So the P0 was open on the serving path, masked only by adoption
+  itself being broken — and pgw#1573 fixed adoption, which arms it.
+
+  `serving/adapter_guard.py` is the same guard on the live dispatcher. One
+  `getattr` per call; a module carrying a live `peft_config` routes to its own
+  eager forward and states the degradation ONCE, on the wire as well as the
+  log (a serve pod's stdout goes nowhere, pgw#760). Both `ctx.compile` hosts —
+  `EndpointHost.setup` and `ServeAdoption.sink_for` — hand out the guarded
+  sink, and that wiring has its own red arm: restore the bare `session.adopt`
+  and a LoRA request serves the compiled base model again.
+
+- **pgw#1573: `lora_fold._compiled_armed` can see a v2 arm.** It asked
+  `aot_serve.serves_compiled`, whose `_cozy_compile` marker no pod has carried
+  since pgw#1373 — so on a real worker it answered False for every armed
+  module and every compiled-aware branch behind it was dead code. It now reads
+  the live dispatcher through `adapter_guard.compiled_armed` first.
+  `adapter_guard.rearm_constants` is the v2 `Rebind` the fold path needs: AOTI
+  folds its constants once on the first `run()` and never re-folds on a bare
+  in-place weight write, and a runner exposing no bound table is a typed
+  refusal rather than a silently stale weight.

--- a/src/gen_worker/models/lora_fold.py
+++ b/src/gen_worker/models/lora_fold.py
@@ -304,13 +304,23 @@ def apply_fold(model: Any, deltas: Mapping[str, Any]) -> FoldScope:
 def _compiled_armed(model: Any) -> bool:
     """Whether a compiled artifact is currently serving this module's forward.
 
-    Read off ``aot_serve``'s own marker rather than a second flag — the
-    question "is something other than this module's forward serving" has one
-    answer and it lives there.
+    TWO ARMING TIERS, and the v2 one is the only one a pod has (pgw#1573).
+    ``aot_serve``'s ``_cozy_compile`` marker is the v1 arm, whose last in-repo
+    caller went with ``executor.py`` in pgw#1373 — so asking only that question
+    answered False for every armed module on every real worker, and every
+    compiled-aware branch behind this predicate was dead there. The live arm is
+    torchcg's ``_ForwardDispatcher``, installed by ``AdoptSession``, and
+    ``serving.adapter_guard`` is what reads it.
     """
-    from .. import aot_serve
+    from ..serving import adapter_guard
 
-    return aot_serve.serves_compiled(model)
+    if adapter_guard.compiled_armed(model):
+        return True
+    try:
+        from .. import aot_serve
+    except ImportError:  # the v1 tier is deleted on this build
+        return False
+    return bool(aot_serve.serves_compiled(model))
 
 
 @contextmanager

--- a/src/gen_worker/serving/adapter_guard.py
+++ b/src/gen_worker/serving/adapter_guard.py
@@ -1,0 +1,246 @@
+"""A LIVE adapter on a compiled-armed module serves EAGER, loudly (pgw#1573).
+
+pgw#1571 measured the defect and stated it exactly: peft wraps a denoiser's
+SUBMODULES, and an armed compiled graph replaces the PARENT's forward with a
+traced computation that never enters them. So an adapter attached after arming
+does not execute — the base model is served, bit-identically, with no refusal
+and no log. Measured there: eager red arm ``max|delta| = 2.2e-02``, armed
+``0.0``, with 32 peft wrappers attached.
+
+**Its fix landed in ``aot_serve``, which nothing on the serving path calls.**
+Verified against ``origin/master``: ``aot_serve.wrap_module`` has zero non-test
+callers — every reference in ``src/`` is a docstring — and the live arm is
+``torchcg.adopt.AdoptSession`` handing ``torchcg.serve.CompiledGraphCall`` to a
+``_ForwardDispatcher``. Neither ``PEFT_MARKER_ATTR``, ``_say_adapter_ops_once``
+nor ``rearm_constants`` is reachable from a pod. The defect was masked only by
+adoption being broken; pgw#1573 fixed adoption, so it arms itself. This module
+is the same guard, on the path that runs.
+
+TWO HALVES, both O(1) on the hot path:
+
+* :func:`install` wraps the dispatcher torchcg installed. A module carrying a
+  live ``peft_config`` routes to the module's own eager forward and says so
+  ONCE. One ``getattr`` per call — a module walk here would cost more than the
+  defect it prevents.
+* :func:`rearm_constants` re-installs a compiled runner's bound constant table
+  after an in-place weight write, which is what makes folding an adapter INTO
+  the weights (:mod:`gen_worker.models.lora_fold`) work on a v2 pod:
+  ``load_constants(..., user_managed=True)`` keeps raw pointers, so a fold is
+  visible — except through AOTI's runtime constant folding, which folds once on
+  the first ``run()`` and never re-folds on a bare tensor write.
+
+**Eager is a correct answer and stays one.** Nothing here refuses a request:
+the cost is speed, never numerics, and the alternative — a silently wrong
+image — is the only outcome that is not acceptable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Tuple
+
+from .. import activity as activity_mod
+
+logger = logging.getLogger(__name__)
+
+#: peft writes this on the module it injects adapters into (diffusers'
+#: ``load_lora_adapter`` -> ``inject_adapter_in_model``) and deletes it on
+#: unload. Same attribute pgw#1571 keyed on, deliberately: one marker, and the
+#: v1 spelling is the one the ecosystem writes.
+PEFT_MARKER_ATTR = "peft_config"
+
+#: Set on a guard so a second ``ctx.compile`` of the same module cannot stack
+#: two of them, and so :func:`armed_graphs` can recognise one.
+_GUARD_ATTR = "_cozy_adapter_guard"
+
+
+def _dispatcher(module: Any) -> Any:
+    """The torchcg dispatcher fronting ``module``, through any guard, or None.
+
+    Duck-typed on the two attributes the dispatcher contract actually has
+    (``eager_forward`` + ``armed_graphs``) rather than on an isinstance against
+    a vendored private class: the vendored snapshot is sha256-fenced, so a
+    check that pins its identity here is a check that breaks on a re-vendor
+    instead of on a real change.
+    """
+    forward = getattr(module, "forward", None)
+    if forward is None:
+        return None
+    inner = getattr(forward, _GUARD_ATTR, None)
+    candidate = inner if inner is not None else forward
+    if hasattr(candidate, "eager_forward") and hasattr(candidate, "armed_graphs"):
+        return candidate
+    return None
+
+
+def armed_graphs(module: Any) -> Tuple[str, ...]:
+    """The graph identities currently armed on ``module``. Empty = eager."""
+    dispatcher = _dispatcher(module)
+    if dispatcher is None:
+        return ()
+    try:
+        return tuple(dispatcher.armed_graphs())
+    except Exception:  # noqa: BLE001 — a probe never costs a request
+        return ()
+
+
+def compiled_armed(module: Any) -> bool:
+    """Whether a compiled artifact is currently serving ``module``'s forward.
+
+    THE v2 ANSWER. ``lora_fold._compiled_armed`` asks ``aot_serve``, whose
+    marker (``_cozy_compile``) no pod has carried since pgw#1373 — so on a real
+    worker that predicate answers False for every armed module and every
+    compiled-aware branch behind it is dead code.
+    """
+    return bool(armed_graphs(module))
+
+
+def has_live_adapter(module: Any) -> bool:
+    """Whether peft currently has adapters injected into ``module``."""
+    return bool(getattr(module, PEFT_MARKER_ATTR, None))
+
+
+def install(module: Any) -> bool:
+    """Guard one adopted module. Returns whether a guard was installed.
+
+    Called after ``AdoptSession.adopt`` has installed its dispatcher, on the
+    same object. Idempotent: a module already guarded is left alone, so the two
+    ``ctx.compile`` hosts and a re-adopt cannot stack guards.
+
+    The dispatcher object is NOT replaced — only ``module.forward`` is — so
+    ``AdoptSession.arm``'s late-mint handoff, which reaches the dispatcher
+    through its own ``_home`` map, keeps working unchanged.
+    """
+    dispatcher = _dispatcher(module)
+    if dispatcher is None:
+        return False
+    if getattr(getattr(module, "forward", None), _GUARD_ATTR, None) is not None:
+        return True  # already guarded
+    state: Dict[str, Any] = {"said": False}
+
+    def guarded(*args: Any, **kwargs: Any) -> Any:
+        if getattr(module, PEFT_MARKER_ATTR, None):
+            if not state["said"]:
+                state["said"] = True
+                _say(module)
+            return dispatcher.eager_forward(*args, **kwargs)
+        return dispatcher(*args, **kwargs)
+
+    setattr(guarded, _GUARD_ATTR, dispatcher)
+    module.forward = guarded
+    return True
+
+
+def sink(adopt: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    """``ctx.compile``'s sink, with the guard on everything it arms.
+
+    Wraps ``AdoptSession.adopt`` rather than living inside it, because the
+    session is vendored and sha256-fenced. The walk is the same one ``adopt``
+    does — the target itself, or every ``nn.Module`` in a pipeline-shaped
+    container's ``components`` mapping — so a marked pipeline is guarded
+    component by component exactly as it is armed.
+    """
+
+    def compile_sink(target: Any) -> Any:
+        armed_target = adopt(target)
+        for module in _adopted_modules(armed_target):
+            try:
+                install(module)
+            except Exception:  # noqa: BLE001 — a guard never fails a load
+                logger.exception(
+                    "adapter guard: could not guard %s; a LoRA on this "
+                    "module would serve the base weights silently",
+                    type(module).__name__)
+        return armed_target
+
+    return compile_sink
+
+
+def _adopted_modules(target: Any) -> List[Any]:
+    components = getattr(target, "components", None)
+    if isinstance(components, dict):
+        return [value for value in components.values()
+                if _dispatcher(value) is not None]
+    return [target] if _dispatcher(target) is not None else []
+
+
+def _say(module: Any) -> None:
+    """Say the degradation ONCE per module, on the wire and in the log.
+
+    Per FORWARD, not per boot: an adapter arrives at request time, so the first
+    guarded call is the first instant this is true. A serve pod's stdout goes
+    nowhere (pgw#760), so the log line alone would be the same silence this
+    guard exists to end.
+    """
+    names = sorted(getattr(module, PEFT_MARKER_ATTR, {}) or {})
+    detail = (
+        f"{type(module).__name__}: live peft adapter(s) {names} on a "
+        f"compiled-armed module ({len(armed_graphs(module))} graph(s) armed) — "
+        f"serving EAGER for the duration, because the compiled graph was "
+        f"traced without them and would silently return the BASE MODEL "
+        f"(pgw#1571). Fold the adapter into the weights "
+        f"(models.lora_fold.folded, rebind=adapter_guard.rearm_constants) to "
+        f"keep compiled speed."
+    )
+    logger.warning("adapter guard: %s", detail)
+    try:
+        activity_mod.emit_event(
+            activity_mod.KIND_LORA_HYGIENE, detail,
+            phase="adapter_ops_on_compiled",
+        )
+    except Exception:  # noqa: BLE001 — the request outlives its telemetry
+        logger.debug("adapter guard: hygiene row failed to emit", exc_info=True)
+
+
+class ConstantRearmUnsupported(RuntimeError):
+    """A compiled runner exposes no bound constant table to re-install.
+
+    Refused BY NAME rather than skipped: the condition this is preventing is a
+    folded constant that keeps serving pre-fold weights, which produces a
+    plausible wrong image and no error at all.
+    """
+
+
+def rearm_constants(module: Any) -> int:
+    """Re-install every armed runner's constant table after a WEIGHT WRITE.
+
+    Returns how many entries were re-armed; 0 when nothing is armed, which is
+    the ordinary eager case and not an error.
+
+    ``load_constants(..., user_managed=True)`` keeps RAW POINTERS to the
+    module's own parameters, so an in-place fold is visible to the artifact
+    with no bookkeeping — except through AOTI's runtime constant folding, which
+    ``torchcg.compiler`` turns on. The container folds once on the first
+    ``run()`` (``fold_state`` INITIALIZED -> FOLDED) and never again, and an
+    in-place tensor write calls nothing. Re-installing the same pointers is
+    what puts ``fold_state`` back to INITIALIZED, so the next call re-folds
+    against the new weights.
+    """
+    dispatcher = _dispatcher(module)
+    if dispatcher is None:
+        return 0
+    rearmed = 0
+    for _record, call in tuple(getattr(dispatcher, "_entries", ()) or ()):
+        runner = getattr(call, "runner", None)
+        package = getattr(runner, "_package", None)
+        values = getattr(runner, "_bound_values", None)
+        if package is None or not values:
+            raise ConstantRearmUnsupported(
+                f"the compiled runner armed on {type(module).__name__} exposes "
+                f"no bound constant table to re-install after a weight "
+                f"mutation; a folded constant would serve stale weights")
+        package.load_constants(values, check_full_update=True, user_managed=True)
+        rearmed += 1
+    return rearmed
+
+
+__all__ = [
+    "ConstantRearmUnsupported",
+    "PEFT_MARKER_ATTR",
+    "armed_graphs",
+    "compiled_armed",
+    "has_live_adapter",
+    "install",
+    "rearm_constants",
+    "sink",
+]

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -228,6 +228,7 @@ class EndpointHost:
         """
         from .._vendor.torchcg import EnvironmentMismatch
         from .._vendor.torchcg.adopt import AdoptSession
+        from . import adapter_guard
         from ..env_identity import installed_stack_drift
 
         started = time.monotonic()
@@ -303,9 +304,15 @@ class EndpointHost:
                 model_cls, self.lanes[model_cls]
             )
             model: Model[Any] = model_cls()  # cheap __init__ — no GPU, by contract
+            # GUARDED (pgw#1573/pgw#1571): a peft adapter attached after
+            # arming never executes inside a compiled graph, so an unguarded
+            # sink serves the base model bit-identically and says nothing.
             load_context = self._load_context(
                 model_cls,
-                compile_sink=session.adopt if session is not None else None,
+                compile_sink=(
+                    adapter_guard.sink(session.adopt)
+                    if session is not None else None
+                ),
             )
             model.load(load_context)
             self.instances[model_cls] = ModelInstance(model, load_context)

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -167,14 +167,29 @@ class ServeAdoption:
         """
         with self._lock:
             if self._settled:
-                return self.adoption.adopt if self.adoption is not None else None
+                return self._sink()
             self._settled = True
             try:
                 self._build(lane)
             except Exception as exc:  # noqa: BLE001 — adoption never kills a boot
                 self._refuse(type(exc).__name__, str(exc))
                 return None
-        return self.adoption.adopt if self.adoption is not None else None
+        return self._sink()
+
+    def _sink(self) -> Optional[Callable[..., Any]]:
+        """``adopt``, GUARDED (pgw#1573/pgw#1571).
+
+        A peft adapter attached after arming does not execute inside a compiled
+        graph — the parent's forward is the traced computation and never enters
+        the wrapped submodules — so the base model is served bit-identically
+        with no refusal and no log. The guard rides every module this sink
+        arms; `adapter_guard` owns the argument.
+        """
+        from .adapter_guard import sink as guarded_sink
+
+        if self.adoption is None:
+            return None
+        return guarded_sink(self.adoption.adopt)
 
     def loaded(self, model_cls: type = type(None), lane: Any = None) -> None:
         """THE MINT'S TRIGGER: the author's ``load(ctx)`` has returned.

--- a/tests/test_adapter_on_compiled.py
+++ b/tests/test_adapter_on_compiled.py
@@ -1,0 +1,321 @@
+"""A LoRA on a compiled-armed module must never silently serve the base model.
+
+pgw#1571 measured the defect on the v1 arm and fixed it there. pgw#1573's
+reachability read then found that ``aot_serve.wrap_module`` — where that fix
+lives — has ZERO non-test callers: the production arm is
+``torchcg.adopt.AdoptSession``, which none of it touches. So the P0 was open on
+the path that runs, and it was masked only by adoption itself being broken.
+pgw#1573 fixed adoption; this file is the guard on the live path plus the proof
+that it fires.
+
+**These drive the real dispatcher.** ``AdoptSession`` is constructed with a
+real document, a real store and a real artifact, and the module that comes back
+is the one the author's ``ctx.compile`` returned — the same object a request is
+dispatched against. The only stand-in is the bytes-to-callable loader, because
+that is AOTInductor on a GPU; what it returns is a callable that is
+DISTINGUISHABLE from the eager forward, which is the whole measurement.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+import torch
+
+import tcg_artifacts
+from gen_worker import activity as activity_mod
+from gen_worker._vendor.torchcg.adopt import AdoptSession
+from gen_worker._vendor.torchcg.discovery import discover_lane
+from gen_worker._vendor.torchcg.document import GraphSetDocument
+from gen_worker._vendor.torchcg.graph_identity import EnvIdentity
+from gen_worker.serving import adapter_guard
+from gen_worker.serving.mint_store import graph_store
+
+LANE = "toy.bf16@1"
+SM = "sm_89"
+STACK: tuple[tuple[str, str], ...] = (("torch", torch.__version__),)
+ENV = EnvIdentity(stack=STACK, sm=SM)
+
+
+class Toy(torch.nn.Module):
+    """A denoiser-shaped module: one Linear a peft wrapper can sit on."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = torch.nn.Linear(4, 4, bias=False)
+        with torch.no_grad():
+            self.proj.weight.copy_(torch.eye(4))
+
+    def forward(self, sample: torch.Tensor) -> torch.Tensor:
+        return self.proj(sample)
+
+
+def _document(module: Toy) -> GraphSetDocument:
+    """The real publish-time derive over the real module."""
+    def drive() -> None:
+        module(torch.zeros(2, 4))
+
+    lane = discover_lane(LANE, ("proj_owner",), {"proj_owner": module}, drive)
+    return GraphSetDocument(stack=STACK, lanes=(lane,))
+
+
+def _store_with_artifact(tmp_path: Path, document: GraphSetDocument) -> Any:
+    from gen_worker._vendor.torchcg.requirements import RequirementsManifest
+
+    store = graph_store(tmp_path / "cas", None, tmp_path / "no-baked")
+    manifest = RequirementsManifest(
+        include_set=(("torch", torch.__version__),), sm_compiled=SM)
+    for index, record in enumerate(document.lanes[0].graphs):
+        envelope = tcg_artifacts.build(
+            tmp_path / "fleet" / f"{index}.tar.gz",
+            graph_specialization=record.graph, sm=SM)
+        store.publish_artifact(record.graph, ENV, envelope, manifest)
+    return store
+
+
+def _loader(calls: List[str]) -> Any:
+    """A compiled callable that is DISTINGUISHABLE from the eager forward.
+
+    It returns ``sample * 0`` — nothing the eager path can produce for a
+    non-zero input — so "which forward served this call" is a value, not a
+    counter somebody has to trust.
+    """
+
+    def load(path: Path, record: Any, module: Any) -> Any:
+        def compiled(sample: torch.Tensor) -> torch.Tensor:
+            calls.append(record.graph)
+            return torch.zeros_like(sample)
+
+        return compiled
+
+    return load
+
+
+@pytest.fixture()
+def wire(monkeypatch: pytest.MonkeyPatch) -> List[tuple]:
+    seen: List[tuple] = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, phase="", **kw: seen.append((kind, phase, detail)))
+    return seen
+
+
+def _armed(tmp_path: Path, calls: List[str]) -> Toy:
+    """One module, adopted through the GUARDED sink and armed for real."""
+    module = Toy()
+    document = _document(module)
+    store = _store_with_artifact(tmp_path, document)
+    session = AdoptSession(
+        store, document, LANE, SM, loader=_loader(calls),
+        artifacts_dir=tmp_path / "artifacts", stack=STACK)
+    adapter_guard.sink(session.adopt)(module)
+    assert adapter_guard.compiled_armed(module), (
+        "nothing armed, so this file would prove nothing about a compiled "
+        "module")
+    return module
+
+
+def test_the_compiled_graph_serves_when_no_adapter_is_attached(
+    tmp_path: Path,
+) -> None:
+    """POLARITY. The guard must not turn compiled serving off by itself —
+    otherwise every assertion below passes for the wrong reason."""
+    calls: List[str] = []
+    module = _armed(tmp_path, calls)
+
+    out = module(torch.ones(2, 4))
+
+    assert calls, "the guard swallowed a call no adapter had any claim on"
+    assert torch.equal(out, torch.zeros(2, 4)), (
+        "the eager forward served a module with nothing attached to it")
+
+
+def test_a_LIVE_adapter_routes_EAGER_instead_of_serving_the_base_model(
+    tmp_path: Path, wire: List[tuple]
+) -> None:
+    """THE P0 (pgw#1571), on the path that runs.
+
+    peft wraps a denoiser's SUBMODULES; the armed graph replaces the PARENT's
+    forward and never enters them. So an adapter attached after arming does not
+    execute, and the artifact returns the base result with no refusal and no
+    log — measured there as eager ``max|delta| = 2.2e-02`` against armed
+    ``0.0`` with 32 wrappers attached.
+
+    The guard's answer is EAGER: correctness over speed, stated once. What is
+    forbidden is the silence.
+    """
+    calls: List[str] = []
+    module = _armed(tmp_path, calls)
+
+    # peft's own marker, and a wrapper on the submodule the graph traced
+    # through — the exact shape `inject_adapter_in_model` leaves behind.
+    # , not attribute assignment:  types its
+    # own attributes, and peft writes this one from outside that contract.
+    setattr(module, "peft_config", {"default": object()})
+    with torch.no_grad():
+        module.proj.weight.mul_(2.0)
+
+    sample = torch.ones(2, 4)
+    out = module(sample)
+
+    assert calls == [], (
+        "the compiled graph served a request with a live adapter attached — "
+        "this is pgw#1571 exactly: the base model, bit-identically, with "
+        "nothing said")
+    assert torch.equal(out, sample * 2.0), (
+        "the eager forward did not serve, so the adapter's effect is absent "
+        "from the output")
+
+    rows = [row for row in wire
+            if row[0] == activity_mod.KIND_LORA_HYGIENE
+            and row[1] == "adapter_ops_on_compiled"]
+    assert len(rows) == 1, (
+        f"a degradation that reaches only a pod log is the same silence this "
+        f"guard exists to end (pgw#760): {wire}")
+    assert "BASE MODEL" in rows[0][2] and "lora_fold" in rows[0][2], rows[0][2]
+
+    # Said ONCE per module, not per request: an alarm on the hot path is an
+    # alarm operators learn to ignore.
+    module(sample)
+    module(sample)
+    assert len([row for row in wire
+                if row[1] == "adapter_ops_on_compiled"]) == 1
+
+
+def test_detaching_the_adapter_puts_the_compiled_graph_back(
+    tmp_path: Path,
+) -> None:
+    """The degradation is FOR THE DURATION, not for the life of the pod.
+
+    peft deletes `peft_config` on unload, so the next call is compiled again.
+    A guard that latched would quietly cost every later request its speed.
+    """
+    calls: List[str] = []
+    module = _armed(tmp_path, calls)
+
+    # , not attribute assignment:  types its
+    # own attributes, and peft writes this one from outside that contract.
+    setattr(module, "peft_config", {"default": object()})
+    module(torch.ones(2, 4))
+    assert calls == []
+
+    delattr(module, "peft_config")
+    module(torch.ones(2, 4))
+    assert calls, "the guard latched: a detached adapter left the module eager"
+
+
+def test_the_v2_armed_marker_is_what_lora_fold_reads(tmp_path: Path) -> None:
+    """``lora_fold._compiled_armed`` asked ``aot_serve``, whose marker no pod
+    has carried since pgw#1373 — so on a real worker it answered False for
+    every armed module and every compiled-aware branch behind it was dead.
+
+    Red arm: point the predicate back at the v1 tier alone and this goes red
+    on a module that IS armed.
+    """
+    from gen_worker.models import lora_fold
+
+    calls: List[str] = []
+    module = _armed(tmp_path, calls)
+    assert lora_fold._compiled_armed(module) is True
+    assert lora_fold._compiled_armed(Toy()) is False
+
+
+def test_rearm_constants_refuses_by_name_rather_than_serving_stale_weights(
+    tmp_path: Path,
+) -> None:
+    """The fold path's precondition, stated as a refusal.
+
+    AOTI folds its constants once on the first ``run()`` and never re-folds on
+    a bare tensor write, so folding an adapter INTO the weights needs the bound
+    table re-installed. A runner that exposes no such table must say so — a
+    folded constant that keeps serving pre-fold weights is a plausible wrong
+    image and no error at all.
+    """
+    calls: List[str] = []
+    module = _armed(tmp_path, calls)
+
+    # This file's loader returns a bare closure, not a `CompiledGraphCall`, so
+    # there is no runner to re-arm — which is exactly the shape the refusal is
+    # written for.
+    with pytest.raises(adapter_guard.ConstantRearmUnsupported, match="stale"):
+        adapter_guard.rearm_constants(module)
+
+    assert adapter_guard.rearm_constants(Toy()) == 0, (
+        "an eager module has nothing to re-arm and that is not an error")
+
+
+# --------------------------------------------------------------------------
+# The WIRING: both ctx.compile hosts hand out the guarded sink
+# --------------------------------------------------------------------------
+
+
+def _fixture_host(tmp_path: Path, calls: List[str]) -> Any:
+    """The real `EndpointHost`, booted with a real document over a real store.
+
+    Everything above proves the guard WORKS. This proves the production host
+    installs it — without which the guard is a correct object nothing calls,
+    which is the exact shape of the defect it replaces (pgw#1571's fix lives in
+    `aot_serve.wrap_module`, which has no caller).
+    """
+    from test_serving_adopt_first import (
+        ENV as FIXTURE_ENV, LANE as FIXTURE_LANE, OVERRIDES, SM as FIXTURE_SM,
+        STACK as FIXTURE_STACK, fresh_host, manifest, publish_document,
+    )
+    from gen_worker.serving import DeployBinding
+
+    import json as _json
+    root = tmp_path / "checkpoint"
+    root.mkdir()
+    (root / "config.json").write_text(
+        _json.dumps({"seed": 7, "scheduler": {"prediction_type": "epsilon"}}))
+    binding = DeployBinding(
+        checkpoint_ref="ckpt:tiny@1", checkpoint_dir=root, model="sdxl",
+        defaults=dict(OVERRIDES))
+
+    derive_host = fresh_host(binding, tmp_path / "derive")
+    derive_host.setup()
+    document = publish_document(derive_host)
+
+    store = graph_store(tmp_path / "cas", None, tmp_path / "no-baked")
+    for index, record in enumerate(document.lanes[0].graphs):
+        envelope = tcg_artifacts.build(
+            tmp_path / "fleet" / f"{index}.tar.gz",
+            graph_specialization=record.graph, sm=FIXTURE_SM)
+        store.publish_artifact(record.graph, FIXTURE_ENV, envelope, manifest())
+
+    host = fresh_host(binding, tmp_path)
+    host.setup(store=store, document=document, sm=FIXTURE_SM,
+               loader=_loader(calls), artifacts_dir=tmp_path / "artifacts",
+               stack=FIXTURE_STACK)
+    assert len(host.adoption.adopted) == 2, "nothing armed; the wiring is untestable"
+    return host
+
+
+def test_the_PRODUCTION_host_installs_the_guard(
+    tmp_path: Path, wire: List[tuple]
+) -> None:
+    """RED ARM FOR THE WIRING. Hand `EndpointHost.setup` the bare
+    `session.adopt` again and this goes red — which is what makes the guard a
+    property of the serving path rather than of this test file."""
+    calls: List[str] = []
+    host = _fixture_host(tmp_path, calls)
+    (instance,) = host.instances.values()
+    unet = instance.model.pipe.unet
+    assert adapter_guard.compiled_armed(unet), (
+        "the marked module is not armed, so this row proves nothing")
+
+    host.dispatch("generate", {"prompt": "x", "aspect_ratio": "1:1"},
+                  request_id="warm")
+    assert calls, "the compiled graph never served, before any adapter existed"
+    calls.clear()
+
+    setattr(unet, "peft_config", {"default": object()})
+    host.dispatch("generate", {"prompt": "x", "aspect_ratio": "1:1"},
+                  request_id="lora")
+
+    assert calls == [], (
+        "the production host handed out an UNGUARDED ctx.compile sink, so a "
+        "LoRA request served the base model silently (pgw#1571)")
+    assert [row for row in wire if row[1] == "adapter_ops_on_compiled"], wire


### PR DESCRIPTION
## The finding

**pgw#1571's fix is in a module with zero production callers.**

The defect it measured is real and exactly stated: peft wraps a denoiser's **submodules**, an armed compiled graph replaces the **parent's** forward and never enters them, so an adapter attached after arming does not execute — the base model is served bit-identically, with no refusal and no log. Measured there: eager `max|delta| = 2.2e-02` against armed `0.0` with 32 wrappers attached.

The fix (`PEFT_MARKER_ATTR`, `_say_adapter_ops_once`, `rearm_constants`, the `wrap_module` guard) landed in `aot_serve.py`. Verified against `origin/master`:

- `aot_serve.wrap_module` has **zero non-test callers** — every reference in `src/` is a docstring.
- `models/lora_fold.py`'s only in-repo references are from `aot_serve.py` and one docstring in `utils/lora.py`.
- The production arm is `torchcg.adopt.AdoptSession` → `torchcg.serve.aoti_loader` → `_ForwardDispatcher`, which touches none of it.

So the P0 is **open on the serving path**. The coordinator's read is right that it was masked by adoption being broken — and pgw#1573 (PR #1130, merged) fixed adoption, so it arms itself.

There is a second, quieter half: `lora_fold._compiled_armed` asks `aot_serve.serves_compiled`, whose `_cozy_compile` marker no pod has carried since pgw#1373. On a real worker that predicate answers `False` for **every** armed module, so every compiled-aware branch behind it — including `folded()`'s — is dead there too.

## The fix

`serving/adapter_guard.py`, the same guard on the live dispatcher:

- **One `getattr` per call.** A module carrying a live `peft_config` routes to its own eager forward. A module walk on the hot path would cost more than the defect.
- **Stated ONCE per module, on the wire.** `KIND_LORA_HYGIENE` / `phase=adapter_ops_on_compiled` — a serve pod's stdout goes nowhere (pgw#760), so a log line alone is the same silence.
- **Not latched.** peft deletes `peft_config` on unload, so the next call is compiled again — the degradation is for the duration, not for the life of the pod.
- **The dispatcher object is not replaced**, only `module.forward`, so `AdoptSession.arm`'s late-mint handoff (which reaches the dispatcher through its own `_home` map) is untouched.
- `compiled_armed()` gives `lora_fold` the v2 answer, and `rearm_constants()` is the v2 `Rebind` its fold path needs — AOTI folds constants once on the first `run()` and never re-folds on a bare in-place write. A runner exposing no bound table is a **typed refusal**, never a silently stale weight.

Both `ctx.compile` hosts (`EndpointHost.setup`, `ServeAdoption.sink_for`) hand out the guarded sink.

## Tests — `tests/test_adapter_on_compiled.py`

Six, over the **real** `AdoptSession`, the **real** store, a real envelope, and — for the wiring row — the production `EndpointHost` booted from the fixture endpoint. The compiled callable is **value-distinguishable** from the eager forward (`zeros_like` vs the real matmul), so "which forward served this call" is a measured value, not a counter somebody has to trust.

| row | proves |
|---|---|
| polarity | with nothing attached, the compiled graph still serves — otherwise every row below passes for the wrong reason |
| the P0 | a live adapter routes eager, the output carries the adapter's effect, one hygiene row on the wire |
| not latched | detaching restores compiled serving |
| v2 marker | `lora_fold._compiled_armed` is True on an armed module and False on a bare one |
| refusal | `rearm_constants` refuses by name rather than serving stale weights; 0 on an eager module is not an error |
| **the wiring** | the production `EndpointHost` installs the guard — a LoRA request through `host.dispatch` does not reach the compiled graph |

**Red arms proven by mutation:** guard blinded to `peft_config` → red; `EndpointHost` handed the bare `session.adopt` → red ("the production host handed out an UNGUARDED ctx.compile sink").

mypy clean (617 files) · ruff clean · 86 targeted tests green.

## Note for the LoRA lane's owner

I did not touch `aot_serve.py`. Its whole tier is orphaned (the inventory is in PR #1135, held as a **blocked draft** precisely because your fix lives inside it) — that is a ruling for the coordinator, not something this lane should decide two hours after you landed.