### PR TITLE
pgw#1586: EVERY rung confesses the free VRAM its DECISION saw — closing the class #1595 opened

### DIFF
--- a/changelog.d/pgw1586-confession-class.md
+++ b/changelog.d/pgw1586-confession-class.md
@@ -1,0 +1,12 @@
+- **pgw#1586: EVERY rung now confesses the free VRAM its DECISION saw, not a post-placement
+  re-read.** pgw#1595's fix threaded the plan-time figure into the `partial_resident`
+  confession only, leaving six sibling call sites — `model_offload`, `sequential`,
+  `partial_stream`, both `cpu` arms and the fall-through — still re-reading free VRAM at report
+  time, after the weights had landed. Within hours the pgw#1548 lane read `free_gb=0.4` off a
+  `model_offload` line on a card with **7.9 GiB free at boot** and reached for a boot-ordering
+  cause — the same wrong conclusion pgw#1595 was filed on, from the same artefact, on a rung
+  the first fix had not covered. Free VRAM is now read **once, before anything is placed**, and
+  carried to every confession. The regression test asserts the **class** by reading the source
+  (no `_report_offload_engaged` call may omit `plan_free_gb`), because a per-rung test would
+  have passed for `partial_resident` and missed the other six — which is exactly how the first
+  fix shipped incomplete.

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -2455,6 +2455,20 @@ def apply_low_vram_config(
     if prior is not None:
         return {"mode": prior, "already_applied": True}
 
+    # pgw#1586, CLOSING THE CLASS pgw#1595 OPENED. Free VRAM read ONCE here,
+    # before anything is placed, and carried to every confession below.
+    #
+    # pgw#1595's fix threaded the plan-time figure into the `partial_resident`
+    # confession ONLY, and left six sibling call sites — `model_offload`,
+    # `sequential`, `partial_stream`, both `cpu` arms and the fall-through —
+    # still re-reading free VRAM AT REPORT TIME, after placement. Within hours
+    # the pgw#1548 lane read `free_gb=0.4` off a `model_offload` line on a card
+    # with 7.9 GiB free at boot and reached for a boot-ordering cause, which is
+    # the SAME wrong conclusion pgw#1595 was filed on. Fixing the one line that
+    # had bitten me and leaving its five siblings was the defect; this is the
+    # class.
+    decision_free_gb = get_available_vram_gb()
+
     # pgw#1498's tier dial, BEFORE the rung is chosen: spending the lease's
     # surplus on decode-once weights changes the footprint every decision below
     # is made against. A no-op on any pipeline holding no ggml block bytes.
@@ -2576,7 +2590,8 @@ def apply_low_vram_config(
         # pgw#1312's one confession home. This rung is the LOUDEST degradation
         # the ladder has — ~40x — so it may not be the one route that reaches a
         # CPU-touching placement without saying so off the pod.
-        _report_offload_engaged(pipeline, "cpu", applied, log)
+        _report_offload_engaged(pipeline, "cpu", applied, log,
+                                plan_free_gb=decision_free_gb)
         return applied
 
     # Every rung reached from here has a live `oom_ladder` (armed above, on
@@ -2612,7 +2627,8 @@ def apply_low_vram_config(
         applied["mode"] = "cpu"
         _to_host(pipeline)
         setattr(pipeline, _COZY_MODE_ATTR, "cpu")
-        _report_offload_engaged(pipeline, "cpu", applied, log)
+        _report_offload_engaged(pipeline, "cpu", applied, log,
+                                plan_free_gb=decision_free_gb)
         return applied
 
     if offload_to_disk_path is None and _should_auto_disk_offload():
@@ -2637,7 +2653,8 @@ def apply_low_vram_config(
         ):
             setattr(pipeline, _COZY_MODE_ATTR, "partial_stream")
             if applied.get("stream_streamed_leaves"):
-                _report_offload_engaged(pipeline, "partial_stream", applied, log)
+                _report_offload_engaged(pipeline, "partial_stream", applied, log,
+                                        plan_free_gb=decision_free_gb)
             return applied
         # It could not arm (no torch, no hookable tree, a meta/aliased leaf).
         # The next rung down is the honest answer, not a resident placement.
@@ -2731,7 +2748,8 @@ def apply_low_vram_config(
                 log.warning("low_vram: enable_model_cpu_offload failed: %s", exc)
         applied["model_offload"] = ok
         setattr(pipeline, _COZY_MODE_ATTR, "model_offload")
-        _report_offload_engaged(pipeline, "model_offload", applied, log)
+        _report_offload_engaged(pipeline, "model_offload", applied, log,
+                                plan_free_gb=decision_free_gb)
         return applied
 
     if effective_mode == "group_offload":
@@ -2754,12 +2772,14 @@ def apply_low_vram_config(
         applied["sequential_offload"] = ok
         applied["mode"] = "sequential"
         setattr(pipeline, _COZY_MODE_ATTR, "sequential")
-        _report_offload_engaged(pipeline, "sequential", applied, log)
+        _report_offload_engaged(pipeline, "sequential", applied, log,
+                                plan_free_gb=decision_free_gb)
         return applied
 
     setattr(pipeline, _COZY_MODE_ATTR, effective_mode)
     if touches_host_ram(effective_mode):
-        _report_offload_engaged(pipeline, effective_mode, applied, log)
+        _report_offload_engaged(pipeline, effective_mode, applied, log,
+                                plan_free_gb=decision_free_gb)
     else:
         log.info("low_vram: %s applied (%s)", effective_mode, _applied_summary(applied))
     return applied

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -606,3 +606,35 @@ def test_the_probe_counts_the_reusable_allocator_pool_as_available():
         "the reported number must stay the DRIVER-free figure — the soft cache "
         "term belongs in the decision, not in what the log claims is free"
     )
+
+
+def test_EVERY_rung_confesses_the_decision_time_free_vram_not_a_re_read():
+    """pgw#1586 closing the class pgw#1595 opened.
+
+    pgw#1595's fix threaded the plan-time figure into the `partial_resident`
+    confession ONLY. Six siblings — `model_offload`, `sequential`,
+    `partial_stream`, both `cpu` arms and the fall-through — kept re-reading
+    free VRAM AT REPORT TIME, after placement. Within hours the pgw#1548 lane
+    read `free_gb=0.4` off a `model_offload` line on a card with 7.9 GiB free at
+    boot and reached for a boot-ordering cause — the SAME wrong conclusion
+    pgw#1595 was filed on, from the same artefact, on a rung the fix had not
+    covered.
+
+    So this asserts the CLASS, by reading the source: no `_report_offload_engaged`
+    call may omit `plan_free_gb`. A per-rung test would have passed for
+    `partial_resident` and missed the other six, which is exactly how the first
+    fix shipped incomplete.
+    """
+    import inspect
+    import re
+
+    import gen_worker.models.memory as m
+
+    src = inspect.getsource(m.apply_low_vram_config)
+    calls = re.findall(r"_report_offload_engaged\((.*?)\)", src, re.S)
+    assert calls, "no confession call sites found — this test has gone blind"
+    missing = [c for c in calls if "plan_free_gb" not in c]
+    assert missing == [], (
+        f"{len(missing)} rung(s) still confess a post-placement re-read as the "
+        f"decision's input: {missing}"
+    )


### PR DESCRIPTION
## The bug my own #1595 fix left behind

#1595's fix threaded the plan-time figure into the `partial_resident` confession **only**. Six sibling call sites — `model_offload`, `sequential`, `partial_stream`, both `cpu` arms, and the fall-through — kept re-reading free VRAM **at report time, after the weights had landed**.

**Within hours it bit someone.** The #1548 lane read `free_gb=0.4` off a `model_offload` line on a card with **7.9 GiB free at boot** and reached for a boot-ordering cause — *the same wrong conclusion #1595 was filed on*, from the same artefact, on a rung the first fix hadn't covered. Their conclusion may still stand on other evidence; the stated evidence for it was my bug.

## The fix

Free VRAM is read **once, before anything is placed**, and carried to every confession. The `partial_resident` path keeps passing the plan's own recorded figure, which is more precise still.

## The test asserts the CLASS, not the instance

It reads the source of `apply_low_vram_config` and fails if **any** `_report_offload_engaged` call omits `plan_free_gb`:

```
missing = [c for c in calls if "plan_free_gb" not in c]
assert missing == []
```

A per-rung test would have passed for `partial_resident` and missed the other six — which is exactly how the first fix shipped incomplete, so testing the same shape again would have reproduced the same blindness. **Red-armed:** dropping the argument from one sibling turns it red, verified.

## Why it's worth the words

Fixing the line that bit me and leaving its five siblings is the same scope error as predicting from an unverified component-size table, and as re-running the cheap gates while skipping the slow one. Three instances in one day — this is the one caught by reading the class rather than by another lane hitting it.

## Gates

25 tests green, mypy clean (601 files), ruff clean.