### PR TITLE
pgw#1548: score the premise from the COUNTER, not from a defect's warning string

### DIFF
--- a/benchmarks/dynamic_dims_pgw1548.py
+++ b/benchmarks/dynamic_dims_pgw1548.py
@@ -125,7 +125,13 @@ class Sample:
     seconds: float
     round: int = 0
     load1: float = 0.0
-    served: str = ""
+    #: THE MEASURED dispatch facts for THIS request, read off the response
+    #: envelope (`gen-worker run --json` carries `dispatch`). Not inferred from
+    #: a log string, and not a proxy: pgw#1591 was an instrument that INFERRED
+    #: "all N ran eager" from a flag instead of reading the counter beside it.
+    compiled_calls: int = 0
+    eager_calls: int = 0
+    displaced: tuple[str, ...] = ()
 
 
 @dataclass
@@ -272,6 +278,20 @@ class Table:
     def as_dict(self) -> dict[str, Any]:
         return {
             "samples": [vars(s) for s in self.samples],
+            # The premise, carried BESIDE the timings so a reader cannot take
+            # the numbers without the evidence that they measured compiled
+            # serving at all.
+            "dispatch": {
+                f"{arm}": {
+                    "compiled_calls": sum(
+                        s.compiled_calls for s in self.samples if s.arm == arm
+                    ),
+                    "eager_calls": sum(
+                        s.eager_calls for s in self.samples if s.arm == arm
+                    ),
+                }
+                for arm in self.arms()
+            },
             "rounds": self.rounds(),
             "control_spread_pct": {
                 f"{aspect}/{cfg}": self.spread("static", aspect, cfg)
@@ -472,10 +492,42 @@ class Bench:
                 f"[{arm}] request {aspect}/{cfg} failed:\n"
                 f"{result.stdout}\n{result.stderr}"
             )
+        facts = self._dispatch_facts(arm, result.stdout)
         return Sample(
             arm=arm, aspect=aspect, cfg=cfg, seconds=elapsed,
             round=round_index, load1=os.getloadavg()[0],
+            compiled_calls=int(facts.get("compiled_graph_calls", 0) or 0),
+            eager_calls=int(facts.get("eager_calls", 0) or 0),
+            displaced=tuple(facts.get("displaced_modules") or ()),
         )
+
+    def _dispatch_facts(self, arm: str, stdout: str) -> dict[str, Any]:
+        """The `dispatch` block of the response envelope, or a typed refusal.
+
+        `gen-worker run --json` prints the raw envelope and the serving path
+        puts `DispatchCounts.facts()` in it, so every request carries its own
+        compiled/eager counts. An envelope without them is not a request this
+        harness can score: it would leave the premise unmeasured, which is
+        exactly how pgw#1591 nearly shipped a table of eager timings.
+        """
+
+        envelope: dict[str, Any] = {}
+        for line in reversed((stdout or "").splitlines()):
+            line = line.strip()
+            if line.startswith("{"):
+                try:
+                    envelope = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                break
+        facts = envelope.get("dispatch")
+        if not isinstance(facts, dict):
+            raise SystemExit(
+                f"[{arm}] the response envelope carries no `dispatch` facts, so "
+                f"nothing measures whether this request served COMPILED. "
+                f"Refusing to score it."
+            )
+        return facts
 
     def prepare(self, name: str) -> Path:
         """Lock + compile ONE arm. The card cost, paid once per arm."""
@@ -516,13 +568,13 @@ class Bench:
             first = True
             for aspect in self.args.aspects:
                 for cfg in self.args.cfg:
-                    self.request(room, name, aspect, cfg, round_index)
+                    warmup = self.request(room, name, aspect, cfg, round_index)
                     if first:
                         # The warm-up call has now exercised the serve path
-                        # once. Check the PREMISE here, at the cheapest
-                        # possible point, before paying for the rest of the
-                        # arm — let alone the other arm.
-                        self.assert_compiled(name)
+                        # once and CARRIES ITS OWN COUNTS. Check the premise
+                        # here, at the cheapest possible point, before paying
+                        # for the rest of the arm — let alone the other arm.
+                        self.assert_compiled(name, warmup)
                         first = False
                     for _ in range(self.args.reps):
                         self.table.add(
@@ -531,41 +583,41 @@ class Bench:
         finally:
             self.down(room)
 
-    def assert_compiled(self, arm: str) -> None:
-        """Did this arm actually SERVE compiled? Typed abort if not (pgw#1591).
+    def assert_compiled(self, arm: str, sample: Sample) -> None:
+        """Did THIS request actually serve compiled? Typed abort if not.
 
-        A warning was not enough. An arm whose dispatcher was displaced serves
-        eager on every call and still produces perfectly plausible timings —
-        and two such arms compare to ~0%, which reads as "the dynamic axis is
-        free" rather than as "nothing was measured". So an arm that cannot
-        show compiled serving does not get to contribute a row.
+        Reads the MEASURED counts off the request's own envelope. It used to
+        prove compiled serving by grepping the daemon log for `wrapper.tcg` —
+        a string that exists only because of the alignment defect pgw#1593 is
+        fixing. That check would have started aborting every HEALTHY arm the
+        moment someone fixed that defect: an instrument whose green depends on
+        another bug staying unfixed. The counter is the real evidence and it
+        survives both fixes.
+
+        Displacement is no longer read as "everything ran eager" either
+        (pgw#1591): it is a separate fact, and a displaced module can still
+        have served compiled calls. So the bar is what it always should have
+        been — compiled calls happened, and none fell through.
         """
 
-        log = self._daemon_log.get(arm)
-        if log is None or not log.exists():
+        if sample.compiled_calls <= 0:
             raise SystemExit(
-                f"[{arm}] daemon log {log} is absent — nothing can verify this "
-                f"arm serves compiled. Refusing to measure."
+                f"[{arm}] ZERO compiled calls on the warm-up request "
+                f"(eager_calls={sample.eager_calls}, "
+                f"displaced={list(sample.displaced)}). This arm serves EAGER; "
+                f"two such arms compare to ~0% and read as 'the axis is free'. "
+                f"Refusing to measure. See {self._daemon_log.get(arm)}"
             )
-        text = log.read_text(errors="replace")
-        if "DISPLACED" in text:
+        if sample.eager_calls:
             raise SystemExit(
-                f"[{arm}] DISPLACED: the compiled dispatcher is no longer the "
-                f"module's forward, so calls ran EAGER (pgw#1591). Both arms "
-                f"would compare eager-to-eager and report ~0%. Refusing to "
-                f"measure. See {log}"
+                f"[{arm}] MIXED execution on the warm-up request: "
+                f"{sample.compiled_calls} compiled and {sample.eager_calls} "
+                f"eager call(s). A wall that is part compiled and part eager "
+                f"is not this axis's cost. Refusing to measure."
             )
-        if "NO armed graph matched" in text:
-            raise SystemExit(
-                f"[{arm}] the dispatcher matched NOTHING (tcg#76's trace is in "
-                f"{log}); this arm serves eager. Refusing to measure."
-            )
-        if "wrapper.tcg" not in text:
-            raise SystemExit(
-                f"[{arm}] no compiled wrapper ran during the warm-up call, so "
-                f"this arm has not been shown to serve compiled at all. "
-                f"Refusing to measure. See {log}"
-            )
+        if sample.displaced:
+            print(f"[{arm}] note: displaced={list(sample.displaced)} while "
+                  f"{sample.compiled_calls} call(s) still served compiled")
 
     def report(self) -> dict[str, Any]:
         adoption = {}

--- a/tests/test_dynamic_dims_harness_pgw1548.py
+++ b/tests/test_dynamic_dims_harness_pgw1548.py
@@ -145,61 +145,70 @@ def test_the_substrate_note_is_carried_into_every_rendered_table() -> None:
     assert "| 1:1 | on |" in rendered
 
 
-def _armed(tmp_path: Path, arm: str, text: str) -> Any:
-    """A bench whose named arm has a daemon log carrying `text`."""
+def _sample(compiled: int, eager: int, displaced: tuple = ()) -> Any:
+    return harness.Sample(
+        arm="static", aspect="1:1", cfg="on", seconds=1.0,
+        compiled_calls=compiled, eager_calls=eager, displaced=displaced,
+    )
 
-    log = tmp_path / f"{arm}-daemon.log"
-    log.write_text(text)
+
+def test_an_arm_serving_ZERO_compiled_calls_REFUSES(tmp_path: Path) -> None:
+    """pgw#1591's lesson, keyed on the COUNT rather than on a log string."""
+
     bench = _bench(tmp_path)
-    bench._daemon_log = {arm: log}
-    return bench
+    bench._daemon_log = {}
+    with pytest.raises(SystemExit, match="ZERO compiled calls"):
+        bench.assert_compiled("static", _sample(compiled=0, eager=21))
 
 
-def test_a_DISPLACED_arm_REFUSES_to_contribute_a_row(tmp_path: Path) -> None:
-    """pgw#1591: two displaced arms compare to ~0% and read as 'free'.
+def test_MIXED_execution_REFUSES(tmp_path: Path) -> None:
+    """Part compiled, part eager is not this axis's cost."""
 
-    This is the whole reason it is an abort and not a warning — the numbers a
-    displaced arm produces are perfectly plausible and entirely meaningless.
+    bench = _bench(tmp_path)
+    bench._daemon_log = {}
+    with pytest.raises(SystemExit, match="MIXED execution"):
+        bench.assert_compiled("static", _sample(compiled=10, eager=11))
+
+
+def test_a_DISPLACED_module_that_STILL_SERVED_COMPILED_is_allowed(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """pgw#1591's fix: displacement and dispatch are SEPARATE facts.
+
+    The old check aborted on the word DISPLACED alone. After #1591 a displaced
+    module can still have served every call compiled, and refusing that would
+    throw away a valid arm for a flag that no longer implies what it used to.
     """
 
-    bench = _armed(tmp_path, "static", (
-        "wrapper.tcg run_impl\n"
-        "dispatch: DISPLACED on UNet2DConditionModel — the compiled dispatcher "
-        "is no longer this module's forward, so all 21 call(s) ran eager\n"
-    ))
-    with pytest.raises(SystemExit, match="DISPLACED"):
-        bench.assert_compiled("static")
-
-
-def test_an_arm_that_MATCHED_NOTHING_refuses(tmp_path: Path) -> None:
-    """tcg#76's trace means the guards refused every armed record."""
-
-    bench = _armed(tmp_path, "aspect",
-                   "torchcg dispatch: NO armed graph matched a call on UNet\n")
-    with pytest.raises(SystemExit, match="matched NOTHING"):
-        bench.assert_compiled("aspect")
-
-
-def test_an_arm_with_NO_compiled_wrapper_at_all_refuses(tmp_path: Path) -> None:
-    """Silence is not success: no wrapper ran, so nothing was shown."""
-
-    bench = _armed(tmp_path, "static", "ready — functions: generate\n")
-    with pytest.raises(SystemExit, match="not been shown to serve compiled"):
-        bench.assert_compiled("static")
-
-
-def test_an_absent_daemon_log_refuses_rather_than_assuming(tmp_path: Path) -> None:
     bench = _bench(tmp_path)
-    bench._daemon_log = {"static": tmp_path / "nope.log"}
-    with pytest.raises(SystemExit, match="absent"):
-        bench.assert_compiled("static")
+    bench._daemon_log = {}
+    bench.assert_compiled("static", _sample(compiled=21, eager=0, displaced=("UNet",)))
+    assert "still served compiled" in capsys.readouterr().out
 
 
-def test_a_genuinely_compiled_arm_PASSES(tmp_path: Path) -> None:
-    """The green arm: a wrapper ran, nothing displaced, nothing unmatched."""
+def test_a_clean_compiled_arm_PASSES(tmp_path: Path) -> None:
+    bench = _bench(tmp_path)
+    bench._daemon_log = {}
+    bench.assert_compiled("static", _sample(compiled=21, eager=0))
 
-    bench = _armed(tmp_path, "static", (
-        "gen-worker up: ready\n"
-        "[W] cw54nq...wrapper.tcg.cpp:26541 Warning: run_impl\n"
-    ))
-    bench.assert_compiled("static")
+
+def test_an_envelope_without_dispatch_facts_REFUSES(tmp_path: Path) -> None:
+    """No counter means the premise is unmeasured — the pgw#1591 near-miss."""
+
+    bench = _bench(tmp_path)
+    with pytest.raises(SystemExit, match="no `dispatch` facts"):
+        bench._dispatch_facts("static", '{"ok": true, "result": {}}')
+
+
+def test_the_facts_are_read_off_the_real_envelope_shape(tmp_path: Path) -> None:
+    """The shape `gen-worker run --json` actually prints."""
+
+    envelope = {
+        "ok": True,
+        "dispatch": {
+            "module_calls": 21, "compiled_graph_calls": 21, "eager_calls": 0,
+            "armed_modules": 1, "armed_graphs": 14, "displaced_modules": [],
+        },
+    }
+    facts = _bench(tmp_path)._dispatch_facts("static", json.dumps(envelope))
+    assert facts["compiled_graph_calls"] == 21


### PR DESCRIPTION
Re-verifying the displaced-arm abort against pgw#1591's fix (as asked) found it
resting on two string proxies — one of them actively dangerous.

**It proved compiled serving by grepping the daemon log for `wrapper.tcg`** — a
string that exists *only because* of the alignment defect **pgw#1593 is now
fixing**. The moment that lands, the check starts aborting every **healthy**
arm. An instrument whose green depends on another bug staying unfixed is not an
instrument.

**It aborted on the word `DISPLACED` alone.** After #1591, displacement and
dispatch are separate facts and a displaced module can still have served every
call compiled — so that rule would now throw away valid arms.

## The fix: measure it

`gen-worker run --json` carries `DispatchCounts.facts()` in the response
envelope, so:

- every request records its own `compiled_calls` / `eager_calls` / `displaced`
  on its `Sample`;
- the verdict JSON carries per-arm dispatch totals **beside** the timings, so a
  reader cannot take the numbers without the evidence they measured compiled
  serving;
- the warm-up check refuses on what it **measured** — zero compiled calls, or
  mixed compiled/eager execution (a wall that is part compiled and part eager
  is not this axis's cost);
- an envelope with **no** `dispatch` block is itself a refusal: an unmeasured
  premise is exactly how #1591 nearly shipped a table of eager timings.

## Red arms

Six, including the case #1591 created: **displaced AND fully compiled now
PASSES**, with a note. Plus zero-compiled, mixed, missing-envelope, the real
envelope shape, and a clean arm.

ruff + mypy clean on CI's exact targets.