### PR TITLE
pgw#1548: the pod preflight — does the MOUNTED tree satisfy the lane, before any money is spent

### DIFF
--- a/benchmarks/pgw1548_pod_preflight.py
+++ b/benchmarks/pgw1548_pod_preflight.py
@@ -1,0 +1,252 @@
+"""pgw#1548 pod preflight: does the MOUNTED tree satisfy the lane? (FIRST act)
+
+Runs on the pod, immediately after mount and **before anything expensive** —
+before a derive, before a compile, before a single benchmarked request. The
+coordinator's GO condition, 2026-08-20, verbatim in shape: *"the histogram +
+key-convention assert is the FIRST act after mount, before anything expensive;
+a divergence is a typed abort with the readings banked to the hub's durable
+rows, not a retry."*
+
+## Why this exists at all
+
+`artifact_contract` answers ONE of three axes. `plain.bf16@1` is
+`CONTRACT_PLAIN_BF16` (`models/tensor_layout_contract.py:38`) — the
+quant/element-layout axis. The lane `sdxl.diffusers-bf16@1`
+(`models/model_types.py:486`) is family + key topology + dtype. That file's own
+comment (lines 124-139) states why the stamp cannot answer the question, with
+the measured failure: two trees can both stamp `plain.bf16@1` and differ on KEY
+CONVENTION — te#185's fused `qkv_proj` vs split `to_q/to_k/to_v`, **one key in
+common**, discovered after a 71 GB fetch onto a rented 4xH100.
+
+So the stamp is not evidence of lane conformance, and neither is the hub's
+`checkpoints.dtype`: `model_types.py:613-618` records the stable-audio case
+where the inherited `plain.bf16@1` string disagreed with every checkpoint the
+fleet actually shipped, and **the bytes won**.
+
+## What a failure here saves
+
+pgw#1567's shape, arriving on the serve side: a tree whose containers are fp16
+under a lane whose graphs key bf16 gives **armed N, entered 0** — every request
+silently eager. An A/B benchmark on that pod measures eager in BOTH arms and
+reports a beautiful 0% delta, which is the most expensive possible way to learn
+nothing. This costs seconds and runs before the money does.
+
+## Discipline
+
+* `assert_fleet_line` is the FIRST statement (RIG-ENV, binding; Paul
+  2026-08-11) and its printed table belongs in the report.
+* Header bytes only. The safetensors header is a length prefix plus JSON at the
+  head of each file; nothing here reads a weight byte, so a 7 GB tree costs
+  kilobytes.
+* A divergence **ABORTS** with `exit 91` and banks the readings. It is not
+  retried and not downgraded: a rig that measures under a configuration
+  production forbids is worse than no rig.
+
+    python3 benchmarks/pgw1548_pod_preflight.py \\
+        --tree /workspace/checkpoint --lane sdxl.diffusers-bf16@1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+#: Exit codes. 90 is rigcheck's own fleet-line abort (RIG-ENV §1); 91 is this
+#: file's, so a caller can tell "wrong torch" from "wrong tree" without parsing
+#: prose.
+EXIT_FLEET_LINE = 90
+EXIT_NONCONFORMING = 91
+
+#: The lane's dtype spelling -> the safetensors header spelling.
+DTYPE_SPELLINGS = {
+    "bfloat16": "BF16",
+    "float16": "F16",
+    "float32": "F32",
+    "float8_e4m3fn": "F8_E4M3",
+}
+
+#: `…attn*.to_q|to_k|to_v` — the diffusers repackaging
+#: (`KEYS_DIFFUSERS_SPLIT_QKV`). SDXL renders it
+#: `down_blocks.N.attentions.M.transformer_blocks.K.attn1.to_q.weight`; a DiT
+#: renders it `transformer_blocks.N.attn.to_q.weight`. Same axis, different
+#: family spelling — match on the ATTENTION SEGMENT, not on the prefix, or the
+#: check silently passes on the wrong family.
+SPLIT_MARKERS = (".to_q.weight", ".to_k.weight", ".to_v.weight")
+#: `…attn.qkv_proj|to_qkv` — the upstream/native fused set. te#185's tree.
+FUSED_MARKERS = ("qkv_proj", "to_qkv")
+
+
+class Nonconforming(RuntimeError):
+    """The mounted tree does not satisfy the declared lane. Typed, not a retry."""
+
+
+def read_header(path: Path) -> dict[str, Any]:
+    """The safetensors header of ONE file. Header bytes only, never a weight."""
+
+    with path.open("rb") as handle:
+        raw = handle.read(8)
+        if len(raw) != 8:
+            raise Nonconforming(f"{path}: too short to carry a safetensors header")
+        length = struct.unpack("<Q", raw)[0]
+        if length <= 0 or length > 200_000_000:
+            raise Nonconforming(
+                f"{path}: header length {length} is not credible — a 128-byte "
+                f"TFSSTUB projection stub reads exactly this way, and it is not "
+                f"a checkpoint"
+            )
+        body = handle.read(length)
+    if len(body) != length:
+        raise Nonconforming(f"{path}: header truncated ({len(body)} of {length})")
+    return json.loads(body)
+
+
+def survey(tree: Path) -> dict[str, dict[str, Any]]:
+    """Per-component dtype histogram and attention-key census."""
+
+    report: dict[str, dict[str, Any]] = {}
+    for path in sorted(tree.glob("*/*.safetensors")):
+        header = read_header(path)
+        dtypes: Counter[str] = Counter()
+        split = Counter[str]()
+        fused = 0
+        for key, entry in header.items():
+            if key == "__metadata__" or not isinstance(entry, dict):
+                continue
+            if "dtype" in entry:
+                dtypes[str(entry["dtype"]).upper()] += 1
+            if any(marker in key for marker in FUSED_MARKERS):
+                fused += 1
+            for marker in SPLIT_MARKERS:
+                if key.endswith(marker) and "attn" in key:
+                    split[marker] += 1
+        component = path.parent.name
+        row = report.setdefault(
+            component,
+            {"dtypes": Counter(), "split": Counter(), "fused": 0, "files": []},
+        )
+        row["dtypes"].update(dtypes)
+        row["split"].update(split)
+        row["fused"] += fused
+        row["files"].append(path.name)
+    if not report:
+        raise Nonconforming(f"{tree}: no safetensors containers found")
+    return report
+
+
+def assert_conforms(
+    report: dict[str, dict[str, Any]], lane: str, dtype: str
+) -> list[str]:
+    """Both facts, or a typed abort naming exactly which one failed."""
+
+    want = DTYPE_SPELLINGS.get(dtype)
+    if want is None:
+        raise Nonconforming(
+            f"lane {lane!r} declares dtype {dtype!r}, which has no safetensors "
+            f"spelling in this table — extend it deliberately, never guess"
+        )
+
+    lines = []
+    offenders = []
+    for component, row in sorted(report.items()):
+        histogram = dict(row["dtypes"])
+        lines.append(f"  {component:<16} {histogram}")
+        stray = {name: count for name, count in histogram.items()
+                 if name != want and not name.startswith(("I", "U", "BOOL"))}
+        if stray:
+            offenders.append(
+                f"{component}: {stray} — lane {lane} declares {dtype} ({want})"
+            )
+
+    # FACT 2 — the key convention, asserted where attention actually lives.
+    split_total = sum(sum(row["split"].values()) for row in report.values())
+    fused_total = sum(row["fused"] for row in report.values())
+    lines.append(f"  {'key convention':<16} split={split_total} fused={fused_total}")
+    if fused_total:
+        offenders.append(
+            f"key convention: {fused_total} FUSED attention key(s) "
+            f"(qkv_proj/to_qkv) — the lane wants the diffusers split set "
+            f"(te#185: one key in common, 71 GB to find out)"
+        )
+    if not split_total:
+        offenders.append(
+            "key convention: ZERO split attention keys found — this tree "
+            "carries neither convention where attention was looked for, so "
+            "nothing here has actually been verified"
+        )
+
+    if offenders:
+        raise Nonconforming(
+            "the mounted tree does not satisfy the lane:\n  - "
+            + "\n  - ".join(offenders)
+        )
+    return lines
+
+
+def bank(kind: str, detail: str, phase: str) -> None:
+    """Bank the reading in the hub's durable rows — best effort, never fatal.
+
+    A preflight that takes down its own abort message is worse than one that
+    prints it: the ABORT is the product, the row is how the next lane reads it
+    without SSH (pgw#1568 — the pod's logs are not retrievable).
+    """
+
+    try:
+        from gen_worker.activity import emit_event
+
+        emit_event(kind, detail, phase=phase)
+    except Exception as exc:  # noqa: BLE001 — never mask the verdict
+        print(f"[preflight] could not bank the reading ({exc}); the verdict stands",
+              file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tree", required=True, help="the MOUNTED checkpoint tree")
+    parser.add_argument("--lane", required=True, help="e.g. sdxl.diffusers-bf16@1")
+    parser.add_argument("--dtype", default="bfloat16",
+                        help="the dtype the lane declares (default: bfloat16)")
+    parser.add_argument("--skip-fleet-line", action="store_true",
+                        help="box-side dry run of the READER only; never on a pod")
+    args = parser.parse_args(argv)
+
+    if not args.skip_fleet_line:
+        # RIG-ENV §1, binding: FIRST statement, no override, and the printed
+        # table goes in the report.
+        try:
+            from gen_worker.rigcheck import assert_fleet_line
+
+            assert_fleet_line("pgw1548-dynamic-dims", start=__file__)
+        except Exception as exc:  # noqa: BLE001
+            print(f"FLEET_LINE_ABORT: {exc}", file=sys.stderr)
+            return EXIT_FLEET_LINE
+
+    tree = Path(args.tree).resolve()
+    print(f"[preflight] tree={tree}")
+    print(f"[preflight] lane={args.lane} dtype={args.dtype}")
+    try:
+        report = survey(tree)
+        lines = assert_conforms(report, args.lane, args.dtype)
+    except Nonconforming as exc:
+        detail = f"lane={args.lane} tree={tree}: {exc}"
+        print(f"NONCONFORMING_TREE: {detail}", file=sys.stderr)
+        bank("component_miss", detail[:1500], "preflight_nonconforming")
+        return EXIT_NONCONFORMING
+
+    print("[preflight] CONFORMS:")
+    for line in lines:
+        print(line)
+    summary = "; ".join(
+        f"{component}={dict(row['dtypes'])}" for component, row in sorted(report.items())
+    )
+    bank("applied_lane", f"pgw#1548 preflight: lane={args.lane} {summary}"[:1500],
+         "preflight_conforms")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pod_preflight_pgw1548.py
+++ b/tests/test_pod_preflight_pgw1548.py
@@ -1,0 +1,157 @@
+"""pgw#1548: the pod preflight refuses a tree that does not satisfy the lane.
+
+This check is the thing standing between a rental and the most expensive
+possible way to learn nothing: a tree whose containers are fp16 under a lane
+whose graphs key bf16 serves EAGER on every request, so an A/B measures eager
+in both arms and reports a beautiful 0% delta. Every arm below is a shape that
+has actually cost this workspace something.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+# `pythonpath` is ["src", "tests"], so `benchmarks/` is not importable by name.
+# Loading it by PATH keeps the harness where it belongs (beside the other
+# benchmarks) while still putting its refusals under CI — the alternative is a
+# check that only ever runs when someone remembers to run it, which for a gate
+# standing in front of a rental is no gate at all.
+_MODULE = Path(__file__).resolve().parents[1] / "benchmarks" / "pgw1548_pod_preflight.py"
+_spec = importlib.util.spec_from_file_location("pgw1548_pod_preflight", _MODULE)
+assert _spec and _spec.loader
+preflight = importlib.util.module_from_spec(_spec)
+sys.modules["pgw1548_pod_preflight"] = preflight
+_spec.loader.exec_module(preflight)
+
+EXIT_NONCONFORMING = preflight.EXIT_NONCONFORMING
+Nonconforming = preflight.Nonconforming
+assert_conforms = preflight.assert_conforms
+main = preflight.main
+survey = preflight.survey
+
+
+def _tree(root: Path, components: dict[str, tuple[str, list[str]]]) -> Path:
+    """A config-free tree of real safetensors HEADERS (no weight bytes)."""
+
+    for component, (dtype, keys) in components.items():
+        directory = root / component
+        directory.mkdir(parents=True, exist_ok=True)
+        header = {
+            key: {"dtype": dtype, "shape": [2, 2], "data_offsets": [0, 8]}
+            for key in keys
+        }
+        body = json.dumps(header).encode()
+        with (directory / "model.safetensors").open("wb") as handle:
+            handle.write(struct.pack("<Q", len(body)))
+            handle.write(body)
+            handle.write(b"\0" * 8)
+    return root
+
+
+SPLIT = [
+    f"down_blocks.1.attentions.0.transformer_blocks.{i}.attn1.to_{axis}.weight"
+    for i in range(2)
+    for axis in ("q", "k", "v")
+]
+FUSED = [f"transformer_blocks.{i}.attn.qkv_proj.weight" for i in range(3)]
+
+
+def test_a_conforming_tree_passes(tmp_path: Path) -> None:
+    tree = _tree(tmp_path, {"unet": ("BF16", SPLIT), "vae": ("BF16", ["conv.weight"])})
+    lines = assert_conforms(survey(tree), "sdxl.diffusers-bf16@1", "bfloat16")
+    assert any("split=6 fused=0" in line for line in lines)
+
+
+def test_an_fp16_tree_under_a_bf16_lane_is_REFUSED(tmp_path: Path) -> None:
+    """pgw#1567's shape arriving on the serve side — armed N, entered 0."""
+
+    tree = _tree(tmp_path, {"unet": ("F16", SPLIT)})
+    with pytest.raises(Nonconforming, match="declares bfloat16"):
+        assert_conforms(survey(tree), "sdxl.diffusers-bf16@1", "bfloat16")
+
+
+def test_integer_containers_do_not_count_as_a_dtype_violation(tmp_path: Path) -> None:
+    """A real text encoder ships I64 position ids beside its BF16 weights."""
+
+    tree = _tree(tmp_path, {"unet": ("BF16", SPLIT)})
+    directory = tree / "text_encoder"
+    directory.mkdir()
+    header = {
+        "embeddings.position_ids": {"dtype": "I64", "shape": [1, 77], "data_offsets": [0, 8]},
+        "encoder.layer.0.attn.to_q.weight": {"dtype": "BF16", "shape": [2, 2], "data_offsets": [8, 16]},
+    }
+    body = json.dumps(header).encode()
+    with (directory / "model.safetensors").open("wb") as handle:
+        handle.write(struct.pack("<Q", len(body)))
+        handle.write(body)
+        handle.write(b"\0" * 16)
+    assert_conforms(survey(tree), "sdxl.diffusers-bf16@1", "bfloat16")
+
+
+def test_a_FUSED_qkv_tree_is_REFUSED_even_at_the_right_dtype(tmp_path: Path) -> None:
+    """te#185: one key in common, found after a 71 GB fetch onto a 4xH100.
+
+    The dtype axis cannot see this and neither can the `plain.bf16@1` stamp —
+    which is the entire reason the key convention is asserted separately.
+    """
+
+    tree = _tree(tmp_path, {"unet": ("BF16", FUSED)})
+    with pytest.raises(Nonconforming, match="FUSED attention key"):
+        assert_conforms(survey(tree), "sdxl.diffusers-bf16@1", "bfloat16")
+
+
+def test_a_tree_carrying_NEITHER_convention_is_REFUSED_not_passed(tmp_path: Path) -> None:
+    """The silence arm: nothing found is not the same as nothing wrong.
+
+    A check that passes when it located no attention at all has verified
+    nothing while reading as green — the exact vacuity this workspace keeps
+    paying for.
+    """
+
+    tree = _tree(tmp_path, {"unet": ("BF16", ["some.mlp.fc1.weight"])})
+    with pytest.raises(Nonconforming, match="ZERO split attention keys"):
+        assert_conforms(survey(tree), "sdxl.diffusers-bf16@1", "bfloat16")
+
+
+def test_a_projection_STUB_is_refused_by_name(tmp_path: Path) -> None:
+    """A 128-byte TFSSTUB pointer reads its first 8 bytes as a huge length."""
+
+    directory = tmp_path / "unet"
+    directory.mkdir(parents=True)
+    (directory / "model.safetensors").write_bytes(b"TFSSTUB1" + b"\0" * 120)
+    with pytest.raises(Nonconforming, match="not credible"):
+        survey(tmp_path)
+
+
+def test_an_empty_tree_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(Nonconforming, match="no safetensors containers"):
+        survey(tmp_path)
+
+
+def test_an_unknown_lane_dtype_REFUSES_rather_than_guessing(tmp_path: Path) -> None:
+    tree = _tree(tmp_path, {"unet": ("BF16", SPLIT)})
+    with pytest.raises(Nonconforming, match="never guess"):
+        assert_conforms(survey(tree), "x.y@1", "float4_exotic")
+
+
+def test_the_cli_exits_91_on_a_nonconforming_tree(tmp_path: Path) -> None:
+    """The exit code is the contract a rental script reads."""
+
+    tree = _tree(tmp_path, {"unet": ("F16", SPLIT)})
+    code = main([
+        "--skip-fleet-line", "--tree", str(tree), "--lane", "sdxl.diffusers-bf16@1",
+    ])
+    assert code == EXIT_NONCONFORMING
+
+
+def test_the_cli_exits_0_on_a_conforming_tree(tmp_path: Path) -> None:
+    tree = _tree(tmp_path, {"unet": ("BF16", SPLIT)})
+    assert main([
+        "--skip-fleet-line", "--tree", str(tree), "--lane", "sdxl.diffusers-bf16@1",
+    ]) == 0


### PR DESCRIPTION
The FIRST act after mount on a rented pod, before a derive, a compile, or a
single benchmarked request. Header bytes only — a length prefix plus JSON at
the head of each file — so a 7 GB tree costs kilobytes and no weight byte is
read.

## Why a stamp cannot answer this

`artifact_contract` covers ONE of three axes:

- `plain.bf16@1` is `CONTRACT_PLAIN_BF16` (`models/tensor_layout_contract.py:38`) — the quant/element-layout axis.
- The lane `sdxl.diffusers-bf16@1` (`models/model_types.py:486`) is family + key topology + dtype.
- `tensor_layout_contract.py:124-139` states the reason with the measured failure: two trees can both stamp `plain.bf16@1` and differ on KEY CONVENTION — te#185's fused `qkv_proj` vs split `to_q/to_k/to_v`, **one key in common**, found after a **71 GB** fetch onto a rented 4xH100.

The hub's `checkpoints.dtype` is no better: `model_types.py:613-618` records
stable-audio, where an inherited `plain.bf16@1` disagreed with every checkpoint
the fleet actually shipped and **the bytes won**.

## What it buys

pgw#1567's shape arriving on the serve side — fp16 containers under a bf16
lane — is `armed N, entered 0`: every request silently eager. An A/B benchmark
on that pod measures eager in **both** arms and reports a beautiful 0% delta,
which is the most expensive possible way to learn nothing.

## Contract

Typed abort, **exit 91**. rigcheck's fleet-line abort keeps **90**, so a rental
script can tell "wrong torch" from "wrong tree" without parsing prose. Readings
bank to the hub's durable rows because a pod's logs are not retrievable
(pgw#1568); the banking is best-effort and never masks the verdict.
`assert_fleet_line` runs first per RIG-ENV (binding).

## Red-armed against REAL trees before it ever cost money

| tree | dtypes | verdict |
|---|---|---|
| `pgw1460-serve/sd15-tree` | BF16 throughout | **CONFORMS**, exit 0 |
| `image-campaign/_checkpoints/dreamshaper8-tree` | F16 | abort, names all 3 components |
| `pgw1460-serve/sdxl-tree` | F16 | abort, names all 5 components |

That last one is the exact trap this lane refused to rent into.

10 tests, including the key convention refused at the **right** dtype (te#185's
shape), a projection stub refused by name, and the **silence arm**: a tree
carrying NEITHER convention is refused rather than passed, because a check that
goes green having located no attention at all has verified nothing.