### PR TITLE
pgw#1548 / tcg#78: vendor torchcg c609d651 — a contradicted dynamic axis is refused at DERIVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,7 +524,7 @@ torchvision = [
 # uv.lock behind, which breaks `uv sync --locked` — the first step of every CI
 # job — for every open PR; `scripts/lint_lock_pin_agreement.py` now refuses that
 # tree locally and as CI's first step.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "c609d65142c3046a4bb792b4fe9a5929580fb03d" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -131,7 +131,7 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f"
+rev = "c609d65142c3046a4bb792b4fe9a5929580fb03d"
 subdir = "src/torchcg"
 # pgw#1474 / tcg#61 RE-VENDOR (2026-08-19), from `6c91b83d`. `CompiledGraphCall`
 # stops pre-flattening the call: the loaded package is torch's
@@ -350,11 +350,11 @@ rewrites = [
 "contracts/literal_identity_v1.json" = "50cb80e750a8124a45b982415258d8590c37f90ca804326588dfde1b368c6863"
 "contracts/recipe_v1.json" = "d319b5f2e4a3d5c13587da2b7d7cdc25c83b92e0b5b22311c317948c3e610d1a"
 "contracts/toolchain_identity_v1.json" = "f4114c38ae373f62ddcb2aae5498ffbee30630e80adf11fee99e68bcbdb24282"
-"declaration.py" = "8b42bae864a4127cc5e418915f8395d980b8a439a51fd4d6f5ecbb42ba613b21"
-"discovery.py" = "7b294cab60126763cc634f536e3b94f8df36523b42b94bf2ef66deec676de4ec"
+"declaration.py" = "5ea9ad7653ccbc1bda7dffe6e643dc1a55e37de26d5120c8f8bfd918d2d8de9b"
+"discovery.py" = "172f40ea2e7f7c6e88b45699d74a2d029bdb0151f289307a6e9563709042726e"
 "document.py" = "a70f4e53d75dd4cdc5fb6f52be4c8c105e49efee168ab6c295094a09f779d0ad"
-"dynamic.py" = "8466c4a7330513e9ebd381fe89e53ba72e276bfc0dcf8499e004bf0f92961b6d"
-"engine.py" = "577ae142365a67947625df738a10ebc9565ab205c8d470e068a7eccd946a3de2"
+"dynamic.py" = "9aa0e6e094344b74ba62a693da272fd7c86be5b5b00e0f31d45398f249b666a6"
+"engine.py" = "66cf857bc9b9e0fb147385f767d2aeca1868a6c79422dba017ec75fede7aabad"
 "graph_identity.py" = "88c731a681eb1e0b878f30bc33fcaa4efdbfc16bdc612fd6d406a088e299e567"
 "hollow.py" = "d9a0b57b01036588b9182d737ea925c34885b14a4bf88e76c8bb38d6d4ae97f9"
 "host_isa.py" = "679aa81547be2d60ae6593b6e8f75dd29dcd56ab85d8e858e219b5af5d0eadc4"

--- a/src/gen_worker/_vendor/torchcg/declaration.py
+++ b/src/gen_worker/_vendor/torchcg/declaration.py
@@ -78,7 +78,19 @@ class _Symbols:
 
 
 def _render_symbol(value: Any, symbols: _Symbols) -> str:
-    expression = getattr(getattr(value, "node", None), "expr", None)
+    # `_expr` is the symbol the EXPORT established; `.expr` is a property that
+    # folds in whatever the ShapeEnv has been told since. tcg#78: an AOTI
+    # compile shares the program's ShapeEnv and installs replacements there
+    # (measured: `.expr` s53 -> 2 across one compile, `._expr` still s53), so
+    # reading `.expr` made this canonical form a function of COMPILER STATE
+    # rather than of the exported program -- the same program declared twice
+    # around a compile produced two witnesses. A declaration must describe its
+    # input. What the compiler later concludes about the ranges is a separate,
+    # explicit question, asked by name in `engine._admit_symbol_ranges`.
+    node = getattr(value, "node", None)
+    expression = getattr(node, "_expr", None)
+    if expression is None:
+        expression = getattr(node, "expr", None)
     free = getattr(expression, "free_symbols", None) or ()
     if expression is None or not free:
         return str(expression if expression is not None else value)

--- a/src/gen_worker/_vendor/torchcg/discovery.py
+++ b/src/gen_worker/_vendor/torchcg/discovery.py
@@ -32,7 +32,16 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from .document import GraphRecord, LaneGraphs
-from .dynamic import DimPolicy, alias_ingress, plan_exports, resolve_policy
+from .dynamic import (
+    DimPolicy,
+    alias_ingress,
+    contradicted_axes,
+    decomposition_narrowing,
+    format_narrowing,
+    plan_exports,
+    resolve_policy,
+    without_axes,
+)
 from .graph_identity import GraphIdentityError, graph_hash
 from .ingress import IngressError, build_call_ingress
 from .lane import LaneError, LaneRef, require_targets, resolve_target
@@ -429,6 +438,67 @@ def discover_modules(
                     f"(strict={strict}) failed for the observed call: "
                     f"{type(exc).__name__}: {exc}"
                 ) from exc
+            if plan.dynamic:
+                # tcg#78: export ACCEPTING a Dim is not the graph agreeing to
+                # serve its range. The guards that contradict a range live in
+                # the DECOMPOSED graph -- `aten.to.dtype` asks nothing,
+                # `torch._prims.convert_element_type` asks whether the tensor
+                # can be size-1 -- so an axis torch.export admits can still be
+                # narrowed to a single value 84-129 s into the AOTI compile
+                # that finally decomposes it. Asking here costs ~2 s of CPU and
+                # no compiler, and the artifact it prevents is not a slow
+                # failure but a SILENT one: minted past this point, an sd15
+                # UNet whose batch range collapsed to [2, 2] answers a batch-1
+                # call with a batch-2 tensor of garbage and raises nothing.
+                try:
+                    with synthesis:
+                        moved = decomposition_narrowing(program)
+                except Exception as exc:  # the compile would decompose too
+                    moved = {}
+                    logger.warning(
+                        "lane %s target %s: the range probe over %s could not "
+                        "decompose (%s: %s); falling back to one static export "
+                        "per observed shape for this group",
+                        contract, path, sorted(plan.symbols),
+                        type(exc).__name__, exc,
+                    )
+                    pending = plan.static_fallback() + pending
+                    continue
+                if moved:
+                    try:
+                        refused = contradicted_axes(
+                            path,
+                            build_call_ingress(
+                                program, list(plan.param_names), args, kwargs
+                            ),
+                            moved,
+                        )
+                    except IngressError:
+                        refused = set()
+                    dims = without_axes(dims, refused)
+                    logger.warning(
+                        "lane %s target %s: dynamic export over %s was REFUSED "
+                        "— the graph's own guards contradict the declared "
+                        "range (%s); re-planning this group with %s held "
+                        "static",
+                        contract, path, sorted(plan.symbols),
+                        format_narrowing(moved),
+                        sorted(refused) or "the whole group",
+                    )
+                    # Only the CONTRADICTED axes are demoted, and only this
+                    # group is re-planned. A batch axis the guards refuse must
+                    # not take the aspect collapse down with it -- collapsing
+                    # the aspect fan is what the dynamic-dims program is for.
+                    # With nothing left to offer, the re-plan yields exactly
+                    # tcg#77's static fallback, so there is one path, not two.
+                    #
+                    # The probe SHARES this program's ShapeEnv, so the program
+                    # is now polluted by the refinement it revealed. It is
+                    # discarded here and never declared; the re-plan exports
+                    # again from the module.
+                    with synthesis:
+                        pending = plan_exports(path, list(plan.covers), dims) + pending
+                    continue
             # tcg#64: the drive ran on a device that EXISTS; the graph is
             # stamped with the device the session STATES. This is the one
             # place the two meet, and it is before the hash, so a GPU-less

--- a/src/gen_worker/_vendor/torchcg/dynamic.py
+++ b/src/gen_worker/_vendor/torchcg/dynamic.py
@@ -131,6 +131,224 @@ def _dims(flat: Sequence[tuple[str, tuple[Any, ...], Any]]) -> list[tuple[int, i
     ]
 
 
+class RangeRefusal(ValueError):
+    """A declared symbolic range the graph's OWN guards contradict (tcg#78).
+
+    The refusal exists because the alternative was measured, not imagined. An
+    sd15 UNet exported with a batch ``Dim`` over ``[1, 2]`` compiles for
+    84-129 s of GPU and produces an artifact that, called at batch 1, RETURNS
+    A ``(2, 4, 64, 64)`` TENSOR OF GARBAGE AND RAISES NOTHING -- because
+    ``torch._prims.convert_element_type``'s contiguity question
+    (``guard_or_false(prod(sizes) < 2)``) guards ``s53 >= 2``, ``_refine_ranges``
+    narrows ``[1, 2]`` to the singleton ``[2, 2]``, and a singleton range makes
+    the ShapeEnv replace the symbol with the constant 2 everywhere downstream.
+    The lock still said ``[1, 2]``, so the dispatcher would have admitted the
+    batch-1 call the artifact cannot serve.
+
+    The honest answer is not to record the narrowed range -- that makes the
+    declaration a claim the author never made -- but to refuse the AXIS and
+    say which guard refused it. The author then declares the range the graph
+    actually supports, and the shapes outside it get their own concrete
+    specialization or serve eager, exactly as an unobserved bucket always has.
+    """
+
+
+def shape_env_of(program: object) -> Any:
+    """The one ShapeEnv reachable from a program's placeholder metadata."""
+
+    graph = getattr(getattr(program, "graph_module", None), "graph", None)
+    for node in getattr(graph, "nodes", ()) or ():
+        value = (getattr(node, "meta", None) or {}).get("val")
+        for dimension in getattr(value, "shape", ()) or ():
+            environment = getattr(getattr(dimension, "node", None), "shape_env", None)
+            if environment is not None:
+                return environment
+    return None
+
+
+def _integer(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def live_symbol_ranges(program: object) -> dict[str, tuple[int | None, int | None]]:
+    """What the ShapeEnv says RIGHT NOW about every symbol it carries.
+
+    Read before and after a stage, this states what that stage did to the
+    ranges -- which is the only way to see a refinement, because
+    ``ExportedProgram.range_constraints`` is a snapshot taken at export and
+    never moves again. A symbol the environment has REPLACED with a constant
+    reads as that constant's singleton range: a replacement is the strongest
+    narrowing there is, and it must not read as "unchanged".
+    """
+
+    environment = shape_env_of(program)
+    if environment is None:
+        return {}
+    replacements = {
+        str(symbol): value
+        for symbol, value in (getattr(environment, "replacements", {}) or {}).items()
+    }
+    ranges: dict[str, tuple[int | None, int | None]] = {}
+    for symbol, interval in (getattr(environment, "var_to_range", {}) or {}).items():
+        name = str(symbol)
+        replaced = _integer(replacements.get(name))
+        if replaced is not None:
+            ranges[name] = (replaced, replaced)
+            continue
+        ranges[name] = (
+            _integer(getattr(interval, "lower", None)),
+            _integer(getattr(interval, "upper", None)),
+        )
+    return ranges
+
+
+def declared_symbol_ranges(program: object) -> dict[str, tuple[int | None, int | None]]:
+    """The ranges the exported program DECLARES, from its own constraints."""
+
+    return {
+        str(symbol): (
+            _integer(getattr(interval, "lower", None)),
+            _integer(getattr(interval, "upper", None)),
+        )
+        for symbol, interval in (getattr(program, "range_constraints", {}) or {}).items()
+    }
+
+
+def narrowed_symbols(
+    declared: Mapping[str, tuple[int | None, int | None]],
+    live: Mapping[str, tuple[int | None, int | None]],
+) -> dict[str, tuple[tuple[int | None, int | None], tuple[int | None, int | None]]]:
+    """``{symbol: (declared, refined)}`` for every range that got SMALLER.
+
+    Only narrowing is reported. A range that widened -- which nothing observed
+    does -- would still cover every value the declaration promised, so it is
+    not a shape the dispatcher can send somewhere the artifact refuses.
+    """
+
+    moved = {}
+    for name, (low, high) in declared.items():
+        if name not in live:
+            continue
+        live_low, live_high = live[name]
+        if (live_low is not None and low is not None and live_low > low) or (
+            live_high is not None and high is not None and live_high < high
+        ):
+            moved[name] = ((low, high), (live_low, live_high))
+    return moved
+
+
+def range_narrowing(
+    program: object,
+) -> dict[str, tuple[tuple[int | None, int | None], tuple[int | None, int | None]]]:
+    """Which of a program's DECLARED ranges its own ShapeEnv already denies.
+
+    These two are not the same statement and nothing in torch reconciles them.
+    ``range_constraints`` records what the AUTHOR asked for and is frozen at
+    export; the ShapeEnv records what the graph's guards have established and
+    keeps moving. Measured on the sd15 UNet, immediately after an export that
+    raised nothing::
+
+        declared {'s53': (1, 2)}   live {'s53': (2, 2)}
+
+    Every dynamic dim is guarded ``>= 2`` -- torch specializes the sizes 0 and
+    1 rather than reason about broadcasting and contiguity symbolically -- so
+    an axis whose observed minimum is 1 is contradicted the moment it is
+    exported. The lock reads ``range_constraints``, which is why the
+    contradiction survived all the way to a compiled artifact.
+
+    Costs nothing: both sides are already in memory.
+    """
+
+    return narrowed_symbols(declared_symbol_ranges(program), live_symbol_ranges(program))
+
+
+def decomposition_narrowing(
+    program: object,
+) -> dict[str, tuple[tuple[int | None, int | None], tuple[int | None, int | None]]]:
+    """Every declared range the graph's own guards contradict, decomposed.
+
+    The free check first. If it clears, decompose and ask again: an AOTI
+    compile decomposes before it generates code, and some size-1 questions are
+    asked only by the decomposed graph -- ``aten.to.dtype`` carries no such
+    guard, the ``torch._prims.convert_element_type`` it lowers to does. A
+    narrowing found only there would otherwise land 84-129 s into a GPU
+    compile. Asking here costs ~2 s of CPU and no compiler at all (tcg#78).
+
+    The program is not copied: the probe shares its ShapeEnv, so a narrowing
+    it finds has also polluted this program -- which is exactly why a caller
+    that finds one must DISCARD the program rather than declare it. When there
+    is no narrowing, there is nothing to have polluted.
+    """
+
+    if not declared_symbol_ranges(program):
+        return {}
+    moved = range_narrowing(program)
+    if moved:
+        return moved
+    decompose = getattr(program, "run_decompositions", None)
+    if not callable(decompose):
+        return {}
+    decompose()
+    return range_narrowing(program)
+
+
+def contradicted_axes(
+    target: str, ingress: Any, moved: Mapping[str, Any]
+) -> set[tuple[str, str, int]]:
+    """``{(target, ingress name, axis)}`` carried by a contradicted symbol.
+
+    Scoped to the target because ``sample`` axis 0 means one thing on a
+    denoiser and something else on a VAE; a refusal earned by one must not be
+    charged to the other.
+
+    The unit a policy speaks in is the AXIS, not the symbol, so a refusal has
+    to be translated before it can be acted on. A derived dim spells its root
+    in its own name (``16*s3``), which is also the key ``range_constraints``
+    uses, so one ``symbol_terms`` read connects the two.
+
+    Refusing axes rather than the whole export is what keeps a contradicted
+    batch axis from taking the aspect collapse down with it -- the case the
+    dynamic-dims program is actually for (pgw#1548: SDXL 18 -> 2).
+    """
+
+    from .ingress import symbol_terms
+
+    return {
+        (target, row.name, axis)
+        for row in ingress.inputs
+        for axis, dimension in enumerate(row.shape)
+        if isinstance(dimension, str) and symbol_terms(dimension)[1] in moved
+    }
+
+
+def without_axes(
+    policy: DimPolicy | None, refused: set[tuple[str, str, int]]
+) -> DimPolicy:
+    """``policy`` with named axes refused on top of whatever it already refuses."""
+
+    resolved = policy if policy is not None else all_dims
+
+    def narrowed(target: str, name: str, axis: int) -> bool:
+        return (target, name, axis) not in refused and resolved(target, name, axis)
+
+    return narrowed
+
+
+def format_narrowing(
+    moved: Mapping[str, tuple[tuple[int | None, int | None], tuple[int | None, int | None]]],
+) -> str:
+    """``s53 declared [1, 2] but the graph's guards allow only [2, 2]``."""
+
+    return "; ".join(
+        f"{name} declared [{low}, {high}] but the graph's guards allow only "
+        f"[{new_low}, {new_high}]"
+        for name, ((low, high), (new_low, new_high)) in sorted(moved.items())
+    )
+
+
 Call = tuple[tuple[Any, ...], dict[str, Any], Sequence[str]]
 
 
@@ -446,8 +664,18 @@ def alias_ingress(ingress: Any, plan: DynamicPlan) -> Any:
 __all__ = [
     "DimPolicy",
     "DynamicPlan",
+    "RangeRefusal",
     "alias_ingress",
     "all_dims",
+    "contradicted_axes",
+    "declared_symbol_ranges",
+    "decomposition_narrowing",
+    "format_narrowing",
+    "live_symbol_ranges",
+    "narrowed_symbols",
     "plan_exports",
+    "range_narrowing",
     "resolve_policy",
+    "shape_env_of",
+    "without_axes",
 ]

--- a/src/gen_worker/_vendor/torchcg/engine.py
+++ b/src/gen_worker/_vendor/torchcg/engine.py
@@ -19,6 +19,12 @@ from .declaration import (
     RuntimeCompatibility,
     _literal_digest_for,
 )
+from .dynamic import (
+    declared_symbol_ranges,
+    format_narrowing,
+    live_symbol_ranges,
+    narrowed_symbols,
+)
 from .host_isa import HostISAError, _admit_host
 from .identity import GRAPH_SPECIALIZATION_BLOCK, CompiledGraphKey, toolchain_axis_digest
 from .introspection import DeclaredConstant, declared_constants
@@ -107,6 +113,40 @@ def _compile_package(plan: _GraphSpecializationPlan, workspace: Path) -> Path:
         plan.declaration.name,
         files,
         workspace / "model.pt2",
+    )
+
+
+def _admit_symbol_ranges(plan: _GraphSpecializationPlan) -> None:
+    """Refuse an artifact compiled for a NARROWER range than its declaration.
+
+    tcg#78. Compiling shares the exported program's ShapeEnv, and the
+    decomposed graph's own guards can narrow a symbol's range -- a size-1
+    contiguity question on a batch axis guards ``>= 2``, and if that leaves a
+    single value the environment replaces the symbol with a constant. The
+    artifact then serves less than the lock promises, and the dispatcher,
+    reading the lock, sends it calls it cannot serve: an sd15 UNet whose batch
+    range collapsed this way returned a batch-2 tensor of garbage for a
+    batch-1 call and raised nothing.
+
+    This asks the question directly instead of hoping a digest notices. The
+    old guard was `declare() != declaration`, which caught the singleton case
+    ONLY because a replaced symbol happens to render differently -- a
+    narrowing that leaves two or more values moved no digest at all and shipped
+    green. Both are refused here, by name.
+    """
+
+    moved = narrowed_symbols(
+        declared_symbol_ranges(plan.spec.program),
+        live_symbol_ranges(plan.spec.program),
+    )
+    if not moved:
+        return
+    raise AdmissionError(
+        f"graph specialization {plan.declaration.name!r} compiled to a NARROWER "
+        f"range than it declares: {format_narrowing(moved)}. The compiled "
+        f"artifact cannot serve every shape the declaration admits, and the "
+        f"dispatcher guards on the declaration -- re-derive with a range the "
+        f"graph's own guards support (tcg#78)."
     )
 
 
@@ -324,6 +364,7 @@ class Engine:
             _admit_constant_table(plan, constants)
             literals = workspace / "constants.safetensors"
             literal_payload_values = _write_literals(plan.spec.program, constants, literals)
+            _admit_symbol_ranges(plan)
             if plan.spec.declare() != plan.declaration:
                 raise AdmissionError(
                     "exported program changed during compilation, packaging, "

--- a/tests/test_release_derive_dynamic_axes_pgw1548.py
+++ b/tests/test_release_derive_dynamic_axes_pgw1548.py
@@ -91,34 +91,62 @@ def test_the_static_fan_is_the_default_and_is_unchanged(lanes: dict) -> None:
             assert all(isinstance(dim, int) for dim in row["shape"])
 
 
-def test_every_axis_dynamic_is_ONE_graph_for_the_whole_fan(lanes: dict) -> None:
-    (record,) = lanes["all"]["graphs"]
-    sample = next(
-        row for row in record["ingress"]["inputs"] if row["name"] == "sample"
-    )
-    batch, channels, height, width = sample["shape"]
-    assert channels == 4
-    symbols = record["ingress"]["symbols"]
-    assert symbols[batch] == [1, 2], "the CFG axis, as a range"
-    assert symbols[height] == [48, 80] and symbols[width] == [48, 80]
-    assert height != width, "H and W are two degrees of freedom"
+def test_every_axis_dynamic_collapses_the_aspect_fan(lanes: dict) -> None:
+    """Six specializations become TWO: the aspects collapse, CFG does not.
+
+    AMENDED BY tcg#78. This asserted ONE graph, with the CFG axis symbolic
+    over [1, 2] — and that graph could not be minted. Torch specializes the
+    sizes 0 and 1 rather than reason about them symbolically, so it guards
+    every dynamic dim `>= 2`; an axis observed at 1 and 2 is contradicted by
+    the graph's own guards the moment it is exported, and the artifact that
+    came out of compiling it answered a batch-1 call with a batch-2 tensor of
+    garbage and raised nothing. The derive now refuses that axis by name.
+
+    Refusing it costs the ASPECT collapse nothing, which is the point: the
+    aspect axis is the one this program is for (sdxl 18 -> 2).
+    """
+
+    graphs = lanes["all"]["graphs"]
+    assert len(graphs) == 2
+    for record in graphs:
+        sample = next(
+            row for row in record["ingress"]["inputs"] if row["name"] == "sample"
+        )
+        batch, channels, height, width = sample["shape"]
+        assert channels == 4
+        assert batch in (1, 2), "the CFG axis is concrete in each record"
+        symbols = record["ingress"]["symbols"]
+        assert symbols[height] == [48, 80] and symbols[width] == [48, 80]
+        assert height != width, "H and W are two degrees of freedom"
+    assert {
+        next(
+            row for row in record["ingress"]["inputs"] if row["name"] == "sample"
+        )["shape"][0]
+        for record in graphs
+    } == {1, 2}
 
 
 def test_ONE_axis_at_a_time_is_the_acceptance_gates_shape(lanes: dict) -> None:
     """Paul's gate adopts per axis, so the derive must be able to do that.
 
-    `batch` collapses the CFG pair and leaves the three aspect buckets
-    concrete (6 -> 3); `aspect` collapses the three buckets and leaves the two
-    CFG batches concrete (6 -> 2). WHICH axis moved is visible in the record.
+    `aspect` collapses the three buckets and leaves the two CFG batches
+    concrete (6 -> 2). WHICH axis moved is visible in the record.
+
+    AMENDED BY tcg#78: `batch` now collapses NOTHING and says so, because that
+    axis is the one torch's `>= 2` guard contradicts. The fan comes back whole
+    (6 -> 6) — which is also what this lane measured on the real sd15 endpoint
+    from the other direction: the batch axis removed ZERO specializations
+    (14 -> 14) even when it appeared to work. The gate's SHAPE is intact; the
+    axis that pays is `aspect`.
     """
 
-    assert len(lanes["batch"]["graphs"]) == 3
+    assert len(lanes["batch"]["graphs"]) == 6
     assert len(lanes["aspect"]["graphs"]) == 2
 
     for record in lanes["batch"]["graphs"]:
+        assert record["ingress"]["symbols"] == {}
         shape = record["ingress"]["inputs"][0]["shape"]
-        assert isinstance(shape[0], str), "batch is a symbol"
-        assert isinstance(shape[2], int) and isinstance(shape[3], int)
+        assert all(isinstance(dim, int) for dim in shape), "the axis was refused"
 
     for record in lanes["aspect"]["graphs"]:
         shape = record["ingress"]["inputs"][0]["shape"]
@@ -138,7 +166,13 @@ def test_the_dynamic_records_still_dispatch_every_observed_shape(
     from gen_worker._vendor.torchcg.document import GraphRecord
     from gen_worker._vendor.torchcg.ingress import CallIngress
 
-    raw = lanes["all"]["graphs"][0]
+    raw = next(
+        candidate
+        for candidate in lanes["all"]["graphs"]
+        if next(
+            row for row in candidate["ingress"]["inputs"] if row["name"] == "sample"
+        )["shape"][0] == 2
+    )
     record = GraphRecord(
         graph=raw["graph"],
         target=raw["target"],
@@ -167,10 +201,11 @@ def test_the_dynamic_records_still_dispatch_every_observed_shape(
         )
 
     for height, width in ((64, 64), (80, 48), (48, 80)):
-        for batch in (1, 2):
-            assert call(batch, height, width), f"{batch}x{height}x{width}"
+        assert call(2, height, width), f"2x{height}x{width}"
     # And refuses what it was never exported for — a dynamic record is a
-    # range, so an unobserved shape still falls to eager.
+    # range, so an unobserved shape still falls to eager. Batch is concrete
+    # here (tcg#78), so the other CFG mode is the OTHER record's business.
+    assert not call(1, 64, 64)
     assert not call(4, 64, 64)
     assert not call(2, 96, 96)
 

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=c609d65142c3046a4bb792b4fe9a5929580fb03d" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f#14e8b4dfde79f34eefef81f8bbfa1fdef69e7a7f" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=c609d65142c3046a4bb792b4fe9a5929580fb03d#c609d65142c3046a4bb792b4fe9a5929580fb03d" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
pgw#1548 / tcg#78: vendor torchcg c609d651 — a contradicted dynamic axis is refused at DERIVE

Vendor bump only; no gen-worker logic changes. `dynamic_dim_policy` already
speaks the per-axis vocabulary torchcg needs, so the fix arrives through the
snapshot.

## What the bump brings

torchcg tcg#78. An sd15 UNet exported with a batch `Dim` over [1, 2] compiled
for 84-129 s of GPU and was then rejected by torchcg's own admission check.
Bypassing that check and running the artifact it wanted to publish: **a batch-1
call returns a (2, 4, 64, 64) tensor of garbage and raises nothing.**

Cause: `range_constraints` and the ShapeEnv are two different statements and
nothing in torch reconciles them. Immediately after one export that raised
nothing — `declared {'s53': (1, 2)}  live {'s53': (2, 2)}`. Torch specializes
the sizes 0 and 1 rather than reason about broadcasting symbolically, so every
dynamic dim is guarded `>= 2`; an axis observed at 1 and 2 is contradicted the
moment it is exported. The lock is built from `range_constraints`, so the
contradiction survived into the artifact and into the dispatcher's guards.

Now: the derive refuses the contradicted AXIS by name (free — both statements
are already in memory), demoting only that axis so a refused batch axis does
not take the aspect collapse with it; the mint keeps an explicit post-compile
range check as defence in depth.

## What changes for `--dynamic-axes`

| flag | before | after |
|---|---|---|
| `off` | 6 concrete | 6 concrete (unchanged) |
| `batch` | 6 -> 3 | **6 -> 6, refused loudly** |
| `aspect` | 6 -> 2 | 6 -> 2 (unchanged) |
| `all` | 6 -> 1 | **6 -> 2** |

The `batch` row is the defect, not a regression: this lane already measured
that the batch axis removes ZERO specializations on the real sd15 endpoint
(14 -> 14), and Paul has since ruled the CFG/batch axis permanently static.
`aspect` — the axis the program is actually for — is untouched.

`tests/test_release_derive_dynamic_axes_pgw1548.py` is AMENDED, not weakened:
it asserted that a batch axis over [1, 2] collapses into one servable graph,
which is precisely the defect. It now asserts the aspect collapse survives the
batch refusal, and that a refused axis says so.

18 tests pass across both dynamic-dims files. ruff clean. Pin agreement
verified: pyproject.toml, uv.lock and VENDORED.toml all name c609d651.

Note: torchcg's canonical graph form changed, so DYNAMIC graph hashes move.
Content addressed and dynamic dims landed the same day, so nothing migrates —
the next derive republishes. Static graphs carry no symbols and are unaffected.
