### PR TITLE
pgw#1587: the lane VRAM number is a CLAIM the card verifies, not permission to build

### DIFF
--- a/changelog.d/pgw1587.md
+++ b/changelog.d/pgw1587.md
@@ -1,0 +1,28 @@
+- **pgw#1587: the lane VRAM number stops being a REFUSAL and becomes a per-contract CLAIM
+  the card verifies.** `lanes={contract: "vram12g"}` was read by `gen-worker compile` as
+  permission to build: when the run's VRAM grant was smaller, every specialization was
+  no-opped (`below_floor`) and nothing was minted. That number sized the whole PIPELINE
+  resident, while what a card must actually hold is the COMPILED GRAPH's working set — its
+  weights bound BY REFERENCE plus its activation peak — with every component outside the
+  graph offloadable to make room. On a 7.3 GiB card, SDXL's 12 GiB declaration therefore made
+  minting and arming impossible for a graph that fits. **`declared_floor_gb`, `grant_gb` and
+  the `BELOW_FLOOR` outcome are deleted.** The declaration slot stays: it is the hub's buying
+  signal and the claim the load-time probe verifies, and it never gates the JOB.
+
+- **pgw#1587: `ctx.compile` asks whether THIS TARGET's weights move, not whether some rung
+  touches host RAM.** `Rung.touches_host_ram` answers an ACCOUNTING question (are weights
+  held on the host?) and was standing in for a STABILITY question (do the compile target's
+  device pointers move per forward?). Under `partial_resident` (pgw#1577) those answers
+  differ: it parks only the components it NAMED and forces the denoiser resident, so the
+  compiled UNet's constants are stable — and the rung parked the text encoders precisely to
+  make room for it. New `Rung.parks_named_components_only` + `rung.moves_every_component()`
+  split the two facts, and `partial_resident.parks_module()` answers the per-target question
+  from the armed plan. accelerate-hooked rungs (`model_offload`, `group_offload`,
+  `sequential`, `cpu`) still refuse every target — pgw#1486 is unchanged.
+
+- **pgw#1587: an operator's `serve_posture{eager_only:true}` now suppresses ARMING on the v2
+  serving path.** Its only arming reader was `compile_cache.arming_block`, the v1 tier's
+  precondition authority; on the v2 path the order was observed at CALL time only, so a pod
+  told to serve eager still paid for every adopt. `provision.arm_aot` refuses first, with the
+  `operator_eager_only` reason, and unwraps nothing — releasing the order lets the next
+  arming pass adopt normally.

--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -61,15 +61,15 @@ graph CAS does not hold the program for a specialization, ``compile``
 RE-DERIVES it locally from the committed source + lock (~2 min CPU) instead of
 fetching one. There is no program-blob route to call and there must never be.
 
-## The compiled floor
+## No floor (pgw#1587)
 
-A graph executes atomically with by-reference weights — nothing pages
-mid-graph — so below a certain grant no compiled specialization can ever be
-armed. Under such a grant this command NO-OPS by name rather than minting
-artifacts that could not be used. The floor is read from the endpoint's own
-declared lane floor today; a measured peak-VRAM stamp (pgw#1494) supersedes it
-when one exists. An UNKNOWN floor never reads as zero and never reads as
-infinite: it simply does not fire the refusal.
+This command MINTS; it does not decide what a particular card can arm. It used
+to no-op the whole run when the endpoint's declared lane number exceeded this
+run's VRAM grant — a refusal to BUILD, taken from a declaration, sized to the
+whole pipeline rather than to the compiled graph. Deleted. Servability is
+settled on the serving card at load, by probe, and a card that cannot hold the
+graph's working set serves EAGER with a typed reason. See the block above
+:func:`_env_identity` for the whole argument.
 """
 
 from __future__ import annotations
@@ -101,8 +101,10 @@ PRESENT = "present"        # already readable through the store (local or fleet)
 BUILT = "built"            # compiled here
 REUSED = "reused"          # resolved out of the engine's own compile cache
 CLAIMED = "claimed"        # another process holds the lease; it is doing it
-BELOW_FLOOR = "below_floor"  # no grant this run targets could arm it
 FAILED = "failed"
+# pgw#1587: `BELOW_FLOOR` is DELETED. A declared lane requirement is a claim
+# about what a COMPILED GRAPH needs of a card, verified by a probe at serve —
+# never permission to build. Nothing here refuses a mint on a declaration.
 
 #: What this run does with the specializations that are NOT the first one.
 #: Closed, and stated rather than inferred from a flag combination.
@@ -256,58 +258,36 @@ def order(specs: Tuple[Spec, ...], selector: str) -> Tuple[Spec, ...]:
 
 
 # --------------------------------------------------------------------------
-# The compiled floor
+# pgw#1587: THERE IS NO COMPILED FLOOR HERE ANY MORE
 # --------------------------------------------------------------------------
-
-
-def declared_floor_gb(endpoint_dir: Path) -> Optional[float]:
-    """The endpoint's declared per-lane VRAM floor, or ``None`` if it declares
-    none. ``None`` means UNKNOWN and is never treated as 0 or as infinite."""
-    try:
-        from ..discovery.discover import prime_sys_path
-        from ..serving.loader import load_endpoint
-        from ..serving.model import model_requires
-    except Exception:  # noqa: BLE001 - an import failure is not a floor
-        return None
-    try:
-        prime_sys_path(endpoint_dir)
-        loaded = load_endpoint(endpoint_dir)
-    except Exception:  # noqa: BLE001
-        return None
-    floors: List[float] = []
-    for cls in loaded.models:
-        for requirements in (model_requires(cls) or {}).values():
-            # `model_requires` answers LayoutRequirements, whose floor lives on
-            # `.minimum` (a RequirementTerms). Reading `min_vram_gb` off the
-            # outer object returns None — which this function would have
-            # rendered as "no floor declared" and the caller as "proceed". A
-            # missing floor and a floor read one level too shallow are
-            # indistinguishable downstream, so the access is explicit here.
-            terms = getattr(requirements, "minimum", None) or requirements
-            value = float(getattr(terms, "min_vram_gb", 0.0) or 0.0)
-            if value > 0.0:
-                floors.append(value)
-    return min(floors) if floors else None
-
-
-def grant_gb(stated: float) -> Optional[float]:
-    """This run's VRAM grant: the stated one, else what the card has free.
-
-    Probed ONCE and frozen (pgw#1495's shape), because a grant re-probed later
-    is a grant that can disagree with the decision it justified.
-    """
-    if stated > 0.0:
-        return stated
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return None
-        free, _total = torch.cuda.mem_get_info()
-        return float(free) / float(1024 ** 3)
-    except Exception:  # noqa: BLE001 - absent never renders as zero
-        return None
-
+#
+# `declared_floor_gb` + `grant_gb` used to read the endpoint's declared
+# per-lane VRAM number, compare it against this run's grant, and NO-OP the
+# whole mint when the grant was smaller ("nothing this endpoint compiles to
+# could be armed under this grant"). Two things were wrong with it and Paul
+# named both (2026-08-20):
+#
+#   "Remove this '12gb floor'. I don't even know what this is. I didn't ask
+#    for this. this is the completely wrong model."
+#   "having some memory requirement per tensor-layout-contract makes sense.
+#    But yeah, this limit is too high. And we should be able to serve
+#    no-compiled below this limit."
+#
+#  1. THE NUMBER DESCRIBED THE WRONG THING. A declared lane number sized the
+#     whole PIPELINE, while what a compiled graph needs of a card is its OWN
+#     working set — its weights BY REFERENCE plus its activation peak — with
+#     every component outside the graph free to be offloaded to make room.
+#     SDXL is the case: park the two text encoders and the compiled UNet
+#     serves on a 7.3 GiB card the 12 GiB number refused outright.
+#  2. BUILDING IS NOT SERVING. This command mints artifacts; whether a
+#     PARTICULAR card can arm one is decided on that card, at load, by probe
+#     (`adopt_fit`, `partial_resident.probe_plan`) and never by a declaration
+#     read here. A card that cannot hold the graph serves EAGER, loudly, with
+#     a typed reason — it never refuses the job.
+#
+# The declaration itself is NOT deleted: `lanes={contract: "vram7g"}` stays as
+# the per-tensor-layout-contract memory requirement — the hub's buying signal
+# and the claim the probe verifies. What is deleted is its power to refuse.
 
 # --------------------------------------------------------------------------
 # Store + env
@@ -963,44 +943,6 @@ def compile_all(
 
     reuse = _EngineReuse(Path(cas_root), sm)
 
-    # PRESENCE BEFORE POLICY (pgw#1546). The floor/grant question only decides
-    # whether to BUILD, and the grant probe + declared-floor read import torch
-    # and the author's whole module (~4.5 s measured) to answer it. A run whose
-    # artifacts are all already in the serving band builds nothing, and a miss
-    # the engine cache claims a mint for costs a verified resolve rather than
-    # a mint — neither asks the floor anything. Only a specialization that
-    # would genuinely COMPILE does, so only that shape pays the imports; the
-    # warm re-run is bookkeeping-free by construction, not by a fast
-    # implementation of the bookkeeping.
-    if any(
-        not _known_present(spec) and not reuse.offers(spec.graph)
-        for spec in specs
-    ):
-        floor = declared_floor_gb(endpoint_dir)
-        grant = grant_gb(vram_budget_gb)
-        if floor is not None and grant is not None and grant < floor:
-            logger.info(
-                "compile: grant_below_compiled_floor(grant=%.1f GiB, floor=%.1f GiB) "
-                "— a compiled graph executes atomically with by-reference weights, "
-                "so nothing this endpoint compiles to could be armed under this "
-                "grant. NO-OP: %d specialization(s) left unbuilt on purpose.",
-                grant, floor, len(specs),
-            )
-            return Report(
-                [
-                    Outcome(spec, BELOW_FLOOR,
-                            f"grant {grant:.1f} GiB < floor {floor:.1f} GiB")
-                    for spec in specs
-                ],
-                [],
-            )
-        if floor is None:
-            logger.info(
-                "compile: compiled floor UNKNOWN for this endpoint (no declared "
-                "lane floor, no measured stamp) — proceeding; an unknown floor is "
-                "not a floor of zero"
-            )
-
     from ..serving.mint import publish_compiled
 
     build = builder if builder is not None else _default_builder(cas_root, sm)
@@ -1319,7 +1261,7 @@ def summarize(report: Report) -> Tuple[str, int]:
         return "".join(lines), 1
     if counts.get(FAILED):
         return "".join(lines), 1
-    if counts.get(BELOW_FLOOR) or not report.outcomes:
+    if not report.outcomes:
         return "".join(lines), 0
     if pending:
         # THE PARTIAL VERDICT, and it is a different sentence on purpose. The
@@ -1431,7 +1373,6 @@ def _write_verdict(
 
 
 __all__ = [
-    "BELOW_FLOOR",
     "BUILT",
     "CLAIMED",
     "Builder",

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -53,6 +53,14 @@ COMPONENT_RESIDENCY_ATTR = "_cozy_component_residency"
 #: reader can state where each evicted component actually is.
 PARKED_COMPONENTS_ATTR = "_cozy_parked_components"
 
+#: Set on each MODULE this rung parks (pgw#1587). The mark rides the module
+#: rather than the pipeline because the reader that needs it — ``ctx.compile``
+#: — is handed a compile TARGET and nothing else, and a mark it has to find a
+#: pipeline to interpret is a mark it will one day fail to find. A module
+#: without it keeps a stable device pointer for the life of the load, which is
+#: exactly the precondition a compiled graph's by-reference constants need.
+PARKED_MODULE_ATTR = "_cozy_parked_module"
+
 #: The device this rung's resident set actually executes on. ``DiffusionPipeline.device``
 #: answers with the FIRST component's device, and an evicted encoder parked on
 #: the host makes that ``cpu`` for a pipeline whose denoiser is on the card —
@@ -435,6 +443,17 @@ def _install_residency_hooks(
             _c.onload()
 
         comp.module.register_forward_pre_hook(_pre)
+        # pgw#1587: the mark goes on HERE and not at `mirror()`, because THIS
+        # is the moment the component starts moving per forward. A mirror the
+        # probe then refuses is rolled up by the caller's fall to the next
+        # rung, and marking it would have told `ctx.compile` that a component
+        # nothing is hooking relocates — a refusal on a load where no rung
+        # armed at all. (Found by the pgw#1587 red arm, which is the shape a
+        # gate keyed on the wrong moment always has.)
+        try:
+            setattr(comp.module, PARKED_MODULE_ATTR, True)
+        except Exception:  # noqa: BLE001 — a module that refuses an attribute
+            log.debug("partial_resident: %s could not carry the park mark", name)
 
     seen_parked = False
     for name in order:
@@ -493,6 +512,35 @@ def probe_plan(
     free = int(free_bytes_now())
     worst.park()
     return free >= floor_bytes, free
+
+
+def parks_module(target: Any) -> bool:
+    """Does this rung MOVE ``target``'s weights between host and device per
+    forward? (pgw#1587)
+
+    The question ``ctx.compile`` asks before arming a compiled graph on a
+    target. A compiled graph binds its constants to device pointers and cannot
+    page mid-graph, so a target this rung parks must serve eager — while every
+    other component, denoiser included, keeps a stable pointer for the life of
+    the load and compiles exactly as it would with no rung engaged. That is
+    Paul's SDXL case: the text encoders come off the card, the compiled UNet
+    stays on it, and the two do not conflict.
+
+    Accepts a module OR a pipeline: for a pipeline the answer is "does it park
+    ANY of my components", which is the honest answer for ``ctx.compile(pipe)``
+    — that form marks the whole component tree.
+    """
+    if target is None:
+        return False
+    if bool(getattr(target, PARKED_MODULE_ATTR, False)):
+        return True
+    components = getattr(target, "components", None)
+    if isinstance(components, Mapping):
+        return any(
+            bool(getattr(component, PARKED_MODULE_ATTR, False))
+            for component in components.values()
+        )
+    return False
 
 
 def apply_component_residency(
@@ -585,12 +633,14 @@ def apply_component_residency(
 __all__ = [
     "COMPONENT_RESIDENCY_ATTR",
     "PARKED_COMPONENTS_ATTR",
+    "PARKED_MODULE_ATTR",
     "PARTIAL_RESIDENT_DEVICE_ATTR",
     "PARTIAL_RESIDENT_RESERVE_GB",
     "PARTIAL_RESIDENT_UNARMED_PHASE",
     "ParkedComponent",
     "ResidencyPlan",
     "apply_component_residency",
+    "parks_module",
     "plan_component_residency",
     "plan_for_pipeline",
     "probe_plan",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -380,7 +380,27 @@ def arm_aot(
     """
     # Deferred: hoisting drags aot_serve onto the `import gen_worker` path
     # (+39 modules).
-    from .. import aot_serve
+    from .. import aot_serve, serve_posture
+
+    # pgw#1587 / §4.32 item 4, FIRST because it is the cheapest and the most
+    # authoritative: an operator has ordered this worker eager. The ARMING half
+    # of that order used to be read only through `compile_cache.arming_block`,
+    # which is the v1 tier's precondition authority — so on the v2 serving path
+    # `serve_posture{eager_only:true}` suppressed nothing at arm time and the
+    # order was observed only at CALL time (`aot_serve.wrap_module`). That left
+    # a live operator control half-wired: the pod still paid for every adopt it
+    # had been told not to make.
+    #
+    # Refusing HERE is the reversibility-safe half: nothing is unwrapped and no
+    # state is de-armed, so releasing the order lets the next arming pass adopt
+    # normally. It is the third entry into this path's loud-eager branch,
+    # beside `adopt_fit`'s probed capacity refusal and a card that cannot hold
+    # the graph's working set — one behaviour, three named causes.
+    ordered_eager = serve_posture.block()
+    if ordered_eager:
+        logger.warning(
+            "aot arm: serving EAGER by operator order — %s", ordered_eager)
+        return AdoptOutcome.miss(serve_posture.REASON, ordered_eager)
 
     if meta is None:
         meta = _compiled_graph_metadata(artifact)

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -55,6 +55,14 @@ class Rung:
     #: :func:`price` does not describe one — a caller standing on such a rung
     #: passes its NAME.
     admission_only: bool = False
+    #: pgw#1587. True when the rung moves only the components it NAMED at
+    #: admission and leaves every other one device-resident for the life of
+    #: the load. This is the fact `ctx.compile` needs and `touches_host_ram`
+    #: cannot answer: a compiled graph binds its constants to device pointers,
+    #: so it may be armed on a target whose weights do not move — but not on
+    #: one accelerate onloads and frees per forward. `touches_host_ram` is
+    #: about ACCOUNTING (host RAM is charged); this is about STABILITY.
+    parks_named_components_only: bool = False
 
 
 # Wire run modes (Go-mirrored: tensorhub profiling.RunMode). Values are the
@@ -81,9 +89,17 @@ FP8_STORAGE = Rung("fp8_storage", "", "fp8", RUN_FP8_STORAGE, 1.05, False)
 # descent has neither in hand when it fires. `_walk` therefore sends any
 # resident token to `model_offload`, exactly as before, and `price(RUN_OFFLOAD)`
 # keeps answering with `model_offload`'s coarse number rather than this rung's.
+#
+# `parks_named_components_only`: the plan NAMES its offload set and forces the
+# denoiser resident, so every component outside that set keeps a stable device
+# pointer for the life of the load. That is what makes this the one offload
+# rung a COMPILED graph can be armed under (pgw#1587, Paul: *"For SDXL in
+# particular, we need to offload the text encoders to free up room for the
+# Unet, and then it works, during inference. This doesn't conflict with
+# compilation however because [we] are only running the compiled UNet."*).
 PARTIAL_RESIDENT = Rung(
     "partial_resident", "partial_resident", "", RUN_OFFLOAD, 1.3, True,
-    admission_only=True,
+    admission_only=True, parks_named_components_only=True,
 )
 MODEL_OFFLOAD = Rung("model_offload", "model_offload", "", RUN_OFFLOAD, 2.5, True)
 # pgw#1497 — per-LEAF-MODULE budgeted residency, the tail cast per forward from
@@ -277,6 +293,21 @@ def touches_host_ram(mode: Optional[str]) -> bool:
     and streams to the card per forward, so host-RAM accounting must charge
     the full tree."""
     return str(mode or "") in PLACEMENT_LADDER
+
+
+def moves_every_component(mode: Optional[str]) -> bool:
+    """True when this placement token moves EVERY component's weights between
+    host and device per forward (pgw#1587).
+
+    The question `ctx.compile` has to ask, and the one ``touches_host_ram``
+    was standing in for. Under such a rung no compiled graph can be armed on
+    anything, because the device pointers it binds are freed after each
+    forward. Under a rung that parks only the components it named, the answer
+    is per-TARGET and the plan holds it — see
+    :func:`gen_worker.models.partial_resident.parks_module`.
+    """
+    r = _BY_NAME.get(str(mode or ""))
+    return bool(r and r.touches_host_ram and not r.parks_named_components_only)
 
 
 def floor_of(a: Optional[str], b: Optional[str]) -> str:

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -966,9 +966,11 @@ class LoadContext(Generic[MT_co]):
         marking is always safe."""
         if self._compile_sink is None:
             return target
-        from ..models.rung import touches_host_ram
+        from ..models.partial_resident import parks_module
+        from ..models.rung import moves_every_component, touches_host_ram
 
-        if touches_host_ram(self._engaged_rung):
+        rung = self._engaged_rung
+        if moves_every_component(rung):
             # pgw#1486, the ADMISSION half. An offload rung hands each
             # component's weights to accelerate, which onloads them for a
             # forward and frees the device copy after — so the device pointers
@@ -982,9 +984,40 @@ class LoadContext(Generic[MT_co]):
                 "engaged, and a compiled graph cannot bind constants to "
                 "weights accelerate moves between host and device per forward "
                 "(pgw#1486). Fit the model on the card to get compiled speed.",
-                type(target).__name__, self._engaged_rung,
+                type(target).__name__, rung,
             )
             return target
+        if touches_host_ram(rung):
+            # pgw#1587. A rung that parks only the components it NAMED is not
+            # the case above, and treating it as one is what made a small card
+            # mean "no compiled graph, ever". Paul, 2026-08-20: *"For SDXL in
+            # particular, we need to offload the text encoders to free up room
+            # for the Unet, and then it works, during inference. This doesn't
+            # conflict with compilation however because [we] are only running
+            # the compiled UNet."*
+            #
+            # So the question is per-TARGET and the armed plan answers it: a
+            # parked target serves eager (its pointers really do move), and
+            # everything the plan left resident compiles exactly as it would
+            # with no rung engaged. The rung's whole reason for parking those
+            # encoders was to make room for THIS.
+            if parks_module(target):
+                logger.warning(
+                    "ctx.compile: serving EAGER for %s — the %r rung parks "
+                    "this component, so its weights move between pinned host "
+                    "RAM and the card per forward and a compiled graph cannot "
+                    "bind constants to them (pgw#1587). The components the "
+                    "plan left resident still compile.",
+                    type(target).__name__, rung,
+                )
+                return target
+            logger.info(
+                "ctx.compile: compiling %s UNDER the %r rung — this target is "
+                "in the plan's resident set, so its device pointers are stable "
+                "for the life of the load; the components the rung parked are "
+                "what made room for it (pgw#1587).",
+                type(target).__name__, rung,
+            )
         return self._compile_sink(target)
 
     def defaults(self: "LoadContext[ModelType[DT]]") -> DT:

--- a/tests/test_compile_servability.py
+++ b/tests/test_compile_servability.py
@@ -415,20 +415,38 @@ def test_the_shell_learns_unservable_even_when_every_build_returned() -> None:
     assert "built=1" in summary and "NOT SERVABLE" in summary
 
 
-def test_a_below_floor_no_op_is_not_an_unservable_run(
+def test_a_tiny_grant_no_longer_refuses_the_mint(
     endpoint: Path, tmp_path: Path
 ) -> None:
-    """Refusing to build under a grant that could never arm is a SUCCESS.
+    """pgw#1587 — THE REFUSAL IS GONE, and this is the red arm for its return.
 
-    It must not be swept into the new refusal: the store is legitimately empty
-    and nothing was promised.
+    This ran `BELOW_FLOOR` before: a declared lane number bigger than the run's
+    VRAM grant no-opped every specialization, which is how a 12 GiB declaration
+    made a 7.3 GiB card unable to mint SDXL at all (va#3 leg C). Paul,
+    2026-08-20: *"we should be able to serve no-compiled below this limit."*
+    Building is not serving; whether a PARTICULAR card can arm the artifact is
+    decided on that card, by probe, at load.
+
+    Named `--vram-budget 1.0` because that is the operand the old gate read.
     """
-    spec = compile_cli.Spec(contract=LANE, graph=GRAPHS[0], target=TARGET, ingress={})
-    report = compile_cli.Report(
-        [compile_cli.Outcome(spec, compile_cli.BELOW_FLOOR, "grant 1.0 < floor 4.0")],
-        [],
+    cas = tmp_path / "graph-cas"
+    store = LocalGraphStore(LocalCAS(cas))
+    _seed_programs(store, tmp_path)
+    built: List[str] = []
+
+    report = _run(
+        endpoint, cas, store=store, builder=_builder(built), vram_budget_gb=1.0
     )
+
+    assert built == list(GRAPHS), "a 1 GiB grant must not veto the mint"
+    assert {outcome.state for outcome in report.outcomes} == {compile_cli.BUILT}
+    assert report.unservable == []
     assert compile_cli.summarize(report)[1] == 0
+    assert not hasattr(compile_cli, "declared_floor_gb"), (
+        "the declared-floor read is deleted, not merely unused — a function "
+        "left standing is a gate somebody re-wires"
+    )
+    assert not hasattr(compile_cli, "BELOW_FLOOR")
 
 
 # --------------------------------------------------------------------------
@@ -516,9 +534,12 @@ def test_an_all_present_run_asks_no_policy_questions_and_republishes_nothing(
     endpoint: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The fully-warm run (pgw#1546): every artifact already in the serving
-    band means NO floor read, NO grant probe, NO builder, NO publish — the
-    ~4.5 s of author-module/torch import the old path paid was bookkeeping for
-    a build that was never going to happen. The census still decides.
+    band means NO builder and NO publish. The census still decides.
+
+    pgw#1587 dropped the two policy reads this test also fenced (the declared
+    floor and the grant probe) — with no gate there is no ~4.5 s import to
+    avoid — but the builder/publish half of the claim is unchanged and is the
+    half that guards real work.
     """
     cas = tmp_path / "graph-cas"
     store = LocalGraphStore(LocalCAS(cas))
@@ -527,9 +548,6 @@ def test_an_all_present_run_asks_no_policy_questions_and_republishes_nothing(
 
     def refuse(*args: Any, **kwargs: Any) -> Any:
         raise AssertionError("an all-present run consulted build policy")
-
-    monkeypatch.setattr(compile_cli, "declared_floor_gb", refuse)
-    monkeypatch.setattr(compile_cli, "grant_gb", refuse)
 
     report = _run(endpoint, cas, store=_PublishRefused(store), builder=refuse)
 
@@ -723,10 +741,9 @@ def test_an_unreadable_module_name_is_a_typed_refusal_not_a_traceback(
     """pgw#1537: `compile` reads the endpoint's module name and can now fail on
     the author's own import.
 
-    `declared_floor_gb` calls `load_endpoint` too and swallows everything,
-    because an unreadable floor genuinely IS "no floor stated". An unreadable
-    module NAME is not "no name" — nothing can be published under a name that
-    could not be read — so it refuses, in one sentence, with the cause.
+    An unreadable module NAME is not "no name" — nothing can be published
+    under a name that could not be read — so it refuses, in one sentence, with
+    the cause.
     """
     empty = tmp_path / "not-an-endpoint"
     empty.mkdir()

--- a/tests/test_compiled_admission_pgw1587.py
+++ b/tests/test_compiled_admission_pgw1587.py
@@ -1,0 +1,310 @@
+"""Compiled admission is PROBED and per-target — never a declared refusal.
+
+pgw#1587. Paul, 2026-08-20, on the ``vram12g`` lane declaration that made a
+7.3 GiB card refuse to mint or arm SDXL at all:
+
+    *"Every card should be able to run any job. There is a minimum floor,
+    below which running compiled does not work; we keep eager. The advantage
+    of eager is that it's more flexible. For SDXL in particular, we need to
+    offload the text encoders to free up room for the Unet, and then it works,
+    during inference. This doesn't conflict with compilation however because
+    [we] are only running the compiled UNet. Remove this '12gb floor'."*
+
+    *"having some memory requirement per tensor-layout-contract makes sense.
+    But yeah, this limit is too high. And we should be able to serve
+    no-compiled below this limit."*
+
+So the declaration stays and the REFUSAL is gone. What decides compiled
+admission is the compiled graph's own working set — its weights held by
+reference, its activation peak — measured on the card, with every component
+outside the graph offloadable to make room for it. Three causes send a load to
+eager and all three are LOUD and NAMED: the operator ordered it, the probe
+refused, or the target's own weights move. Nothing refuses the JOB.
+
+The two directions are both armed here, because the failure this replaces was
+symmetric: a card that fits must ARM (the old gate said no on a declaration),
+and a card that cannot must fall to EAGER by name (never an OOM, never a
+crash).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, List, cast
+
+import pytest
+
+torch = pytest.importorskip("torch")
+diffusers = pytest.importorskip("diffusers")
+
+from diffusers import DiffusionPipeline, ModelMixin  # noqa: E402
+from diffusers.configuration_utils import ConfigMixin, register_to_config  # noqa: E402
+
+from gen_worker import serve_posture  # noqa: E402
+from gen_worker.models import provision  # noqa: E402
+from gen_worker.models.partial_resident import (  # noqa: E402
+    apply_component_residency,
+    parks_module,
+    plan_for_pipeline,
+)
+from gen_worker.models.rung import moves_every_component, touches_host_ram  # noqa: E402
+from gen_worker.serving.context import DeployBinding, LoadContext  # noqa: E402
+
+_MIB = 1 << 20
+
+
+class _Block(ModelMixin, ConfigMixin):
+    @register_to_config
+    def __init__(self, width: int = 8):
+        super().__init__()
+        self.lin = torch.nn.Linear(width, width)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+class _Pipeline(DiffusionPipeline):
+    """SDXL's shape in miniature: two things before the denoiser, one after."""
+
+    model_cpu_offload_seq = "text_encoder->unet->vae"
+    text_encoder: Any
+    unet: Any
+    vae: Any
+
+    def __init__(self, text_encoder: Any, unet: Any, vae: Any) -> None:
+        super().__init__()
+        cast(Any, self).register_modules(
+            text_encoder=text_encoder, unet=unet, vae=vae
+        )
+
+
+def _armed_pipeline() -> Any:
+    """A pipeline with the rung ARMED: encoder parked, denoiser resident.
+
+    Same shape the rung takes on the campaign card — the components before the
+    denoiser go to pinned host RAM so the denoiser can stay on the card.
+    """
+    pipe = _Pipeline(_Block(8), _Block(16), _Block(4))
+    plan = plan_for_pipeline(
+        pipe,
+        budget_bytes=1200,
+        free_bytes=64 * _MIB,
+        transient_reserve_bytes=0,
+        forced_resident=("vae",),
+        sizer=lambda m: sum(p.numel() * p.element_size() for p in m.parameters()),
+    )
+    assert plan.fits, plan.refusal
+    assert plan.offloaded == ("text_encoder",) and "unet" in plan.resident
+    assert apply_component_residency(
+        pipe, plan, device="cpu", log=logging.getLogger("t")
+    )
+    return pipe
+
+
+def _ctx(sink_calls: List[Any]) -> "LoadContext[Any]":
+    """A context whose compile sink RECORDS and answers ``"ARMED"``.
+
+    The sink is torchcg's adoption seam; what it returns is irrelevant here and
+    what it was CALLED WITH is the whole fact under test.
+    """
+
+    def sink(target: Any) -> Any:
+        sink_calls.append(target)
+        return "ARMED"
+
+    return LoadContext(
+        binding=DeployBinding(checkpoint_ref="r", checkpoint_dir=Path(".")),
+        compile_sink=sink,
+    )
+
+
+# --------------------------------------------------------------------------
+# The rung vocabulary: two different facts, no longer one
+# --------------------------------------------------------------------------
+
+
+def test_the_rung_that_parks_named_components_is_not_the_rung_that_moves_all() -> None:
+    """`touches_host_ram` is ACCOUNTING; `moves_every_component` is STABILITY.
+
+    Reading the first as the second is the whole defect: `partial_resident`
+    charges host RAM (it really does hold weights there) and leaves every
+    component it did not name device-resident for the life of the load. One
+    boolean answering both questions is what made "small card" mean "no
+    compiled graph, ever".
+    """
+    assert touches_host_ram("partial_resident"), "it does hold weights on the host"
+    assert not moves_every_component("partial_resident"), (
+        "it moves only what it named — that is the point of the rung"
+    )
+    for every in ("model_offload", "group_offload", "sequential", "cpu"):
+        assert moves_every_component(every), every
+    assert not moves_every_component(""), "no rung engaged moves nothing"
+    assert not moves_every_component("native")
+
+
+# --------------------------------------------------------------------------
+# Direction 1 — A CARD THAT FITS MUST ADMIT COMPILED
+# --------------------------------------------------------------------------
+
+
+def test_the_resident_denoiser_compiles_under_the_offload_rung() -> None:
+    """PAUL'S CASE, as a test. The encoders come off the card, the compiled
+    UNet stays on it, and the two do not conflict.
+
+    RED ARM: before pgw#1587 `ctx.compile` refused every target whenever any
+    host-RAM-touching rung was engaged, so this assertion failed and SDXL on a
+    7.3 GiB card served eager no matter what was minted for it.
+    """
+    pipe = _armed_pipeline()
+    sink_calls: List[Any] = []
+    ctx = _ctx(sink_calls)
+    ctx._engaged_rung = "partial_resident"
+
+    assert ctx.compile(pipe.unet) == "ARMED", (
+        "the denoiser is in the plan's RESIDENT set — its device pointers are "
+        "stable for the life of the load, which is exactly the precondition a "
+        "compiled graph's by-reference constants need"
+    )
+    assert sink_calls == [pipe.unet]
+
+
+def test_the_parked_component_serves_eager_and_says_so(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The other half of per-target: what the rung DID park still cannot
+    compile, and the refusal names the rung and the reason."""
+    pipe = _armed_pipeline()
+    sink_calls: List[Any] = []
+    ctx = _ctx(sink_calls)
+    ctx._engaged_rung = "partial_resident"
+
+    assert parks_module(pipe.text_encoder), "the fixture must have parked it"
+    with caplog.at_level(logging.WARNING):
+        assert ctx.compile(pipe.text_encoder) is pipe.text_encoder
+    assert sink_calls == [], "a parked target must never reach the sink"
+    assert any("EAGER" in r.message and "pgw#1587" in r.message
+               for r in caplog.records), (
+        "falling to eager is a real degradation and must be said out loud"
+    )
+
+
+def test_a_rung_that_moves_everything_still_refuses_every_target(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """pgw#1486 IS NOT WEAKENED. Under accelerate's hooks every component's
+    weights are onloaded per forward and freed after, so a bound constant is a
+    dangling pointer — an uncatchable SIGSEGV, not an OOM anyone retries."""
+    module = torch.nn.Linear(2, 2)
+    sink_calls: List[Any] = []
+    ctx = _ctx(sink_calls)
+
+    for rung in ("model_offload", "group_offload", "sequential", "cpu"):
+        ctx._engaged_rung = rung
+        with caplog.at_level(logging.WARNING):
+            assert ctx.compile(module) is module, rung
+    assert sink_calls == []
+
+
+def test_no_rung_engaged_is_unchanged() -> None:
+    module = torch.nn.Linear(2, 2)
+    sink_calls: List[Any] = []
+    ctx = _ctx(sink_calls)
+    ctx._engaged_rung = ""
+    assert ctx.compile(module) == "ARMED"
+    assert sink_calls == [module]
+
+
+# --------------------------------------------------------------------------
+# Direction 2 — A CARD THAT CANNOT HOLD IT FALLS TO EAGER, BY NAME
+# --------------------------------------------------------------------------
+
+
+def test_the_probe_refuses_a_plan_the_arithmetic_admitted() -> None:
+    """The admission is asked of the CARD, not of a constant (pgw#1577).
+
+    Arithmetic over component sizes and a free-VRAM read cannot see allocator
+    fragmentation or a co-tenant's share; on the campaign card a plan those
+    numbers admitted then died 5 MiB short. The probe does the worst onload
+    once and reads what is left, and a refusal leaves NOTHING armed — the
+    caller falls to the next rung rather than inheriting half an arrangement.
+    """
+    pipe = _Pipeline(_Block(8), _Block(16), _Block(4))
+    plan = plan_for_pipeline(
+        pipe,
+        budget_bytes=1200,
+        free_bytes=64 * _MIB,
+        transient_reserve_bytes=0,
+        forced_resident=("vae",),
+        sizer=lambda m: sum(p.numel() * p.element_size() for p in m.parameters()),
+    )
+    assert plan.fits
+
+    armed = apply_component_residency(
+        pipe, plan, device="cpu", log=logging.getLogger("t"),
+        # The card answers with almost nothing free once the worst evicted
+        # component is on it. Same shape as the measured 5 MiB shortfall.
+        free_bytes_now=lambda: 0,
+    )
+    assert not armed, "the card disagreed with the plan, and the card is right"
+    assert not parks_module(pipe.text_encoder), (
+        "a refused probe must leave no parked component behind"
+    )
+
+
+def test_an_operator_eager_only_order_refuses_the_v2_arm_by_name() -> None:
+    """The third entry into loud eager, and it was HALF-WIRED.
+
+    `serve_posture{eager_only:true}` reaches `apply_command` from
+    `worker.py`, but its arming reader was `compile_cache.arming_block` — the
+    v1 tier's precondition authority. On the v2 serving path the order was
+    observed only at CALL time, so a pod told not to adopt still paid for
+    every adopt. Refusing at the arm seam is the reversibility-safe half:
+    nothing is unwrapped, so releasing the order lets the next pass adopt.
+    """
+    serve_posture.reset()
+    try:
+        assert serve_posture.apply_command(
+            True, actor="operator@test", reason="a card under investigation")
+        outcome = provision.arm_aot(
+            object(), object(), None, Path("/nonexistent.pt2"), 0, meta={},
+        )
+        assert not outcome, "an ordered-eager worker must not arm"
+        assert outcome.reason == serve_posture.REASON
+        assert "operator@test" in outcome.detail
+        assert "a card under investigation" in outcome.detail
+
+        # RELEASED: the same call must no longer answer with the order. It may
+        # still miss for its own reasons (the artifact is a fiction here) — the
+        # claim is that POLICY stopped being the cause.
+        assert serve_posture.apply_command(False, actor="operator@test")
+        after = provision.arm_aot(
+            object(), object(), None, Path("/nonexistent.pt2"), 0, meta={},
+        )
+        assert after.reason != serve_posture.REASON, (
+            "releasing the order must let arming decisions run normally again"
+        )
+    finally:
+        serve_posture.reset()
+
+
+def test_the_declared_requirement_never_refuses_a_load() -> None:
+    """A lane requirement INFORMS; it does not permit (Paul, 2026-08-18, and
+    again 2026-08-20). The worker's reader warns on every request and loads.
+
+    This is the fence on the deleted gate: if a declared number ever regains
+    the power to stop a load, it fails here rather than on a card.
+    """
+    from gen_worker.serving.placement import DeviceFacts, Shortfall, shortfalls
+
+    facts = DeviceFacts(name="tiny", vram_gib=4.0, sm=89)
+
+    class _NoLanes:
+        pass
+
+    assert shortfalls(_NoLanes, None, facts=facts) == (), (
+        "an eager-permanent model declares no lane and so no requirement"
+    )
+    message = Shortfall("min_vram_gb", "sdxl.diffusers-bf16@1", 7.0, 4.0, "tiny").message
+    assert "Running anyway" in message
+    assert "never permission" in message


### PR DESCRIPTION
Paul, 2026-08-20 (both messages, the second refining the first):

> "Every card should be able to run any job. There is a minimum floor, below which running compiled does not work; we keep eager. … For SDXL in particular, we need to offload the text encoders to free up room for the Unet, and then it works, during inference. This doesn't conflict with compilation however because [we] are only running the compiled UNet. Remove this '12gb floor'."

> "having some memory requirement per tensor-layout-contract makes sense. But yeah, this limit is too high. And we should be able to serve no-compiled below this limit."

## The census, before the deletion

Exactly **one** consumer ever refused on the declaration: `cli/compile.py`'s `declared_floor_gb` + `grant_gb` → `BELOW_FLOOR`, which no-opped every specialization when the run's grant was smaller. That is what made SDXL unmintable on the 7.3 GiB box (va#3 leg C). Every other reader warns (`serving/placement.py`), buys (tensorhub's `MachineFloor` → runpod/vast filters) or already decides on measured evidence (`adopt_fit`, `aot_serve`'s `insufficient_adopt_vram`). torchcg and varena have no consumers at all.

So the **slot stays** and the **refusal goes**. Building is not serving; whether a particular card can arm an artifact is settled on that card, by probe, at load.

## And the floor was not what actually blocked Paul's case

`ctx.compile` refused **every** target whenever `touches_host_ram(engaged_rung)` — so the `partial_resident` rung, which parks the text encoders *precisely to make room for the UNet*, also forbade compiling that UNet. One boolean was answering two questions:

* **ACCOUNTING** — are weights held in host RAM? (`partial_resident`: yes, pinned mirrors)
* **STABILITY** — do the compile target's device pointers move per forward? (`partial_resident`: **no** — only NAMED components park, denoiser forced resident)

Split into `Rung.parks_named_components_only` + `rung.moves_every_component()`, with the stability question asked **per target** of the armed plan (`partial_resident.parks_module`). accelerate-hooked rungs still refuse everything — pgw#1486 is not weakened.

## Also: the operator posture was half-wired

`serve_posture.apply_command` is live from `worker.py`, but its **arming** reader was `compile_cache.arming_block` — the v1 tier's precondition authority. On the v2 path the order was observed at CALL time only, so a pod told to serve eager still paid for every adopt. `provision.arm_aot` now refuses first, by name, unwrapping nothing.

Compiled admission has three named causes for loud eager, none of which refuse the job: **operator-ordered**, **probe-refused**, **target-moves**.

## Red arms

- A fitting card must admit compiled — proved RED against the old gate.
- A card that cannot must fall to eager with a typed reason, never an OOM.
- The probe test found a real defect in this change's first draft: the park mark was set at mirror time, so a plan the probe REFUSED left marks behind on a load where no rung armed at all.

Local: 8 new tests + the touched suites green (`test_compile_servability` 33, `test_partial_resident`/`test_vram_fit`/adopt+ladder suites 109), mypy clean over 621 files, `ruff check src/gen_worker` clean, changelog fragment present.

Pairs with cozy-creator/serverless-endpoints#(se#810) — sdxl `vram12g` → `vram7g`.

Tracker: pgw#1587. Cross-refs pgw#1577, #1497, #1503, #1560, va#3 leg C, va#9.