### PR TITLE
pgw#1587 follow-up: --vram-budget's help still described the deleted no-op

### DIFF
--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -1212,9 +1212,11 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
                              "state of every specialization, and every "
                              "remaining gap")
     parser.add_argument("--vram-budget", type=float, default=0.0, metavar="GB",
-                        help="the grant this compile targets; below the "
-                             "endpoint's compiled floor it no-ops by name. "
-                             "0 = probe this card once.")
+                        help="the VRAM grant this compile targets, passed to "
+                             "the mint child as its residency budget. 0 = "
+                             "probe this card once. It does NOT gate the "
+                             "build: nothing here refuses a mint on a "
+                             "declared number (pgw#1587).")
     parser.set_defaults(_handler=run_compile)
 
 


### PR DESCRIPTION
Found while driving the acceptance leg: `gen-worker compile --help` still reads

> the grant this compile targets; **below the endpoint's compiled floor it no-ops by name**. 0 = probe this card once.

That is the behaviour pgw#1587 deleted. A user reading `--help` is told the gate still exists — and `--vram-budget` is the first operand anyone reaches for when a mint does not produce what they expected, so the stale sentence actively misleads at exactly the wrong moment.

The flag itself is unchanged and keeps its real consumer: it is the residency budget passed through to the mint child. What it never does again is decide whether to build.

`ruff` clean, `test_compile_servability` 33 passed.