### PR TITLE
pgw#1584: the boot warm pass has a writer again (+ pgw#1583's contract lie)

### DIFF
--- a/changelog.d/pgw1584-boot-warmup.md
+++ b/changelog.d/pgw1584-boot-warmup.md
@@ -1,0 +1,52 @@
+- **pgw#1584: `ctx.boot_warmup` has a WRITER again, so the first-call tax is
+  paid by the pod's boot instead of by a paying request.** The property, its
+  constructor kwarg, its docstring (*"a handler MAY cheapen the run — `steps = 1
+  if ctx.boot_warmup else steps`"*) and its reader in
+  `output_integrity.judged` all shipped; `grep -rn "boot_warmup=True" src/`
+  returned nothing, so every `if ctx.boot_warmup:` arm in the fleet was
+  unreachable code and every endpoint that wrote one had written it for a flag
+  that was permanently `False`. v1 had a functioning warm pass and no
+  `v1_deleted.py` tombstone row was ever written for it, so by this campaign's
+  own rule — *every field with a tombstone row was a decision, every one without
+  is an accident* — it is restored, not retired. `ServeLoop.boot_warmup` runs
+  one synthetic invocation per entrypoint through the SAME `invoke` a dispatch
+  calls: real envelope decode, real residency lease, real author body.
+
+- **pgw#1584: the payload is the entrypoint's own schema at its NEUTRAL
+  DEFAULTS**, which is v1's warm-plan shape (the int32 incident's record:
+  *"a single run at the schema's neutral defaults, at BOOT, before any request
+  exists"*). `gen_worker.warm_payload` synthesizes it: every defaulted field
+  keeps its declared default, a required `str` takes `WARMUP_TEXT`, a required
+  `ImageAsset`/`AudioAsset` gets a stdlib-generated flat mid-gray PNG / silence
+  WAV, and a schema that cannot synthesize honestly — a required `VideoAsset` —
+  is SKIPPED with the reason, never faked. There is no `warmup=` declaration and
+  no `NoWarmup`: both are tombstoned (*"warmup is not an author declaration"*),
+  and an endpoint cheapens its warm run through `ctx.boot_warmup` in the body.
+
+- **pgw#1584: the placement is the deliverable.** The pass runs after the last
+  weight lands and BEFORE the state flips to ready — while the worker still
+  advertises `loading_functions` and `first_request_servable` cannot be stamped
+  — so that milestone stops meaning "the process is up" and starts meaning "a
+  real forward has completed on this pod". th#2233's false-servable fix gets an
+  actual readiness probe to hang on. `boot_phases.PHASE_WARMUP`, declared in the
+  vocabulary and emitted by nothing since the hardcut, gets its producer.
+
+- **pgw#1584: a warm-pass failure degrades LOUDLY and does not brick the pod.**
+  v1 propagated one as a load failure; that turns a defect in an optimization
+  into an unservable pod. Now: a `serve_degrade` event naming the function and
+  the exception (pgw#760 — a hub-spawned worker exposes no stdout, so a log line
+  is invisible), the boot continues, and the first real request takes the cold
+  cost it would have taken anyway. Never worse than the state before this.
+
+- **pgw#1583: `RequestContext.for_request`'s docstring promised what its body
+  ruled out, in the same function.** It stated twice that the resolved
+  checkpoint's OBJECTIVE was applied to the per-request view and that ambiguity
+  raised *"never a silent objective-less fallback"* — while the body opened
+  `objective = ""` and never read `slot=`, so the body WAS that fallback and the
+  raise was unreachable. Settled toward the CODE, because there is no fact to
+  apply: `ModelBinding.objective` has no reader anywhere in the SDK. The
+  docstring now states the measured behaviour and names the surface that does
+  honour one (`gen_worker.view.for_request(pipeline, objective=…)`), and `slot=`
+  is GONE from both the serving and the trace context — it was accepted and
+  discarded on each, and a kwarg that changes nothing is a third way to be
+  silently wrong.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -563,14 +563,31 @@ lands on (or, on a function with no selectable slot, to the slots that declared
 a `family`), so auxiliary slots — interpolators, upscalers — are never asked
 for evidence they cannot carry.
 
-The boot WARM PLAN is DERIVED
-— defaulted fields keep their schema defaults, `CompileAxis` fields
-cross-product their classes' `warm=` representatives, required fields
-synthesize neutral values — so there is no `warmup=` payload dict to
-write or to drift. Cheapen non-graph work on `ctx.boot_warmup`
-(`steps = 1 if ctx.boot_warmup else steps`). A per-function
-`@worker_function(warm={...}, warm_reason=...)` override exists only for
-a non-axis field that genuinely changes tracing. When the serve path
+The boot WARM PASS is DERIVED and default-on (pgw#1584). After the pod's
+weights land and *before* it advertises a single function, the worker runs
+one synthetic invocation per inference entrypoint through the ordinary
+dispatch path, so the first-call tax — allocator pool growth to the
+activation peak, cuBLAS/cuDNN heuristic selection — is paid by the boot
+instead of by a paying request. The payload is your own schema at its
+neutral defaults: defaulted fields keep their defaults, a required `str`
+fills `"warmup"`, a required `ImageAsset`/`AudioAsset` gets a tiny
+generated PNG/WAV. There is no `warmup=` payload dict to write or to
+drift, and no opt-out declaration — a schema that cannot synthesize
+honestly (a required `VideoAsset`) is skipped with a logged reason.
+
+**Cheapen it from inside the body**, on `ctx.boot_warmup`:
+
+```python
+steps = 1 if ctx.boot_warmup else payload.num_inference_steps
+```
+
+The flag is `True` only on that pass; the output is discarded, nothing is
+uploaded and nothing banks, and the output-integrity floor exempts it (a
+degenerate output from a degenerate input is the expected result there).
+Cheapen non-graph work freely — the allocator peak is shape-driven, not
+step-driven, so dropping steps still warms what matters. A warm pass that
+raises does **not** brick the pod: it emits a `serve_degrade` event and
+the first real request takes the cold cost. When the serve path
 modifies a requested value (clamps, substitutions), record it with
 `ctx.adjusted(field, requested, applied, reason)` / `ctx.clamp(...)` —
 the rows ride the result envelope to the caller.
@@ -905,7 +922,8 @@ The members you will actually reach for (the class has ~27 public members;
 | `request_id` | unique id for this request |
 | `models` | resolved model refs by slot |
 | `defaults` | the catalog-resolved recipe, typed as `RequestContext[D]` |
-| `for_request(pipeline, sampler=, seed=)` | per-request view (own scheduler over shared weights) |
+| `for_request(pipeline, sampler=, seed=)` | per-request view (own scheduler over shared weights); carries NO objective — pass one to `gen_worker.view.for_request` (pgw#1583) |
+| `boot_warmup` | `True` only on the boot warm pass; cheapen the run off it |
 | `device` | the torch device to run on |
 | `generator(seed)` | seeded `torch.Generator` on `device` |
 | `deadline` | absolute deadline |

--- a/src/gen_worker/boot_materialize.py
+++ b/src/gen_worker/boot_materialize.py
@@ -156,12 +156,21 @@ class CheckpointMaterialization:
         store: ModelStore,
         *,
         announce: Optional[Callable[[], Awaitable[None]]] = None,
+        warm: Optional[Callable[[], Awaitable[None]]] = None,
     ) -> None:
         self._store = store
         #: Pushes a StateDelta the moment readiness changes, so the hub learns
         #: this worker is routable at materialization time and not up to one
         #: heartbeat later.
         self._announce_cb = announce
+        #: pgw#1584: the BOOT WARM PASS, run between the last byte landing and
+        #: this worker calling itself ready. The placement is the whole point:
+        #: `ready` is still False while it runs, so the heartbeat still reports
+        #: `loading_functions`, `first_request_servable` cannot be stamped, and
+        #: the hub cannot route here — which turns that milestone from "the
+        #: process is up" into "a real forward has completed on this pod"
+        #: (th#2233's false-servable gets an actual readiness probe).
+        self._warm_cb = warm
         self._task: Optional["asyncio.Task[None]"] = None
         self._applied: Optional[CheckpointConfig] = None
         self.state: str = STATE_PENDING
@@ -300,6 +309,12 @@ class CheckpointMaterialization:
                 return
             logger.info("checkpoint %s materialized at %s", ref, path)
 
+        # pgw#1584: WEIGHTS ARE DOWN, NOTHING IS SERVABLE YET. The warm pass
+        # goes exactly here — after the last byte and before the state flips —
+        # so the first synthetic forward happens while this worker is still
+        # advertising `loading_functions`. It never raises (see `_warm`).
+        await self._warm()
+
         self.state = STATE_READY
         self.failure = ""
         logger.info(
@@ -308,6 +323,30 @@ class CheckpointMaterialization:
             config.version, len(config.refs),
         )
         await self._announce()
+
+    # ---- the boot warm pass ------------------------------------------------
+
+    async def _warm(self) -> None:
+        """Run the boot warm pass, if one is wired. NEVER raises.
+
+        The posture is pgw#1584's ruling: a warm-pass failure degrades LOUDLY
+        and does not brick the pod. `ServeLoop.boot_warmup` already confesses
+        per entrypoint with a `serve_degrade` event and returns rather than
+        raising; this is the second belt, because a pod that refuses to become
+        ready over a failed OPTIMIZATION is strictly worse than one that serves
+        and pays the first-call tax it would have paid anyway.
+        """
+        if self._warm_cb is None:
+            return
+        try:
+            await self._warm_cb()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — an optimization never costs a boot
+            logger.warning(
+                "boot warm pass raised; this worker becomes ready anyway and "
+                "the first real request pays the cold cost", exc_info=True,
+            )
 
     # ---- readiness announcement -------------------------------------------
 

--- a/src/gen_worker/boot_materialize.py
+++ b/src/gen_worker/boot_materialize.py
@@ -234,6 +234,17 @@ class CheckpointMaterialization:
             # A weightless release, or a release whose config names nothing.
             # There is nothing to wait for, so readiness is immediate — the
             # gate must never be able to strand a pod that has no weights.
+            #
+            # NO WARM PASS HERE, and the reason is th#2233 rather than this
+            # branch. A config naming zero refs also names zero checkpoint
+            # BINDINGS, so `boot_picks` has nothing to bind and every function
+            # would skip with "no boot-time checkpoint binding" — a warm call
+            # placed here would do nothing but say so. th#2233 measured that
+            # the hub sends zero `disk_refs` for `fixed` bindings FLEET-WIDE
+            # (the only HelloAck seeder covers dynamic slots, of which the hub
+            # has none), so today every pod lands in this branch and the warm
+            # pass rides that fix — which is the same fix that makes
+            # `first_request_servable` mean anything at all.
             self.state = STATE_READY
             self.failure = ""
             logger.info(

--- a/src/gen_worker/release/trace_context.py
+++ b/src/gen_worker/release/trace_context.py
@@ -561,7 +561,6 @@ class TraceRequestContext:
         self,
         pipeline: Any,
         *,
-        slot: str = "",
         sampler: str = "",
         seed: Optional[int] = None,
         generator: Optional[Any] = None,
@@ -575,11 +574,16 @@ class TraceRequestContext:
         a different sampler is a different scheduler is a different denoise
         call. A stub returning ``pipeline`` would derive graphs for a
         pipeline no request ever runs, and nothing downstream could tell.
+
+        pgw#1583: ``slot=`` is GONE from both this and the serving twin. It was
+        accepted and immediately discarded (``del slot`` lived right here), and
+        a kwarg that changes nothing is a third way to be silently wrong. This
+        signature must keep matching the serving one or a trace derives graphs
+        for a call the serve path cannot make.
         """
 
         from ..view import for_request as _view_for_request
 
-        del slot
         gen = generator
         if gen is None and seed is not None:
             gen = self.generator(seed)

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -503,7 +503,6 @@ class RequestContext(Generic[D]):
         self,
         pipeline: Any,
         *,
-        slot: str = "",
         sampler: str = "",
         seed: Optional[int] = None,
         generator: Optional["torch.Generator"] = None,
@@ -512,14 +511,28 @@ class RequestContext(Generic[D]):
     ) -> Any:
         """A per-request VIEW of ``pipeline``: same module objects (shared
         weights; the compiled graph stays bound), OWN scheduler — cloned from
-        the instance scheduler's config, with the resolved checkpoint's
-        OBJECTIVE applied (v-prediction/flow are checkpoint facts the SDK
-        applies here, never payload logic) and ``sampler`` selecting the
+        the instance scheduler's config, with ``sampler`` selecting the
         scheduler class from the SDK table (``gen_worker.view.SAMPLERS``).
 
-        ``slot`` names the resolving slot on a multi-slot class; omitted, the
-        declared root resolves. Ambiguity raises — never a silent
-        objective-less fallback.
+        **THIS VIEW CARRIES NO OBJECTIVE, and that is now stated rather than
+        promised (pgw#1583).** Until this docstring was corrected it claimed
+        twice that the resolved checkpoint's objective was applied here and
+        that ambiguity raised; the body passed ``objective=""`` unconditionally
+        and ``slot=`` was accepted and discarded, so the raise was unreachable
+        and every view built through this method denoised under the platform
+        default. That is worse than an error: v-prediction and flow change what
+        the scheduler DOES, so a wrong objective returns plausible output.
+
+        The reason is plumbing, not policy: ``ModelBinding.objective`` (proto
+        field 6) has no reader anywhere in the SDK — no ``_Pick`` field, no
+        ``DeployBinding`` field, nothing on this context — so there is no
+        checkpoint fact here to apply. **An author who needs one passes it
+        explicitly to the module-level gate**, which is the only surface that
+        honours it::
+
+            from gen_worker.view import for_request
+
+            view = for_request(model.pipe, objective="flow", sampler="ddim")
 
         EVERY sampler-shaped attribute is cloned, not just ``scheduler``: a
         second stateful sampler such as an ltx ``audio_scheduler`` would
@@ -531,12 +544,11 @@ class RequestContext(Generic[D]):
         through, and a module swap the compiled graph guards against.
         """
 
-        objective = ""
         gen = generator
         if gen is None and seed is not None:
             gen = self.generator(seed)
         return _view_for_request(
-            pipeline, sampler=sampler, objective=objective, generator=gen,
+            pipeline, sampler=sampler, objective="", generator=gen,
             scheduler_config=scheduler_config, schedulers=schedulers,
         )
 

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -17,6 +17,12 @@ The wire-facing serving path over the pgw#1382 primitives:
    order)``; release the leases; return the result with the request's
    accumulated ``ctx.warn`` rows.
 
+:meth:`ServeLoop.boot_warmup` (pgw#1584) runs that same walk once per
+entrypoint AT BOOT, on a payload synthesized from the entrypoint's own schema
+at its neutral defaults and a context carrying ``boot_warmup=True`` — so the
+first-call tax is paid by the pod's boot rather than by a paying request. It
+is not a second serving path; it is this one, called earlier.
+
 Instances are keyed by (model class, checkpoint ref, lane): one resident
 author object per key, built inside the lease's admission window via
 ``Model()`` + ``model.load(LoadContext)`` and dropped via the author's
@@ -30,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import tempfile
 import threading
 import time
 from contextlib import ExitStack
@@ -37,7 +44,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Sequence, Tuple
 
-from .. import boot_phases
+import msgspec
+
+from .. import activity, boot_phases
+from ..warm_payload import neutral_payload
 from ..input_assets import (
     InputManifestEntry,
     cleanup_input_assets,
@@ -91,6 +101,36 @@ class InvokeOutcome:
     #: breakdown against ``runtime_ms``, and the dispatch — not the loop — is
     #: what measures that.
     stages: Optional[StageTimer] = None
+
+
+@dataclass(frozen=True, slots=True)
+class WarmPass:
+    """What the boot warm pass did about ONE entrypoint.
+
+    Three outcomes and they are deliberately distinguishable: ``warmed`` (a
+    real forward ran and its cost is off the first paying request),
+    ``skipped`` (nothing could honestly be warmed — the reason says what) and
+    ``failed`` (the pass ran and raised; the pod SERVES and the first real
+    request pays the cold cost). "Nobody warmed" and "warming was free" are
+    different answers, so a skip never renders as a success.
+    """
+
+    function: str
+    outcome: str
+    reason: str = ""
+    duration_ms: int = 0
+
+    @property
+    def warmed(self) -> bool:
+        return self.outcome == WARM_OK
+
+
+#: A real synthetic forward ran under ``boot_warmup=True``.
+WARM_OK = "warmed"
+#: Nothing was warmed and nothing went wrong — the reason names which.
+WARM_SKIPPED = "skipped"
+#: The warm pass raised. LOUD (``serve_degrade``), never fatal.
+WARM_FAILED = "failed"
 
 
 class _InstanceBackend:
@@ -437,23 +477,34 @@ class ServeLoop:
 
         per_request = dict(context or {})
         input_fetch_t0 = time.monotonic()
-        try:
-            materialize_input_assets(
-                decoded.payload,
-                request_id,
-                attempt=int(attempt),
-                manifest=tuple(input_assets),
-                file_base_url=str(per_request.get("file_api_base_url") or ""),
-                capability_token=str(
-                    per_request.get("worker_capability_token") or ""
-                ),
-            )
-        except BaseException:
-            # `materialize_input_assets` already cleared its own attempt
-            # directory; this only guarantees it for anything that raised
-            # around it. The refusal itself is typed and propagates.
-            cleanup_input_assets(request_id, int(attempt))
-            raise
+        # pgw#1584: THE BOOT WARM PASS CARRIES NO FETCHABLE INPUT. Its payload
+        # is the platform's own synthesis (`warm_payload`) and any asset in it
+        # is a file this process just wrote, referenced by `local_path` — there
+        # is no dispatch, no manifest, no capability token and nothing hub-side
+        # to resolve a ref against. `materialize_input_assets` NULLS every
+        # `local_path` first, on the correct reasoning that a path in RunJob
+        # input is caller-controlled wire data; a boot warm payload is the one
+        # input on this path that is not caller-controlled, and `boot_warmup`
+        # is the same authority `output_integrity.judged` reads to decide the
+        # blank-render exemption. Skipped, never faked with a stub manifest.
+        if not ctx.boot_warmup:
+            try:
+                materialize_input_assets(
+                    decoded.payload,
+                    request_id,
+                    attempt=int(attempt),
+                    manifest=tuple(input_assets),
+                    file_base_url=str(per_request.get("file_api_base_url") or ""),
+                    capability_token=str(
+                        per_request.get("worker_capability_token") or ""
+                    ),
+                )
+            except BaseException:
+                # `materialize_input_assets` already cleared its own attempt
+                # directory; this only guarantees it for anything that raised
+                # around it. The refusal itself is typed and propagates.
+                cleanup_input_assets(request_id, int(attempt))
+                raise
         # A PRE-handler stage: input fetch is not the author's runtime, and
         # folding it in makes every asset-taking endpoint look slow.
         ctx._stages.record_pre("input_fetch", time.monotonic() - input_fetch_t0)
@@ -565,6 +616,149 @@ class ServeLoop:
             stages=ctx._stages,
         )
 
+    # -- the boot warm pass (pgw#1584) --------------------------------------
+
+    def boot_warmup(
+        self, *, prepare: Optional[Callable[[str], str]] = None
+    ) -> Tuple[WarmPass, ...]:
+        """One synthetic invocation per entrypoint, at boot, before servable.
+
+        **What it is.** The worker's first-call tax is EAGER cost — allocator
+        pool growth to the activation peak plus cuBLAS/cuDNN heuristic
+        selection — and today a PAYING request pays it. This runs that forward
+        once at boot instead, through :meth:`invoke`: the real envelope decode,
+        the real residency lease, the real author body. Not a second serving
+        path; the same one, called earlier.
+
+        **The context carries ``boot_warmup=True``, and that is load-bearing
+        in two directions.** An endpoint cheapens the run off it (musicgen: one
+        second of tokens; the qwens: one token) — the surface
+        ``RequestContext.boot_warmup``'s docstring has advertised since v1 and
+        which had no writer at all between the v2 hardcut and pgw#1584. And
+        :func:`gen_worker.output_integrity.judged` reads the SAME object to
+        exempt this pass from the blank-render floor: a degenerate output from
+        a degenerate input is the expected result here, and without the flag
+        reaching the reader the warm pass would fail on its own discarded
+        output.
+
+        **The payload is the schema's neutral defaults** (:mod:`.warm_payload`)
+        — v1's warm plan shape, *"a single run at the schema's neutral
+        defaults, at BOOT, before any request exists"*. Not the largest preset,
+        not an author declaration (``NoWarmup`` is tombstoned): one run at the
+        point every request is measured against.
+
+        **FAILURE DEGRADES, IT DOES NOT BRICK.** A warm pass that raises emits
+        a ``serve_degrade`` event naming the function and the exception, and
+        the boot CONTINUES — the pod serves, and the first real request simply
+        takes the cold cost it would have taken anyway. The alternative, v1's
+        posture of failing the load, turns a warm-pass defect into an
+        unservable pod, which is strictly worse than the tax this exists to
+        remove.
+
+        ``prepare(function)`` is the caller's per-entrypoint hook, called just
+        before each warm invocation: it returns ``""`` to proceed, or a SKIP
+        REASON to decline this one. It is where the worker binds the deploy's
+        checkpoint picks for the function — boot has no dispatch to read them
+        off, and a release the hub seeded no per-function bindings for is a
+        skip with a reason, never a guess about which bytes to serve.
+
+        Returns one :class:`WarmPass` per entrypoint, in route order.
+
+        Never raises. The caller places it after weights materialize and
+        before ``first_request_servable`` is stamped, which is what makes it a
+        REAL readiness probe rather than a stamp asserting the process is up
+        (th#2233).
+        """
+        results: list[WarmPass] = []
+        with tempfile.TemporaryDirectory(prefix="gw-boot-warmup-") as scratch:
+            for name in sorted(self.loaded.entrypoints):
+                results.append(self._warm_one(name, scratch, prepare))
+        warmed = [row for row in results if row.warmed]
+        logger.info(
+            "boot warmup: %d/%d entrypoint(s) warmed (%s)",
+            len(warmed), len(results),
+            ", ".join(f"{row.function}={row.outcome}" for row in results) or "none",
+        )
+        return tuple(results)
+
+    def _warm_one(
+        self,
+        function: str,
+        scratch: str,
+        prepare: Optional[Callable[[str], str]] = None,
+    ) -> WarmPass:
+        spec = self.loaded.entrypoints[function]
+        # A WEIGHTLESS entrypoint takes no lease, loads nothing and allocates
+        # no activation peak (pgw#1392) — there is no cold cost to move, so
+        # warming it would spend a boot second to save nothing.
+        if not spec.model_params:
+            return WarmPass(function, WARM_SKIPPED,
+                            "weightless: nothing is resident to warm")
+        kind = str(getattr(spec, "kind", "") or "inference")
+        if kind != "inference":
+            # A producer's cost is its own job's, and its payload names
+            # reserved repos the platform materializes per REQUEST — there is
+            # no boot-time answer for what `ctx.source_path` would point at.
+            return WarmPass(function, WARM_SKIPPED,
+                            f"kind={kind!r}: only inference pays a first-call tax")
+        payload, reason = neutral_payload(spec.payload_type, scratch)
+        if payload is None:
+            # Stated rather than faked. A required VideoAsset has no honest
+            # 2 KB stand-in, and inventing one warms a path with bytes no
+            # request will ever carry.
+            return WarmPass(function, WARM_SKIPPED, reason)
+        if prepare is not None:
+            declined = str(prepare(function) or "")
+            if declined:
+                return WarmPass(function, WARM_SKIPPED, declined)
+        envelope = {"input": msgspec.to_builtins(payload)}
+        started = time.monotonic()
+        try:
+            # SPANNED, and this is the phase's first producer: `PHASE_WARMUP`
+            # has been in `boot_phases`' vocabulary — with the module's own
+            # rule that "a declared phase with no producer is a default read as
+            # a fact" printed above it — and nothing in `src/` has emitted one
+            # since the hardcut.
+            with boot_phases.span(boot_phases.PHASE_WARMUP, function=function):
+                self.invoke(
+                    function,
+                    envelope,
+                    request_id=f"boot-warmup-{function}",
+                    context={
+                        "boot_warmup": True,
+                        # Discarded by construction: whatever the body saves
+                        # lands in the scratch directory this pass owns and
+                        # dies with it. Nothing is uploaded and nothing banks.
+                        "local_output_dir": scratch,
+                    },
+                )
+        except BaseException as exc:  # noqa: BLE001 — a warm pass never bricks
+            duration_ms = int((time.monotonic() - started) * 1000)
+            detail = (
+                f"function={function} payload=schema-defaults "
+                f"{type(exc).__name__}: {exc}"
+            )
+            logger.warning(
+                "boot warmup FAILED for %s (%s: %s); this pod SERVES and the "
+                "first real request pays the cold cost",
+                function, type(exc).__name__, exc, exc_info=True,
+            )
+            # pgw#760: a fail-soft outcome that changes what this worker
+            # serves rides a TYPED event, never only a log line — a hub-spawned
+            # worker exposes no stdout, so a warning here is invisible.
+            try:
+                activity.emit_event(
+                    activity.KIND_SERVE_DEGRADE, detail,
+                    phase="boot_warmup_failed", duration_ms=duration_ms,
+                )
+            except Exception:  # noqa: BLE001 — the confession never fails boot
+                logger.debug("serve_degrade emit failed", exc_info=True)
+            return WarmPass(function, WARM_FAILED,
+                            f"{type(exc).__name__}: {exc}", duration_ms)
+        return WarmPass(
+            function, WARM_OK, "", int((time.monotonic() - started) * 1000)
+        )
+
     def _make_context(
         self,
         request_id: str,
@@ -650,5 +844,9 @@ __all__ = [
     "BindingResolver",
     "InvokeOutcome",
     "ServeLoop",
+    "WARM_FAILED",
+    "WARM_OK",
+    "WARM_SKIPPED",
+    "WarmPass",
     "manifest_sizer",
 ]

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -662,9 +662,11 @@ class ServeLoop:
         off, and a release the hub seeded no per-function bindings for is a
         skip with a reason, never a guess about which bytes to serve.
 
-        Returns one :class:`WarmPass` per entrypoint, in route order.
+        Returns one :class:`WarmPass` per entrypoint, in route-name order.
 
-        Never raises. The caller places it after weights materialize and
+        Never raises (except a `KeyboardInterrupt`/`SystemExit` tearing the
+        process down, which is not a warm-pass failure). The caller places it
+        after weights materialize and
         before ``first_request_servable`` is stamped, which is what makes it a
         REAL readiness probe rather than a stamp asserting the process is up
         (th#2233).
@@ -732,6 +734,10 @@ class ServeLoop:
                         "local_output_dir": scratch,
                     },
                 )
+        except (KeyboardInterrupt, SystemExit):
+            # NOT a warm-pass failure — the process is being torn down, and
+            # swallowing that would make a boot un-interruptible.
+            raise
         except BaseException as exc:  # noqa: BLE001 — a warm pass never bricks
             duration_ms = int((time.monotonic() - started) * 1000)
             detail = (

--- a/src/gen_worker/warm_payload.py
+++ b/src/gen_worker/warm_payload.py
@@ -1,0 +1,229 @@
+"""The boot warm pass's payload: one entrypoint's schema at NEUTRAL DEFAULTS.
+
+pgw#1584. The v1 warm plan was *"a single run at the schema's neutral
+defaults, at BOOT, before any request exists"* (the int32 incident's own
+record), and the v2 hardcut dropped it with no tombstone row. This module is
+that synthesis, restored: given an ``@entrypoint``'s payload struct it builds
+ONE instance where every DEFAULTED field keeps its declared default and every
+REQUIRED field takes a minimal, self-contained value.
+
+**Why defaults rather than an author declaration.** v1 also shipped
+``@endpoint(warmup=…)`` and ``NoWarmup(reason)``. Both are TOMBSTONED —
+``v1_deleted.REPLACEMENTS["NoWarmup"]`` reads *"no successor — warmup is not an
+author declaration"* — so the restoration is the default-on synthesis half and
+nothing else. An endpoint cheapens its warm pass through ``ctx.boot_warmup``
+inside the body (``steps = 1 if ctx.boot_warmup else steps``), which is the
+surface the docstring has advertised all along.
+
+**A schema that cannot synthesize is SKIPPED, never invented.** A required
+``VideoAsset`` has no honest 2 KB stand-in, and a fabricated one would warm a
+code path with bytes no request will ever carry. :func:`neutral_payload`
+returns the reason instead, and the caller records it — "nobody warmed" and
+"warming was free" have to stay different answers.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import struct
+import types as py_types
+import typing
+import wave
+import zlib
+from typing import Any, Callable, List, Optional, Sequence, Tuple
+
+import msgspec
+
+from .api.types import Asset, AudioAsset, ImageAsset, VideoAsset
+
+#: The filler for a required ``str`` field. Named because
+#: ``output_integrity.judged`` documents the warm input by this name: a
+#: degenerate output from a degenerate input is the expected result there.
+WARMUP_TEXT = "warmup"
+
+#: 128px, not v1's 512. The warm pass exists to grow the allocator pool and
+#: settle cuBLAS/cuDNN heuristics, and both are driven by the SHAPES the
+#: schema's own defaults ask for — an oversized input asset only enlarges the
+#: encode, and `output_integrity`'s docstring already describes the warm image
+#: as "a flat mid-gray 128px PNG".
+_IMAGE_SIDE = 128
+_AUDIO_SECONDS = 1.0
+_AUDIO_RATE = 48_000
+_MAX_DEPTH = 4
+
+#: ``factory(dir_path) -> value``; ``dir_path`` hosts any synthetic asset file.
+_Factory = Callable[[str], Any]
+
+
+def synthetic_png(dir_path: str) -> str:
+    """Write a flat mid-gray RGB PNG (stdlib only) and return its path."""
+    path = os.path.join(dir_path, "boot-warmup.png")
+    side = _IMAGE_SIDE
+    row = b"\x00" + b"\x80" * (side * 3)  # filter byte 0 + gray pixels
+    idat = zlib.compress(row * side, 6)
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data)) + tag + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", side, side, 8, 2, 0, 0, 0)
+    with open(path, "wb") as handle:
+        handle.write(b"\x89PNG\r\n\x1a\n")
+        handle.write(chunk(b"IHDR", ihdr))
+        handle.write(chunk(b"IDAT", idat))
+        handle.write(chunk(b"IEND", b""))
+    return path
+
+
+def synthetic_wav(dir_path: str) -> str:
+    """Write a short stereo silence WAV (stdlib only) and return its path."""
+    path = os.path.join(dir_path, "boot-warmup.wav")
+    with wave.open(path, "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(_AUDIO_RATE)
+        handle.writeframes(b"\x00\x00" * 2 * int(_AUDIO_RATE * _AUDIO_SECONDS))
+    return path
+
+
+def _image_asset(dir_path: str) -> ImageAsset:
+    return ImageAsset(
+        ref="boot-warmup.png",
+        local_path=synthetic_png(dir_path),
+        mime_type="image/png",
+    )
+
+
+def _audio_asset(dir_path: str) -> AudioAsset:
+    return AudioAsset(
+        ref="boot-warmup.wav",
+        local_path=synthetic_wav(dir_path),
+        mime_type="audio/wav",
+    )
+
+
+def _unwrap(annotation: Any) -> Any:
+    while typing.get_origin(annotation) is typing.Annotated:
+        annotation = typing.get_args(annotation)[0]
+    return annotation
+
+
+def _field_factory(annotation: Any, depth: int) -> Tuple[Optional[_Factory], str]:
+    """``(factory, blocked_reason)`` — exactly one side is meaningful."""
+    annotation = _unwrap(annotation)
+    if depth > _MAX_DEPTH:
+        return None, f"nesting deeper than {_MAX_DEPTH}"
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, py_types.UnionType):
+        args = typing.get_args(annotation)
+        if type(None) in args:
+            # An optional required field: absent IS the neutral value.
+            return (lambda _dir: None), ""
+        for arm in args:
+            factory, _ = _field_factory(arm, depth + 1)
+            if factory is not None:
+                return factory, ""
+        return None, f"no synthesizable union arm in {annotation!r}"
+    if origin is typing.Literal:
+        values = list(typing.get_args(annotation))
+        if not values:
+            return None, "empty Literal"
+        first = values[0]
+        return (lambda _dir: first), ""
+    if annotation is str:
+        return (lambda _dir: WARMUP_TEXT), ""
+    if annotation is bool:
+        return (lambda _dir: False), ""
+    if annotation is int:
+        return (lambda _dir: 0), ""
+    if annotation is float:
+        return (lambda _dir: 0.0), ""
+    if isinstance(annotation, type):
+        # Concrete media kinds BEFORE the ambiguous bases: `ImageAsset` and
+        # `AudioAsset` both subclass `MediaAsset` subclasses `Asset`, so a
+        # base-first walk would answer "not synthesizable" for both.
+        if issubclass(annotation, ImageAsset):
+            return _image_asset, ""
+        if issubclass(annotation, AudioAsset):
+            return _audio_asset, ""
+        if issubclass(annotation, VideoAsset):
+            return None, "required video input is not synthesizable"
+        if issubclass(annotation, Asset):
+            return None, f"required {annotation.__name__} input is not synthesizable"
+        if issubclass(annotation, enum.Enum):
+            members = list(annotation)
+            if not members:
+                return None, f"enum {annotation.__name__} has no members"
+            first_member = members[0]
+            return (lambda _dir: first_member), ""
+        if issubclass(annotation, msgspec.Struct):
+            return _struct_factory(annotation, depth + 1)
+    if origin in (list, typing.List, Sequence, typing.Sequence, tuple, typing.Tuple):
+        args = tuple(a for a in typing.get_args(annotation) if a is not Ellipsis)
+        if len(args) == 1:
+            inner, reason = _field_factory(args[0], depth + 1)
+            if inner is None:
+                return None, reason
+            if origin in (tuple, typing.Tuple):
+                return (lambda d: (inner(d),)), ""
+            return (lambda d: [inner(d)]), ""
+        return None, f"unsupported sequence shape {annotation!r}"
+    return None, f"required field type {annotation!r} is not synthesizable"
+
+
+def _struct_factory(
+    payload_type: type, depth: int = 0
+) -> Tuple[Optional[_Factory], str]:
+    factories: List[Tuple[str, _Factory]] = []
+    try:
+        struct_fields = msgspec.structs.fields(payload_type)
+    except TypeError as exc:
+        return None, f"{payload_type!r} is not a msgspec struct: {exc}"
+    for field in struct_fields:
+        # NOT required means the schema already states its neutral value.
+        # Leaving it out of the constructor call is what "at the schema's
+        # defaults" MEANS — this is the whole warm plan in one branch.
+        if not field.required:
+            continue
+        factory, reason = _field_factory(field.type, depth)
+        if factory is None:
+            return None, (
+                f"required field {field.name!r}: {reason}"
+                if reason
+                else f"required field {field.name!r} is not synthesizable"
+            )
+        factories.append((field.name, factory))
+
+    def build(dir_path: str) -> Any:
+        return payload_type(**{name: fac(dir_path) for name, fac in factories})
+
+    return build, ""
+
+
+def payload_factory(payload_type: type) -> Tuple[Optional[_Factory], str]:
+    """``(factory, reason)`` for one entrypoint's payload struct.
+
+    The factory takes a scratch directory (any synthetic asset file is written
+    there and referenced by ``local_path``) and returns a fresh payload.
+    """
+    return _struct_factory(payload_type, 0)
+
+
+def neutral_payload(payload_type: type, dir_path: str) -> Tuple[Any, str]:
+    """One payload at the schema's neutral defaults, or ``(None, reason)``."""
+    factory, reason = payload_factory(payload_type)
+    if factory is None:
+        return None, reason
+    return factory(dir_path), ""
+
+
+__all__ = [
+    "WARMUP_TEXT",
+    "neutral_payload",
+    "payload_factory",
+    "synthetic_png",
+    "synthetic_wav",
+]

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -56,6 +56,7 @@ from .models.cache_paths import tensorhub_cache_dir, tensorhub_cas_dir
 from .models.cozy_snapshot import snapshot_dir_key
 from .models.disk_gc import tree_bytes
 from .models.projection import SNAPSHOTS_DIR
+from .models.refs import WireRef
 from .models.store import ModelStore, bind_active_store
 from .boot_materialize import (
     REASON_MODEL_UNAVAILABLE,
@@ -313,6 +314,91 @@ def _picks_of(run: pb.RunJob) -> _DispatchPicks:
         by_ref[pick.ref] = pick
         by_slot[pick.slot] = pick.ref
     return _DispatchPicks(by_ref=by_ref, by_slot=by_slot)
+
+
+def _picks_of_bindings(bindings: Any) -> _DispatchPicks:
+    """``_picks_of``'s table over a bare ``ModelBinding`` list.
+
+    ``DesiredInstance.models`` and ``RunJob.models`` are the SAME message, so
+    the boot warm pass reads its picks through the same builder the dispatch
+    does. The difference is only where the digest fallback comes from: a
+    dispatch has ``RunJob.snapshots`` beside the bindings, boot has the
+    config's, so the caller supplies it below.
+    """
+    by_ref: Dict[str, _Pick] = {}
+    by_slot: Dict[str, str] = {}
+    for binding in bindings or ():
+        pick = _Pick(
+            slot=str(binding.slot),
+            ref=str(binding.ref),
+            manifest_digest=str(binding.manifest_digest).strip(),
+            model=str(binding.model).strip(),
+            inference_defaults=str(binding.inference_defaults),
+        )
+        by_ref[pick.ref] = pick
+        by_slot[pick.slot] = pick.ref
+    return _DispatchPicks(by_ref=by_ref, by_slot=by_slot)
+
+
+def boot_picks(
+    desired: Any, loaded: Any, config: "CheckpointConfig"
+) -> Dict[str, _DispatchPicks]:
+    """Per-function checkpoint picks for the BOOT WARM PASS (pgw#1584).
+
+    Boot has no dispatch, and ``default_pick`` reads one — so without this the
+    warm pass would decode every envelope into *"model slot has no envelope
+    pick and no deployment default"*. The picks exist on the wire the pod
+    already receives: ``DesiredResidency.Hot`` is ``repeated DesiredInstance
+    {function_name, models}``, and ``models`` is the very ``ModelBinding`` the
+    dispatch carries — slot, ref, the recognized ``model`` name and its
+    ``inference_defaults`` row. Nothing is invented; the hub's own boot seed is
+    read.
+
+    **The ONE inference, and its fence.** The hub seeds ``Hot`` for dynamic
+    slot defaults and compile-cache prewarm; a release whose bindings are all
+    static may arrive with ``Hot`` empty. For that case, and ONLY when the
+    entrypoint declares exactly one model slot and the config materialized
+    exactly one ref, the two are bound: with one slot and one ref there is
+    exactly one possible answer, so this is arithmetic rather than a guess.
+    Every other shape yields NO entry, the warm pass skips that function with
+    a reason, and the worker keeps `decode_envelope`'s rule intact — the worker
+    never guesses which bytes to serve.
+    """
+    functions = sorted(getattr(loaded, "entrypoints", {}) or {})
+    picks: Dict[str, _DispatchPicks] = {}
+    for instance in getattr(desired, "hot", ()) or ():
+        name = str(getattr(instance, "function_name", "")).strip()
+        if not name:
+            continue
+        table = _picks_of_bindings(getattr(instance, "models", ()))
+        if table.by_slot:
+            picks[name] = table
+    refs = [str(ref) for ref in config.refs]
+    if len(refs) != 1:
+        return picks
+    only_ref = refs[0]
+    snapshot = config.snapshots.get(WireRef(only_ref))
+    digest = str(getattr(snapshot, "digest", "") or "").strip()
+    for name in functions:
+        if name in picks:
+            continue
+        spec = loaded.entrypoints[name]
+        slots = [slot for slot, _cls in spec.model_params]
+        if len(slots) != 1:
+            continue
+        pick = _Pick(
+            slot=slots[0], ref=only_ref, manifest_digest=digest,
+            # UNKNOWN, and left so. `ctx.defaults()`'s unclassified arm (no
+            # name, no row) is pgw#1377's warn-and-serve platform fallback; a
+            # fabricated classification would warm under a recipe the hub never
+            # resolved, and `resolve()`'s pgw#1415 fence only fires on the
+            # broken pair (a row with no name), which this is not.
+            model="", inference_defaults="",
+        )
+        picks[name] = _DispatchPicks(
+            by_ref={only_ref: pick}, by_slot={slots[0]: only_ref}
+        )
+    return picks
 
 
 class HubBindingResolver:
@@ -682,8 +768,16 @@ class Worker:
         # routable — which is what makes "never fetch inside a user request"
         # true by construction, with no hub-side parking to enforce it.
         self.materialization = CheckpointMaterialization(
-            self.store, announce=self._announce_readiness,
+            self.store,
+            announce=self._announce_readiness,
+            # pgw#1584: one synthetic forward per entrypoint, run between the
+            # last weight landing and this worker calling itself ready.
+            warm=self._run_boot_warmup,
         )
+        #: pgw#1584: per-function checkpoint picks for the warm pass, read off
+        #: the HelloAck's own `DesiredResidency` (see `boot_picks`). Empty
+        #: until the ack arrives, which is also before the warm pass can run.
+        self._boot_picks: Dict[str, _DispatchPicks] = {}
 
         self.draining = False
         self.drained = asyncio.Event()
@@ -840,6 +934,46 @@ class Worker:
             except Exception:  # noqa: BLE001
                 logger.warning("fn_unavailable send failed for %s", fn, exc_info=True)
 
+    # ---- the boot warm pass (pgw#1584) -------------------------------------
+
+    async def _run_boot_warmup(self) -> None:
+        """Drive :meth:`ServeLoop.boot_warmup` off the event loop.
+
+        `invoke` is synchronous and does real work — an admission, a weight
+        load, a forward — so it goes to a thread for the same reason every
+        dispatch does. `asyncio.to_thread` COPIES the context, which is what
+        lets `_bind_boot_picks` set `_DISPATCH` per function from in here.
+
+        Never raises: `boot_warmup` confesses per entrypoint with a
+        `serve_degrade` event and `CheckpointMaterialization._warm` is the
+        second belt. A failed OPTIMIZATION must never cost this pod its boot.
+        """
+        await asyncio.to_thread(self.serve.boot_warmup, prepare=self._bind_boot_picks)
+
+    def _bind_boot_picks(self, function: str) -> str:
+        """Bind the deploy's picks for one warm invocation; '' = proceed.
+
+        The warm pass runs with NO dispatch, and `HubBindingResolver` reads its
+        bindings off `_DISPATCH`. This sets that contextvar to the function's
+        boot picks so `default_pick`/`resolve`/`tree_for` answer exactly as
+        they would for a real request against the same checkpoint.
+
+        A function the ack seeded no bindings for returns a SKIP REASON rather
+        than an empty table: an empty table decodes into "model slot has no
+        envelope pick and no deployment default", which is a correct refusal
+        wearing the costume of a warm-pass defect.
+        """
+        picks = self._boot_picks.get(function)
+        if picks is None or not picks.by_slot:
+            return (
+                "no boot-time checkpoint binding: the HelloAck's "
+                "DesiredResidency seeded no per-function ModelBinding for "
+                f"{function!r} and its slot/ref shape is not unambiguous "
+                "(the worker never guesses which bytes to serve)"
+            )
+        _DISPATCH.set(picks)
+        return ""
+
     def build_hello(self) -> pb.Hello:
         # NO `resources`: the split parent measures the silicon in a process
         # that imported no tenant code and stamps every relayed Hello, so
@@ -887,9 +1021,13 @@ class Worker:
         # the pods least able to explain themselves. Non-blocking: the pull
         # runs on its own task while the transport keeps reading, and the
         # worker stays connected-and-unroutable until it finishes.
-        self.materialization.configure(
-            CheckpointConfig.from_wire(ack.desired_residency)
-        )
+        config = CheckpointConfig.from_wire(ack.desired_residency)
+        # pgw#1584: BEFORE `configure`, because `configure` is what starts the
+        # materialization task that ends in the warm pass. The picks come off
+        # the same ack — `DesiredResidency.Hot` carries the hub's own
+        # per-function `ModelBinding` rows.
+        self._boot_picks = boot_picks(ack.desired_residency, self.loaded, config)
+        self.materialization.configure(config)
         if self.functions and self.materialization.ready:
             # THE cold-boot number, and it now means what it says: the pod
             # holds its weights AND the hub has a Hello advertising these

--- a/tests/test_boot_warmup_pgw1584.py
+++ b/tests/test_boot_warmup_pgw1584.py
@@ -1,0 +1,629 @@
+"""THE BOOT WARM PASS HAS A WRITER AGAIN (pgw#1584).
+
+`ctx.boot_warmup` shipped a constructor kwarg, a public `@property`, a
+docstring prescribing `steps = 1 if ctx.boot_warmup else steps`, and a READER
+in `output_integrity.judged` — and, between the v2 hardcut and this issue, no
+producer anywhere in `src/`. `grep -rn "boot_warmup=True" src/` was empty, so
+every `if ctx.boot_warmup:` arm in the fleet was unreachable code and the
+first-call tax was paid by a PAYING request. Ruled an accidental drop (v1 had a
+functioning warm pass and no `v1_deleted.py` tombstone row was ever written for
+it), so the wire is restored rather than the feature retired.
+
+Integration, on the real path: the `serving_v2_endpoint` fixture — the
+main_v2-contract-exact endpoint that serves real requests on CPU with fake
+weights from config-only checkpoints — is booted through `ServeLoop` and warmed
+through `ServeLoop.boot_warmup`, which calls the SAME `invoke` a dispatch calls.
+No mock of the serve path; the only doubles are the ones the design names
+(`BindingResolver`, the static sizer).
+
+The two halves the issue insisted on are BOTH here, because they fail
+independently:
+
+* the flag is TRUE on a real boot path — asserted at
+  `output_integrity.judged`, i.e. at the reader itself, so it proves the warm
+  pass's context is the same object the reader sees rather than a second one;
+* a blank warm output PASSES the integrity floor under it, and is REFUSED
+  without it. With no writer, that exemption had never engaged, so the restored
+  warm pass would otherwise have failed on its own discarded output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Tuple
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import boot_phases
+from gen_worker import output_integrity
+from gen_worker import request_context as request_context_mod
+from gen_worker.boot_materialize import (
+    STATE_READY,
+    CheckpointConfig,
+    CheckpointMaterialization,
+)
+from gen_worker.api.errors import OutputIntegrityError
+from gen_worker.models.refs import WireRef
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.serving import DeployBinding, load_endpoint
+from gen_worker.serving.loader import load_endpoint_module
+from gen_worker.serving.context import RequestContext
+from gen_worker.serving.residency import ResidencyManager
+from gen_worker.serving.serve_loop import (
+    WARM_FAILED,
+    WARM_OK,
+    WARM_SKIPPED,
+    ServeLoop,
+    manifest_sizer,
+)
+from gen_worker.warm_payload import WARMUP_TEXT, neutral_payload
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "serving_v2_endpoint"
+RELEASE_FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+GB = 1024**3
+DREAM = "org/dreamshaper@2"
+LANE = "sdxl.diffusers-bf16@1"
+
+
+class LocalResolver:
+    """Deploy state over local config-only trees — the BindingResolver seam."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.resolved: List[str] = []
+
+    def _tree(self, ref: str) -> Path:
+        tree = self.root / ref.replace("/", "_").replace("@", "_")
+        if not tree.exists():
+            tree.mkdir(parents=True)
+            (tree / "config.json").write_text(json.dumps({"seed": len(ref)}))
+        return tree
+
+    def resolve(self, model_cls: type, checkpoint_ref: str) -> DeployBinding:
+        self.resolved.append(checkpoint_ref)
+        return DeployBinding(
+            checkpoint_ref=checkpoint_ref,
+            checkpoint_dir=self._tree(checkpoint_ref),
+            model="sdxl",
+            defaults={},
+        )
+
+    def default_pick(self, model_cls: type, slot_name: str) -> str:
+        return DREAM
+
+
+def make_loop(tmp_path: Path) -> Tuple[ServeLoop, LocalResolver]:
+    loaded = load_endpoint(FIXTURE_DIR)
+    resolver = LocalResolver(tmp_path / "trees")
+    loop = ServeLoop(
+        loaded,
+        residency=ResidencyManager(
+            64 * GB, manifest_sizer({DREAM: 3 * GB}, headroom_bytes=1 * GB)
+        ),
+        resolver=resolver,
+        lane_contract=LANE,
+        output_dir=tmp_path / "outputs",
+    )
+    return loop, resolver
+
+
+@pytest.fixture()
+def judged_calls(monkeypatch: pytest.MonkeyPatch) -> List[bool]:
+    """Record `ctx.boot_warmup` AT THE READER, for every judged output.
+
+    `request_context` imports `judged` into its own namespace, so this patches
+    the name the save path actually calls. The recorder DELEGATES — the floor
+    keeps its real verdict — it only writes down which context object arrived.
+    """
+    seen: List[bool] = []
+    real = output_integrity.judged
+
+    def recording(ctx: Any) -> bool:
+        seen.append(bool(getattr(ctx, "boot_warmup", False)))
+        return real(ctx)
+
+    monkeypatch.setattr(request_context_mod, "judged", recording)
+    return seen
+
+
+@pytest.fixture(autouse=True)
+def _clean_activity() -> Iterator[None]:
+    activity_mod.reset_for_tests()
+    boot_phases.reset_for_tests()
+    yield
+    activity_mod.reset_for_tests()
+    boot_phases.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# the writer exists, and it drives the real serve path
+# ---------------------------------------------------------------------------
+
+
+def test_the_warm_pass_runs_a_REAL_forward_through_the_REAL_serve_path(
+    tmp_path: Path,
+) -> None:
+    """One synthetic invocation per entrypoint, through `invoke`.
+
+    Not a second serving path — the same one, called earlier. The proof it is
+    the same one is that the resolver was asked to resolve a checkpoint (so an
+    admission and a real `Model.load` happened) and the handler's output landed
+    on disk.
+    """
+    loop, resolver = make_loop(tmp_path)
+
+    passes = loop.boot_warmup()
+
+    assert [row.function for row in passes] == ["generate"]
+    (row,) = passes
+    assert row.outcome == WARM_OK, row
+    assert row.warmed and row.reason == ""
+    # A real lease, a real load: the resolver was asked for the deploy's bytes
+    # exactly as a dispatch asks (the primary-binding lookup, then the lease).
+    assert set(resolver.resolved) == {DREAM} and len(resolver.resolved) == 2
+    # And a real forward: the residency ledger holds the instance the warm pass
+    # loaded, so the FIRST REAL REQUEST reuses it instead of paying for it.
+    assert loop.residency.tier_of(DREAM, f"SdxlModel/{LANE}") is not None
+
+
+def test_the_flag_is_TRUE_on_a_real_boot_path_and_FALSE_on_a_real_request(
+    tmp_path: Path, judged_calls: List[bool]
+) -> None:
+    """HALF ONE of the issue's must-know, asserted AT THE READER.
+
+    "The absence of exactly this test is why the drop survived", so it is
+    asserted where it matters: `output_integrity.judged` is handed the context
+    the author's `ctx.save_image` was called on, so recording the flag there
+    proves the warm pass's `boot_warmup=True` object is the SAME object the
+    reader sees — not a second context that merely also exists.
+    """
+    loop, _ = make_loop(tmp_path)
+
+    loop.boot_warmup()
+    assert judged_calls == [True], judged_calls
+
+    loop.invoke(
+        "generate",
+        {"model": DREAM, "input": {"prompt": "a lighthouse", "seed": 3}},
+        request_id="req-1",
+    )
+    assert judged_calls == [True, False], judged_calls
+
+
+def test_a_BLANK_warm_output_passes_integrity_and_is_refused_without_the_flag(
+    tmp_path: Path,
+) -> None:
+    """HALF TWO, and the reason the restoration needed it.
+
+    `output_integrity.py:475` makes `boot_warmup=True` the blank-render
+    exemption, and with no writer it had NEVER engaged. The warm pass's whole
+    input is degenerate by construction (`WARMUP_TEXT` and, where a schema
+    needs one, a flat mid-gray PNG), so its output is exactly the degenerate
+    render the floor refuses — which would have made the restored warm pass
+    fail on its own discarded output.
+
+    Same image, same call, one flag apart.
+    """
+    from PIL import Image
+
+    blank = Image.new("RGB", (64, 64), (128, 128, 128))
+
+    warm: RequestContext[Any] = RequestContext(
+        "boot-warmup-generate", boot_warmup=True,
+        local_output_dir=str(tmp_path / "warm"),
+    )
+    asset = warm.save_image(blank, format="png")
+    assert asset.ref.endswith(".png")
+    assert (tmp_path / "warm" / asset.ref).is_file()
+
+    paying: RequestContext[Any] = RequestContext(
+        "req-1", local_output_dir=str(tmp_path / "paying")
+    )
+    with pytest.raises(OutputIntegrityError):
+        paying.save_image(blank, format="png")
+
+
+def test_the_exemption_is_the_predicate_both_ways() -> None:
+    """The reader's own verdict, stated as an assertion rather than inferred
+    from a save that happened to succeed."""
+    warm: RequestContext[Any] = RequestContext("r", boot_warmup=True)
+    paying: RequestContext[Any] = RequestContext("r")
+    assert output_integrity.judged(warm) is False
+    assert output_integrity.judged(paying) is True
+
+
+# ---------------------------------------------------------------------------
+# the payload: the schema's NEUTRAL DEFAULTS, v1's warm-plan shape
+# ---------------------------------------------------------------------------
+
+
+def test_the_warm_payload_is_the_schema_at_its_NEUTRAL_DEFAULTS(
+    tmp_path: Path,
+) -> None:
+    """The int32 incident's own record of the v1 warm plan: *"a single run at
+    the schema's neutral defaults"*. Not the largest preset, not an author
+    declaration (`NoWarmup` is tombstoned: "warmup is not an author
+    declaration"), and not a value invented for a field the schema already
+    answers for.
+    """
+    sys.path.insert(0, str(FIXTURE_DIR / "src"))
+    try:
+        from serving_v2_fixture.main import (  # type: ignore[import-not-found]
+            AspectRatio,
+            TextToImageInput,
+        )
+    finally:
+        sys.path.remove(str(FIXTURE_DIR / "src"))
+
+    payload, reason = neutral_payload(TextToImageInput, str(tmp_path))
+
+    assert reason == ""
+    # The ONE required field is filled minimally...
+    assert payload.prompt == WARMUP_TEXT
+    # ...and every defaulted field keeps the value the schema declares. This is
+    # what "at the defaults" means, and it is one branch in the synthesizer:
+    # a non-required field is simply left out of the constructor call.
+    assert payload.aspect_ratio is AspectRatio.RATIO_1_1
+    assert payload.num_inference_steps is None
+    assert payload.guidance_scale is None
+    assert payload.scheduler is None
+    assert payload.enhance_prompt is True
+    assert payload.output_format == "webp"
+
+
+def test_a_payload_that_cannot_synthesize_is_SKIPPED_with_a_reason(
+    tmp_path: Path,
+) -> None:
+    """Stated, never faked. A required `VideoAsset` has no honest 2 KB
+    stand-in, and inventing one warms a code path with bytes no request will
+    ever carry — so the warm pass declines and says which field stopped it."""
+    import msgspec
+
+    from gen_worker.api.types import AudioAsset, ImageAsset, VideoAsset
+
+    # Module-scope names: msgspec resolves a struct's annotations by NAME, and
+    # a class defined in a function body cannot see this function's locals.
+    globals().update(
+        AudioAsset=AudioAsset, ImageAsset=ImageAsset, VideoAsset=VideoAsset
+    )
+
+    class NeedsVideo(msgspec.Struct):
+        clip: VideoAsset
+
+    payload, reason = neutral_payload(NeedsVideo, str(tmp_path))
+    assert payload is None
+    assert "clip" in reason and "video" in reason
+
+    # The media kinds that CAN be synthesized are, and the file really exists —
+    # the concrete subclasses are matched before the ambiguous `Asset` base, or
+    # both would answer "not synthesizable".
+    class NeedsMedia(msgspec.Struct):
+        image: ImageAsset
+        audio: AudioAsset
+
+    media, reason = neutral_payload(NeedsMedia, str(tmp_path))
+    assert reason == ""
+    assert Path(media.image.local_path).is_file()
+    assert Path(media.audio.local_path).is_file()
+    assert media.image.mime_type == "image/png"
+
+
+def test_a_weightless_entrypoint_is_SKIPPED_not_warmed(tmp_path: Path) -> None:
+    """pgw#1392: zero model slots means no lease, no admission, no load and no
+    activation peak — there is no first-call tax to move, so warming it would
+    spend a boot second to save nothing. "Nobody warmed" and "warming was free"
+    stay different answers."""
+    sys.path.insert(0, str(RELEASE_FIXTURES))
+    try:
+        loaded = load_endpoint_module("weightless_endpoint")
+    finally:
+        sys.path.remove(str(RELEASE_FIXTURES))
+    loop = ServeLoop(
+        loaded,
+        residency=ResidencyManager(GB, manifest_sizer({}, headroom_bytes=1)),
+        resolver=LocalResolver(tmp_path / "trees"),
+        output_dir=tmp_path / "outputs",
+    )
+    passes = loop.boot_warmup()
+    assert passes and all(row.outcome == WARM_SKIPPED for row in passes), passes
+    assert all("weightless" in row.reason for row in passes), passes
+
+
+# ---------------------------------------------------------------------------
+# failure posture: LOUD, and never fatal
+# ---------------------------------------------------------------------------
+
+
+def test_a_FAILING_warm_pass_degrades_loudly_and_does_NOT_brick_the_pod(
+    tmp_path: Path,
+) -> None:
+    """The ruling's posture, and the one place v1's differs.
+
+    v1 propagated a warm failure as a LOAD failure. That turns a defect in an
+    OPTIMIZATION into an unservable pod, which is strictly worse than the tax
+    the optimization exists to remove. So: a `serve_degrade` event (pgw#760 —
+    a hub-spawned worker exposes no stdout, so a log line is invisible), and
+    the boot continues.
+    """
+    loop, _ = make_loop(tmp_path)
+    spec = loop.loaded.entrypoints["generate"]
+
+    def boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("the warm forward exploded")
+
+    loop.loaded.entrypoints["generate"] = dataclasses.replace(spec, fn=boom)
+    events: List[pb.ActivityUpdate] = []
+    activity_mod._sink = events.append  # the bound-sink contract
+
+    passes = loop.boot_warmup()  # must NOT raise
+
+    (row,) = passes
+    assert row.outcome == WARM_FAILED, row
+    assert "the warm forward exploded" in row.reason
+    degrades = [
+        e for e in events
+        if e.kind == activity_mod.KIND_SERVE_DEGRADE
+        and e.phase == "boot_warmup_failed"
+    ]
+    assert len(degrades) == 1, [(e.kind, e.phase) for e in events]
+    assert "generate" in degrades[0].detail
+    assert "the warm forward exploded" in degrades[0].detail
+
+    # AND THE POD STILL SERVES. Restore the real body and take a real request:
+    # the first one pays the cold cost, which is exactly the state the fleet
+    # was in before this issue — never worse.
+    loop.loaded.entrypoints["generate"] = spec
+    outcome = loop.invoke(
+        "generate",
+        {"model": DREAM, "input": {"prompt": "a lighthouse", "seed": 3}},
+        request_id="req-after-a-failed-warm",
+    )
+    assert outcome.result.model == DREAM
+
+
+def test_a_function_with_no_boot_binding_is_a_SKIP_not_a_failure(
+    tmp_path: Path,
+) -> None:
+    """`prepare` is the worker's seam for the deploy's picks, and declining is
+    a first-class answer.
+
+    Boot carries no dispatch, so a release the hub seeded no per-function
+    `ModelBinding` for has no pick — and an empty pick table decodes into
+    *"model slot has no envelope pick and no deployment default"*, a CORRECT
+    refusal wearing the costume of a warm-pass defect. It is reported as the
+    skip it is, and emits no `serve_degrade`.
+    """
+    loop, resolver = make_loop(tmp_path)
+    events: List[pb.ActivityUpdate] = []
+    activity_mod._sink = events.append
+
+    passes = loop.boot_warmup(prepare=lambda _fn: "no boot-time binding")
+
+    assert [(r.outcome, r.reason) for r in passes] == [
+        (WARM_SKIPPED, "no boot-time binding")
+    ]
+    # A declined warm never loaded anything and never confessed a degrade.
+    assert resolver.resolved == []
+    assert not [e for e in events if e.kind == activity_mod.KIND_SERVE_DEGRADE]
+
+
+# ---------------------------------------------------------------------------
+# placement: after the weights, BEFORE this pod calls itself servable
+# ---------------------------------------------------------------------------
+
+
+def test_the_warm_pass_runs_BEFORE_the_worker_is_ready_or_servable() -> None:
+    """The placement is the deliverable, not an implementation detail.
+
+    Running the warm pass while the state is still `materializing` is what
+    turns `first_request_servable` from "the process is up" into "a real
+    forward has completed on this pod" — the readiness probe th#2233's
+    false-servable fix needs something real to hang on.
+
+    Asserted on the ORDER as `CheckpointMaterialization` executes it: the warm
+    callback observes `ready is False`, and the readiness announce (which is
+    what stamps the milestone) has not fired yet when it runs.
+    """
+    observed: Dict[str, Any] = {}
+
+    class _Store:
+        def replace_desired_snapshots(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        async def announce_resident(self, *_a: Any, **_k: Any) -> bool:
+            return True  # a warm volume: no byte moves
+
+    announced: List[str] = []
+
+    async def announce() -> None:
+        announced.append("announce")
+
+    async def warm() -> None:
+        observed["ready"] = mat.ready
+        observed["state"] = mat.state
+        observed["announced_before_warm"] = list(announced)
+        observed["servable_ms"] = boot_phases.servable_ms()
+        boot_phases.mark_once(boot_phases.PHASE_WARMUP, function="generate")
+
+    mat = CheckpointMaterialization(
+        _Store(), announce=announce, warm=warm  # type: ignore[arg-type]
+    )
+
+    async def drive() -> None:
+        ref = WireRef("acme/model-a")
+        desired = pb.DesiredResidency(generation=1, disk_refs=[str(ref)])
+        desired.snapshots[str(ref)].CopyFrom(pb.Snapshot(digest="sha256:beef"))
+        mat.configure(CheckpointConfig.from_wire(desired))
+        assert mat._task is not None
+        await mat._task
+        for _ in range(8):
+            await asyncio.sleep(0)
+
+    asyncio.run(drive())
+
+    assert observed["ready"] is False, observed
+    assert observed["state"] != STATE_READY, observed
+    # `_announce_soon` fires once at CONFIGURE, to say "materializing" — the
+    # readiness announce that stamps `first_request_servable` is the one at the
+    # END of `_materialize`, and it has not run when the warm pass does.
+    assert observed["announced_before_warm"] == ["announce"], observed
+    assert observed["servable_ms"] is None, observed
+    # ...and only afterwards does this worker become routable.
+    assert mat.state == STATE_READY
+    assert announced == ["announce", "announce"]
+
+
+def test_a_raising_warm_callback_never_costs_the_pod_its_boot() -> None:
+    """The second belt. `ServeLoop.boot_warmup` already returns rather than
+    raising; this proves the materialization would survive one that did."""
+
+    class _Store:
+        def replace_desired_snapshots(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        async def announce_resident(self, *_a: Any, **_k: Any) -> bool:
+            return True
+
+    async def warm() -> None:
+        raise RuntimeError("the whole warm pass exploded")
+
+    mat = CheckpointMaterialization(_Store(), warm=warm)  # type: ignore[arg-type]
+
+    async def drive() -> None:
+        ref = WireRef("acme/model-a")
+        desired = pb.DesiredResidency(generation=1, disk_refs=[str(ref)])
+        desired.snapshots[str(ref)].CopyFrom(pb.Snapshot(digest="sha256:beef"))
+        mat.configure(CheckpointConfig.from_wire(desired))
+        assert mat._task is not None
+        await mat._task
+
+    asyncio.run(drive())
+    assert mat.state == STATE_READY
+    assert mat.failure == ""
+
+
+def test_PHASE_WARMUP_finally_has_a_producer(tmp_path: Path) -> None:
+    """`boot_phases`' own rule, printed above the vocabulary: *"a declared
+    phase with no producer is not coverage we have not gotten to: every reader
+    of the ladder sees a name that can only ever report nothing"*.
+
+    `PHASE_WARMUP` has been declared, and mapped into `boot_stages`' roll-up,
+    with NOTHING in `src/` emitting one since the hardcut. The warm pass is its
+    producer.
+    """
+    loop, _ = make_loop(tmp_path)
+    loop.boot_warmup()
+
+    table = boot_phases.phase_table()
+    warm_rows = [row for row in table if row.phase == boot_phases.PHASE_WARMUP]
+    assert warm_rows, [row.phase for row in table]
+    assert warm_rows[0].function == "generate", warm_rows[0]
+
+
+# ---------------------------------------------------------------------------
+# pgw#1583: the contract lie in `for_request`, settled toward the CODE
+# ---------------------------------------------------------------------------
+
+
+def test_for_request_no_longer_takes_a_slot_it_silently_ignores() -> None:
+    """`slot=` was accepted and discarded on BOTH context implementations —
+    the serving one passed `objective=""` regardless, the trace one wrote
+    `del slot`. A kwarg that changes nothing is a third way to be silently
+    wrong, so it is gone from both and the two signatures still match."""
+    import inspect
+
+    from gen_worker.release.trace_context import TraceRequestContext
+
+    serving = inspect.signature(RequestContext.for_request).parameters
+    trace = inspect.signature(TraceRequestContext.for_request).parameters
+    assert "slot" not in serving
+    assert "slot" not in trace
+    assert set(serving) == set(trace)
+
+
+def test_the_for_request_docstring_states_the_MEASURED_behaviour() -> None:
+    """The docstring promised the objective was applied here and that ambiguity
+    raised; the body passed `objective=""` unconditionally, so the promise was
+    contradicted by the code beneath it and the raise was unreachable.
+
+    Settled toward the CODE, because the fact does not exist to apply:
+    `ModelBinding.objective` has no reader anywhere in the SDK. So the
+    docstring now says so and names the surface that DOES honour an objective.
+    """
+    doc = RequestContext.for_request.__doc__ or ""
+    assert "CARRIES NO OBJECTIVE" in doc
+    assert "gen_worker.view" in doc and "objective=" in doc
+    # And the old promises are gone, not merely qualified.
+    assert "Ambiguity raises" not in doc
+
+    source = Path(request_context_mod.__file__).read_text(encoding="utf-8")
+    # The one remaining `objective=` in `for_request` is the literal empty
+    # string the docstring now advertises.
+    assert 'objective="", generator=gen' in source
+
+
+# ---------------------------------------------------------------------------
+# the boot picks: read off the ack, inferred only where there is one answer
+# ---------------------------------------------------------------------------
+
+
+def _config_for(ref: str, digest: str = "sha256:beef") -> CheckpointConfig:
+    desired = pb.DesiredResidency(generation=1, disk_refs=[ref])
+    desired.snapshots[ref].CopyFrom(pb.Snapshot(digest=digest))
+    return CheckpointConfig.from_wire(desired)
+
+
+def test_the_boot_picks_come_off_the_hubs_OWN_DesiredResidency_Hot() -> None:
+    """Nothing is invented: `DesiredResidency.Hot` is
+    `repeated DesiredInstance {function_name, models}` and `models` is the very
+    `ModelBinding` a dispatch carries — slot, ref, the recognized `model` name
+    and its `inference_defaults` row. The warm pass resolves through the same
+    table a real request resolves through."""
+    from gen_worker.worker import boot_picks
+
+    loaded = load_endpoint(FIXTURE_DIR)
+    desired = pb.DesiredResidency(generation=1, disk_refs=[DREAM, "org/other@1"])
+    desired.snapshots[DREAM].CopyFrom(pb.Snapshot(digest="sha256:beef"))
+    instance = desired.hot.add()
+    instance.function_name = "generate"
+    binding = instance.models.add()
+    binding.slot, binding.ref = "model", DREAM
+    binding.model, binding.inference_defaults = "sdxl", '{"steps": 4}'
+
+    picks = boot_picks(desired, loaded, CheckpointConfig.from_wire(desired))
+
+    assert set(picks) == {"generate"}
+    table = picks["generate"]
+    assert table.by_slot == {"model": DREAM}
+    assert table.by_ref[DREAM].model == "sdxl"
+    assert table.by_ref[DREAM].inference_defaults == '{"steps": 4}'
+
+
+def test_one_slot_and_one_ref_is_ARITHMETIC_but_anything_else_is_a_GUESS() -> None:
+    """The hub seeds `Hot` for dynamic-slot defaults and compile-cache prewarm;
+    a static-binding release can arrive with it empty. With ONE model slot and
+    ONE materialized ref there is exactly one possible answer, so the two are
+    bound. Two refs is a guess, and `decode_envelope`'s rule stands: the worker
+    never guesses which bytes to serve — no entry, and the warm pass skips."""
+    from gen_worker.worker import boot_picks
+
+    loaded = load_endpoint(FIXTURE_DIR)
+
+    single = _config_for(DREAM)
+    picks = boot_picks(pb.DesiredResidency(), loaded, single)
+    assert picks["generate"].by_slot == {"model": DREAM}
+    # The digest travels so `tree_for` resolves exactly as a dispatch does.
+    assert picks["generate"].by_ref[DREAM].manifest_digest == "sha256:beef"
+    # Unknown classification stays unknown — `ctx.defaults()`'s unclassified arm
+    # is pgw#1377's warn-and-serve fallback, and inventing a name would warm
+    # under a recipe the hub never resolved.
+    assert picks["generate"].by_ref[DREAM].model == ""
+
+    two = pb.DesiredResidency(generation=1, disk_refs=[DREAM, "org/other@1"])
+    assert boot_picks(two, loaded, CheckpointConfig.from_wire(two)) == {}

--- a/tests/test_boot_warmup_pgw1584.py
+++ b/tests/test_boot_warmup_pgw1584.py
@@ -627,3 +627,50 @@ def test_one_slot_and_one_ref_is_ARITHMETIC_but_anything_else_is_a_GUESS() -> No
 
     two = pb.DesiredResidency(generation=1, disk_refs=[DREAM, "org/other@1"])
     assert boot_picks(two, loaded, CheckpointConfig.from_wire(two)) == {}
+
+
+def test_a_synthesized_ASSET_survives_the_envelope_the_warm_pass_builds(
+    tmp_path: Path,
+) -> None:
+    """The warm payload becomes an envelope (`msgspec.to_builtins`) and is
+    decoded back by the REAL `decode_envelope` — so `local_path` has to survive
+    the round trip, or an asset-taking entrypoint warms with an asset it cannot
+    open.
+
+    This is the half `materialize_input_assets` would otherwise have destroyed:
+    it NULLs every `local_path` on the correct reasoning that a path in RunJob
+    input is caller-controlled wire data. A boot warm payload is the one input
+    on that path which is not — the platform wrote the file — so `invoke` skips
+    that step, and only that step, under `ctx.boot_warmup`.
+    """
+    import msgspec
+
+    from gen_worker.serving.entrypoints import ENTRYPOINT_ATTR
+    from gen_worker.serving.envelope import decode_envelope
+
+    sys.path.insert(0, str(RELEASE_FIXTURES))
+    try:
+        import media_endpoint  # type: ignore[import-not-found]
+    finally:
+        sys.path.remove(str(RELEASE_FIXTURES))
+    spec = getattr(media_endpoint.analyze, ENTRYPOINT_ATTR)
+
+    payload, reason = neutral_payload(spec.payload_type, str(tmp_path))
+    assert reason == "", reason
+    written = Path(payload.audio.local_path)
+    assert written.is_file() and written.stat().st_size > 0
+
+    decoded = decode_envelope(spec, {"input": msgspec.to_builtins(payload)})
+
+    assert decoded.payload.audio.local_path == str(written)
+    assert decoded.payload.audio.mime_type == "audio/wav"
+    # ...and the handler really can open it — the raise site a production
+    # failure came from (`_local_path`) is satisfied.
+    assert media_endpoint.analyze(
+        RequestContext("boot-warmup-analyze", boot_warmup=True), decoded.payload
+    ).size_bytes == written.stat().st_size
+
+    # The sibling entrypoint's REQUIRED VideoAsset is the honest refusal.
+    video_spec = getattr(media_endpoint.extract_frame, ENTRYPOINT_ATTR)
+    nothing, why = neutral_payload(video_spec.payload_type, str(tmp_path))
+    assert nothing is None and "video" in why


### PR DESCRIPTION
Closes pgw#1584 and pgw#1583. Depends on serverless-endpoints#536 (**MERGED**), which relabelled the seven suites that banned `boot_warmup` as a deleted name — four flux suites would have failed this restoration as written.

---

## The defect

`ctx.boot_warmup` shipped a constructor kwarg, a public `@property`, a docstring prescribing `steps = 1 if ctx.boot_warmup else steps`, and a READER in `output_integrity.judged` — and **no producer anywhere in `src/`**. `grep -rn "boot_warmup=True" src/` was empty, so every `if ctx.boot_warmup:` arm in the fleet was unreachable code, every endpoint that wrote one wrote it for a flag that was permanently `False`, and the first-call tax was paid by a **paying request**.

v1 had a functioning warm pass (`src/gen_worker/warmup.py`, gw#470) and no `v1_deleted.py` tombstone row was ever written for it — so by this campaign's own ratified rule (*every field with a tombstone row was a decision; every one without is an accident*) it is an accidental drop. Restored, not retired.

## The writer

`ServeLoop.boot_warmup` runs one synthetic invocation per inference entrypoint through **the same `invoke` a dispatch calls** — real envelope decode, real residency lease, real author body. Not a second serving path; this one, called earlier.

`gen_worker.warm_payload` synthesizes the payload at the schema's **neutral defaults**, which is v1's warm-plan shape (the int32 incident's own record: *"a single run at the schema's neutral defaults, at BOOT, before any request exists"*):

| field | value |
|---|---|
| defaulted | keeps its declared default — this is what "at the defaults" *means*, and it is one branch: a non-required field is left out of the constructor call |
| required `str` | `WARMUP_TEXT` (`"warmup"`) |
| required `ImageAsset` / `AudioAsset` | a stdlib-generated flat mid-gray 128px PNG / 1 s silence WAV — the input `output_integrity`'s own docstring already describes |
| required `VideoAsset` | **SKIPPED with the reason.** No honest 2 KB stand-in exists, and inventing one warms a path with bytes no request will ever carry |

There is no `warmup=` declaration and no `NoWarmup` — both tombstoned (*"warmup is not an author declaration"*). An endpoint cheapens its warm run through `ctx.boot_warmup` in the body, which is the surface the docstring has advertised all along (musicgen: 1 s of tokens; the qwens: 1 token).

## Both halves of the issue's MUST-KNOW, tested independently

`output_integrity.py:475` makes `boot_warmup=True` the **blank-render exemption**, and with no writer it had never engaged. The warm pass's input is degenerate by construction, so its output is exactly the render the floor refuses — the restoration would have failed on its own discarded output.

1. **The flag is `True` on a real boot path** — asserted *at* `judged`, by recording `ctx.boot_warmup` inside the reader the author's `ctx.save_image` actually calls. That proves the warm pass's context is the **same object** the reader sees, not a second one that also exists. The same test then takes a real request and records `False`.
2. **A blank output passes integrity under the flag and is refused without it** — same flat gray image, same call, one flag apart.

The issue said *"the absence of exactly this test is why the drop survived"*, so both are pinned by name.

## Placement — this is the deliverable, not an implementation detail

The pass runs **after the last weight lands and before the state flips to ready**, while the worker still advertises `loading_functions` and `first_request_servable` cannot be stamped. That turns the milestone from "the process is up" into "a real forward has completed on this pod" — the readiness probe **th#2233**'s false-servable fix needs something real to hang on. Asserted on the order `CheckpointMaterialization` executes: the warm callback observes `ready is False`, `state == "materializing"`, and `boot_phases.servable_ms() is None`.

`boot_phases.PHASE_WARMUP` — declared in the vocabulary, mapped into `boot_stages`' roll-up, under that module's own printed rule that *"a declared phase with no producer is a default read as a fact"*, and emitted by **nothing** in `src/` since the hardcut — finally gets its producer.

## Failure posture: LOUD, never fatal

v1 propagated a warm failure as a **load** failure. That turns a defect in an *optimization* into an unservable pod, which is strictly worse than the tax the optimization removes. Now: a `serve_degrade` event with `phase=boot_warmup_failed` naming the function and the exception (pgw#760 — a hub-spawned worker exposes no stdout, so a log line is invisible), the boot continues, and the first real request takes the cold cost it would have taken anyway. Two belts: `boot_warmup` returns rather than raises, and `CheckpointMaterialization._warm` swallows one that did. Stated in the docstring, and both belts have a test.

Three outcomes stay distinguishable — `warmed` / `skipped` / `failed`. A skip never renders as a success: *"nobody warmed"* and *"warming was free"* are different answers.

## The boot picks, and the ONE inference

Boot carries no dispatch and `HubBindingResolver` reads `_DISPATCH`, so `boot_picks` reads the hub's **own** `DesiredResidency.Hot` — `DesiredInstance {function_name, models}`, where `models` is the very `ModelBinding` a dispatch carries (slot, ref, the recognized `model` name, its `inference_defaults` row). Nothing is invented.

For a static-binding release that arrives with `Hot` empty, and **only** when the entrypoint declares one model slot and the config materialized one ref, the two are bound — one slot and one ref is arithmetic, not a guess. Every other shape yields no entry and the warm pass **skips with a reason**, so `decode_envelope`'s rule stands: the worker never guesses which bytes to serve.

`materialize_input_assets` is skipped on the warm path, and only there. It NULLs every `local_path` on the correct reasoning that a path in RunJob input is caller-controlled wire data — and a boot warm payload is the one input on that path which is not: it is a file this process just wrote. Gated on `ctx.boot_warmup`, the same authority `judged` reads, rather than faked with a stub manifest.

---

## pgw#1583, folded in: the docstring promised what the body ruled out

`RequestContext.for_request` stated twice that the resolved checkpoint's **objective** was applied to the per-request view and that ambiguity raised *"never a silent objective-less fallback"* — while the body opened `objective = ""` and never read `slot=`. The body **was** that fallback and the raise was unreachable. A view built under the wrong objective does not fail; it denoises wrong and returns plausible output.

**Settled toward the CODE**, and the reason is measured: `ModelBinding.objective` (proto field 6) has **no reader anywhere in the SDK** — no `_Pick` field, no `DeployBinding` field, nothing on the context. There is no checkpoint fact here to apply. The docstring now states the measured behaviour, names the surface that *does* honour an objective (`gen_worker.view.for_request(pipeline, objective=…)`), and names the plumbing a future restoration would owe.

`slot=` is **gone** from the serving *and* the trace context — it was accepted and discarded on each (the trace one wrote `del slot` in place), and a kwarg that changes nothing is a third way to be silently wrong. No caller in the fleet passes it (grepped across all 26 endpoints). A test asserts both signatures still match, because a trace whose `for_request` differs from serving's derives graphs for a call the serve path cannot make.

---

## Verification

* **16 new cases**, integration on the real path: the `serving_v2_endpoint` fixture — the main_v2-contract-exact endpoint that serves real requests on CPU with fake weights from config-only checkpoints — booted through `ServeLoop` and warmed through `boot_warmup`. No mock of the serve path; the only doubles are the ones the design names (`BindingResolver`, the static sizer). `CUDA_VISIBLE_DEVICES=""` throughout; no inference, no GPU, no pod.
* Related suites green: `test_serve_loop_envelope`, `test_boot_materialize`, `test_weightless_entrypoints`, `test_serve_path_wires`, `test_output_integrity_trace_exempt`, `test_trace_context_surface`, `test_release_derive_component_dtype`, `test_eager_bridge_dtype`, `test_boot_stages_pgw1355` — 106 passed.
* **mypy strict over `src/gen_worker` + `tests`: clean.** ruff clean. Changelog fragment parses.

This lands for FUTURE builds. It does not touch the in-flight 0.12.6 train or the route-matrix legs.

---

## ⚠️ Read this before measuring the effect on a pod: it is gated on th#2233, today, fleet-wide

th#2233 measured that the hub sends **zero `disk_refs` for `fixed` bindings fleet-wide** — the only HelloAck seeder covers dynamic slots, of which the standing stack has none (0 rows in `endpoint_release_slot_declarations`; all 1128 `release_function_bindings` rows are `kind = 'fixed'`). So every production pod lands in `boot_materialize.configure`'s empty-refs branch.

A config naming zero refs also names zero checkpoint **bindings**, so `boot_picks` has nothing to bind and every function would skip with *"no boot-time checkpoint binding"*. **Until th#2233's seeder lands, the restored warm pass correctly does nothing on a real pod.** The comment saying so sits beside that branch, naming the issue.

That is not a reason to hold this: the writer, the exemption pair, the payload synthesis, the placement and the failure posture are all the half that belongs here, and they are what make th#2233's seeder worth more than one saved attempt per cold pod. It is noted on th#2233, with the concrete ask that the seeder populate `DesiredResidency.Hot` per function alongside `disk_refs` — `Hot` carries the same `ModelBinding` a dispatch does (slot, ref, `model`, `inference_defaults`), which is exactly what this reads. With `disk_refs` alone the worker falls back to the fenced one-slot/one-ref inference, which is honest but silently declines every multi-slot release and warms without the checkpoint's own resolved defaults row.
