### PR TITLE
pgw#1591: a WRAPPED dispatcher is not a DISPLACED one — and a displaced one reports what it MEASURED

### DIFF
--- a/changelog.d/pgw1591-displaced.md
+++ b/changelog.d/pgw1591-displaced.md
@@ -1,0 +1,28 @@
+- **pgw#1591: a WRAPPED compiled dispatcher is not a DISPLACED one — and a
+  displaced one now reports what it measured.** `DispatchCounter` asked
+  `module.forward is dispatcher`, and pgw#1573's adapter guard installs itself
+  AS `module.forward`, so every guarded module read DISPLACED from the moment
+  that guard landed. Measured in the field: sd15, `dispatch: DISPLACED on
+  UNet2DConditionModel`, 12 of 12 requests on BOTH arms of the pgw#1548
+  dynamic-dims benchmark — a whole GPU leg discarded because the lane could
+  not tell eager from compiled. The arm was healthy the entire time; the
+  question was wrong. `adapter_guard.dispatcher_of` is now the one resolver
+  and resolves THROUGH wrappers, so adding a wrapper is not a change every
+  reader has to learn about; a module it cannot resolve is genuinely displaced
+  (accelerate restoring `_old_forward` after an offload rung is the real shape
+  of that) and still reports so.
+
+- **pgw#1591: the displaced verdict states the counts instead of inferring
+  them.** The branch ended `"so all N call(s) ran eager"` — a claim it never
+  measured. The same logs carried 120 AOTI wrapper invocations per arm, so the
+  filing lane had two irreconcilable readings and correctly refused to pick
+  one. **Neither was right:** compiled DID execute and the message overcounted
+  eager. Displacement and dispatch are separate facts and both are now stated
+  (`… still served COMPILED` vs `… ran eager`, whichever the counter measured).
+
+- **pgw#1591: the three-leg adopt test now installs the DAEMON's witness.** It
+  asserted on a loader stub's call list; `cli/daemon.py` installs a
+  `DispatchCounter` after `host.setup` and prints its verdict per request. That
+  difference is why the legs stayed green against a displacing daemon — the two
+  booths were not measuring the same thing. All three legs now take the
+  daemon's reading and refuse a displaced arm.

--- a/src/gen_worker/serving/adapter_guard.py
+++ b/src/gen_worker/serving/adapter_guard.py
@@ -54,8 +54,20 @@ PEFT_MARKER_ATTR = "peft_config"
 _GUARD_ATTR = "_cozy_adapter_guard"
 
 
-def _dispatcher(module: Any) -> Any:
-    """The torchcg dispatcher fronting ``module``, through any guard, or None.
+def dispatcher_of(module: Any) -> Any:
+    """The torchcg dispatcher fronting ``module``, THROUGH any wrapper, or None.
+
+    PUBLIC, and it is the answer to "is this module still routing through its
+    compiled dispatcher" (pgw#1591). This guard installs itself AS
+    ``module.forward``, so the obvious test — ``module.forward is dispatcher``
+    — reads False on every guarded module and calls a perfectly healthy arm
+    DISPLACED. Measured on the live sd15 benchmark: 12/12 requests of both
+    arms reported the dispatcher displaced while the compiled graphs were in
+    fact executing, and a whole GPU leg was thrown away comparing eager to
+    eager that was not eager.
+
+    Anything asking that question must ask it HERE, so that adding a wrapper
+    is not a change every reader has to learn about.
 
     Duck-typed on the two attributes the dispatcher contract actually has
     (``eager_forward`` + ``armed_graphs``) rather than on an isinstance against
@@ -75,7 +87,7 @@ def _dispatcher(module: Any) -> Any:
 
 def armed_graphs(module: Any) -> Tuple[str, ...]:
     """The graph identities currently armed on ``module``. Empty = eager."""
-    dispatcher = _dispatcher(module)
+    dispatcher = dispatcher_of(module)
     if dispatcher is None:
         return ()
     try:
@@ -111,7 +123,7 @@ def install(module: Any) -> bool:
     ``AdoptSession.arm``'s late-mint handoff, which reaches the dispatcher
     through its own ``_home`` map, keeps working unchanged.
     """
-    dispatcher = _dispatcher(module)
+    dispatcher = dispatcher_of(module)
     if dispatcher is None:
         return False
     if getattr(getattr(module, "forward", None), _GUARD_ATTR, None) is not None:
@@ -171,8 +183,8 @@ def _adopted_modules(target: Any) -> List[Any]:
     components = getattr(target, "components", None)
     if isinstance(components, dict):
         return [value for value in components.values()
-                if _dispatcher(value) is not None]
-    return [target] if _dispatcher(target) is not None else []
+                if dispatcher_of(value) is not None]
+    return [target] if dispatcher_of(target) is not None else []
 
 
 def _eager_only_reason() -> str:
@@ -283,7 +295,7 @@ def rearm_constants(module: Any) -> int:
     what puts ``fold_state`` back to INITIALIZED, so the next call re-folds
     against the new weights.
     """
-    dispatcher = _dispatcher(module)
+    dispatcher = dispatcher_of(module)
     if dispatcher is None:
         return 0
     rearmed = 0
@@ -306,6 +318,7 @@ __all__ = [
     "PEFT_MARKER_ATTR",
     "armed_graphs",
     "compiled_armed",
+    "dispatcher_of",
     "has_live_adapter",
     "install",
     "rearm_constants",

--- a/src/gen_worker/serving/dispatch_counter.py
+++ b/src/gen_worker/serving/dispatch_counter.py
@@ -95,10 +95,23 @@ class DispatchCounts:
         if self.armed_modules == 0:
             return "dispatch: no compiled graph armed — served eager (nothing adopted)"
         if self.displaced_modules:
+            # THE COUNTS, NEVER AN INFERENCE FROM THE FLAG (pgw#1591). This
+            # branch used to end "so all N call(s) ran eager" — a claim it did
+            # not measure and, in the field, a false one: the sd15 benchmark
+            # read it on 12/12 requests of both arms while 120 AOTI wrapper
+            # invocations per arm were in the same log, and the lane could not
+            # reconcile the two because one of them was not a measurement.
+            # Displacement and dispatch are separate facts; both are stated.
+            served = (
+                f"{self.compiled_graph_calls} of {self.module_calls} call(s) "
+                f"still served COMPILED"
+                if self.compiled_graph_calls
+                else f"all {self.module_calls} call(s) ran eager"
+            )
             return (
-                f"dispatch: DISPLACED on {', '.join(self.displaced_modules)} — the "
-                f"compiled dispatcher is no longer this module's forward, so all "
-                f"{self.module_calls} call(s) ran eager"
+                f"dispatch: DISPLACED on {', '.join(self.displaced_modules)} — "
+                f"the compiled dispatcher is no longer reachable as this "
+                f"module's forward; {served}"
             )
         if self.compiled_graph_calls == 0:
             return (
@@ -204,7 +217,16 @@ class DispatchCounter:
             if graphs:
                 armed_modules += 1
                 armed_graphs += len(graphs)
-            if getattr(module, "forward", None) is not dispatcher:
+            # THROUGH any wrapper (pgw#1591). `module.forward is dispatcher`
+            # calls every WRAPPED dispatcher displaced — and pgw#1573's
+            # adapter guard is a legitimate wrapper installed on every adopted
+            # module, so this read went false fleet-wide the moment it landed.
+            # `adapter_guard.dispatcher_of` is the one resolver; a module it
+            # cannot resolve is genuinely displaced (accelerate restoring
+            # `_old_forward` after an offload rung is the real shape of that).
+            from .adapter_guard import dispatcher_of
+
+            if dispatcher_of(module) is not dispatcher:
                 displaced.append(label)
         counts = DispatchCounts(
             module_calls=self._module_calls,

--- a/tests/test_adapter_on_compiled.py
+++ b/tests/test_adapter_on_compiled.py
@@ -19,6 +19,7 @@ DISTINGUISHABLE from the eager forward, which is the whole measurement.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, List
 
 import pytest
@@ -375,3 +376,69 @@ def test_an_operator_eager_only_order_suppresses_compiled_dispatch(
             "latched, so the order is one-way")
     finally:
         serve_posture.reset()
+
+
+# --------------------------------------------------------------------------
+# pgw#1591: a WRAPPED dispatcher is not a displaced one, and a displaced one
+# still reports what it measured
+# --------------------------------------------------------------------------
+
+
+def test_the_guard_does_not_read_as_a_DISPLACED_dispatcher(
+    tmp_path: Path,
+) -> None:
+    """THE P1. `DispatchCounter` asked `module.forward is dispatcher`, and this
+    guard installs itself AS `module.forward` — so every guarded module read
+    DISPLACED the moment pgw#1573 landed.
+
+    Measured in the field before it was understood: sd15, 12/12 requests of
+    both benchmark arms, `dispatch: DISPLACED on UNet2DConditionModel`, and a
+    whole GPU leg discarded because the lane could not tell eager from
+    compiled. The arm was fine; the question was wrong.
+    """
+    from gen_worker.serving.dispatch_counter import DispatchCounter
+
+    calls: List[str] = []
+    module = _armed(tmp_path, calls)
+    session = SimpleNamespace(_dispatchers=[
+        (module, adapter_guard.dispatcher_of(module))])
+    counter = DispatchCounter().install(SimpleNamespace(adoption=session))
+
+    module(torch.ones(2, 4))
+    counts = counter.take()
+
+    assert counts.displaced_modules == (), (
+        f"a GUARDED dispatcher is not a displaced one: {counts.facts()}")
+    assert counts.compiled_graph_calls == 1 and counts.eager_calls == 0
+    assert "DISPLACED" not in counts.summary()
+
+
+def test_a_DISPLACED_module_still_reports_what_it_MEASURED(
+    tmp_path: Path,
+) -> None:
+    """The second half, and the one that cost the #1548 lane its window.
+
+    The displaced branch used to end "so all N call(s) ran eager" — a sentence
+    it never measured. The same logs carried 120 AOTI wrapper invocations per
+    arm, so the lane had two irreconcilable readings and correctly refused to
+    pick one. Neither was right: compiled DID execute and the message
+    overcounted eager.
+
+    Displacement and dispatch are separate facts. Both get stated.
+    """
+    from gen_worker.serving.dispatch_counter import DispatchCounts
+
+    displaced_but_served = DispatchCounts(
+        module_calls=21, compiled_graph_calls=10, armed_modules=1,
+        armed_graphs=14, displaced_modules=("UNet2DConditionModel",))
+    line = displaced_but_served.summary()
+    assert "DISPLACED" in line
+    assert "10 of 21 call(s) still served COMPILED" in line, line
+    assert "ran eager" not in line, (
+        f"the summary asserted eager over a measurement that says otherwise: "
+        f"{line}")
+
+    truly_eager = DispatchCounts(
+        module_calls=21, compiled_graph_calls=0, armed_modules=1,
+        armed_graphs=14, displaced_modules=("UNet2DConditionModel",))
+    assert "all 21 call(s) ran eager" in truly_eager.summary()

--- a/tests/test_adopt_flow.py
+++ b/tests/test_adopt_flow.py
@@ -161,6 +161,36 @@ def mint_the_holes(host: Any, store: Any, tmp_path: Path,
     ).run()
 
 
+def dispatch_counts(host: Any) -> Any:
+    """THE DAEMON'S OWN WITNESS, which this file used not to build (pgw#1591).
+
+    `cli/daemon.py` installs a `DispatchCounter` right after `host.setup` and
+    prints its verdict after every request; this file asserted on a loader
+    stub's call list instead. So the daemon could report the dispatcher
+    DISPLACED on 12/12 requests of a real sd15 benchmark while these legs
+    stayed green — the two booths were not measuring the same thing, and the
+    difference was the instrument, not the arm.
+
+    Every leg now takes the daemon's reading. Install AFTER setup, exactly as
+    `daemon.py` does, because the order is part of what broke.
+    """
+    from gen_worker.serving.dispatch_counter import DispatchCounter
+
+    return DispatchCounter().install(host)
+
+
+def assert_served_compiled(counter: Any, *, at_least: int = 1) -> Any:
+    """The reading a compiled claim rests on, in the daemon's own terms."""
+    counts = counter.take()
+    assert counts.displaced_modules == (), (
+        f"the compiled dispatcher is not reachable as the module's forward: "
+        f"{counts.facts()} — this is what the live sd15 benchmark read on "
+        f"12/12 requests of both arms (pgw#1591)")
+    assert counts.compiled_graph_calls >= at_least, (
+        f"served eager while claiming compiled: {counts.facts()}")
+    return counts
+
+
 def bank_both(store: Any, document: Any, tmp_path: Path) -> None:
     """Put a real envelope at both positions of ``store``."""
     from gen_worker.serving.mint import publish_compiled
@@ -215,6 +245,7 @@ def test_cold_boot_serves_EAGER_then_mints_then_serves_COMPILED(
         "a minted graph that did not arm leaves this host eager forever")
 
     # THE HOT SWAP: same host, same instance, no reboot — now compiled.
+    counter = dispatch_counts(host)
     host.dispatch("generate", {"prompt": "x", "aspect_ratio": first},
                   request_id="cold-2")
     host.dispatch("generate", {"prompt": "x", "aspect_ratio": second},
@@ -222,6 +253,10 @@ def test_cold_boot_serves_EAGER_then_mints_then_serves_COMPILED(
     armed = {record.graph for record in document.lanes[0].graphs}
     assert set(calls) == armed, (
         f"the eager forward is still serving after a landed mint: {calls}")
+    # ...and the DAEMON's own witness agrees. This is the half that was
+    # missing: without it these legs stayed green while `gen-worker up`
+    # reported the dispatcher DISPLACED on 12/12 requests (pgw#1591).
+    assert_served_compiled(counter, at_least=2)
 
     # And the bytes are in the LOCAL CAS, at the band adoption reads.
     for record in document.lanes[0].graphs:
@@ -250,9 +285,11 @@ def test_warm_local_reboot_arms_from_the_store_and_compiles_NOTHING(
 
     assert len(host.adoption.adopted) == 2 and host.holes == ()
     first, _second = ratios(document)
+    counter = dispatch_counts(host)
     host.dispatch("generate", {"prompt": "x", "aspect_ratio": first},
                   request_id="warm-1")
     assert calls, "a warm boot served eager over a full store"
+    assert_served_compiled(counter)
 
     # Nothing to mint, and the mint says so as a NAMED state rather than a
     # zero count (pgw#1371's `nothing_to_mint`).
@@ -396,9 +433,11 @@ def test_warm_remote_fetches_verifies_arms_serves_and_BANKS_locally(
             f"the fleet pool answered and nothing armed; holes: "
             f"{[(h.record.graph[-12:], h.reason) for h in host.holes]}")
         first, _second = ratios(document)
+        counter = dispatch_counts(host)
         host.dispatch("generate", {"prompt": "x", "aspect_ratio": first},
                       request_id="remote-1")
         assert calls, "adopted from the hub and still served eager"
+        assert_served_compiled(counter)
 
         # (4) BANKED. Without this the pod re-downloads every boot.
         for record in document.lanes[0].graphs:


### PR DESCRIPTION
## The address, and it was in my own diff

The coordinator framed this as a differential: *"that lane's three-leg integration test asserts `compiled_graph_calls > 0` and PASSES, while live `gen-worker up` DISPLACES. Whatever differs is the defect's address."*

`DispatchCounter.take()` asked:

```python
if getattr(module, "forward", None) is not dispatcher:
    displaced.append(label)
```

pgw#1573's `adapter_guard.install` sets `module.forward = guarded`. **So every guarded module reads DISPLACED from the moment that guard merged.** Verified, not assumed: the failing benchmark's branch (`1548-substrate`, merged #1142) has `2e8b015e` (#1139) as an ancestor.

Field cost: sd15, 12/12 requests on **both** arms, `dispatch: DISPLACED on UNet2DConditionModel`. A GPU leg stopped, the card released. **The arm was healthy the whole time; the question was wrong.**

## The reconciliation #1591 deliberately left open — settled with evidence

The issue refused to pick between "the message overcounts" and "a second compiled target is executing", and was right to. **Neither. The message overcounted, and there is no second target.** Reproduced in-process at $0:

```
served ZEROS (compiled) ? True
facts  : {'module_calls': 1, 'compiled_graph_calls': 1, 'eager_calls': 0,
          'armed_modules': 1, 'armed_graphs': 1, 'displaced_modules': ['Toy']}
summary: dispatch: DISPLACED on Toy — ... so all 1 call(s) ran eager
```

`compiled_graph_calls=1`, `eager_calls=0`, the module returning the compiled result — beside a sentence asserting the opposite. The displaced branch **inferred** "all N ran eager" from a flag instead of reading the counter sitting next to it. That is why 120 AOTI wrapper invocations per arm coexisted with an all-eager verdict: both observations were real and the message was the wrong one.

## The fix

- **`adapter_guard.dispatcher_of` is public and is the ONE resolver.** It resolves *through* wrappers, so adding a wrapper is no longer a change every reader has to learn about. A module it cannot resolve is genuinely displaced — accelerate restoring `_old_forward` after an offload rung is the real shape of that — and still reports so.
- **The displaced summary states both facts** — displacement, and what the counter measured (`… still served COMPILED` vs `… ran eager`).
- **The three-leg adopt test installs the DAEMON's witness.** It asserted on a loader stub's call list; `cli/daemon.py` installs a `DispatchCounter` after `host.setup` and prints its verdict per request. That omission is exactly why the legs stayed green against a displacing daemon — the coordinator's *"the green test is the more interesting half"*, confirmed. All three legs now take the daemon's reading and refuse a displaced arm.

## Red arms

Restore the old predicate → **all three legs go red with the field's own signature**, including the contradiction itself in a test:

```
displaced_modules=['TinyUnet']  beside  compiled_graph_calls=4, eager_calls=0
```

Plus a unit row pinning both forms of the displaced summary, so the sentence cannot drift back into an inference.

mypy clean (599 files) · ruff clean · 34 targeted tests green.

## Not addressed here, deliberately

The **16-byte alignment copy** on every compiled call is a second finding and a real per-call tax. It needs the module identified first, and pgw already owns alignment machinery whose v1 home (`aot_serve.AOTI_ALIGNMENT`, `RECAST_TARGETS`) went with the orphaned tier in #1135 — so it wants its own issue against the v2 ingress rather than a rushed port. Filing separately.