### PR TITLE
pgw#1548: the substrate attribution rides WITH the numbers, structurally

### DIFF
--- a/benchmarks/dynamic_dims_pgw1548.py
+++ b/benchmarks/dynamic_dims_pgw1548.py
@@ -350,15 +350,34 @@ class Bench:
         return time.monotonic() - started
 
     def specializations(self, room: Path) -> list[dict[str, Any]]:
+        """Every graph specialization this arm's lock declares.
+
+        `read_lock` answers a plain dict (NOT an object with attributes) and
+        the derive document sits under `["derive"]["document"]` as a JSON
+        STRING. Both facts are asserted here rather than assumed: an attribute
+        read that works on nothing would have raised on the pod, minutes into
+        a paid window, after the compile it was supposed to plan.
+        """
+
         from gen_worker.cli import endpoint_lock as el
 
         block = el.read_lock(room / el.LOCK_FILENAME)
-        document = json.loads(block.document) if isinstance(block.document, (str, bytes)) else block.document
-        return [
+        derive = block.get("derive") if isinstance(block, dict) else None
+        if not isinstance(derive, dict) or "document" not in derive:
+            raise SystemExit(
+                f"{room / el.LOCK_FILENAME}: no [derive] document — a lock "
+                f"written with --discovery-only has no graphs to benchmark"
+            )
+        raw = derive["document"]
+        document = json.loads(raw) if isinstance(raw, (str, bytes)) else raw
+        records = [
             record
             for lane in document["graphs"]["lanes"]
             for record in lane["graphs"]
         ]
+        if not records:
+            raise SystemExit(f"{room}: the lock declares zero specializations")
+        return records
 
     def compile(self, room: Path, arm: str, selectors: list[str]) -> float:
         """Build ONLY what this run benchmarks. One selector per child."""

--- a/benchmarks/dynamic_dims_pgw1548.py
+++ b/benchmarks/dynamic_dims_pgw1548.py
@@ -189,8 +189,20 @@ class Table:
         return (high - low) / low * 100.0 if low else None
 
     def undecidable(self, aspect: str, cfg: str, limit: float = 15.0) -> bool:
+        """Is this cell's verdict unreadable — for EITHER reason?
+
+        Two ways, and the second one used to read as decidable, which is the
+        silent-vacuity shape this file exists to avoid: a cell measured in
+        only ONE round has no reproducibility evidence at all, so `spread`
+        answers None, and "no evidence" must never score as "no problem". A
+        run cut short to fit a window is exactly when that happens, so the
+        absence is treated as undecidable rather than as a pass.
+        """
+
         spread = self.spread("static", aspect, cfg)
-        return spread is not None and spread > limit
+        if spread is None:
+            return True
+        return spread > limit
 
     def regression(self, arm: str, aspect: str, cfg: str) -> float | None:
         """Percent SLOWER than the static control in this cell. Negative = faster."""
@@ -242,10 +254,13 @@ class Table:
         for aspect, cfg in self.shapes():
             if self.undecidable(aspect, cfg):
                 spread = self.spread("static", aspect, cfg)
-                offenders.append(
-                    f"{aspect}/{cfg}: UNDECIDABLE (control spread "
-                    f"{spread:.1f}% > 15%; re-run on a quiet slot)"
+                why = (
+                    f"control spread {spread:.1f}% > 15%; re-run on a quiet slot"
+                    if spread is not None
+                    else "measured in ONE round, so nothing establishes that "
+                         "the control reproduces; re-run with >= 2 rounds"
                 )
+                offenders.append(f"{aspect}/{cfg}: UNDECIDABLE ({why})")
                 continue
             delta = self.regression(arm, aspect, cfg)
             if delta is None:
@@ -552,11 +567,15 @@ def self_test() -> int:
 
     print("[self-test] the per-shape table CAN show a regression")
     table = Table()
-    for _ in range(3):
-        table.add(Sample("static", "1:1", "on", 1.000))
-        table.add(Sample("aspect", "1:1", "on", 1.010))
-        table.add(Sample("static", "3:4", "on", 2.000))
-        table.add(Sample("aspect", "3:4", "on", 2.600))
+    # TWO rounds: a single-round cell is undecidable by construction now, so a
+    # fixture that wants to exercise the regression arithmetic has to supply
+    # the reproducibility evidence a real run would.
+    for round_index in range(2):
+        for _ in range(3):
+            table.add(Sample("static", "1:1", "on", 1.000, round=round_index))
+            table.add(Sample("aspect", "1:1", "on", 1.010, round=round_index))
+            table.add(Sample("static", "3:4", "on", 2.000, round=round_index))
+            table.add(Sample("aspect", "3:4", "on", 2.600, round=round_index))
     check("a 1% cell reads +1.0%", round(table.regression("aspect", "1:1", "on"), 1) == 1.0)
     check("a 30% cell reads +30.0%", round(table.regression("aspect", "3:4", "on"), 1) == 30.0)
     ok, offenders = table.verdict("aspect", tolerance=5.0)
@@ -584,11 +603,23 @@ def self_test() -> int:
 
     print("[self-test] an unmeasured cell is NOT silently adopted")
     thin = Table()
-    thin.add(Sample("static", "1:1", "on", 1.0))
-    thin.add(Sample("aspect", "1:1", "on", 1.0))
-    thin.add(Sample("static", "16:9", "on", 1.0))
+    for round_index in range(2):
+        thin.add(Sample("static", "1:1", "on", 1.0, round=round_index))
+        thin.add(Sample("aspect", "1:1", "on", 1.0, round=round_index))
+        thin.add(Sample("static", "16:9", "on", 1.0, round=round_index))
     ok, offenders = thin.verdict("aspect", tolerance=5.0)
     check("a missing cell refuses", not ok and any("NOT MEASURED" in o for o in offenders))
+
+    print("[self-test] ONE round is UNDECIDABLE, never a quiet pass")
+    single = Table()
+    single.add(Sample("static", "1:1", "on", 1.0, round=0))
+    single.add(Sample("aspect", "1:1", "on", 1.0, round=0))
+    check("a single-round cell has no spread", single.spread("static", "1:1", "on") is None)
+    check("and is UNDECIDABLE", single.undecidable("1:1", "on"))
+    ok, offenders = single.verdict("aspect", tolerance=3.0)
+    check("so it cannot adopt", not ok)
+    check("and the reason names the ROUND count, not a spread",
+          any("ONE round" in o for o in offenders))
 
     print("[self-test] the table never averages across shapes")
     rendered = table.render()

--- a/benchmarks/dynamic_dims_pgw1548.py
+++ b/benchmarks/dynamic_dims_pgw1548.py
@@ -308,6 +308,8 @@ class Bench:
         self.out.mkdir(parents=True, exist_ok=True)
         self.table = Table()
         self.mint: dict[str, dict[str, Any]] = {}
+        #: arm -> the SERVING daemon's log (not the launcher's output).
+        self._daemon_log: dict[str, Path | None] = {}
 
     # -- the endpoint copy: never mutate a shared checkout ------------------
     def _workspace(self, arm: str) -> Path:
@@ -426,15 +428,24 @@ class Bench:
         up = self._gen_worker(room, argv, timeout=self.args.boot_timeout)
         if up.returncode != 0:
             raise SystemExit(f"[{arm}] up failed:\n{up.stdout}\n{up.stderr}")
-        (self.out / f"up-{arm}.log").write_text(
-            (up.stdout or "") + "\n--- stderr ---\n" + (up.stderr or "")
-        )
-        # Adoption is the PREMISE of every number below it. A boot that adopted
-        # nothing is not a slow arm, it is a different experiment.
         banner = (up.stdout or "") + (up.stderr or "")
-        if "adopt" not in banner.lower():
-            print(f"[{arm}] WARNING: the boot said nothing about adoption — "
-                  f"check {self.out / f'up-{arm}.log'} before trusting this arm")
+        (self.out / f"up-{arm}.log").write_text(banner)
+        # `up -d` DETACHES: its own output is a three-line launcher banner and
+        # says nothing about adoption. The serving daemon's log is a different
+        # file, and the launcher prints where — so read THAT. Checking the
+        # launcher's output for the word "adopt" is how this harness spent a
+        # window measuring eager against eager (pgw#1591).
+        self._daemon_log[arm] = None
+        for line in banner.splitlines():
+            if "logs:" in line:
+                candidate = Path(line.split("logs:", 1)[1].strip())
+                if candidate.name:
+                    self._daemon_log[arm] = candidate
+        if self._daemon_log[arm] is None:
+            raise SystemExit(
+                f"[{arm}] the boot did not name its daemon log, so nothing can "
+                f"verify that this arm serves COMPILED. Refusing to measure."
+            )
 
     def down(self, room: Path) -> None:
         self._gen_worker(room, ["down"], timeout=120)
@@ -502,15 +513,59 @@ class Bench:
 
         self.serve(room, name)
         try:
+            first = True
             for aspect in self.args.aspects:
                 for cfg in self.args.cfg:
                     self.request(room, name, aspect, cfg, round_index)
+                    if first:
+                        # The warm-up call has now exercised the serve path
+                        # once. Check the PREMISE here, at the cheapest
+                        # possible point, before paying for the rest of the
+                        # arm — let alone the other arm.
+                        self.assert_compiled(name)
+                        first = False
                     for _ in range(self.args.reps):
                         self.table.add(
                             self.request(room, name, aspect, cfg, round_index)
                         )
         finally:
             self.down(room)
+
+    def assert_compiled(self, arm: str) -> None:
+        """Did this arm actually SERVE compiled? Typed abort if not (pgw#1591).
+
+        A warning was not enough. An arm whose dispatcher was displaced serves
+        eager on every call and still produces perfectly plausible timings —
+        and two such arms compare to ~0%, which reads as "the dynamic axis is
+        free" rather than as "nothing was measured". So an arm that cannot
+        show compiled serving does not get to contribute a row.
+        """
+
+        log = self._daemon_log.get(arm)
+        if log is None or not log.exists():
+            raise SystemExit(
+                f"[{arm}] daemon log {log} is absent — nothing can verify this "
+                f"arm serves compiled. Refusing to measure."
+            )
+        text = log.read_text(errors="replace")
+        if "DISPLACED" in text:
+            raise SystemExit(
+                f"[{arm}] DISPLACED: the compiled dispatcher is no longer the "
+                f"module's forward, so calls ran EAGER (pgw#1591). Both arms "
+                f"would compare eager-to-eager and report ~0%. Refusing to "
+                f"measure. See {log}"
+            )
+        if "NO armed graph matched" in text:
+            raise SystemExit(
+                f"[{arm}] the dispatcher matched NOTHING (tcg#76's trace is in "
+                f"{log}); this arm serves eager. Refusing to measure."
+            )
+        if "wrapper.tcg" not in text:
+            raise SystemExit(
+                f"[{arm}] no compiled wrapper ran during the warm-up call, so "
+                f"this arm has not been shown to serve compiled at all. "
+                f"Refusing to measure. See {log}"
+            )
 
     def report(self) -> dict[str, Any]:
         adoption = {}

--- a/benchmarks/dynamic_dims_pgw1548.py
+++ b/benchmarks/dynamic_dims_pgw1548.py
@@ -399,14 +399,27 @@ class Bench:
 
     def serve(self, room: Path, arm: str) -> None:
         require_window()
-        up = self._gen_worker(
-            room,
-            ["up", str(room), "-d", "--checkpoint", str(self.args.checkpoint),
-             "--idle-timeout", str(self.args.idle_timeout)],
-            timeout=self.args.boot_timeout,
-        )
+        # --sm is NOT optional: `gen-worker up --help` says it is "required to
+        # adopt compiled graphs". Without it the boot serves EAGER, both arms
+        # measure eager, and the table reports a beautiful 0% delta — the same
+        # vacuous green the preflight exists to stop, arriving from the boot
+        # side. The whole run would be worthless and would look fine.
+        argv = ["up", str(room), "-d", "--checkpoint", str(self.args.checkpoint),
+                "--idle-timeout", str(self.args.idle_timeout)]
+        if self.args.sm:
+            argv += ["--sm", self.args.sm]
+        up = self._gen_worker(room, argv, timeout=self.args.boot_timeout)
         if up.returncode != 0:
             raise SystemExit(f"[{arm}] up failed:\n{up.stdout}\n{up.stderr}")
+        (self.out / f"up-{arm}.log").write_text(
+            (up.stdout or "") + "\n--- stderr ---\n" + (up.stderr or "")
+        )
+        # Adoption is the PREMISE of every number below it. A boot that adopted
+        # nothing is not a slow arm, it is a different experiment.
+        banner = (up.stdout or "") + (up.stderr or "")
+        if "adopt" not in banner.lower():
+            print(f"[{arm}] WARNING: the boot said nothing about adoption — "
+                  f"check {self.out / f'up-{arm}.log'} before trusting this arm")
 
     def down(self, room: Path) -> None:
         self._gen_worker(room, ["down"], timeout=120)
@@ -630,6 +643,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--guidance", type=float, default=7.5)
     parser.add_argument("--seed", type=int, default=1548)
     parser.add_argument("--prompt", default="a fisherman at dawn")
+    parser.add_argument("--sm", default="",
+                        help="this GPU's sm (e.g. sm_89). REQUIRED to adopt "
+                             "compiled graphs — without it every arm serves "
+                             "eager and the table reads 0%% for the wrong reason")
     parser.add_argument("--substrate", choices=sorted(SUBSTRATES), default="raw-pod",
                         help="what produced these numbers; stamped into the "
                              "verdict and the table so the bound on what they "

--- a/benchmarks/dynamic_dims_pgw1548.py
+++ b/benchmarks/dynamic_dims_pgw1548.py
@@ -58,6 +58,25 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+#: What substrate produced these numbers, stamped into the verdict and the
+#: table so a row CANNOT be published without it (coordinator, 2026-08-20).
+#:
+#: A raw pod runs `gen-worker lock/compile/up/run` — the endpoint's own serving
+#: code, which is what the measurement law asks for — but it does NOT go
+#: through release packaging and deploy. That is the right subject for a
+#: graph-shape A/B (packaging does not touch a per-step wall) and it is a real
+#: limit on what the number describes, so the limit travels WITH the number
+#: rather than in a paragraph someone has to remember to quote.
+SUBSTRATES = {
+    "raw-pod": (
+        "raw-pod substrate; numbers describe the graphs, not the deploy path"
+    ),
+    "local": (
+        "local-card substrate; numbers describe the graphs, not the deploy path"
+    ),
+    "release": "release-built substrate; the full deploy path",
+}
+
 ARMS = ("static", "aspect", "batch", "all")
 AXES = {"static": "off", "aspect": "aspect", "batch": "batch", "all": "all"}
 
@@ -182,9 +201,10 @@ class Table:
             return None
         return (measured - control) / control * 100.0
 
-    def render(self) -> str:
+    def render(self, substrate: str = "") -> str:
         arms = self.arms()
-        lines = [
+        lines = [f"_{SUBSTRATES[substrate]}_", ""] if substrate else []
+        lines += [
             "| shape | cfg | " + " | ".join(
                 f"{arm} (s)" + ("" if arm == "static" else " / vs static")
                 for arm in arms
@@ -449,9 +469,14 @@ class Bench:
             adoption[arm] = {"adopt": ok, "outside_tolerance": offenders}
         return {
             "endpoint": str(self.endpoint),
+            "substrate": self.args.substrate,
+            # The attribution rides in the verdict itself, not only in the
+            # rendered table, so a consumer reading the JSON cannot get the
+            # numbers without the sentence that bounds them.
+            "substrate_note": SUBSTRATES[self.args.substrate],
             "tolerance_pct": self.args.tolerance,
             "mint": self.mint,
-            "table_markdown": self.table.render(),
+            "table_markdown": self.table.render(self.args.substrate),
             "adoption": adoption,
             **self.table.as_dict(),
         }
@@ -538,6 +563,16 @@ def self_test() -> int:
     )
     check("the control column carries no percentage", "static (s) / vs static" not in rendered)
 
+    print("[self-test] the substrate attribution cannot be dropped")
+    stamped = table.render("raw-pod")
+    check("the table leads with the substrate note",
+          stamped.splitlines()[0].strip("_") == SUBSTRATES["raw-pod"])
+    check("and it names the deploy-path limit",
+          "not the deploy path" in stamped)
+    check("every substrate carries a note", all(SUBSTRATES.values()))
+    check("an unstamped render is only reachable deliberately",
+          "substrate" not in table.render())
+
     print("[self-test] the arm plan is exhaustive over the axes")
     check("every arm names an axis policy", set(ARMS) == set(AXES))
     check("static is the OFF control", AXES["static"] == "off")
@@ -571,6 +606,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--guidance", type=float, default=7.5)
     parser.add_argument("--seed", type=int, default=1548)
     parser.add_argument("--prompt", default="a fisherman at dawn")
+    parser.add_argument("--substrate", choices=sorted(SUBSTRATES), default="raw-pod",
+                        help="what produced these numbers; stamped into the "
+                             "verdict and the table so the bound on what they "
+                             "describe travels with them")
     parser.add_argument("--tolerance", type=float, default=3.0,
                         help="percent slower than static that still adopts")
     parser.add_argument("--selectors", default="",
@@ -620,6 +659,8 @@ def main(argv: list[str] | None = None) -> int:
     for arm, verdict in report["adoption"].items():
         state = "ADOPT" if verdict["adopt"] else "KEEP STATIC"
         print(f"{arm}: {state} {verdict['outside_tolerance'] or ''}")
+    print()
+    print(report["substrate_note"])
     return 0
 
 

--- a/benchmarks/dynamic_dims_pgw1548.py
+++ b/benchmarks/dynamic_dims_pgw1548.py
@@ -444,7 +444,12 @@ class Bench:
         room = self._workspace(name)
         lock_s = self.lock(room, name)
         records = self.specializations(room)
-        selectors = self.args.selectors or [r["graph"][-16:] for r in records]
+        # `--first` matches a facet by EQUALITY or the graph identity by
+        # PREFIX (>= 8 chars) — `compile.Spec.short` is `graph[:16]`, scheme
+        # included. A SUFFIX matches neither, so every compile would have been
+        # refused with "names no specialization this endpoint has" — on the
+        # pod, after the lock, inside the paid window.
+        selectors = self.args.selectors or [r["graph"][:16] for r in records]
         compile_s = self.compile(room, name, selectors)
         self.mint[name] = {
             "lock_s": lock_s,

--- a/tests/test_dynamic_dims_harness_pgw1548.py
+++ b/tests/test_dynamic_dims_harness_pgw1548.py
@@ -143,3 +143,63 @@ def test_the_substrate_note_is_carried_into_every_rendered_table() -> None:
     rendered = table.render("raw-pod")
     assert "not the deploy path" in rendered.splitlines()[0]
     assert "| 1:1 | on |" in rendered
+
+
+def _armed(tmp_path: Path, arm: str, text: str) -> Any:
+    """A bench whose named arm has a daemon log carrying `text`."""
+
+    log = tmp_path / f"{arm}-daemon.log"
+    log.write_text(text)
+    bench = _bench(tmp_path)
+    bench._daemon_log = {arm: log}
+    return bench
+
+
+def test_a_DISPLACED_arm_REFUSES_to_contribute_a_row(tmp_path: Path) -> None:
+    """pgw#1591: two displaced arms compare to ~0% and read as 'free'.
+
+    This is the whole reason it is an abort and not a warning — the numbers a
+    displaced arm produces are perfectly plausible and entirely meaningless.
+    """
+
+    bench = _armed(tmp_path, "static", (
+        "wrapper.tcg run_impl\n"
+        "dispatch: DISPLACED on UNet2DConditionModel — the compiled dispatcher "
+        "is no longer this module's forward, so all 21 call(s) ran eager\n"
+    ))
+    with pytest.raises(SystemExit, match="DISPLACED"):
+        bench.assert_compiled("static")
+
+
+def test_an_arm_that_MATCHED_NOTHING_refuses(tmp_path: Path) -> None:
+    """tcg#76's trace means the guards refused every armed record."""
+
+    bench = _armed(tmp_path, "aspect",
+                   "torchcg dispatch: NO armed graph matched a call on UNet\n")
+    with pytest.raises(SystemExit, match="matched NOTHING"):
+        bench.assert_compiled("aspect")
+
+
+def test_an_arm_with_NO_compiled_wrapper_at_all_refuses(tmp_path: Path) -> None:
+    """Silence is not success: no wrapper ran, so nothing was shown."""
+
+    bench = _armed(tmp_path, "static", "ready — functions: generate\n")
+    with pytest.raises(SystemExit, match="not been shown to serve compiled"):
+        bench.assert_compiled("static")
+
+
+def test_an_absent_daemon_log_refuses_rather_than_assuming(tmp_path: Path) -> None:
+    bench = _bench(tmp_path)
+    bench._daemon_log = {"static": tmp_path / "nope.log"}
+    with pytest.raises(SystemExit, match="absent"):
+        bench.assert_compiled("static")
+
+
+def test_a_genuinely_compiled_arm_PASSES(tmp_path: Path) -> None:
+    """The green arm: a wrapper ran, nothing displaced, nothing unmatched."""
+
+    bench = _armed(tmp_path, "static", (
+        "gen-worker up: ready\n"
+        "[W] cw54nq...wrapper.tcg.cpp:26541 Warning: run_impl\n"
+    ))
+    bench.assert_compiled("static")

--- a/tests/test_dynamic_dims_harness_pgw1548.py
+++ b/tests/test_dynamic_dims_harness_pgw1548.py
@@ -1,0 +1,120 @@
+"""pgw#1548: the benchmark harness reads a REAL lock, and says so when it can't.
+
+Caught by running the reader against a real `endpoint.lock` before the GPU
+window rather than during it: `endpoint_lock.read_lock` answers a plain **dict**
+(not an object with attributes) and the derive document sits under
+`["derive"]["document"]` as a JSON **string**. The harness had `block.document`,
+which would have raised on the pod — minutes into a paid window, after the
+compile it was supposed to plan.
+
+The lesson is the test: every structural assumption the harness makes about
+another module's return value is asserted at $0, because the alternative is
+asserting it at $0.49/hr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE = Path(__file__).resolve().parents[1] / "benchmarks" / "dynamic_dims_pgw1548.py"
+_spec = importlib.util.spec_from_file_location("dynamic_dims_pgw1548", _MODULE)
+assert _spec and _spec.loader
+harness = importlib.util.module_from_spec(_spec)
+# Registered BEFORE exec: dataclass field resolution reads the module out of
+# sys.modules, and an unregistered module fails deep inside `dataclasses`.
+sys.modules["dynamic_dims_pgw1548"] = harness
+_spec.loader.exec_module(harness)
+
+
+def _bench(tmp_path: Path) -> object:
+    args = argparse.Namespace(
+        endpoint=str(tmp_path), out=str(tmp_path / "out"), substrate="local"
+    )
+    bench = harness.Bench.__new__(harness.Bench)
+    bench.args = args
+    bench.endpoint = Path(args.endpoint)
+    bench.out = Path(args.out)
+    return bench
+
+
+def _lock(room: Path, records: list[dict], *, derive: bool = True) -> Path:
+    """A lock in the REAL shape: TOML, with derive.document a JSON STRING.
+
+    Both facts matter and both were assumed wrong at some point: the file is
+    TOML (not JSON), and the document inside it is a JSON string (not a
+    table).
+    """
+
+    room.mkdir(parents=True, exist_ok=True)
+    lines = ["[[entrypoints]]", 'name = "generate"', ""]
+    if derive:
+        document = {"graphs": {"lanes": [{"contract": "x@1", "graphs": records}]}}
+        encoded = json.dumps(json.dumps(document))
+        lines += [
+            "[derive]",
+            "v = 1",
+            f'document = {encoded}',
+            f'document_digest = "{"d" * 64}"',
+            'endpoint = "x:Y"',
+            'interface_v = 4',
+            'inputs_digest = "%s"' % ("e" * 64),
+            'trace_device = "cuda"',
+        ]
+    (room / "endpoint.lock").write_text("\n".join(lines) + "\n")
+    return room
+
+
+def _record(graph: str, shape: list) -> dict:
+    return {
+        "graph": graph,
+        "target": "unet",
+        "ingress": {"inputs": [{"name": "sample", "shape": shape}]},
+    }
+
+
+def test_the_reader_gets_every_specialization_out_of_a_real_shaped_lock(
+    tmp_path: Path,
+) -> None:
+    room = _lock(tmp_path / "arm", [
+        _record("cg-graph-v1-" + "a" * 52, [2, 4, 64, 64]),
+        _record("cg-graph-v1-" + "b" * 52, [1, 4, 64, 64]),
+    ])
+    records = _bench(tmp_path).specializations(room)
+    assert [r["graph"][-16:] for r in records] == ["a" * 16, "b" * 16]
+
+
+def test_a_discovery_only_lock_REFUSES_instead_of_reading_zero(
+    tmp_path: Path,
+) -> None:
+    """`--discovery-only` writes no [derive]; benchmarking it is meaningless.
+
+    Silently reading zero specializations would compile nothing, serve eager
+    and report a 0% delta — the same vacuous green the preflight exists to
+    stop, arriving from the lock side instead of the tree side.
+    """
+
+    room = _lock(tmp_path / "arm", [], derive=False)
+    with pytest.raises(SystemExit, match="no .derive. document"):
+        _bench(tmp_path).specializations(room)
+
+
+def test_a_lock_declaring_zero_graphs_REFUSES(tmp_path: Path) -> None:
+    room = _lock(tmp_path / "arm", [])
+    with pytest.raises(SystemExit, match="zero specializations"):
+        _bench(tmp_path).specializations(room)
+
+
+def test_the_substrate_note_is_carried_into_every_rendered_table() -> None:
+    table = harness.Table()
+    for round_index in range(2):
+        table.add(harness.Sample("static", "1:1", "on", 1.0, round=round_index))
+        table.add(harness.Sample("aspect", "1:1", "on", 1.0, round=round_index))
+    rendered = table.render("raw-pod")
+    assert "not the deploy path" in rendered.splitlines()[0]
+    assert "| 1:1 | on |" in rendered

--- a/tests/test_dynamic_dims_harness_pgw1548.py
+++ b/tests/test_dynamic_dims_harness_pgw1548.py
@@ -19,6 +19,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -32,7 +33,7 @@ sys.modules["dynamic_dims_pgw1548"] = harness
 _spec.loader.exec_module(harness)
 
 
-def _bench(tmp_path: Path) -> object:
+def _bench(tmp_path: Path) -> Any:
     args = argparse.Namespace(
         endpoint=str(tmp_path), out=str(tmp_path / "out"), substrate="local"
     )

--- a/tests/test_dynamic_dims_harness_pgw1548.py
+++ b/tests/test_dynamic_dims_harness_pgw1548.py
@@ -110,6 +110,30 @@ def test_a_lock_declaring_zero_graphs_REFUSES(tmp_path: Path) -> None:
         _bench(tmp_path).specializations(room)
 
 
+def test_the_default_selectors_are_PREFIXES_the_compiler_can_match(
+    tmp_path: Path,
+) -> None:
+    """`--first` matches a facet by equality or the graph id by PREFIX.
+
+    `compile.Spec.short` is `graph[:16]` — scheme included — and `_selects`
+    does `spec.graph.startswith(term)`. A suffix matches neither, so a harness
+    passing one gets "names no specialization this endpoint has" for every
+    arm, on the pod, inside the paid window. This test fails if the harness
+    ever goes back to a suffix.
+    """
+
+    graph = "cg-graph-v1-" + "a" * 52
+    room = _lock(tmp_path / "arm", [_record(graph, [2, 4, 64, 64])])
+    records = _bench(tmp_path).specializations(room)
+    selector = records[0]["graph"][:16]
+    assert selector == "cg-graph-v1-aaaa"
+    assert graph.startswith(selector), "the compiler matches by prefix"
+    assert len(selector) >= 8, "eight characters minimum, so a word cannot collide"
+    assert not graph.startswith(records[0]["graph"][-16:]), (
+        "a suffix does NOT match — this is the bug the prefix fixes"
+    )
+
+
 def test_the_substrate_note_is_carried_into_every_rendered_table() -> None:
     table = harness.Table()
     for round_index in range(2):


### PR DESCRIPTION
The coordinator's condition on the raw-pod ruling: every reported row carries
*"raw-pod substrate; numbers describe the graphs, not the deploy path"*.

Making that a habit is how it gets dropped from the one table someone quotes,
so it is **stamped** instead:

- `--substrate {raw-pod,local,release}` picks the note;
- `Table.render()` leads with it;
- the verdict JSON carries `substrate_note` beside the cells — a consumer
  reading the JSON cannot get the numbers without the sentence that bounds
  them;
- the console verdict ends on it.

Raw pod runs `gen-worker lock/compile/up/run`, which *is* the endpoint's own
serving code, so the measurement law is satisfied; what it skips is release
packaging and deploy, which does not touch a per-step wall. That makes it the
right subject for a graph-shape A/B **and** a real limit on what the number
describes — so the limit travels with the number.

Four new `--self-test` checks, red-armed with the rest. Self-test green.