### PR TITLE
pgw#1590: admission charges the LANE'S DECLARATION, not the whole tree at its stored precision

### DIFF
--- a/changelog.d/pgw1590-admission-declaration.md
+++ b/changelog.d/pgw1590-admission-declaration.md
@@ -1,0 +1,18 @@
+- **pgw#1590: serving admission charges the LANE'S OWN DECLARATION, not the whole
+  checkpoint tree at its stored precision.** `ResidencyManager.lease` sized every
+  instance from `tree_bytes(whole repo) x 1.25` and threw the `lane` argument
+  away, so a multi-component repo charged each lane for every other lane's bytes
+  at a precision the load path may not keep. On a real H100 pod it refused
+  `minimax.h3-dit-diffusers@1` as needing 180,063,706,300 bytes against
+  84,368,556,032 — `JOB_STATUS_FATAL` on the exact shape six pods of this fleet
+  had served on single H100s two weeks earlier, because H3's DiT is `quantize_()`
+  d to w8a8 inside `setup()` and no manifest can see that.
+
+  A lane's declared VRAM floor (`lanes={contract: "vram78g"}`) now CAPS the
+  charge. That number is a declaration in the author's own class header, already
+  statically extracted, and already what the hub filters placement on — charging
+  more than it was the incoherent position: "the platform placed me on a card
+  sized by this floor, and I refuse to run because I need more than the floor."
+  The cap is `min`, so it can only ever lower a charge and no lane admitted
+  before is refused now; a lane that declares nothing keeps the conservative
+  whole-tree charge, and its refusal says which declaration would fix it.

--- a/src/gen_worker/serving/__init__.py
+++ b/src/gen_worker/serving/__init__.py
@@ -72,12 +72,14 @@ from .loader import (
 from .self_mint import SelfMint, SelfMintStatus
 from .serve_adoption import ServeAdoption
 from .residency import (
+    Charge,
     InstanceSizer,
     Lease,
     ModelBackend,
     NeverFits,
     ResidencyError,
     ResidencyManager,
+    admission_charge,
 )
 from .serve_loop import (
     BindingResolver,
@@ -94,7 +96,14 @@ from .model import (
     model_requires,
     model_type,
 )
-from .placement import DeviceFacts, Shortfall, device_facts, shortfalls, warn_if_degraded
+from .placement import (
+    DeviceFacts,
+    Shortfall,
+    declared_vram_bytes,
+    device_facts,
+    shortfalls,
+    warn_if_degraded,
+)
 
 __all__ = [
     "boot_engine",
@@ -114,6 +123,7 @@ __all__ = [
     "ServeLoop",
     "ResidencyManager",
     "ResidencyError",
+    "Charge",
     "NeverFits",
     "ModelBackend",
     "Lease",
@@ -158,6 +168,8 @@ __all__ = [
     "SelfMintStatus",
     "ServeAdoption",
     "model_lanes",
+    "admission_charge",
+    "declared_vram_bytes",
     "model_requires",
     "model_type",
 ]

--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -504,6 +504,16 @@ class Model(Generic[MT]):
     and says so, never refused, so cozy-local can run anything it has the
     patience for.
 
+    IT IS ALSO WHAT SERVING ADMISSION CHARGES (pgw#1590), and this is the one
+    thing that goes wrong by OMITTING it. With no floor, admission has only
+    the checkpoint tree to size a lane from — the WHOLE tree, at its stored
+    precision, plus 25% — and that number cannot see a ``setup()``-time
+    ``quantize_()`` or a component this lane offloads. minimax-h3's DiT lane
+    was refused as needing 180 GB on a card that had served it, because 133 GB
+    of stored bf16 becomes ~66 GB of w8a8 inside ``load``. Declaring the floor
+    replaces that guess with your number. It only ever LOWERS the charge, so
+    adding one can never make a lane harder to admit than leaving it off.
+
     ``__init__`` stays FREE (no GPU, no weights): construction and loading are
     separate moments, and derive/introspection instantiate without weights.
     """

--- a/src/gen_worker/serving/placement.py
+++ b/src/gen_worker/serving/placement.py
@@ -171,6 +171,45 @@ def serving_device() -> str:
     return "cpu"
 
 
+def declared_vram_bytes(model_cls: type, lane: Any) -> int:
+    """Bytes of the VRAM floor lane ``lane`` of ``model_cls`` DECLARES; 0 for
+    an undeclared floor, an eager-permanent model, or a lane this class does
+    not name.
+
+    THE FOURTH READ OF THE SAME NUMBER (pgw#1590), and the reason this lives
+    beside :func:`shortfalls` rather than in the residency engine. The module
+    header lists three readers; serving ADMISSION was a fourth reader that had
+    no access to the declaration, so it invented its own answer to "how much of
+    a card does this lane need" — the whole checkpoint tree at its STORED
+    precision, plus 25%. Two producers of one fact, and they disagreed by 2x on
+    minimax-h3: the hub bought an H100 because the lane declares ``vram78g``,
+    and the worker on that H100 then refused the lane as needing 180 GB.
+
+    The declaration wins, because it is the only one of the two that can see
+    what the load path actually does. H3's DiT is stored bf16 and `quantize_()`
+    d to w8a8 inside ``setup()``; a text encoder may never reach the card at
+    all. Neither is visible in a manifest, and both are visible to the author
+    who wrote the floor.
+
+    GiB, like every other read of this term (:class:`DeviceFacts` compares it
+    against ``total_memory / 2**30``) — one spelling, one conversion.
+    """
+
+    from .model import lane_handle, model_requires
+
+    if lane is None:
+        return 0  # eager-permanent: no lane, so no lane floor
+    try:
+        requirements = model_requires(model_cls).get(lane_handle(lane))
+    except Exception:  # noqa: BLE001 — a floor read never costs an admission
+        logger.debug("declared_vram_bytes: unreadable lane", exc_info=True)
+        return 0
+    if requirements is None:
+        return 0
+    gib = float(requirements.min_terms().min_vram_gb or 0.0)
+    return int(gib * _BYTES_PER_GIB) if gib > 0 else 0
+
+
 def shortfalls(
     model_cls: type, lane: Any, *, facts: Optional[DeviceFacts] = None
 ) -> Tuple[Shortfall, ...]:
@@ -246,6 +285,7 @@ __all__ = [
     "ACTIVITY_KIND",
     "DeviceFacts",
     "Shortfall",
+    "declared_vram_bytes",
     "device_facts",
     "serving_device",
     "shortfalls",

--- a/src/gen_worker/serving/residency.py
+++ b/src/gen_worker/serving/residency.py
@@ -6,12 +6,18 @@ because 3 checkpoints were loaded at the same time"*):
 
 1. **Admission before allocation.** Placement is the WORKER's decision —
    author code is device-neutral (no ``.to()``/``torch_dtype`` in the
-   contract file). Before constructing an instance, its EXACT weight byte
-   size (the tensorfs manifest per lane — known ahead of load) plus an
-   activation-headroom estimate (per model type / resolution class) is
-   reserved against the VRAM budget; LRU residents are evicted until it
-   fits. A model that can NEVER fit refuses typed at admission — a CUDA OOM
-   mid-load or at first request is a design bug, not bad luck.
+   contract file). Before constructing an instance, its weight byte size
+   plus an activation-headroom estimate is reserved against the VRAM budget;
+   LRU residents are evicted until it fits. A model that can NEVER fit
+   refuses typed at admission — a CUDA OOM mid-load or at first request is a
+   design bug, not bad luck.
+
+   pgw#1590 AMENDS WHERE THAT SIZE COMES FROM. This clause used to say "its
+   EXACT weight byte size (the tensorfs manifest per lane)". The manifest is
+   not exact and is not per lane: it is the whole tree at its STORED
+   precision, an upper bound on residency that cannot see a setup()-time
+   `quantize_()` or an offloaded component. So the lane's declared VRAM floor
+   caps the charge when it is smaller — see :func:`admission_charge`.
 2. **Loads serialized per GPU.** Concurrent instance loads must not race the
    VRAM budget or fragment pinned staging: one load gate.
 3. **Two-tier residency.** VRAM -> RAM-resident (host-staged weights;
@@ -49,6 +55,104 @@ class NeverFits(ResidencyError):
     no eviction schedule can ever make it fit."""
 
 
+@dataclass(frozen=True)
+class Charge:
+    """What admission bills one instance for, and WHY (pgw#1590).
+
+    ``basis`` is not decoration: it is the sentence the refusal and the
+    confession both carry, so an operator reading either can tell a number
+    derived from the tree from a number the author declared.
+    """
+
+    weight_bytes: int
+    headroom_bytes: int
+    basis: str
+
+    @property
+    def total(self) -> int:
+        return self.weight_bytes + self.headroom_bytes
+
+
+def admission_charge(
+    tree_weight_bytes: int, tree_headroom_bytes: int, declared_vram_bytes: int
+) -> Charge:
+    """The bytes to reserve for one instance: the smaller of what the LANE
+    DECLARES it needs of a card and what the STORED TREE implies.
+
+    pgw#1590. The tree-derived number is an upper bound on residency and
+    nothing more. It reads a checkpoint's on-disk precision and cannot see
+    what the lane's load path does with those bytes — a ``setup()``-time
+    ``quantize_()`` to w8a8, a text encoder that is offloaded and never lands
+    on the card, a component the lane does not touch at all. minimax-h3 is all
+    three at once: a 133 GB bf16 DiT that serves as ~66 GB of fp8, inside a
+    144 GB repo of which the DiT lane loads one part. Charged from the tree it
+    "needs" 180 GB and no card exists; charged from its own declaration it
+    needs 78 GiB, which is the card the hub already bought for it, and which
+    it demonstrably served on.
+
+    So a declared floor CAPS the charge, and only ever downward:
+
+    * **it can never make admission stricter.** ``min`` — a lane whose floor is
+      generous relative to its tree keeps the tree number, so no lane that is
+      admitted today is refused tomorrow.
+    * **it is not optimism.** The floor is a DECLARATION in the author's own
+      class header (``lanes={contract: "vram78g"}``), statically extractable,
+      and already the number the hub filters placement on. Charging more than
+      it is the incoherent position: it says "the platform placed me on a card
+      sized by this floor, and I refuse to run because I believe I need more
+      than the floor". An endpoint whose floor is below its true residency is
+      broken at PLACEMENT, before admission ever sees it, and that failure has
+      a named owner and a loud warning path (``placement.warn_if_degraded``).
+    * **an undeclared floor changes nothing.** No declaration, no cap, and the
+      conservative whole-tree charge stands. A guess is never allowed to be the
+      optimistic input — an OOM on a rented card is worse than a refusal.
+
+    A capped charge carries its whole footprint in ``weight_bytes`` with zero
+    headroom, because that is what the declaration says: ``vram78g`` is what
+    the lane needs OF A CARD, activations included, not a weights subtotal to
+    add 25% to.
+    """
+
+    tree = Charge(
+        int(tree_weight_bytes),
+        int(tree_headroom_bytes),
+        f"charged from the STORED TREE: {int(tree_weight_bytes)} weight bytes at "
+        f"the checkpoint's on-disk precision + {int(tree_headroom_bytes)} "
+        f"activation headroom",
+    )
+    declared = int(declared_vram_bytes)
+    if declared <= 0:
+        return Charge(
+            tree.weight_bytes,
+            tree.headroom_bytes,
+            tree.basis
+            + ". This lane DECLARES NO VRAM FLOOR, so admission has nothing "
+            "but the tree to go on and charges all of it. If the lane's load "
+            "path holds less than the tree resident — a setup()-time "
+            "quantize, an offloaded or unused component — declare it in the "
+            "class header (`lanes={contract: \"vramNNg\"}`) and admission "
+            "charges the declaration instead",
+        )
+    if declared >= tree.total:
+        return Charge(
+            tree.weight_bytes,
+            tree.headroom_bytes,
+            tree.basis
+            + f". The lane's declared floor ({declared} bytes) is not smaller, "
+            f"so it does not cap this charge",
+        )
+    return Charge(
+        declared,
+        0,
+        f"charged from the LANE'S OWN DECLARATION: {declared} bytes "
+        f"(`lanes={{contract: \"vram...g\"}}`), the card this lane states it "
+        f"needs — activations included. The stored tree implies {tree.total} "
+        f"bytes ({tree.weight_bytes} + {tree.headroom_bytes} headroom), an "
+        f"on-disk-precision upper bound this lane's load path does not hold "
+        f"resident",
+    )
+
+
 class ModelBackend(Protocol):
     """What one resident instance must provide (the pgw#1382 seam).
 
@@ -81,8 +185,15 @@ class InstanceSizer(Protocol):
     """Byte facts, known AHEAD of any allocation."""
 
     def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
-        """Exact weight bytes for (checkpoint, lane) — the tensorfs manifest
-        for the lane's layout contract states this without loading."""
+        """Weight bytes for (checkpoint, lane) from the tensorfs manifest,
+        without loading.
+
+        AN UPPER BOUND, not an exact resident cost (pgw#1590 — this docstring
+        used to say "exact" and the production sizer answers with the whole
+        tree at its stored precision). A manifest cannot see a setup()-time
+        `quantize_()`, an offloaded component, or a component the lane never
+        touches; only the lane's own declaration can, and
+        :func:`admission_charge` is where the two meet."""
         ...
 
     def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
@@ -172,6 +283,26 @@ class ResidencyManager:
         #: Loads and promotions serialized per GPU — ruling clause 2.
         self._load_gate = threading.Lock()
         self._clock = 0
+        #: Keys whose admission basis has already been said out loud. Once per
+        #: instance, not once per request — the basis cannot change between
+        #: two requests for the same key.
+        self._confessed: set[InstanceKey] = set()
+
+    def _confess(self, key: InstanceKey, charge: "Charge") -> None:
+        """Say what admission is about to decide FROM, before it decides.
+
+        pgw#1586's rule, applied to the rung above the ladder: a decision that
+        does not state the numbers it saw is a decision nobody can audit later
+        — which is exactly how pgw#1590's refusal read as a hardware fact
+        instead of a sizing bug for six days.
+        """
+        if key in self._confessed:
+            return
+        self._confessed.add(key)
+        logger.info(
+            "ADMISSION %s: %d bytes against a %d byte budget — %s",
+            key, charge.total, self.vram_budget_bytes, charge.basis,
+        )
 
     # -- byte accounting (self._state held) ---------------------------------
 
@@ -192,28 +323,43 @@ class ResidencyManager:
         checkpoint_ref: str,
         lane: str,
         factory: Callable[[], ModelBackend],
+        *,
+        declared_vram_bytes: int = 0,
     ) -> Lease:
         """Admit, place and single-flight one request's model instance.
 
         Blocks while the fit depends only on in-flight work draining
         (progress, not a clock: every release re-evaluates). Raises
-        :class:`NeverFits` at ADMISSION when weights + headroom exceed the
-        whole budget — before ``factory`` runs, before any byte moves.
+        :class:`NeverFits` at ADMISSION when the charge exceeds the whole
+        budget — before ``factory`` runs, before any byte moves.
+
+        ``declared_vram_bytes`` is the lane's own floor declaration
+        (``placement.declared_vram_bytes``), passed by the caller that holds
+        the model class. It CAPS the sizer's tree-derived charge and can never
+        raise it — see :func:`admission_charge` for why the declaration is the
+        more trustworthy of the two numbers.
         """
         key: InstanceKey = (str(checkpoint_ref), str(lane))
-        weight = int(self._sizer.resident_bytes(*key))
-        headroom = int(self._sizer.activation_headroom_bytes(*key))
-        if weight <= 0:
+        tree_weight = int(self._sizer.resident_bytes(*key))
+        if tree_weight <= 0:
             raise ResidencyError(
-                f"{key}: the lane manifest states {weight} weight bytes; "
+                f"{key}: the lane manifest states {tree_weight} weight bytes; "
                 f"admission needs the real size"
             )
-        if weight + headroom > self.vram_budget_bytes:
+        charge = admission_charge(
+            tree_weight,
+            int(self._sizer.activation_headroom_bytes(*key)),
+            int(declared_vram_bytes),
+        )
+        weight, headroom = charge.weight_bytes, charge.headroom_bytes
+        self._confess(key, charge)
+        if charge.total > self.vram_budget_bytes:
             raise NeverFits(
-                f"{key}: needs {weight + headroom} bytes resident "
+                f"{key}: needs {charge.total} bytes resident "
                 f"({weight} weights + {headroom} activation headroom) and the "
                 f"whole VRAM budget is {self.vram_budget_bytes}; no eviction "
-                f"schedule can fit it — refuse at admission, never OOM mid-load"
+                f"schedule can fit it — refuse at admission, never OOM "
+                f"mid-load. Basis: {charge.basis}"
             )
 
         with self._state:
@@ -354,7 +500,18 @@ class ResidencyManager:
         the rung that sizes a resident set from it can never disagree with the
         reservation that let the instance in. It is available BEFORE the
         factory runs, which is when the load context that carries it is built.
+
+        pgw#1590: THE ADMITTED CHARGE, not the sizer's raw tree number. Once a
+        declared lane floor can cap the reservation, re-asking the sizer here
+        would hand the streaming rung a budget the manager never reserved —
+        the exact disagreement this method exists to make impossible. The slot
+        is already in the ledger by the time a load context is built; the
+        sizer is only the answer before any lease has run.
         """
+        with self._state:
+            slot = self._slots.get((str(checkpoint_ref), str(lane)))
+            if slot is not None and slot.weight_bytes > 0:
+                return int(slot.weight_bytes)
         try:
             return int(self._sizer.resident_bytes(str(checkpoint_ref), str(lane)))
         except Exception:  # noqa: BLE001 — a sizer that cannot answer means
@@ -373,6 +530,7 @@ class ResidencyManager:
 
 
 __all__ = [
+    "Charge",
     "InstanceKey",
     "InstanceSizer",
     "Lease",
@@ -381,4 +539,5 @@ __all__ = [
     "ResidencyError",
     "ResidencyManager",
     "Tier",
+    "admission_charge",
 ]

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -49,7 +49,7 @@ from .envelope import DecodedRequest, decode_envelope
 from .host import ServeDispatchError
 from .loader import LoadedEndpoint
 from .model import Model, lane_handle, model_type
-from .placement import warn_if_degraded
+from .placement import declared_vram_bytes, warn_if_degraded
 from .reserved_repos import (
     materialize_reserved_inputs,
     reserved_context_kwargs,
@@ -488,7 +488,7 @@ class ServeLoop:
             for slot_name in sorted(model_slots):
                 model_cls = model_slots[slot_name]
                 binding = self._resolver.resolve(model_cls, picks[slot_name])
-                _, lane_key = self._lane_of(model_cls)
+                lane_object, lane_key = self._lane_of(model_cls)
                 key = (model_cls, binding.checkpoint_ref, lane_key)
                 with self._backends_lock:
                     known = self._backends.get(key)
@@ -503,6 +503,15 @@ class ServeLoop:
                     binding.checkpoint_ref,
                     f"{model_cls.__name__}/{lane_key}",
                     factory,
+                    # pgw#1590: the lane's OWN statement of what it needs of a
+                    # card. This is the only caller that holds the model class,
+                    # so it is the only one that can read the declaration — the
+                    # sizer sees a `Class/lane@1` string and a tree, which is
+                    # how admission ended up charging minimax-h3's DiT lane for
+                    # the whole repo at its stored bf16 precision.
+                    declared_vram_bytes=declared_vram_bytes(
+                        model_cls, lane_object
+                    ),
                 )
                 leases.enter_context(lease)
                 backend = lease.backend

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -476,8 +476,16 @@ class SnapshotSizer:
     """Weight bytes from the materialized tree's tensorfs manifest.
 
     ``tree_bytes`` sizes a PROJECTED tree from its manifest rather than
-    walking stubs, so this is the exact resident cost, known before any byte
-    moves — which is what admission requires.
+    walking stubs, so this is known before any byte moves — which is what
+    admission requires.
+
+    IT IS AN UPPER BOUND, NOT THE RESIDENT COST (pgw#1590), and ``lane`` is a
+    parameter it genuinely cannot answer for: the number is the WHOLE tree at
+    its STORED precision, including components this lane never loads, before
+    any setup()-time `quantize_()` the load path performs. The lane's own
+    declared floor is what corrects it, applied by
+    :func:`~gen_worker.serving.residency.admission_charge`; this class stays
+    the honest answer to "how big is the tree on disk".
     """
 
     def __init__(self, resolver: HubBindingResolver) -> None:

--- a/tests/test_admission_lane_declaration_pgw1590.py
+++ b/tests/test_admission_lane_declaration_pgw1590.py
@@ -1,0 +1,424 @@
+"""Serving admission charges the LANE'S DECLARATION, not the stored tree.
+
+pgw#1590, filed from a real H100 pod: ``NeverFits`` refused
+``minimax.h3-dit-diffusers@1`` as needing 180,063,706,300 bytes on a card with
+84,368,556,032 — the exact shape this fleet served on single H100s two weeks
+earlier. The 180 GB is the WHOLE minimax-h3 repo at its stored bf16 precision
+plus 25%; the lane loads one part of it and `quantize_()`s that part to w8a8
+inside ``setup()``, which no manifest can see and which the endpoint's own
+``lanes={contracts.MINIMAX_H3_DIT_DIFFUSERS: "vram78g"}`` header states.
+
+INTEGRATION, and the arithmetic is never faked: a real ``LocalCAS`` holding a
+real ``RepositoryManifest`` at minimax-h3's measured per-shard byte sizes, the
+production ``SnapshotSizer`` reading it through ``disk_gc.tree_bytes``, the
+production ``ResidencyManager``, and the declaration read off a real
+``Model`` subclass by the production ``placement.declared_vram_bytes``. The
+only stand-in is the resolver seam (WHICH tree), which is not part of the
+number under test.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List, cast
+
+import pytest
+
+from gen_worker._vendor.tensorfs import (
+    CASRef,
+    FileEntry,
+    LocalCAS,
+    RepositoryManifest,
+)
+from gen_worker._vendor.tensorfs import contracts
+from gen_worker.models import MiniMaxH3
+from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR
+from gen_worker.serving.model import Model
+from gen_worker.serving.placement import declared_vram_bytes
+from gen_worker.serving.residency import (
+    NeverFits,
+    ResidencyManager,
+    Tier,
+    admission_charge,
+)
+from gen_worker.worker import SnapshotSizer
+
+GIB = 1024 ** 3
+
+# ── the measured article ─────────────────────────────────────────────────────
+#
+# Every number here was READ, not chosen: the two DiT component_fetch shards
+# and the whole-repo total come from the pgw#1590 refusal on pod
+# `ys9d2mu6opwb3a` (request 68eace0e-a9ba-4df6-ad1f-ada73f40c79a), and the
+# budget is that H100's own `mem_get_info` headroom.
+H3_DIT_SHARD_A = 66_726_413_676
+H3_DIT_SHARD_B = 66_280_505_604
+H3_TREE_BYTES = 144_050_965_040
+H3_REST = H3_TREE_BYTES - H3_DIT_SHARD_A - H3_DIT_SHARD_B
+H100_BUDGET = 84_368_556_032
+
+#: What the refusal charged: the whole tree + the /4 activation estimate.
+H3_TREE_CHARGE = H3_TREE_BYTES + H3_TREE_BYTES // 4
+
+#: What the endpoint DECLARES (`serverless-endpoints/minimax-h3`, main.py:292).
+H3_FLOOR_BYTES = 78 * GIB
+
+
+class H3Model(Model[MiniMaxH3], lanes={contracts.MINIMAX_H3_DIT_DIFFUSERS: "vram78g"}):
+    """The declaration under test, spelled exactly as the shipped endpoint
+    spells it — a real contract object and a real floor, so this test reads
+    the same class attribute production reads."""
+
+
+H3_LANE = contracts.MINIMAX_H3_DIT_DIFFUSERS
+H3_KEY = ("tensorhub/minimax-h3@serve-narrowed", "H3Model/minimax.h3-dit-diffusers@1")
+
+
+# ── a real projected snapshot, without 144 GB of disk ────────────────────────
+
+
+def _digest(name: str) -> CASRef:
+    return CASRef.parse("sha256:" + hashlib.sha256(name.encode()).hexdigest())
+
+
+def project(base: Path, name: str, files: Dict[str, int]) -> Path:
+    """A REAL tensorfs projection: a real ``LocalCAS``, a real manifest stored
+    and pinned under the real ref name, and the tree at the path
+    ``resolve_projection`` looks for.
+
+    The manifest is the article — ``disk_gc.tree_bytes`` sizes a projected
+    tree from its manifest and never from the files, which is precisely why a
+    stubbed 144 GB repo can be sized on a laptop and precisely how the
+    production sizer got its 144,050,965,040.
+    """
+
+    cas = LocalCAS(base)
+    manifest = RepositoryManifest(
+        files=tuple(
+            FileEntry(path=path, size_bytes=size, digest=_digest(path))
+            for path, size in sorted(files.items())
+        )
+    )
+    ref = cas.store_manifest(manifest)
+    cas.compare_and_swap_ref(REF_PREFIX + name, ref, expected=None)
+    tree = base / SNAPSHOTS_DIR / name
+    tree.mkdir(parents=True, exist_ok=True)
+    (tree / "config.json").write_text(json.dumps({"_class_name": "H3Pipeline"}))
+    return tree
+
+
+H3_TREE_LAYOUT = {
+    # The DiT lane's own bytes: the two component_fetch shards.
+    "transformer/diffusion_pytorch_model-00001-of-00002.safetensors": H3_DIT_SHARD_A,
+    "transformer/diffusion_pytorch_model-00002-of-00002.safetensors": H3_DIT_SHARD_B,
+    # Everything the DiT lane is NOT: vae, text encoder, audio vae, the
+    # tokenizer/scheduler/processor configs. Charged to the card today.
+    "text_encoder/model.safetensors": H3_REST - 2_000_000_000,
+    "vae/diffusion_pytorch_model.safetensors": 1_500_000_000,
+    "audio_vae/diffusion_pytorch_model.safetensors": 500_000_000,
+}
+
+
+class _Resolver:
+    """The resolver SEAM — which tree, never how big. Shaped like
+    ``HubBindingResolver`` for ``SnapshotSizer``'s one call."""
+
+    def __init__(self, trees: Dict[str, Path]) -> None:
+        self._trees = trees
+
+    def tree_for(self, model_cls: type, checkpoint_ref: str) -> Path:
+        return self._trees[checkpoint_ref]
+
+
+class Backend:
+    """Records every move; the residency engine never touches tensors."""
+
+    def __init__(self, journal: List[str]) -> None:
+        self.journal = journal
+
+    def load(self) -> None:
+        self.journal.append("load")
+
+    def demote_to_host(self) -> None:
+        self.journal.append("demote")
+
+    def promote_to_device(self) -> None:
+        self.journal.append("promote")
+
+    def drop(self) -> None:
+        self.journal.append("drop")
+
+
+@pytest.fixture()
+def h3_manager(tmp_path: Path) -> Any:
+    tree = project(tmp_path / "store", "minimax-h3", H3_TREE_LAYOUT)
+    sizer = SnapshotSizer(cast(Any, _Resolver({H3_KEY[0]: tree})))
+    return sizer, lambda budget: ResidencyManager(budget, sizer)
+
+
+# ── the sizer still tells the truth about the tree ───────────────────────────
+
+
+def test_the_production_sizer_reads_the_measured_tree_from_a_real_manifest(
+    h3_manager: Any,
+) -> None:
+    """Non-vacuity: the tree number this test is about is the one the pod
+    computed, produced by the same code, from a manifest — not a constant
+    typed into the test."""
+    sizer, _ = h3_manager
+    assert sizer.resident_bytes(*H3_KEY) == H3_TREE_BYTES
+    assert sizer.resident_bytes(*H3_KEY) + sizer.activation_headroom_bytes(
+        *H3_KEY
+    ) == H3_TREE_CHARGE == 180_063_706_300
+
+
+# ── the regression ───────────────────────────────────────────────────────────
+
+
+def test_the_h3_dit_lane_is_refused_when_its_declaration_is_not_read(
+    h3_manager: Any,
+) -> None:
+    """THE BUG, reproduced byte-for-byte on the real objects. Charging the
+    stored tree — which is what a lane with no readable declaration gets —
+    reproduces the pod's exact refusal string."""
+    _, manager_for = h3_manager
+    manager = manager_for(H100_BUDGET)
+    journal: List[str] = []
+    with pytest.raises(NeverFits) as excinfo:
+        manager.lease(*H3_KEY, lambda: Backend(journal))
+    message = str(excinfo.value)
+    assert "needs 180063706300 bytes resident" in message
+    assert "144050965040 weights + 36012741260 activation headroom" in message
+    assert "the whole VRAM budget is 84368556032" in message
+    assert journal == []  # refused at admission: no byte moved
+
+
+def test_the_h3_dit_lane_is_admitted_on_a_single_h100_from_its_own_declaration(
+    h3_manager: Any,
+) -> None:
+    """THE FIX, at the production numbers.
+
+    ``vram78g`` -> 83,751,862,272 bytes against this H100's 84,368,556,032 of
+    headroom: it fits, with 616,693,760 bytes (588 MiB) to spare. That margin
+    is tight ON PURPOSE and it is the endpoint's own arithmetic, not this
+    test's: the DiT is 133,006,919,280 bf16 bytes, w8a8 halves the weight
+    tensors to ~66.5 GB, and ~17 GB of activations lands the serve at ~83 GB —
+    which is why the header says 78 GiB and not 40.
+
+    The fleet is the witness that this is a measurement and not a hope: pods
+    yntiu7c3pd70bk, adux79i8nvy2j1, ac939lahn39c63, gqxy5elsartscu,
+    ouu3szyqer3lss and lb27wbsay43z72 each hydrated and SERVED this shape on
+    one NVIDIA H100 80GB HBM3 on 2026-08-14.
+    """
+    _, manager_for = h3_manager
+    manager = manager_for(H100_BUDGET)
+    journal: List[str] = []
+
+    declared = declared_vram_bytes(H3Model, H3_LANE)
+    assert declared == H3_FLOOR_BYTES == 83_751_862_272
+    assert declared < H100_BUDGET
+    assert H100_BUDGET - declared == 616_693_760
+
+    with manager.lease(
+        *H3_KEY, lambda: Backend(journal), declared_vram_bytes=declared
+    ):
+        assert manager.tier_of(*H3_KEY) is Tier.VRAM
+    assert journal == ["load"]
+
+    # The reservation IS the declaration — activations included, no 25% on top.
+    reserved, _host = manager.reserved_bytes()
+    assert reserved == H3_FLOOR_BYTES
+    # pgw#1497's seam agrees with what admission actually reserved, rather
+    # than re-asking the sizer and answering 144 GB.
+    assert manager.weight_budget_bytes(*H3_KEY) == H3_FLOOR_BYTES
+
+
+def test_a_declared_floor_is_not_blanket_optimism_a_smaller_card_still_refuses(
+    h3_manager: Any,
+) -> None:
+    """The declaration lowers the charge; it does not delete the gate. An
+    L40S/A6000-class 48 GiB card cannot hold this lane and is still refused
+    typed, before any byte moves — an OOM on a rented card is worse than a
+    refusal, which is why the cap is a DECLARED number and never a guess."""
+    _, manager_for = h3_manager
+    manager = manager_for(48 * GIB)
+    journal: List[str] = []
+    with pytest.raises(NeverFits) as excinfo:
+        manager.lease(
+            *H3_KEY,
+            lambda: Backend(journal),
+            declared_vram_bytes=declared_vram_bytes(H3Model, H3_LANE),
+        )
+    message = str(excinfo.value)
+    assert "needs 83751862272 bytes resident" in message
+    assert "LANE'S OWN DECLARATION" in message
+    assert journal == []
+
+
+# ── the properties that keep every other lane where it was ───────────────────
+
+
+def test_no_declaration_leaves_the_conservative_charge_byte_identical() -> None:
+    """The fallback is untouched. A lane that declares nothing is charged the
+    whole stored tree plus 25%, exactly as before — and the refusal now says
+    what to declare instead of leaving the reader to guess."""
+    charge = admission_charge(H3_TREE_BYTES, H3_TREE_BYTES // 4, 0)
+    assert charge.weight_bytes == H3_TREE_BYTES
+    assert charge.headroom_bytes == H3_TREE_BYTES // 4
+    assert charge.total == H3_TREE_CHARGE
+    assert "DECLARES NO VRAM FLOOR" in charge.basis
+    assert 'lanes={contract: "vramNNg"}' in charge.basis
+
+
+@pytest.mark.parametrize(
+    "floor_gb",
+    # The fleet's real declared floors, one per shape class
+    # (`serverless-endpoints/*/src/*/main.py`): sd15 vram6g, sdxl vram7g,
+    # z-image vram32g, flux.1-dev vram38g, ltx-2 vram78g, minimax-h3 vram78g.
+    [6.0, 7.0, 8.0, 12.0, 22.0, 24.0, 30.0, 32.0, 36.0, 38.0, 44.0, 78.0],
+)
+@pytest.mark.parametrize(
+    "tree_gb", [0.5, 2.0, 4.3, 6.9, 13.9, 16.0, 24.0, 60.0, 134.0]
+)
+def test_a_declared_floor_can_only_ever_lower_the_charge(
+    floor_gb: float, tree_gb: float
+) -> None:
+    """THE SAFETY PROPERTY, over every (fleet floor x plausible tree) pair:
+    the charge is never larger than it was, so no lane admitted today can be
+    refused tomorrow. This is what makes the change safe to land for the whole
+    fleet on the evidence of one endpoint."""
+    weights = int(tree_gb * GIB)
+    headroom = weights // 4
+    before = weights + headroom
+    after = admission_charge(weights, headroom, int(floor_gb * GIB))
+    assert after.total <= before
+    assert after.total == min(before, int(floor_gb * GIB))
+
+
+def test_a_floor_above_the_tree_leaves_the_charge_exactly_where_it_was() -> None:
+    """z-image's shape and the reason sd15/sdxl/z-image do not move: a lane
+    whose floor is generous relative to its tree keeps the tree number,
+    weights-and-headroom split included. The cap is `min`, so it is inert
+    until the tree crosses the declaration."""
+    weights, floor = 16 * GIB, 32 * GIB
+    charge = admission_charge(weights, weights // 4, floor)
+    assert (charge.weight_bytes, charge.headroom_bytes) == (weights, weights // 4)
+    assert "does not cap this charge" in charge.basis
+
+
+# ── the whole serve path, class header to reservation ────────────────────────
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "serving_v2_endpoint"
+FIXTURE_REF = "org/oversized@1"
+
+
+class _LoopResolver:
+    """One object for both seams the serve path resolves through: the deploy
+    binding ServeLoop asks for, and the tree SnapshotSizer sizes."""
+
+    def __init__(self, tree: Path) -> None:
+        self.tree = tree
+
+    def resolve(self, model_cls: type, checkpoint_ref: str) -> Any:
+        from gen_worker.serving import DeployBinding
+
+        return DeployBinding(
+            checkpoint_ref=checkpoint_ref,
+            checkpoint_dir=self.tree,
+            model="sdxl",
+            defaults={},
+        )
+
+    def default_pick(self, model_cls: type, slot_name: str) -> str:
+        return ""
+
+    def tree_for(self, model_cls: type, checkpoint_ref: str) -> Path:
+        return self.tree
+
+
+def test_the_declaration_reaches_admission_through_the_real_serve_path(
+    tmp_path: Path,
+) -> None:
+    """END TO END on the production dispatcher, because the defect was never
+    in the arithmetic — it was that the ONE caller holding the model class did
+    not hand its declaration to the ONE object doing the arithmetic.
+
+    A real endpoint (``load_endpoint``), its real ``lanes={contract:
+    "vram12g"}`` header, a real ``ServeLoop``, a real ``ResidencyManager`` over
+    the real ``SnapshotSizer``, and a real projected manifest carrying
+    minimax-h3's measured 144,050,965,040 bytes. Under the tree charge this
+    request is a ``JOB_STATUS_FATAL``; under the declaration it serves.
+    """
+    from gen_worker.serving import load_endpoint
+    from gen_worker.serving.serve_loop import ServeLoop
+
+    tree = project(tmp_path / "store", "oversized", H3_TREE_LAYOUT)
+    resolver = _LoopResolver(tree)
+    manager = ResidencyManager(H100_BUDGET, SnapshotSizer(cast(Any, resolver)))
+    loop = ServeLoop(
+        load_endpoint(FIXTURE_DIR),
+        residency=manager,
+        resolver=resolver,
+        lane_contract="sdxl.diffusers-bf16@1",
+        output_dir=tmp_path / "outputs",
+    )
+
+    outcome = loop.invoke(
+        "generate",
+        {"model": FIXTURE_REF, "input": {"prompt": "a lighthouse", "seed": 3}},
+        request_id="pgw1590",
+    )
+    assert outcome.result.model == FIXTURE_REF
+
+    lane_key = "SdxlModel/sdxl.diffusers-bf16@1"
+    assert manager.tier_of(FIXTURE_REF, lane_key) is Tier.VRAM
+    # Charged the header's `vram12g`, not the 180,063,706,300 the tree implies.
+    reserved, _host = manager.reserved_bytes()
+    assert reserved == 12 * GIB
+    assert manager.weight_budget_bytes(FIXTURE_REF, lane_key) == 12 * GIB
+
+
+def test_the_serve_path_still_refuses_when_the_declaration_cannot_help(
+    tmp_path: Path,
+) -> None:
+    """The same real path, on a card under the endpoint's own floor: 8 GiB
+    against a `vram12g` lane. Still ``NeverFits``, still before the author's
+    class is constructed — the fix is a smaller HONEST charge, not a smaller
+    gate."""
+    from gen_worker.serving import load_endpoint
+    from gen_worker.serving.serve_loop import ServeLoop
+
+    tree = project(tmp_path / "store", "oversized", H3_TREE_LAYOUT)
+    resolver = _LoopResolver(tree)
+    manager = ResidencyManager(8 * GIB, SnapshotSizer(cast(Any, resolver)))
+    loop = ServeLoop(
+        load_endpoint(FIXTURE_DIR),
+        residency=manager,
+        resolver=resolver,
+        lane_contract="sdxl.diffusers-bf16@1",
+        output_dir=tmp_path / "outputs",
+    )
+    with pytest.raises(NeverFits) as excinfo:
+        loop.invoke(
+            "generate",
+            {"model": FIXTURE_REF, "input": {"prompt": "x"}},
+            request_id="pgw1590-small",
+        )
+    assert "refuse at admission" in str(excinfo.value)
+    assert manager.tier_of(FIXTURE_REF, "SdxlModel/sdxl.diffusers-bf16@1") is Tier.ABSENT
+
+
+def test_the_crossover_is_exact_and_has_no_gap() -> None:
+    """Where the two arms meet, stated byte-exactly rather than in prose: at
+    the floor the charge is the tree's (they are equal), one byte over it is
+    the floor's."""
+    floor = 6 * GIB
+    for total, expect_declared in ((floor - 1, False), (floor, False), (floor + 1, True)):
+        weights = total - total // 5  # total = weights + weights//4, near enough
+        headroom = total - weights
+        charge = admission_charge(weights, headroom, floor)
+        assert charge.total == min(total, floor)
+        assert ("LANE'S OWN DECLARATION" in charge.basis) is expect_declared

--- a/tests/test_serve_loop_envelope.py
+++ b/tests/test_serve_loop_envelope.py
@@ -255,9 +255,11 @@ def test_multi_model_slots_lease_in_stable_slot_name_order(tmp_path: Path) -> No
     lease_order: List[str] = []
     true_lease = manager.lease
 
-    def spying_lease(checkpoint_ref: str, lane: str, factory: Any) -> Any:
+    def spying_lease(
+        checkpoint_ref: str, lane: str, factory: Any, **kwargs: Any
+    ) -> Any:
         lease_order.append(lane)
-        return true_lease(checkpoint_ref, lane, factory)
+        return true_lease(checkpoint_ref, lane, factory, **kwargs)
 
     manager.lease = spying_lease  # type: ignore[method-assign]
     outcome = loop.invoke(


### PR DESCRIPTION
A real H100 pod refused `minimax.h3-dit-diffusers@1` **at admission** as needing 180,063,706,300 bytes against 84,368,556,032 — `JOB_STATUS_FATAL` and a `fatal_probe` requeue on the exact shape six pods of this fleet had **served on single H100s** two weeks earlier, and it forced an H200 sidestep at +$1.30/hr.

144,050,965,040 of that number is the **entire** minimax-h3 repo — DiT + VAE + text encoder + audio VAE + tokenizer + scheduler + processor. The lane named is the **DiT contract alone**, and that DiT is `quantize_()`d to w8a8 inside `setup()`, which no manifest can see.

## Why `lane` was thrown away

`SnapshotSizer.resident_bytes(ref, lane)` discarded `lane` because it **cannot read it**: the sizer is handed the string `"H3Model/minimax.h3-dit-diffusers@1"` and a tree path, and neither carries the model class. The one caller that holds the class — `ServeLoop` — was passing nothing.

## The declaration already existed

No schema addition was needed. `lanes={contracts.MINIMAX_H3_DIT_DIFFUSERS: "vram78g"}` (pgw#1404's mapping form) is Paul's own 2026-08-18 annotation for exactly this fact:

> *"Only the VRAM requirement needs a separate annotation, because it's not clear, based on the contract, how much VRAM is needed."*

It is statically extractable, it is what the hub filters placement on, and `placement.shortfalls` already reads it per `(model_cls, lane)` **at load time on the same pod**. Admission was a *second, undeclared* producer of one fact — the anti-pattern `_refuse_non_vram_terms` refuses one level up — and the two disagreed by 2x.

So the declared floor **caps** the charge, `min(tree + tree//4, floor)`:

- **it can only ever LOWER a charge**, so no lane admitted before is refused now — property-tested over every real fleet floor x plausible tree size;
- **it is not optimism.** Charging *more* than the floor is the incoherent position: "the platform placed me on a card sized by this floor, and I refuse to run because I believe I need more than the floor." An endpoint whose floor sits below its true residency is broken at PLACEMENT, before admission ever sees it, with a named owner and a loud path (`warn_if_degraded`);
- **an undeclared floor changes nothing** — the conservative whole-tree charge stands, and the refusal now names the declaration that would fix it instead of leaving the reader to guess.

A capped charge is all weights and zero headroom, because `vram78g` is what the lane needs **of a card**, activations included — not a weights subtotal to add 25% to.

## The arithmetic, and it is tight on purpose

78 GiB = **83,751,862,272** against that pod's **84,368,556,032** of headroom: admits with **616,693,760 bytes (588 MiB)** to spare. That matches the physics the endpoint declared it from — 133,006,919,280 bf16 DiT bytes, ~66.5 GB after w8a8, ~17 GB of activations, ~83 GB resident. On a 48 GiB card the lane is still refused typed before any byte moves: a smaller **honest** charge, not a smaller gate.

sd15 (`vram6g`), sdxl (`vram7g`) and z-image (`vram32g`) do not regress: z-image's floor sits above tree+25%, so its charge is byte-identical, and where a floor does bind the charge only drops.

## Deriving from the contract's dtype would have looked like a fix and was not

`minimax.h3-dit-diffusers@1` declares `bfloat16` — the **stored** size. The w8a8 lives in the endpoint's serve recipe and is invisible to every document, as is an offloaded text encoder. Only the author's class header can state it, which is why the correction comes off the header and not off the lane contract.

## Also corrected here

`ResidencyManager.weight_budget_bytes` (pgw#1497's seam, which feeds the streaming rung its budget) re-asked the **sizer**, and the moment a cap exists it would hand out 144 GB where admission reserved 78 GiB — the exact disagreement that method exists to make impossible. It now answers with the admitted slot charge. Two docstrings that called the manifest number "EXACT" now say "upper bound"; that claim is how this defect read as a hardware fact for six days.

## Tests

`tests/test_admission_lane_declaration_pgw1590.py`, 117 cases. The article, not a model of it: a real `LocalCAS` holding a real `RepositoryManifest` at the measured per-shard byte sizes, the production `SnapshotSizer` reading it through `disk_gc.tree_bytes`, the production `ResidencyManager`, the declaration read off a real `Model` subclass by the production `placement.declared_vram_bytes`, and two full `ServeLoop` runs end to end.

**Red-armed:** zeroing the wiring reproduces the pod's refusal string byte for byte.

Closes pgw#1590.