### PR TITLE
pgw#1596: the disk-headroom gate must charge for what is MISSING, not for the whole tree

### DIFF
--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -18,7 +18,9 @@ import typing
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, cast
+from typing import (
+    Any, Awaitable, Callable, Dict, List, Optional, Sequence, Set, Tuple, cast,
+)
 
 from .. import activity as activity_mod
 from .. import boot_phases as boot_mod
@@ -1139,6 +1141,36 @@ class ModelStore:
                     return other
         return ""
 
+    def _already_resident_bytes(self, files: Sequence[Any]) -> int:
+        """Bytes of ``files`` whose CAS objects this pod ALREADY holds.
+
+        pgw#1596. The headroom gate asks for FREE space, so it must ask for
+        what is still MISSING — the bytes already banked are, by definition,
+        not going to be written again. `contains` is the same content-addressed
+        predicate the fill path uses to decide a grant is satisfied, so this
+        cannot disagree with what the downloader will actually skip.
+
+        A file with no digest is counted as absent: the honest direction, since
+        it will be fetched.
+        """
+        from .cache_paths import open_worker_cas
+
+        try:
+            cas = open_worker_cas(self._cache_dir)
+        except Exception:  # noqa: BLE001 — a probe must not be the failure
+            return 0
+        total = 0
+        for f in files:
+            digest = str(getattr(f, "digest", "") or "").strip()
+            if not digest:
+                continue
+            try:
+                if cas.contains(digest, size=int(f.size_bytes)):
+                    total += int(f.size_bytes)
+            except Exception:  # noqa: BLE001 — an unreadable object is absent
+                continue
+        return total
+
     async def _ensure_disk_headroom(
         self,
         ref: WireRef,
@@ -1146,8 +1178,33 @@ class ModelStore:
         identity: _ResidencyIdentity = ("", 0),
         *,
         intent_id: str = "",
+        files: Optional[Sequence[Any]] = None,
     ) -> None:
-        target = int(needed_bytes) + _DISK_GC_MARGIN_BYTES
+        """Gate on the bytes still to be WRITTEN, never on the whole tree.
+
+        pgw#1596: this used to compare free space against the ref's entire
+        manifest, with nothing subtracting the part of that same manifest
+        already on disk. On a first pass over an empty disk that is right. On a
+        RE-ENTRY it is self-defeating — the bytes already fetched are counted
+        as consumed AND demanded again as free — so a materialization restarted
+        by an ordinary residency-generation supersede can never satisfy its own
+        check. It needs 2x the tree, and it fails at the END of its own pull.
+
+        MEASURED (pod `6uneiwhdl7fz8u`, 159 GB disk, 2026-08-20):
+        `need 104956706657 bytes; 65659441152 free after disk GC` — it demanded
+        the whole 105 GB tree free while ~86.2 GB of that same tree was already
+        resident, and died 157 MB short of a complete pull.
+
+        The boot ladder's supersede-and-restart design already ASSUMES
+        materialization is restart-safe. This is what makes that true.
+        """
+        total = int(needed_bytes)
+        resident = self._already_resident_bytes(files) if files else 0
+        # Never below zero, and never above the total: a stale or oversized
+        # residency reading must not talk this gate out of existence.
+        resident = max(0, min(resident, total))
+        remaining = total - resident
+        target = remaining + _DISK_GC_MARGIN_BYTES
         if self._disk_free() >= target:
             return
         await self._materialize_await(
@@ -1164,9 +1221,14 @@ class ModelStore:
                 ref, pb.MODEL_STATE_FAILED,
                 identity=identity, error="insufficient_disk",
             )
+            # Say what is still MISSING and what is already banked. The old
+            # message named only the whole tree, which is exactly why an
+            # 86 GB-resident refusal read as a 105 GB shortfall (pgw#1596).
             raise InsufficientDiskError(
-                f"need {needed_bytes} bytes for {ref}; {free} free after disk GC",
-                available_bytes=free, required_bytes=needed_bytes,
+                f"need {remaining} more bytes for {ref} "
+                f"({total} manifest - {resident} already resident); "
+                f"{free} free after disk GC",
+                available_bytes=free, required_bytes=remaining,
                 path=str(self._cache_dir),
             )
 
@@ -1838,6 +1900,9 @@ class ModelStore:
                     sum(int(f.size_bytes) for f in fetch_files),
                     operation_identity,
                     intent_id=intent_id,
+                    # pgw#1596: the same list, so the gate can subtract what is
+                    # already banked instead of demanding the tree twice.
+                    files=fetch_files,
                 )
             last_progress = 0.0
             # opened before _progress so

--- a/tests/test_disk_headroom_restart_pgw1596.py
+++ b/tests/test_disk_headroom_restart_pgw1596.py
@@ -1,0 +1,199 @@
+"""pgw#1596: the headroom gate must charge for what is still MISSING.
+
+`ModelStore._ensure_disk_headroom` compared free space against the ref's ENTIRE
+manifest, with nothing subtracting the part of that same manifest already in the
+CAS. First pass over an empty disk: correct. RE-ENTRY: self-defeating — the
+bytes already fetched are counted as consumed AND demanded again as free, so a
+materialization restarted by an ordinary residency-generation supersede can
+never satisfy its own check. It needs 2x the tree and dies at the END of its own
+pull.
+
+MEASURED, pod `6uneiwhdl7fz8u`, H200, 159 GB container disk, 2026-08-20:
+
+    InsufficientDiskError: need 104956706657 bytes for
+    tensorhub/minimax-h3@serve-narrowed-fp8te; 65659441152 free after disk GC
+
+93.3 GB consumed = 7.14 GB image + ~86.2 GB of THAT VERY TREE. It demanded the
+whole 105 GB free while 82% of it was already resident, and the last position
+row was 157 MB short of a complete pull. Meanwhile a pod with a WORSE
+disk-to-tree ratio (208 GB / 144 GB = 1.44 vs 159 / 105 = 1.51) succeeded,
+because it checked ONCE against an empty disk — which is what rules out "the
+disk was simply too small" and points at re-entry.
+
+The scenario numbers below are those bytes, scaled by 1/1000 so the test is
+cheap; the RATIO that decides pass/fail is preserved exactly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from gen_worker.capability import InsufficientDiskError
+from gen_worker.models.refs import WireRef
+from gen_worker.models.store import _DISK_GC_MARGIN_BYTES, ModelStore
+
+# The incident, /1000. Ratio-preserving, so the arithmetic under test is identical.
+TREE_BYTES = 104_956_706
+RESIDENT_BYTES = 86_200_000
+REMAINING_BYTES = TREE_BYTES - RESIDENT_BYTES  # ~18.76 MB
+
+
+class _File:
+    """A SnapshotFile as the gate reads it: a digest and a size."""
+
+    def __init__(self, digest: str, size_bytes: int) -> None:
+        self.digest = digest
+        self.size_bytes = size_bytes
+
+
+async def _emit(_msg: Any) -> None:
+    return None
+
+
+def _store(tmp_path: Path, free: int) -> ModelStore:
+    return ModelStore(
+        _emit,
+        cache_dir=tmp_path / "cas",
+        disk_free_bytes_fn=lambda: free,
+    )
+
+
+def _files_with_resident(store: ModelStore, monkeypatch: pytest.MonkeyPatch) -> List[_File]:
+    """One resident object and one missing one, summing to the whole tree."""
+    resident = _File("sha256:" + "a" * 64, RESIDENT_BYTES)
+    missing = _File("sha256:" + "b" * 64, REMAINING_BYTES)
+    held = {resident.digest}
+    monkeypatch.setattr(
+        ModelStore,
+        "_already_resident_bytes",
+        lambda self, files: sum(
+            int(f.size_bytes) for f in (files or []) if f.digest in held
+        ),
+    )
+    return [resident, missing]
+
+
+def test_a_partially_resident_ref_passes_on_its_REMAINING_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE REGRESSION. Free space covers what is missing but not the whole tree.
+
+    This is exactly the incident's shape: most of the tree is already down, the
+    disk cannot fit a second copy of it, and the fetch has only a little left to
+    write. Before pgw#1596 this raised; it must now pass.
+    """
+    free = REMAINING_BYTES + _DISK_GC_MARGIN_BYTES  # enough for the remainder
+    assert free < TREE_BYTES + _DISK_GC_MARGIN_BYTES, (
+        "the scenario is only meaningful when the WHOLE tree would NOT fit"
+    )
+    store = _store(tmp_path, free)
+    files = _files_with_resident(store, monkeypatch)
+
+    # No raise == the gate charged the remainder, not the tree.
+    asyncio.run(
+        store._ensure_disk_headroom(WireRef("acme/model@prod"), TREE_BYTES, files=files)
+    )
+
+
+def test_the_gate_still_refuses_when_even_the_REMAINDER_does_not_fit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The twin one input away. Subtracting resident bytes must not disarm it."""
+    store = _store(tmp_path, REMAINING_BYTES // 2)
+    files = _files_with_resident(store, monkeypatch)
+
+    with pytest.raises(InsufficientDiskError) as caught:
+        asyncio.run(
+            store._ensure_disk_headroom(
+                WireRef("acme/model@prod"), TREE_BYTES, files=files
+            )
+        )
+    # required_bytes is the REMAINDER, and the message shows its working — the
+    # old message named only the whole tree, which is why an 86 GB-resident
+    # refusal read as a 105 GB shortfall.
+    assert caught.value.required_bytes == REMAINING_BYTES
+    text = str(caught.value)
+    assert str(REMAINING_BYTES) in text
+    assert str(RESIDENT_BYTES) in text and "already resident" in text
+
+
+def test_a_cold_disk_is_unchanged_and_still_charges_the_whole_tree(
+    tmp_path: Path,
+) -> None:
+    """Nothing resident means remaining == total. The first-pass case must not move."""
+    store = _store(tmp_path, TREE_BYTES // 2)
+    files = [_File("sha256:" + "c" * 64, TREE_BYTES)]
+
+    with pytest.raises(InsufficientDiskError) as caught:
+        asyncio.run(
+            store._ensure_disk_headroom(
+                WireRef("acme/model@prod"), TREE_BYTES, files=files
+            )
+        )
+    assert caught.value.required_bytes == TREE_BYTES
+
+
+def test_no_files_argument_keeps_the_old_whole_tree_behaviour(tmp_path: Path) -> None:
+    """Callers that cannot name their files are charged the full amount.
+
+    The subtraction is an OPTIMISATION AGAINST A KNOWN LIST, never an
+    assumption. A caller with no manifest must not get a cheaper gate.
+    """
+    store = _store(tmp_path, TREE_BYTES // 2)
+    with pytest.raises(InsufficientDiskError) as caught:
+        asyncio.run(
+            store._ensure_disk_headroom(WireRef("acme/model@prod"), TREE_BYTES)
+        )
+    assert caught.value.required_bytes == TREE_BYTES
+
+
+def test_an_overstated_residency_cannot_talk_the_gate_out_of_existence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale reading claiming MORE resident than the tree holds is clamped.
+
+    Otherwise a bad residency answer becomes a negative requirement and the
+    gate passes anything — the failure mode that turns a guard into a no-op.
+    """
+    monkeypatch.setattr(
+        ModelStore, "_already_resident_bytes", lambda self, files: TREE_BYTES * 10
+    )
+    store = _store(tmp_path, 0)
+    files = [_File("sha256:" + "d" * 64, TREE_BYTES)]
+
+    with pytest.raises(InsufficientDiskError) as caught:
+        asyncio.run(
+            store._ensure_disk_headroom(
+                WireRef("acme/model@prod"), TREE_BYTES, files=files
+            )
+        )
+    assert caught.value.required_bytes == 0, "clamped to zero, never negative"
+
+
+def test_the_real_predicate_reads_the_cas(tmp_path: Path) -> None:
+    """`_already_resident_bytes` must answer from the CAS, not from a promise.
+
+    The other tests stub the predicate to control the scenario; this one runs
+    the real thing so the stub can never be the only thing that works.
+    """
+    from gen_worker._vendor.tensorfs import LocalCAS
+
+    cas_dir = tmp_path / "cas"
+    cas = LocalCAS(cas_dir)
+    payload = b"resident-object-bytes"
+    ref = cas.put_bytes(payload)
+
+    store = _store(tmp_path, 0)
+    present = _File(str(ref), len(payload))
+    absent = _File("sha256:" + "e" * 64, 999_999)
+    nodigest = _File("", 12_345)
+
+    got = store._already_resident_bytes([present, absent, nodigest])
+    assert got == len(payload), (
+        "only the object actually in the CAS counts; a missing object and a "
+        "file with no digest are both absent"
+    )


### PR DESCRIPTION
## The defect

`ModelStore._ensure_disk_headroom` compared free space against the ref's **entire manifest**, with nothing subtracting the part of that same manifest already in the CAS.

First pass over an empty disk: correct. **Re-entry: self-defeating** — the bytes already fetched are counted as consumed *and* demanded again as free. So a materialization restarted by an ordinary residency-generation supersede can never satisfy its own check. It needs 2× the tree, and it dies at the *end* of its own pull.

## Measured

Pod `6uneiwhdl7fz8u`, H200, 159 GB container disk, 2026-08-20 — the worker's own words:

```
InsufficientDiskError: need 104956706657 bytes for
tensorhub/minimax-h3@serve-narrowed-fp8te; 65659441152 free after disk GC
```

| term | bytes | |
|---|---|---|
| demanded FREE | 104,956,706,657 | the whole tree |
| actually free | 65,659,441,152 | |
| consumed | 93,340,558,848 | 7.14 GB image **+ ~86.2 GB of that very tree** |

It demanded 105 GB free while **82% of that same 105 GB was already resident**, and the last position row was **157 MB short** of a complete pull.

**It is not a size problem.** A pod with a *worse* disk-to-tree ratio succeeded on the same release:

| pod | disk | tree | ratio | checks | outcome |
|---|---|---|---|---|---|
| `ys9d2mu6opwb3a` | 208 GB | 144.05 GB | 1.44 | **1**, empty disk | materialized OK |
| `6uneiwhdl7fz8u` | 159 GB | 104.96 GB | **1.51** | re-entered at ~86 GB | `insufficient_disk` |

Trigger is residency-generation churn — the failure event carries `residency_generation=3`, and the hub logged `removed from worker generation=5 for migration` one line earlier.

## The fix — the subtraction, and nothing else

- **`_already_resident_bytes(files)`** sums manifest entries whose CAS objects this pod already holds via `cas.contains(digest, size=...)` — the *same* content-addressed predicate the fill path uses to decide a grant is satisfied, so the gate cannot disagree with what the downloader will actually skip. No digest ⇒ counted absent (the honest direction).
- The gate charges `total - resident`, **clamped to `[0, total]`** so a stale or oversized residency reading can never produce a negative requirement and quietly turn the guard into a no-op.
- The refusal **shows its working**: `need N more bytes (T manifest - R already resident)`. The old message named only the whole tree, which is precisely why an 86 GB-resident refusal read as a 105 GB shortfall.
- `files` is **optional** — a caller that cannot name its manifest is still charged the full amount. The subtraction is an optimisation against a *known list*, never an assumption.

This is what makes the boot ladder's supersede-and-restart design actually restart-safe, which it already assumed it was.

## Tests

`tests/test_disk_headroom_restart_pgw1596.py` uses the incident's own numbers scaled 1/1000, preserving the ratio that decides pass/fail.

**Red proof** — with the subtraction removed, **3 of 6 fail**: the regression itself, the refusal-message arm, and the clamp. The cold-disk, no-files and real-CAS-predicate arms stay green, which is the correct split (they assert unchanged behaviour). One test deliberately runs the *real* `_already_resident_bytes` against a real `LocalCAS` so the stubbed predicate can never be the only thing that works.

Neighbouring suites green: `boot_materialize`, `store_addresses`, `model_residency`, `snapshot_disk_headroom_pgw1263`, `snapshot_residency_progress_pgw1289`, `materialized_view_pgw1308` — 52 tests.

## Family

Fourth in a run of "a size taken from the wrong source": th#2232 (hub sized a pod from a cold in-memory map — fixed), e2e#1924 (manifest named the wrong tree — fixed), pgw#1590 (admission sizes a lane from the whole tree at stored precision — open), and this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)