### PR TITLE
pgw#1595/#1586: the confession states the decision, and the reserve stops being a guess from the wrong configuration

### DIFF
--- a/changelog.d/pgw1586.md
+++ b/changelog.d/pgw1586.md
@@ -1,0 +1,37 @@
+- **pgw#1595: the offload confession states the DECISION'S input, not a post-placement re-read.**
+  `_report_offload_engaged` was calling `get_available_vram_gb()` at report time — after the
+  weights landed — so a rung chosen against 7.3 GiB of free VRAM printed `free_gb=0.4` beside
+  its own name. A P1 issue was filed against the wrong cause on the strength of that line. The
+  loud line now carries the plan-time figure, plus `plan_budget_gb`, `plan_peak_gb` and the
+  post-placement `free_after_gb`, which is a real and different fact.
+- **pgw#1595: the residency reserve comes from the REQUEST, not a constant.**
+  `PARTIAL_RESIDENT_RESERVE_GB` (1.25 GiB) was derived from ONE workload shape — pgw#1570's
+  20-step 1024² SDXL — and a 28-step job overran it, thrashing the allocator at 6.6 MB free.
+  The endpoint's declared `Resources.peak_vram_per_request_gb` was already reaching
+  `apply_low_vram_config` and being forwarded to `select_auto_mode`, but the residency planner
+  never received it. It does now: the activation share of the declared peak raises the reserve,
+  and the constant stays as a floor for endpoints that declare nothing.
+- **pgw#1559 class, in this rung's own code: a passing probe now leaves a measurement behind.**
+  `probe OK` was `log.info` while `PROBE REFUSED` was `log.warning`, so at the endpoint's
+  WARNING level "the probe passed" and "the probe never ran" were the same picture. The probe's
+  measured headroom is reported as `probe_free_gb` on the loud line.
+- **pgw#1586: `_applied_summary` no longer counts data as techniques.** It printed the KEY of
+  anything truthy, so pgw#1577's two data entries rendered as savers that engaged —
+  `vae_slicing,partial_resident,partial_resident_offloaded,partial_resident_bytes`, four names
+  for two techniques. Booleans print as names and everything else as `key=value`, so the
+  distinction is by TYPE and the next data entry cannot masquerade either.
+- **pgw#1595: the residency reserve is raised 1.25 → 2.00 GiB, because 1.25 was derived from
+  the WRONG residency configuration.** It came from pgw#1570's `model_offload` run — 5956 MiB
+  peak over 5437 MiB of weights, so 519 MiB of activations. That figure does not transfer to
+  this rung: pgw#1586's own GREEN arm measured **7540 MiB peak over 5693 MiB of resident
+  weights — 1847 MiB, 3.6× larger.** Under `model_offload` the denoiser is freed and
+  re-allocated every request so the pool churns and blocks are reused; under
+  `partial_resident` the weights are pinned for the process's life and activations come out of
+  what is left, carrying fragmentation the offloaded rung never pays. **The rung was
+  under-reserved from the day it shipped**, which is why one leg survived by 13.5 MB and
+  another thrashed at 6.6 MB. Consequence, stated rather than discovered later: the rung needs
+  `free − reserve ≥ 5.31 GiB`, so on a 7.62 GiB card it is now only available above ~7.31 GiB
+  free and will often refuse to `model_offload` — the honest answer, not a regression. Fleet
+  cards (12/16/24 GiB) never demote this far and are unaffected. **TEMPORARY:** a constant
+  standing in for a measurement, replaced by the per-endpoint measured peak
+  (`reserve_source=measured`) when that lands.

--- a/changelog.d/pgw1586.md
+++ b/changelog.d/pgw1586.md
@@ -35,3 +35,20 @@
   cards (12/16/24 GiB) never demote this far and are unaffected. **TEMPORARY:** a constant
   standing in for a measurement, replaced by the per-endpoint measured peak
   (`reserve_source=measured`) when that lands.
+- **pgw#1586: the residency probe counts the reusable allocator pool as available.** A parked
+  component's blocks stay in the caching allocator's pool — `park()` drops the reference, the
+  allocator keeps the block, and `mem_get_info` never sees it return — so the same bytes were
+  counted as freed by the plan and as used by the probe. Measured on the card:
+  `driver_free 0.45 + reusable cache 1.56 = 2.01 GiB` against a 2.00 GiB reserve, i.e. the
+  reserve was honoured all along and the probe was reading a number 1.56 GiB too small. It
+  could therefore **spuriously refuse a workable plan** — the conservative direction, which is
+  why nothing had failed from it. The floor is now checked against `driver_free + attr_cache`,
+  while the *reported* figure stays driver-free. Cache is **soft** availability, not a hard
+  budget term: cached bytes are not contiguous bytes, and the 214 allocator retries this leg
+  logged are that discount at runtime.
+- **pgw#1586: `_placement_attribution` splits what the process holds on the card four ways** —
+  `attr_alloc` (live tensors), `attr_cache` (`reserved − allocated`, reusable but invisible to
+  driver-free), `attr_ctx` (`(total − driver_free) − reserved`, CUDA context and workspaces),
+  and driver-free — all on the loud line. On the campaign card the split closes to within
+  0.005 GiB of the card total, and it is what falsified two successive explanations of where
+  the memory went, including one of mine.

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -1488,8 +1488,13 @@ def _execution_device() -> Any:
     return "cuda:0"
 
 
+#: Where the last residency reserve came from, for the confession to state.
+_LAST_RESERVE: Dict[str, Any] = {}
+
+
 def _plan_partial_resident(
     pipeline: Any, log: logging.Logger, *, min_moved_bytes: int = 0,
+    peak_vram_gb: Optional[float] = None, model_size_gb: Optional[float] = None,
 ) -> Any:
     """The pgw#1577 component-residency plan, or None to keep ``model_offload``.
 
@@ -1507,9 +1512,44 @@ def _plan_partial_resident(
         free_gb = get_available_vram_gb()
         if free_gb <= 0.0:
             return None
+        # pgw#1595/#1586 item 5. THE RESERVE MUST COME FROM THE REQUEST, NOT A
+        # CONSTANT. `PARTIAL_RESIDENT_RESERVE_GB` was derived from ONE workload
+        # shape (pgw#1570's 20-step 1024^2 SDXL); a 28-step job overran it and
+        # thrashed the allocator at 6.6 MB free. The endpoint's DECLARED
+        # per-request peak is already in this function's caller and was being
+        # dropped on the floor — `select_auto_mode` gets it, this planner did
+        # not. `peak_vram_gb` is a TOTAL requirement, so the activation share is
+        # what it asks for beyond the weights; the constant stays as a FLOOR for
+        # endpoints that declare nothing or under-declare.
+        reserve_gb = PARTIAL_RESIDENT_RESERVE_GB
+        # NOT A COSMETIC FIELD. Measured 2026-08-20: ZERO of the 26 shipped
+        # endpoints declare `peak_vram_per_request_gb`, so on every real serve
+        # today this reserve is an ASSUMPTION carried over from one workload
+        # shape, not a measurement of this one. pgw#1595's 28-step job overran
+        # it. Until endpoints declare, the honest thing the log can do is say
+        # which of the two it used.
+        reserve_source = "default"
+        declared = 0.0
+        if peak_vram_gb is not None and peak_vram_gb > 0.0:
+            weights_gb = (
+                model_size_gb if model_size_gb is not None
+                else estimate_pipeline_size_gb(pipeline)
+            )
+            declared = max(0.0, float(peak_vram_gb) - float(weights_gb))
+            reserve_source = "declared" if declared > reserve_gb else "default"
+            if declared > reserve_gb:
+                log.info(
+                    "low_vram: partial_resident reserve %.2f -> %.2f GiB, from "
+                    "the endpoint's declared per-request peak (%.2f GiB total, "
+                    "%.2f GiB of weights)",
+                    reserve_gb, declared, float(peak_vram_gb), float(weights_gb),
+                )
+                reserve_gb = declared
+        _LAST_RESERVE.clear()
+        _LAST_RESERVE.update(reserve_gb=reserve_gb, reserve_source=reserve_source)
         plan = plan_for_pipeline(
             pipeline,
-            budget_bytes=int(max(0.0, free_gb - PARTIAL_RESIDENT_RESERVE_GB) * _GIB),
+            budget_bytes=int(max(0.0, free_gb - reserve_gb) * _GIB),
             free_bytes=int(free_gb * _GIB),
             sizer=lambda m: module_storage_bytes(m),
             forced_resident=unhookable_components(pipeline),
@@ -2219,6 +2259,7 @@ def component_placement_census(pipeline: Any) -> str:
 
 def _report_offload_engaged(
     pipeline: Any, rung: str, applied: Dict[str, Any], log: logging.Logger,
+    *, plan_free_gb: Optional[float] = None,
 ) -> None:
     """THE offload-activation confession — one home for every route into a
     CPU-touching rung (pgw#1312).
@@ -2237,7 +2278,15 @@ def _report_offload_engaged(
     placement has already succeeded when this runs.
     """
     needed_gb = estimate_pipeline_size_gb(pipeline)
-    free_gb = get_available_vram_gb()
+    # pgw#1595. THE LINE STATES THE DECISION, SO IT MUST STATE THE DECISION'S
+    # INPUT. This used to re-read free VRAM HERE — after placement — so a rung
+    # chosen against 7.3 GiB printed `free_gb=0.4` beside its own name, and a
+    # whole issue was filed against the wrong cause on the strength of it. The
+    # plan-time figure is authoritative when the rung recorded one; the
+    # post-placement figure is still reported, as `free_after_gb`, because "what
+    # the card looks like now" is a real and different fact.
+    free_after_gb = get_available_vram_gb()
+    free_gb = free_after_gb if plan_free_gb is None else plan_free_gb
     _confess_serve_degrade(
         phase=OFFLOAD_ENGAGED_PHASE,
         line=transition_line(
@@ -2246,7 +2295,8 @@ def _report_offload_engaged(
             detail=f"CPU offload ENGAGED ({_applied_summary(applied)}); every "
                    f"forward on this pipeline now moves weights over PCIe; "
                    f"{attention_kernel_census(pipeline)}; "
-                   f"{component_placement_census(pipeline)}",
+                   f"{component_placement_census(pipeline)}; "
+                   f"free_after_gb={free_after_gb:.1f}",
         ),
         detail=(
             f"pipeline={type(pipeline).__name__}: CPU offload ENGAGED at rung "
@@ -2488,7 +2538,9 @@ def apply_low_vram_config(
     # only honest place to decide.
     partial_resident_plan = None
     if effective_mode == "model_offload":
-        partial_resident_plan = _plan_partial_resident(pipeline, log)
+        partial_resident_plan = _plan_partial_resident(
+            pipeline, log, peak_vram_gb=peak_vram_gb, model_size_gb=model_size_gb,
+        )
         if partial_resident_plan is not None:
             effective_mode = "partial_resident"
 
@@ -2614,15 +2666,18 @@ def apply_low_vram_config(
         # every attempt is at load: no OOM can reach a request from here.
         plan = partial_resident_plan
         armed = False
+        probe_facts: Dict[str, Any] = {}
         for _ in range(_MAX_PROBE_ATTEMPTS):
             armed = apply_component_residency(
                 pipeline, plan, device=_execution_device(), log=log,
                 free_bytes_now=lambda: int(get_available_vram_gb() * _GIB),
+                facts=probe_facts,
             )
             if armed:
                 break
             nxt = _plan_partial_resident(
-                pipeline, log, min_moved_bytes=plan.offloaded_bytes
+                pipeline, log, min_moved_bytes=plan.offloaded_bytes,
+                peak_vram_gb=peak_vram_gb, model_size_gb=model_size_gb,
             )
             if nxt is None:
                 break
@@ -2631,8 +2686,25 @@ def apply_low_vram_config(
             applied["partial_resident"] = True
             applied["partial_resident_offloaded"] = list(plan.offloaded)
             applied["partial_resident_bytes"] = plan.offloaded_bytes
+            # The decision's own arithmetic, on the LOUD line. pgw#1595: these
+            # lived at INFO and vanished at the endpoint's WARNING level, so the
+            # only surviving diagnostic was the misleading one.
+            applied["plan_budget_gb"] = plan.budget_bytes / _GIB
+            applied["reserve_gb"] = float(_LAST_RESERVE.get("reserve_gb", 0.0))
+            applied["reserve_source"] = str(
+                _LAST_RESERVE.get("reserve_source", "default"))
+            applied["plan_peak_gb"] = plan.transient_peak_bytes / _GIB
+            probe_free = probe_facts.get("probe_free_bytes")
+            if probe_free is not None:
+                # Probe SUCCESS was `log.info` and therefore inaudible, which
+                # makes "probe passed" and "probe never ran" the same picture
+                # (pgw#1559 class). It is a number now, on the loud line.
+                applied["probe_free_gb"] = float(probe_free) / _GIB
             setattr(pipeline, _COZY_MODE_ATTR, "partial_resident")
-            _report_offload_engaged(pipeline, "partial_resident", applied, log)
+            _report_offload_engaged(
+                pipeline, "partial_resident", applied, log,
+                plan_free_gb=plan.free_bytes / _GIB,
+            )
             return applied
         # Same discipline as `partial_stream`: a rung the operator was told
         # about and did not get is a placement lie. Confess and descend.
@@ -2689,8 +2761,28 @@ def apply_low_vram_config(
 
 
 def _applied_summary(applied: Dict[str, Any]) -> str:
-    keys = [k for k, v in applied.items() if v and k not in ("mode", "already_applied")]
-    return ",".join(keys) or "none"
+    """The engaged savers, and the numbers beside them — TYPED APART.
+
+    pgw#1586 item 3: this used to print the KEY of anything truthy, so pgw#1577's
+    two DATA entries rendered as if they were savers that engaged
+    (``vae_slicing,partial_resident,partial_resident_offloaded,partial_resident_bytes``
+    — four names for two techniques). The distinction is by TYPE, not by an
+    allowlist, so the next data entry anyone adds cannot masquerade either.
+    """
+    names: List[str] = []
+    values: List[str] = []
+    for k, v in applied.items():
+        if k in ("mode", "already_applied") or not v:
+            continue
+        if isinstance(v, bool):
+            names.append(k)
+        elif isinstance(v, float):
+            values.append(f"{k}={v:.2f}")
+        elif isinstance(v, (list, tuple)):
+            values.append(f"{k}={'+'.join(str(x) for x in v)}")
+        else:
+            values.append(f"{k}={v}")
+    return ",".join(names + values) or "none"
 
 
 def _should_auto_disk_offload() -> bool:

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -2694,6 +2694,11 @@ def apply_low_vram_config(
             applied["reserve_source"] = str(
                 _LAST_RESERVE.get("reserve_source", "default"))
             applied["plan_peak_gb"] = plan.transient_peak_bytes / _GIB
+            for _k, _lbl in (("attr_alloc_bytes", "attr_alloc_gb"),
+                             ("attr_cache_bytes", "attr_cache_gb"),
+                             ("attr_ctx_bytes", "attr_ctx_gb")):
+                if _k in probe_facts:
+                    applied[_lbl] = float(probe_facts[_k]) / _GIB
             probe_free = probe_facts.get("probe_free_bytes")
             if probe_free is not None:
                 # Probe SUCCESS was `log.info` and therefore inaudible, which

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -104,15 +104,36 @@ PARTIAL_RESIDENT_UNARMED_PHASE = "partial_resident_unarmed"
 _TRANSIENT_RESERVE_BYTES = 512 * (1 << 20)
 
 #: The activation headroom this rung reserves, and it is NOT
-#: ``memory._DEFAULT_SAFETY_MARGIN_GB``. That 2.0 GiB is a PLACEMENT heuristic
-#: for the resident-vs-offload decision, deliberately pessimistic because it
-#: guards a rung with no offload at all. Here the measurement exists: pgw#1570
-#: recorded SDXL 1024^2 batch-2 CFG at a 5956 MiB peak with 5437 MiB of weights
-#: resident — **519 MiB of activations**. 1.25 GiB is 2.4x that, and holding
-#: back 2.0 would refuse the plan that keeps the denoiser resident, which is
-#: Paul's ruling inverted: *"if the space is available, and it helps us run
-#: faster, why wouldn't varena take it?"*
-PARTIAL_RESIDENT_RESERVE_GB = 1.25
+#: ``memory._DEFAULT_SAFETY_MARGIN_GB``'s twin by accident any more — see below.
+#:
+#: ⚠️ **RAISED 1.25 -> 2.00 GiB, 2026-08-20 (pgw#1595, coordinator ruling). THE 1.25 WAS
+#: DERIVED FROM THE WRONG RESIDENCY CONFIGURATION AND WAS UNDER-SIZED FROM THE DAY IT
+#: SHIPPED.** It came from pgw#1570's ``model_offload`` run — 5956 MiB peak over 5437 MiB of
+#: weights, so **519 MiB** of activations. That number does not transfer to THIS rung, and
+#: pgw#1586's own GREEN arm proves it: 7540 MiB peak over 5693 MiB of resident weights is
+#: **1847 MiB = 1.80 GiB**, 3.6x the figure the constant was built on.
+#:
+#: The two configurations differ in the allocator, not in the maths. Under ``model_offload``
+#: the denoiser is freed and re-allocated every request, so the pool churns and blocks are
+#: reused; under ``partial_resident`` the weights are PINNED in the pool for the process's
+#: life and activations must come out of what is left, so the high-water mark carries
+#: fragmentation the offloaded rung never pays.
+#:
+#: 2.00 = the measured 1.80 plus margin. It is also what the safer plan needs: at 2.00 the
+#: search takes BOTH encoders (peak 6.70 GiB, ~1.1 GiB of headroom) instead of the single
+#: encoder the 1.25 admitted (peak 6.95, **268 MB** of headroom — the configuration that
+#: survived pgw#1586's leg by 13.5 MB and thrashed pgw#1595's by 6.6 MB).
+#:
+#: **CONSEQUENCE, STATED RATHER THAN DISCOVERED LATER:** the rung needs
+#: ``free - reserve >= 5.31 GiB`` (the forced unet+vae set), so at 2.00 it is only available
+#: above **~7.31 GiB free**. On this 7.62 GiB card that means a nearly-empty card and the rung
+#: will often REFUSE to ``model_offload`` — which is the honest answer, not a regression. On
+#: fleet cards (12/16/24 GiB) SDXL never demotes this far and none of this applies.
+#:
+#: **TEMPORARY.** This is a constant standing in for a measurement, sized to the worst shape
+#: we have actually run. It is replaced by the per-endpoint measured peak (pgw#1586 item (c),
+#: ``reserve_source=measured``) as soon as that lands.
+PARTIAL_RESIDENT_RESERVE_GB = 2.00
 
 #: What the ON-CARD PROBE demands still be free with the largest evicted
 #: component onloaded. The arithmetic above is an ESTIMATE — measured on the
@@ -550,6 +571,7 @@ def apply_component_residency(
     device: Any,
     log: logging.Logger,
     free_bytes_now: Any = None,
+    facts: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """Arm ``plan`` on ``pipeline``, PROBING it on the card first. Returns
     whether it armed.
@@ -598,6 +620,12 @@ def apply_component_residency(
             return False
         if free_bytes_now is not None:
             ok, free = probe_plan(parked, free_bytes_now=free_bytes_now)
+            # The probe's MEASUREMENT, handed back so the caller can put it on
+            # the loud line. pgw#1595: success was `log.info` and inaudible at
+            # the endpoint's WARNING level, which makes "probe passed" and
+            # "probe never ran" the same picture (pgw#1559 class).
+            if facts is not None:
+                facts["probe_free_bytes"] = int(free)
             if not ok:
                 log.warning(
                     "partial_resident: PROBE REFUSED %s — onloading the largest "

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -513,6 +513,41 @@ def _install_residency_hooks(
     log.debug("partial_resident: hooks installed for %s", ",".join(parked))
 
 
+def _placement_attribution(torch_mod: Any) -> Dict[str, int]:
+    """Split what the PROCESS holds on the card into its four real parts.
+
+    pgw#1586: the budget subtracts a reserve from DRIVER-level free
+    (``mem_get_info``), but the resident SET is sized in WEIGHT BYTES — so
+    everything the process holds that is not a weight is spent out of the
+    reserve before the first activation, invisibly. Measured on the campaign
+    card: arithmetic said ~2.1 GiB should remain for activations and the probe
+    read 0.45. Attribution, not inference, is the only way to say where the
+    difference went, so the four parts are read from the allocator itself:
+
+    * ``alloc`` — live tensors. The weights, and what the plan actually sized.
+    * ``cache`` — ``reserved - allocated``: blocks the allocator holds and WILL
+      reuse for activations, but which driver-free counts as gone. A parked
+      component's device blocks land here: ``park()`` drops the reference, the
+      caching allocator keeps the block, and ``mem_get_info`` never sees it come
+      back without ``empty_cache()``.
+    * ``ctx`` — ``(total - driver_free) - reserved``: the CUDA context, cuDNN and
+      cuBLAS workspaces, and anything else outside the caching allocator.
+    * ``driver_free`` — what a fresh allocation can take from the driver.
+    """
+    out: Dict[str, int] = {}
+    try:
+        alloc = int(torch_mod.cuda.memory_allocated())
+        reserved = int(torch_mod.cuda.memory_reserved())
+        driver_free, total = torch_mod.cuda.mem_get_info()
+    except Exception:  # noqa: BLE001 - attribution must never fail a placement
+        return out
+    out["attr_alloc_bytes"] = alloc
+    out["attr_cache_bytes"] = max(0, reserved - alloc)
+    out["attr_ctx_bytes"] = max(0, (int(total) - int(driver_free)) - reserved)
+    out["attr_driver_free_bytes"] = int(driver_free)
+    return out
+
+
 def probe_plan(
     parked: Dict[str, ParkedComponent], *, free_bytes_now: Any,
     floor_bytes: int = _PROBE_FLOOR_BYTES,
@@ -531,8 +566,33 @@ def probe_plan(
     worst = max(parked.values(), key=lambda c: c.bytes)
     worst.onload()
     free = int(free_bytes_now())
+    cache = 0
+    try:
+        import torch
+
+        cache = int(_placement_attribution(torch).get("attr_cache_bytes", 0))
+    except Exception:  # noqa: BLE001 - a probe that cannot attribute still probes
+        cache = 0
     worst.park()
-    return free >= floor_bytes, free
+    # pgw#1586. THE FLOOR IS CHECKED AGAINST WHAT ACTIVATIONS CAN ACTUALLY HAVE,
+    # WHICH IS NOT DRIVER-FREE. A parked component's blocks stay in the caching
+    # allocator's pool: `park()` drops the reference, the allocator keeps the
+    # block, and `mem_get_info` never sees it return. So the same bytes were
+    # counted as freed by the plan and as used by this probe. Measured on the
+    # card: driver_free 0.45 + reusable cache 1.56 = 2.01 GiB against a 2.00 GiB
+    # reserve — the reserve was honoured all along and the probe was reading a
+    # number 1.56 GiB too small.
+    #
+    # ⚠️ CACHE IS *SOFT* AVAILABILITY, NOT A HARD BUDGET TERM. 1.56 GiB of
+    # cached blocks is not 1.56 GiB of CONTIGUOUS space, and the 214 allocator
+    # retries this leg logged ARE that discount showing up at runtime — the
+    # allocator freeing and remapping segments that do not fit the requested
+    # activation. Counting it here is right because the bug being fixed is a
+    # SPURIOUS REFUSAL and the failure mode past the probe is retries-and-serve,
+    # not a fatal (degrade-never-OOM holds). Do NOT promote this term into a
+    # hard budget: the measured-placement work should treat it as soft, with the
+    # retry count as the natural signal for how soft.
+    return (free + cache) >= floor_bytes, free
 
 
 def parks_module(target: Any) -> bool:
@@ -626,6 +686,7 @@ def apply_component_residency(
             # "probe never ran" the same picture (pgw#1559 class).
             if facts is not None:
                 facts["probe_free_bytes"] = int(free)
+                facts.update(_placement_attribution(torch))
             if not ok:
                 log.warning(
                     "partial_resident: PROBE REFUSED %s — onloading the largest "

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -566,3 +566,43 @@ def test_the_production_planner_leaves_room_for_the_reserve_it_planned_against()
         f"the admitted plan leaves {headroom} bytes for activations, under the "
         f"{PARTIAL_RESIDENT_RESERVE_GB} GiB reserve it was planned against"
     )
+
+
+def test_the_probe_counts_the_reusable_allocator_pool_as_available():
+    """pgw#1586. A parked component's blocks stay in the caching allocator's
+    pool — `park()` drops the reference, the allocator keeps the block, and
+    `mem_get_info` never sees it return. The plan counted those bytes as freed
+    while this probe counted them as used, so the SAME bytes were both.
+
+    Measured on the card: driver_free 0.45 + reusable cache 1.56 = 2.01 GiB
+    against a 2.00 GiB reserve. Reading driver-free alone made a workable plan
+    look 1.56 GiB short, which is a SPURIOUS REFUSAL — the conservative
+    direction, which is why nothing had failed from it yet.
+    """
+    import gen_worker.models.partial_resident as pr
+
+    pipe = _pipeline()
+    plan, armed = _arm(pipe)
+    assert armed
+    parked = getattr(pipe, PARKED_COMPONENTS_ATTR)
+
+    floor = 256 * _MIB
+    driver_free = 100 * _MIB          # on its own, below the floor
+    cache = 400 * _MIB                # reusable pool the allocator still holds
+
+    real_attr = pr._placement_attribution
+    pr._placement_attribution = lambda _t: {"attr_cache_bytes": cache}
+    try:
+        ok, reported = pr.probe_plan(
+            parked, free_bytes_now=lambda: driver_free, floor_bytes=floor)
+    finally:
+        pr._placement_attribution = real_attr
+
+    assert ok, (
+        "the probe refused a plan with 500 MiB genuinely available to "
+        "activations because only 100 MiB of it was visible to driver-free"
+    )
+    assert reported == driver_free, (
+        "the reported number must stay the DRIVER-free figure — the soft cache "
+        "term belongs in the decision, not in what the log claims is free"
+    )

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -62,14 +62,13 @@ def _plan(sizes, *, free_gb, budget_gb=None, forced=(), denoiser="unet", order=N
 # --------------------------------------------------------------------------
 
 
-def test_sdxl_on_a_7_3_gib_card_keeps_the_denoiser_and_evicts_the_encoders():
-    # free 7.3, reserve 1.25 -> budget 6.05. Weights 6.95; must free 0.90, and
-    # `vae` is forced resident on this family (the `force_upcast` one), so the
-    # fewest bytes that clear the BUDGET is {text_encoder_2} at 1.39 — whose
-    # transient peak is 6.95 of 7.3, 96%. MEASURED: that plan OOMs in the
-    # onload. The transient ceiling rejects it and the search takes both
-    # encoders at 1.64 for a 6.70 peak.
-    plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
+def test_sdxl_on_a_7_45_gib_card_keeps_the_denoiser_and_evicts_the_encoders():
+    # free 7.45, reserve 2.00 -> budget 5.45. `vae` is forced resident on this
+    # family (the `force_upcast` one) and unet+vae alone is 5.31, so the budget
+    # admits only the plan that evicts BOTH encoders: resident 5.31, peak 6.70.
+    # The single-encoder plan (resident 5.56) is excluded because 5.56 + the
+    # 2.00 reserve exceeds 7.45 — which is exactly what the reserve is for.
+    plan = _plan(_SDXL, free_gb=7.45, forced=("vae",), order=_SDXL_ORDER)
     assert plan.fits, plan.refusal
     assert plan.offloaded == ("text_encoder", "text_encoder_2")
     assert plan.resident == ("unet", "vae")
@@ -86,7 +85,10 @@ def test_a_busier_card_refuses_the_rung_rather_than_admitting_a_plan_that_ooms()
     # measured on this card and it is an OOM inside `ParkedComponent.onload`.
     plan = _plan(_SDXL, free_gb=7.1, forced=("vae",), order=_SDXL_ORDER)
     assert not plan.fits
-    assert "transient ceiling" in plan.refusal
+    # At the truthful 2.00 reserve the denoiser plus its activations no longer
+    # fit at all on this card, so the refusal comes from the BUDGET rather than
+    # the transient ceiling. Falling to `model_offload` is the honest answer.
+    assert "forced-resident set alone" in plan.refusal
 
 
 def test_fewest_bytes_wins_over_fewest_components():
@@ -119,7 +121,7 @@ def test_forced_resident_components_are_never_evicted():
     # own `_exclude_from_cpu_offload` does NOT achieve this — it is consulted
     # only for components absent from `model_cpu_offload_seq`, and `vae` is in
     # SDXL's — so this rung enforces it itself.
-    plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
+    plan = _plan(_SDXL, free_gb=7.45, forced=("vae",), order=_SDXL_ORDER)
     assert plan.fits, plan.refusal
     assert "vae" not in plan.offloaded
 
@@ -137,7 +139,7 @@ def test_the_transient_ceiling_rejects_a_plan_the_budget_alone_admits():
 
 
 def test_a_plan_that_fits_reports_the_arithmetic_it_used():
-    plan = _plan(_SDXL, free_gb=7.3, forced=("vae",), order=_SDXL_ORDER)
+    plan = _plan(_SDXL, free_gb=7.45, forced=("vae",), order=_SDXL_ORDER)
     assert plan.resident_bytes + plan.offloaded_bytes == sum(_SDXL.values())
     assert plan.resident_bytes <= plan.budget_bytes
     assert plan.transient_peak_bytes == plan.resident_bytes + _SDXL["text_encoder_2"]
@@ -397,3 +399,170 @@ def test_the_placement_census_reads_live_devices_not_the_flag_that_set_them():
         "a flag, not the tensors"
     )
     assert "vae@cpu" in moved
+
+
+# --------------------------------------------------------------------------
+# pgw#1595 / pgw#1586 — the confession states the DECISION, and the reserve
+# comes from the REQUEST
+# --------------------------------------------------------------------------
+
+
+def test_the_applied_summary_separates_techniques_from_their_numbers():
+    """pgw#1586 item 3. It used to print the KEY of anything truthy, so two data
+    entries rendered as savers that engaged — four names for two techniques. The
+    split is by TYPE so the next data entry cannot masquerade either."""
+    from gen_worker.models.memory import _applied_summary
+
+    line = _applied_summary({
+        "mode": "partial_resident",
+        "vae_slicing": True,
+        "partial_resident": True,
+        "vae_tiling": False,
+        "partial_resident_offloaded": ["text_encoder_2"],
+        "partial_resident_bytes": 1492501790,
+        "plan_budget_gb": 6.05,
+    })
+    techniques = [p for p in line.split(",") if "=" not in p]
+    assert techniques == ["vae_slicing", "partial_resident"], (
+        "a data entry is being counted as an engaged technique"
+    )
+    assert "partial_resident_offloaded=text_encoder_2" in line
+    assert "plan_budget_gb=6.05" in line
+
+
+def test_the_confession_reports_the_free_vram_the_DECISION_saw():
+    """RED ARM for pgw#1595, which was filed against the wrong cause because of
+    exactly this. The rung is chosen against free VRAM BEFORE placement; the old
+    line re-read it AFTER, so a plan made at 7.3 GiB printed `free_gb=0.4`
+    beside its own name."""
+    import gen_worker.models.memory as m
+
+    seen = {}
+
+    def fake_line(**kw):
+        seen.update(kw)
+        return "line"
+
+    real_line, real_free, real_size = (
+        m.transition_line, m.get_available_vram_gb, m.estimate_pipeline_size_gb)
+    m.transition_line = fake_line
+    m.get_available_vram_gb = lambda *a, **k: 0.4       # post-placement truth
+    m.estimate_pipeline_size_gb = lambda *a, **k: 6.5
+    try:
+        m._report_offload_engaged(
+            _pipeline(), "partial_resident", {"partial_resident": True},
+            logging.getLogger("t"), plan_free_gb=7.3,
+        )
+    finally:
+        m.transition_line, m.get_available_vram_gb, m.estimate_pipeline_size_gb = (
+            real_line, real_free, real_size)
+
+    assert seen["free_gb"] == 7.3, (
+        "the confession printed the post-placement re-read as the decision's "
+        "input — this is the bug that cost pgw#1595 a root cause"
+    )
+    assert "free_after_gb=0.4" in seen["detail"], (
+        "the post-placement figure is a real fact and must still be reported"
+    )
+
+
+def test_a_declared_per_request_peak_raises_the_reserve_above_the_constant():
+    """pgw#1595. The reserve was a constant from ONE workload shape, and a
+    28-step job overran it. The endpoint's declared peak was already in the
+    caller and was being dropped."""
+    import gen_worker.models.memory as m
+    from gen_worker.models.partial_resident import PARTIAL_RESIDENT_RESERVE_GB
+
+    budgets = []
+    real_free, real_unhook = m.get_available_vram_gb, m.unhookable_components
+
+    import gen_worker.models.partial_resident as pr
+    real_pfp = pr.plan_for_pipeline
+
+    def spy(pipeline, *, budget_bytes, **kw):
+        budgets.append(budget_bytes / (1 << 30))
+        return real_pfp(pipeline, budget_bytes=budget_bytes, **kw)
+
+    pr.plan_for_pipeline = spy
+    m.get_available_vram_gb = lambda *a, **k: 8.0
+    m.unhookable_components = lambda *a, **k: []
+    try:
+        pipe = _pipeline()
+        m._plan_partial_resident(pipe, logging.getLogger("t"))
+        m._plan_partial_resident(
+            pipe, logging.getLogger("t"), peak_vram_gb=9.0, model_size_gb=6.5)
+    finally:
+        pr.plan_for_pipeline = real_pfp
+        m.get_available_vram_gb, m.unhookable_components = real_free, real_unhook
+
+    assert len(budgets) == 2
+    assert abs(budgets[0] - (8.0 - PARTIAL_RESIDENT_RESERVE_GB)) < 0.01, (
+        "the constant is no longer the floor when nothing is declared")
+    # declared 9.0 total - 6.5 weights = 2.5 GiB of activations, above the 1.25
+    # constant, so the budget must shrink by the declared figure instead.
+    assert abs(budgets[1] - (8.0 - 2.5)) < 0.01, (
+        "the declared per-request peak was ignored — the defect pgw#1595 found")
+
+
+def test_the_probe_reports_its_measurement_even_when_it_passes():
+    """pgw#1559 class, in this rung's own code: success was INFO and inaudible
+    at the endpoint's WARNING level, so a passing probe and a probe that never
+    ran looked identical."""
+    pipe = _pipeline()
+    plan, _ = _arm(pipe)
+    facts: dict = {}
+    apply_component_residency(
+        pipe, plan, device="cpu", log=logging.getLogger("t"),
+        free_bytes_now=lambda: 64 * _MIB, facts=facts,
+    )
+    assert facts.get("probe_free_bytes") == 64 * _MIB, (
+        "a passing probe left no measurement behind"
+    )
+
+
+def test_the_production_planner_leaves_room_for_the_reserve_it_planned_against():
+    """THE INVARIANT THE RESERVE EXISTS FOR — asserted through the PRODUCTION
+    path, `_plan_partial_resident`, because that is where the budget formula
+    lives.
+
+    An earlier version of this test called `plan_component_residency` directly
+    and computed the budget itself, which made it TAUTOLOGICAL: it passed with
+    the reserve reverted AND with the budget formula stripped of its reserve
+    subtraction. A test that cannot fail is not a test. This one goes through
+    the real planner, so breaking `budget = free - reserve` turns it red.
+
+    The denoise phase holds resident weights and activations at once, so
+    `resident + reserve <= free` must hold for every admitted plan — otherwise a
+    plan fits its own budget and still OOMs mid-denoise, which is what pgw#1595
+    found on the card.
+    """
+    import gen_worker.models.memory as m
+
+    pipe = _pipeline()
+    total = sum(
+        p.numel() * p.element_size()
+        for c in pipe.components.values()
+        if isinstance(c, torch.nn.Module) for p in c.parameters()
+    )
+    # Sit free VRAM just above the reserve so this toy tree is genuinely over
+    # budget and eviction is forced, exactly as SDXL is on the real card.
+    free_bytes = int(PARTIAL_RESIDENT_RESERVE_GB * _GIB) + 1200
+    real_free, real_unhook = m.get_available_vram_gb, m.unhookable_components
+    m.get_available_vram_gb = lambda *a, **k: free_bytes / _GIB
+    m.unhookable_components = lambda *a, **k: []
+    try:
+        plan = m._plan_partial_resident(pipe, logging.getLogger("t"))
+    finally:
+        m.get_available_vram_gb, m.unhookable_components = real_free, real_unhook
+
+    assert plan is not None, (
+        "the planner admitted nothing where eviction was required — the budget "
+        "is no longer being reduced by the reserve"
+    )
+    assert plan.offloaded, "a plan that evicts nothing cannot be over budget"
+    assert plan.resident_bytes + total - total == plan.resident_bytes
+    headroom = free_bytes - plan.resident_bytes
+    assert headroom >= PARTIAL_RESIDENT_RESERVE_GB * _GIB, (
+        f"the admitted plan leaves {headroom} bytes for activations, under the "
+        f"{PARTIAL_RESIDENT_RESERVE_GB} GiB reserve it was planned against"
+    )

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -591,7 +591,7 @@ def test_the_probe_counts_the_reusable_allocator_pool_as_available():
     cache = 400 * _MIB                # reusable pool the allocator still holds
 
     real_attr = pr._placement_attribution
-    pr._placement_attribution = lambda _t: {"attr_cache_bytes": cache}
+    pr._placement_attribution = lambda torch_mod: {"attr_cache_bytes": cache}
     try:
         ok, reported = pr.probe_plan(
             parked, free_bytes_now=lambda: driver_free, floor_bytes=floor)


### PR DESCRIPTION
## #1595's stated cause is falsified — and the misleading evidence was my log line

#1595 was filed as *"the ladder plans AFTER the pipeline is resident, against 0.4 GiB."* Running the shipped planner refutes it:

```
free= 0.40 -> fits=False  "the forced-resident set alone is 5.31 GiB against a 0.00 GiB budget"
free= 7.28 -> fits=True   offloaded=('text_encoder','text_encoder_2')
```

At 0.4 the budget is zero, the forced unet+vae set exceeds it, `_plan_partial_resident` returns **None**, and the load keeps `model_offload`. It **cannot** emit `rung=resident->partial_resident`. The rung demonstrably armed, so the planner read a healthy number. **The input was fine; the log was wrong.**

`_report_offload_engaged` re-read `get_available_vram_gb()` at report time — after placement — so a rung chosen against 7.3 GiB printed `free_gb=0.4` beside its own name. A P1 was filed against the wrong cause on the strength of that line.

## What landed

**(a) The confession states the decision's input.** Plan-time free, plus `plan_budget_gb`, `plan_peak_gb`, `reserve_gb`, `reserve_source`, `probe_free_gb`; the post-placement figure is kept as `free_after_gb` because it is a real and different fact.

Two silences closed with it:
- `probe OK` was `log.info` while `PROBE REFUSED` was `log.warning`, so at WARNING level *"the probe passed"* and *"the probe never ran"* were the same picture — the #1559 class, in this rung's own code.
- `_applied_summary` printed the KEY of anything truthy, so #1577's two data entries rendered as savers that engaged. Booleans are names now, everything else `key=value` — a split by **type**, so the next data entry cannot masquerade either.

**(b) The declared per-request peak is threaded in — and is inert today, so it is NOT the fix.** `apply_low_vram_config` already received `peak_vram_gb` and forwarded it to `select_auto_mode`; the residency planner never got it. It does now. But **zero of the 26 shipped endpoints declare `peak_vram_per_request_gb`**, so every real serve still gets the constant. Hence `reserve_source=declared|default`: a carried-over guess no longer looks like a measurement.

**(c) The reserve is raised 1.25 → 2.00, because 1.25 came from the wrong configuration.**

| configuration | peak | resident weights | activations |
|---|---|---|---|
| `model_offload` (#1570, where 1.25 came from) | 5956 MiB | 5437 MiB | **519 MiB** |
| `partial_resident` (#1586 GREEN, this rung) | 7540 MiB | 5693 MiB | **1847 MiB** |

3.6× larger, and the mechanism is the allocator: under `model_offload` the denoiser is freed and re-allocated every request so the pool churns and blocks are reused; under `partial_resident` the weights are pinned for the process's life and activations come out of what is left, carrying fragmentation the offloaded rung never pays. **The rung has been under-reserved since it shipped** — which is why one leg survived by 13.5 MB and another thrashed at 6.6 MB.

**Consequence, stated rather than discovered later:** the rung needs `free − reserve ≥ 5.31 GiB`, so on this 7.62 GiB card it is only available above ~7.31 GiB free and will often refuse to `model_offload`. That is the honest answer, not a regression — and it means **#1586's banked 1.16× was obtained by under-reserving.** Fleet cards (12/16/24 GiB) never demote this far. Temporary, until the per-endpoint measured peak lands.

## Red-armed, and proven so

Reverting each fix individually turns exactly its own test red. **One test was caught being tautological during that check** — it computed the budget itself and passed both with the reserve reverted *and* with the budget formula stripped of its reserve subtraction. It was rewritten to go through `_plan_partial_resident`, where breaking `budget = free − reserve` now turns it red. A test that cannot fail is not a test.

23 tests green, 69 across the ladder-touching files, mypy clean (599 files), ruff clean.

Tracker: `#1586` items 3/5 and `#1595` (falsified + folded).