### PR TITLE
pgw#1607: the checkpoint juggle — backing swap under fixed VAs (pgw#1602 multi-checkpoint scope)

### DIFF
--- a/benchmarks/checkpoint_juggle_curate_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_curate_pgw1607.py
@@ -1,0 +1,115 @@
+"""pgw#1607 phase-4 $0 preflight: curate juggle-compatible SDXL fine-tunes.
+
+Header-only: for each candidate HF repo, fetch the safetensors header of its
+UNet (8-byte length prefix + JSON) via a ranged GET — kilobytes, never a
+weight byte — and prove (key -> shape) identity against the SDXL base UNet.
+Emits the compatible list with per-repo dtype and total unet bytes, so the
+pod matrix rents nothing to discover a layout mismatch.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import sys
+import urllib.request
+
+BASE = "stabilityai/stable-diffusion-xl-base-1.0"
+CANDIDATES = [
+    # well-known public SDXL fine-tunes in diffusers layout
+    "stabilityai/stable-diffusion-xl-base-1.0",
+    "playgroundai/playground-v2-1024px-aesthetic",
+    "playgroundai/playground-v2.5-1024px-aesthetic",
+    "RunDiffusion/Juggernaut-XL-v9",
+    "RunDiffusion/Juggernaut-X-v10",
+    "SG161222/RealVisXL_V4.0",
+    "SG161222/RealVisXL_V5.0",
+    "cagliostrolab/animagine-xl-3.1",
+    "cagliostrolab/animagine-xl-4.0",
+    "Lykon/dreamshaper-xl-1-0",
+    "Lykon/dreamshaper-xl-v2-turbo",
+    "stablediffusionapi/nightvision-xl",
+    "misri/zavychromaxl_v80",
+    "misri/epicrealismXL_v10",
+    "GraydientPlatformAPI/albedobase2-xl",
+    "fluently/Fluently-XL-v4",
+    "recoilme/ColorfulXL-Lightning",
+    "zenless-lab/sdxl-blue-pencil-xl-v7",
+    "John6666/copycat-photo-sdxl-v1-sdxl",
+    "dataautogpt3/ProteusV0.4",
+    "dataautogpt3/OpenDalleV1.1",
+    "segmind/SSD-1B",  # expected REFUSAL: distilled, different architecture
+]
+
+
+def fetch_header(repo: str, path: str) -> dict | None:
+    url = f"https://huggingface.co/{repo}/resolve/main/{path}"
+    req = urllib.request.Request(url, headers={"Range": "bytes=0-7"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            (hlen,) = struct.unpack("<Q", r.read(8))
+    except Exception as exc:
+        print(f"  {repo}: no {path} ({type(exc).__name__})", file=sys.stderr)
+        return None
+    if hlen > 100 << 20:
+        return None
+    req = urllib.request.Request(url, headers={"Range": f"bytes=8-{7 + hlen}"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read(hlen))
+
+
+def unet_header(repo: str) -> tuple[dict | None, str]:
+    for path in (
+        "unet/diffusion_pytorch_model.fp16.safetensors",
+        "unet/diffusion_pytorch_model.safetensors",
+    ):
+        h = fetch_header(repo, path)
+        if h is not None:
+            return h, path
+    return None, ""
+
+
+def shape_map(header: dict) -> dict[str, tuple]:
+    return {
+        k: tuple(v["shape"])
+        for k, v in header.items()
+        if k != "__metadata__"
+    }
+
+
+def main() -> None:
+    base_header, base_path = unet_header(BASE)
+    assert base_header is not None, "base UNet header unreachable"
+    base_shapes = shape_map(base_header)
+    print(f"base: {BASE} ({base_path}), {len(base_shapes)} tensors")
+    compatible = []
+    for repo in CANDIDATES:
+        header, path = unet_header(repo)
+        if header is None:
+            print(f"REFUSED {repo}: no unet safetensors in diffusers layout")
+            continue
+        shapes = shape_map(header)
+        dtypes = {v["dtype"] for k, v in header.items() if k != "__metadata__"}
+        total = sum(
+            v["data_offsets"][1] - v["data_offsets"][0]
+            for k, v in header.items() if k != "__metadata__"
+        )
+        if shapes == base_shapes:
+            compatible.append(repo)
+            print(f"OK      {repo}: {path} dtypes={sorted(dtypes)} "
+                  f"unet={total / (1 << 30):.2f} GiB")
+        else:
+            missing = len(base_shapes.keys() - shapes.keys())
+            extra = len(shapes.keys() - base_shapes.keys())
+            diff = sum(
+                1 for k in shapes.keys() & base_shapes.keys()
+                if shapes[k] != base_shapes[k]
+            )
+            print(f"REFUSED {repo}: missing={missing} extra={extra} shape-diff={diff}")
+    print(f"\ncompatible: {len(compatible)}")
+    for r in compatible:
+        print(f"  {r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/checkpoint_juggle_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pgw1607.py
@@ -1,0 +1,503 @@
+"""pgw#1607: the checkpoint juggle's card-side legs.
+
+Run inside a coordinator-arbitrated GPU window (the box's RTX 4070), under
+the micro-rig carve-out and nothing more: the checkpoints are GENERATED on
+this box (random-init toy trees, < 500 MB total, nothing downloaded), the
+device budget is enforced through the arena, the compile phase is STUBBED —
+the zero-re-arm proof here is pointer/forward-identity, and the
+real-compiled arm runs pod-side (phase 4).
+
+    nice -n 19 .venv/bin/python benchmarks/checkpoint_juggle_pgw1607.py --arms ABCDEF
+
+* **A — distinct outputs.** Same input, same seed: serving ck0 -> y0, switch
+  ck1 -> y1, switch back ck0 -> y0'. y0 != y1 (the switch actually switched)
+  and y0 == y0' BITWISE (a round trip restores the checkpoint exactly).
+* **B — zero re-arms.** Every managed parameter's data_ptr and every
+  module's forward identity are snapshotted before the first switch and
+  asserted UNCHANGED after every switch; `juggler.rearms == 0`.
+* **C — integrity.** After each switch, every backed region is read back
+  D2H and its digest compared against the ingest digest banked for the
+  serving checkpoint. Content-level, this lane's half of the va#12 split.
+* **D — the franken fence (RED leg).** A refill is KILLED mid-switch by
+  fault injection at the copy seam. The region must go INVALID, serving
+  must REFUSE under both identities, and an unpatched re-switch must
+  recover to green digests.
+* **E — teardown.** release + `committed == mapped == 0`.
+* **F — the numbers.** Warm switch wall vs the transfer bound (a pinned
+  H2D floor measured on THIS card in the same window), serving-switch ~ 0,
+  disk-cold switch, and a 200-request zipf juggle vs the single-checkpoint
+  baseline.
+
+Discipline: fleet line asserted first, load gate at 24, `uptime` recorded,
+one heavy thing at a time, verdict JSON written before exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+MIB = 1 << 20
+GIB = 1 << 30
+
+#: Micro-rig bound: generated weights, total under 500 MB.
+CHECKPOINTS = 4
+SEED = 1607
+
+SCRATCH = Path(
+    os.environ.get(
+        "PGW1607_SCRATCH",
+        os.path.expanduser("~/.cache/cozy/pgw1607"),
+    )
+)
+
+
+def loud(msg: str) -> None:
+    print(f"[pgw1607] {msg}", flush=True)
+
+
+def load_gate() -> None:
+    load1 = os.getloadavg()[0]
+    if load1 > 24:
+        raise SystemExit(f"load gate: 1-min load {load1:.1f} > 24; refusing to start")
+    loud(f"load gate ok (1-min {load1:.1f}); uptime: "
+         f"{subprocess.run(['uptime'], capture_output=True, text=True).stdout.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# The toy lane: a real tree with stream-sized leaves, generated checkpoints
+# ---------------------------------------------------------------------------
+
+
+def build_template(torch: Any, nn: Any) -> Any:
+    class ToyLane(nn.Module):
+        """~118 MB fp32: three stream-sized leaves + a core, real forward."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.blk0 = nn.Linear(2048, 2048, bias=False)  # 16 MiB
+            self.blk1 = nn.Linear(2048, 2048, bias=False)  # 16 MiB
+            self.blk2 = nn.Linear(2048, 4096, bias=False)  # 32 MiB
+            self.blk3 = nn.Linear(4096, 2048, bias=False)  # 32 MiB
+            self.mid = nn.Linear(1024, 1024, bias=False)  # 4 MiB
+            self.head = nn.Linear(2048, 64, bias=False)  # 0.5 MiB -> core
+            self.norm = nn.LayerNorm(2048)
+
+        def forward(self, x: Any) -> Any:
+            h = torch.tanh(self.blk0(x))
+            h = torch.tanh(self.blk1(h))
+            h = torch.tanh(self.blk3(torch.tanh(self.blk2(h))))
+            return self.head(self.norm(h))
+
+    return ToyLane()
+
+
+def generate_checkpoints(torch: Any, template: Any, directory: Path) -> List[Path]:
+    """CHECKPOINTS distinct random inits of the SAME architecture, on disk.
+
+    Real safetensors files via the test fixture's writer (one header
+    implementation on each side of the seam).
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tests"))
+    from test_checkpoint_juggle import write_safetensors  # noqa: E402
+
+    out = []
+    for i in range(CHECKPOINTS):
+        g = torch.Generator().manual_seed(SEED + i)
+        state = {}
+        for key, tensor in template.state_dict().items():
+            state[key] = torch.randn(tensor.shape, generator=g, dtype=tensor.dtype)
+        ck_dir = directory / f"ck{i}"
+        ck_dir.mkdir(parents=True, exist_ok=True)
+        write_safetensors(ck_dir / "weights.safetensors", state)
+        out.append(ck_dir)
+    total = sum(
+        f.stat().st_size for d in out for f in d.glob("*.safetensors")
+    )
+    assert total < 500 * MIB, f"micro-rig bound violated: {total} bytes generated"
+    loud(f"generated {CHECKPOINTS} checkpoints, {total / MIB:.1f} MiB total (< 500 MiB bound)")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Rig assembly
+# ---------------------------------------------------------------------------
+
+
+def make_rig(torch: Any, nn: Any, ck_dirs: List[Path], *, budget_bytes: int):
+    from gen_worker.models.arena_residency import ArenaResidency
+    from gen_worker.models.checkpoint_juggle import CheckpointJuggler, read_manifest
+
+    template = build_template(torch, nn)
+    manifests = {f"ck{i}": read_manifest(d) for i, d in enumerate(ck_dirs)}
+    # Serve ck0: load its bytes into the live tree, move to the card.
+    state = {}
+    m0 = manifests["ck0"]
+    for key, src in m0.items():
+        t = torch.empty(src.shape, dtype=template.state_dict()[key].dtype)
+        with open(src.path, "rb") as fh:
+            fh.seek(src.offset)
+            fh.readinto(memoryview(t.view(torch.uint8).view(-1).numpy()))
+        state[key] = t
+    template.load_state_dict(state)
+    template.to("cuda").eval()
+
+    triples = {k: (s.path, s.offset, s.length) for k, s in m0.items()}
+    residency = ArenaResidency(
+        [("root", template)],
+        device="cuda",
+        budget_bytes=budget_bytes,
+        triples=triples,
+        min_stream_bytes=1 * MIB,
+    )
+    residency.engage()
+    juggler = CheckpointJuggler(residency, "ck0", m0)
+    for i in range(1, CHECKPOINTS):
+        juggler.admit(f"ck{i}", manifests[f"ck{i}"])
+    return template, residency, juggler
+
+
+def forward_once(torch: Any, juggler: Any, template: Any, x: Any) -> Any:
+    juggler.assert_servable()
+    with torch.no_grad():
+        return template(x).clone()
+
+
+def backed_region_digest(torch: Any, residency: Any, region: Any) -> str:
+    """D2H readback digest of a backed region's WEIGHT bytes (slot-bounded)."""
+    import hashlib
+
+    h = hashlib.blake2b(digest_size=16)
+    for slot in region.slots:
+        view = residency._view(slot)
+        host = view.detach().to("cpu")
+        h.update(host.view(torch.uint8).view(-1).numpy().tobytes())
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Legs
+# ---------------------------------------------------------------------------
+
+
+def leg_a_distinct_outputs(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
+    x = torch.zeros(8, 2048, device="cuda")
+    x[:, :4] = 1.0
+    y0 = forward_once(torch, juggler, template, x)
+    juggler.switch_to("ck1")
+    y1 = forward_once(torch, juggler, template, x)
+    juggler.switch_to("ck0")
+    y0_again = forward_once(torch, juggler, template, x)
+    distinct = not torch.equal(y0, y1)
+    restored = torch.equal(y0, y0_again)
+    assert distinct, "outputs identical across a switch — the swap did not swap"
+    assert restored, "round trip did not restore ck0 bitwise"
+    loud("leg A GREEN: outputs are checkpoint-distinct and the round trip is bitwise")
+    return {"distinct": distinct, "restored_bitwise": restored}
+
+
+def leg_b_zero_rearms(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
+    residency = juggler.residency
+    before_ptrs = {}
+    before_fwd = {}
+    for region in residency.layout.regions:
+        if residency.is_resident(region.name):
+            for slot in region.slots:
+                before_ptrs[(slot.leaf, slot.attr)] = int(
+                    residency._view(slot).data_ptr()
+                )
+    for name, module in template.named_modules():
+        before_fwd[name] = id(module.forward.__func__ if hasattr(module.forward, "__func__") else module.forward)
+    x = torch.randn(4, 2048, generator=torch.Generator().manual_seed(7)).cuda()
+    for target in ("ck1", "ck2", "ck3", "ck0"):
+        juggler.switch_to(target)
+        forward_once(torch, juggler, template, x)
+    moved = []
+    for region in residency.layout.regions:
+        if residency.is_resident(region.name):
+            for slot in region.slots:
+                ptr = int(residency._view(slot).data_ptr())
+                if before_ptrs.get((slot.leaf, slot.attr)) != ptr:
+                    moved.append(f"{slot.leaf}.{slot.attr}")
+    rebound = [
+        name for name, module in template.named_modules()
+        if before_fwd.get(name) != id(module.forward.__func__ if hasattr(module.forward, "__func__") else module.forward)
+    ]
+    assert not moved, f"data_ptr moved across switches: {moved[:5]}"
+    assert not rebound, f"forward identity changed: {rebound[:5]}"
+    assert juggler.rearms == 0, f"rearms counted: {juggler.rearms}"
+    loud(f"leg B GREEN: {len(before_ptrs)} pointers fixed, 0 re-arms across 4 switches")
+    return {"pointers_checked": len(before_ptrs), "rearms": juggler.rearms}
+
+
+def leg_c_integrity(torch: Any, juggler: Any) -> Dict[str, Any]:
+    residency = juggler.residency
+    checked = 0
+    for target in ("ck2", "ck3"):
+        juggler.switch_to(target)
+        image = juggler.catalog.warm(target)
+        assert image is not None, "integrity leg needs the warm tier"
+        for region in residency.layout.regions:
+            if not residency.is_resident(region.name):
+                continue
+            got = backed_region_digest(torch, residency, region)
+            want = image.region_digests[region.name]
+            assert got == want, (
+                f"region {region.name!r}: VRAM bytes digest {got} != ingest {want}"
+            )
+            checked += 1
+    juggler.switch_to("ck0")
+    loud(f"leg C GREEN: {checked} backed-region digests match ingest across 2 switches")
+    return {"regions_checked": checked}
+
+
+def leg_d_franken_fence(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
+    """Kill a refill mid-switch; the fence must refuse; recovery must serve."""
+    from gen_worker.models.checkpoint_juggle import RegionInvalid
+
+    real = juggler._refill_backed
+    calls = {"n": 0}
+
+    def dying_refill(region: Any, image: Any, manifest: Any, stream: Any) -> int:
+        calls["n"] += 1
+        if calls["n"] == 2:
+            # First region lands (state: valid@target); the second dies with
+            # SOME of its bytes possibly moved — the franken shape.
+            raise RuntimeError("injected: H2D died mid-transfer")
+        return real(region, image, manifest, stream)
+
+    juggler._refill_backed = dying_refill  # fault injection at the copy seam
+    died = False
+    try:
+        juggler.switch_to("ck1")
+    except RuntimeError as exc:
+        died = "injected" in str(exc)
+    finally:
+        juggler._refill_backed = real
+    assert died, "the injection did not fire; the leg proved nothing"
+
+    refused = {"as_old": False, "as_new": False}
+    try:
+        juggler.assert_servable()
+    except RegionInvalid:
+        refused["as_old"] = True
+    juggler.serving_id = "ck1"  # even claiming the new identity must refuse
+    try:
+        juggler.assert_servable()
+    except RegionInvalid:
+        refused["as_new"] = True
+    juggler.serving_id = "ck0"
+    assert refused["as_old"] and refused["as_new"], (
+        f"franken state served: {refused}"
+    )
+
+    # Recovery: an unpatched re-switch is idempotent and lands green.
+    juggler.switch_to("ck1")
+    juggler.assert_servable()
+    image = juggler.catalog.warm("ck1")
+    residency = juggler.residency
+    for region in residency.layout.regions:
+        if residency.is_resident(region.name):
+            assert backed_region_digest(torch, residency, region) == \
+                image.region_digests[region.name]
+    juggler.switch_to("ck0")
+    loud("leg D GREEN (red arm fired): mid-refill kill -> INVALID -> refused "
+         "under BOTH identities -> idempotent re-switch recovered to green digests")
+    return {"refused": refused, "recovered": True}
+
+
+def leg_e_teardown(torch: Any, residency: Any) -> Dict[str, Any]:
+    stats_before = residency.stats()
+    residency.release()
+    stats = dict(residency.arena.stats())
+    committed, mapped = int(stats["committed_bytes"]), int(stats["mapped_bytes"])
+    assert committed == 0 and mapped == 0, (
+        f"teardown discipline violated: committed={committed} mapped={mapped}"
+    )
+    loud(f"leg E GREEN: committed==mapped==0 at teardown "
+         f"(peak backed regions {stats_before.get('backed_regions')})")
+    return {"committed": committed, "mapped": mapped}
+
+
+def measure_h2d_floor(torch: Any, nbytes: int) -> float:
+    """Pinned H2D GB/s on THIS card, measured in the same window."""
+    src = torch.empty(nbytes, dtype=torch.uint8, pin_memory=True)
+    dst = torch.empty(nbytes, dtype=torch.uint8, device="cuda")
+    for _ in range(2):
+        dst.copy_(src, non_blocking=True)
+    torch.cuda.synchronize()
+    best = float("inf")
+    for _ in range(3):
+        t0 = time.perf_counter()
+        dst.copy_(src, non_blocking=True)
+        torch.cuda.synchronize()
+        best = min(best, time.perf_counter() - t0)
+    del src, dst
+    torch.cuda.empty_cache()
+    return nbytes / best / 1e9
+
+
+def leg_f_numbers(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
+    residency = juggler.residency
+    lane_bytes = sum(
+        r.span for r in residency.layout.regions if residency.is_resident(r.name)
+    )
+    floor_gbps = measure_h2d_floor(torch, max(64 * MIB, lane_bytes))
+    x = torch.zeros(4, 2048, device="cuda")
+
+    # Warm switches, round-robin, median of ~11.
+    walls: List[float] = []
+    seq = [f"ck{i % CHECKPOINTS}" for i in range(12)]
+    for target in seq:
+        if target == juggler.serving_id:
+            continue
+        report = juggler.switch_to(target)
+        walls.append(report.wall_s)
+    warm_median = statistics.median(walls)
+    warm_gbps = (lane_bytes / warm_median / 1e9) if warm_median else 0.0
+
+    # Serving no-op.
+    noop = juggler.switch_to(juggler.serving_id)
+
+    # Cold, both shapes. (1) evicted image, switch rebuilds it: disk -> image
+    # -> VRAM, the D5 cold path. (2) hysteresis-cold: image refused, the
+    # switch streams disk-direct into the arena.
+    cold_target = "ck1" if juggler.serving_id != "ck1" else "ck2"
+    juggler.catalog.evict(cold_target)
+    t0 = time.perf_counter()
+    rebuild_report = juggler.switch_to(cold_target)
+    cold_rebuild_wall = time.perf_counter() - t0
+    assert rebuild_report.tier == "host-warm", rebuild_report.tier
+
+    direct_target = "ck2" if cold_target != "ck2" else "ck3"
+    juggler.catalog.evict(direct_target)
+    juggler.catalog._evicted_epoch[direct_target] = juggler.catalog.pressure_epoch
+    t0 = time.perf_counter()
+    direct_report = juggler.switch_to(direct_target)
+    cold_direct_wall = time.perf_counter() - t0
+    assert direct_report.tier == "disk-cold", direct_report.tier
+    del juggler.catalog._evicted_epoch[direct_target]
+
+    # Zipf-ish juggle vs single-checkpoint baseline, 200 requests each.
+    import random
+
+    rng = random.Random(SEED)
+    ids = [f"ck{i}" for i in range(CHECKPOINTS)]
+    weights = [1.0 / (i + 1) ** 1.1 for i in range(CHECKPOINTS)]
+    t0 = time.perf_counter()
+    for _ in range(200):
+        forward_once(torch, juggler, template, x)
+    torch.cuda.synchronize()
+    baseline = time.perf_counter() - t0
+    t0 = time.perf_counter()
+    switches_before = juggler.switches
+    for _ in range(200):
+        target = rng.choices(ids, weights)[0]
+        if target != juggler.serving_id:
+            juggler.switch_to(target)
+        forward_once(torch, juggler, template, x)
+    torch.cuda.synchronize()
+    juggled = time.perf_counter() - t0
+    zipf_switches = juggler.switches - switches_before
+
+    out = {
+        "lane_backed_bytes": lane_bytes,
+        "h2d_floor_gbps": round(floor_gbps, 2),
+        "warm_switch_median_s": round(warm_median, 4),
+        "warm_switch_gbps": round(warm_gbps, 2),
+        "warm_vs_floor": round(warm_gbps / floor_gbps, 3) if floor_gbps else None,
+        "serving_noop_s": round(noop.wall_s, 6),
+        "cold_rebuild_switch_s": round(cold_rebuild_wall, 4),
+        "cold_disk_direct_switch_s": round(cold_direct_wall, 4),
+        "zipf_200req_s": round(juggled, 3),
+        "zipf_switches": zipf_switches,
+        "single_ck_200req_s": round(baseline, 3),
+        "zipf_overhead": round(juggled / baseline, 3) if baseline else None,
+    }
+    loud(f"leg F: {json.dumps(out)}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--arms", default="ABCDEF")
+    parser.add_argument("--budget-mib", type=int, default=192,
+                        help="arena VRAM budget; the whole rig stays under the "
+                             "micro-rig 4 GiB device bound")
+    parser.add_argument("--out", default=str(SCRATCH / "verdict.json"))
+    args = parser.parse_args()
+
+    from gen_worker.rigcheck import assert_fleet_line
+
+    assert_fleet_line("pgw#1607 checkpoint-juggle rig")
+    load_gate()
+    guard = os.environ.get("GEN_WORKER_HOST_MOVE_GUARD", "1")
+    if guard == "0":
+        raise SystemExit("GEN_WORKER_HOST_MOVE_GUARD=0: refusing to run")
+
+    import torch
+    import torch.nn as nn
+
+    assert torch.cuda.is_available(), "no CUDA device; this is the card-side rig"
+    budget = args.budget_mib * MIB
+    assert budget <= 4 * GIB, "micro-rig device bound is 4 GiB"
+
+    SCRATCH.mkdir(parents=True, exist_ok=True)
+    ck_dirs = generate_checkpoints(torch, build_template(torch, nn), SCRATCH / "cks")
+    template, residency, juggler = make_rig(torch, nn, ck_dirs, budget_bytes=budget)
+    loud(f"rig up: layout {residency.layout.virtual_bytes / MIB:.1f} MiB virtual, "
+         f"budget {args.budget_mib} MiB, plan resident="
+         f"{len(residency.plan.all_resident)} streamed={len(residency.plan.streamed)}")
+
+    verdict: Dict[str, Any] = {
+        "issue": "pgw#1607", "when": time.strftime("%F %T"),
+        "budget_mib": args.budget_mib, "arms": args.arms, "legs": {},
+    }
+    failed = False
+    try:
+        if "A" in args.arms:
+            verdict["legs"]["A"] = leg_a_distinct_outputs(torch, juggler, template)
+        if "B" in args.arms:
+            verdict["legs"]["B"] = leg_b_zero_rearms(torch, juggler, template)
+        if "C" in args.arms:
+            verdict["legs"]["C"] = leg_c_integrity(torch, juggler)
+        if "D" in args.arms:
+            verdict["legs"]["D"] = leg_d_franken_fence(torch, juggler, template)
+        if "F" in args.arms:
+            verdict["legs"]["F"] = leg_f_numbers(torch, juggler, template)
+    except Exception as exc:  # noqa: BLE001
+        failed = True
+        verdict["failure"] = f"{type(exc).__name__}: {exc}"
+        loud(f"RED: {verdict['failure']}")
+    finally:
+        if "E" in args.arms:
+            try:
+                verdict["legs"]["E"] = leg_e_teardown(torch, residency)
+            except Exception as exc:  # noqa: BLE001
+                failed = True
+                verdict["legs"]["E"] = {"failure": f"{type(exc).__name__}: {exc}"}
+                loud(f"RED teardown: {exc}")
+        juggler.catalog.close()
+        gc.collect()
+        torch.cuda.empty_cache()
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(verdict, indent=2))
+        loud(f"verdict -> {args.out}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/checkpoint_juggle_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pgw1607.py
@@ -346,21 +346,29 @@ def measure_h2d_floor(torch: Any, nbytes: int) -> float:
 
 
 def leg_f_numbers(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
+    # The box is shared and drifts: every timed row carries the 1-min load at
+    # its moment, so a poisoned median is REPORTED load-stamped, never clean.
+    def load1() -> float:
+        return round(os.getloadavg()[0], 1)
+
     residency = juggler.residency
     lane_bytes = sum(
         r.span for r in residency.layout.regions if residency.is_resident(r.name)
     )
+    floor_load = load1()
     floor_gbps = measure_h2d_floor(torch, max(64 * MIB, lane_bytes))
     x = torch.zeros(4, 2048, device="cuda")
 
-    # Warm switches, round-robin, median of ~11.
+    # Warm switches, round-robin, median of ~11, each row load-stamped.
     walls: List[float] = []
+    wall_rows: List[Dict[str, float]] = []
     seq = [f"ck{i % CHECKPOINTS}" for i in range(12)]
     for target in seq:
         if target == juggler.serving_id:
             continue
         report = juggler.switch_to(target)
         walls.append(report.wall_s)
+        wall_rows.append({"wall_s": round(report.wall_s, 4), "load1": load1()})
     warm_median = statistics.median(walls)
     warm_gbps = (lane_bytes / warm_median / 1e9) if warm_median else 0.0
 
@@ -371,6 +379,7 @@ def leg_f_numbers(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
     # -> VRAM, the D5 cold path. (2) hysteresis-cold: image refused, the
     # switch streams disk-direct into the arena.
     cold_target = "ck1" if juggler.serving_id != "ck1" else "ck2"
+    cold_rebuild_load = load1()
     juggler.catalog.evict(cold_target)
     t0 = time.perf_counter()
     rebuild_report = juggler.switch_to(cold_target)
@@ -378,6 +387,7 @@ def leg_f_numbers(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
     assert rebuild_report.tier == "host-warm", rebuild_report.tier
 
     direct_target = "ck2" if cold_target != "ck2" else "ck3"
+    cold_direct_load = load1()
     juggler.catalog.evict(direct_target)
     juggler.catalog._evicted_epoch[direct_target] = juggler.catalog.pressure_epoch
     t0 = time.perf_counter()
@@ -392,11 +402,13 @@ def leg_f_numbers(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
     rng = random.Random(SEED)
     ids = [f"ck{i}" for i in range(CHECKPOINTS)]
     weights = [1.0 / (i + 1) ** 1.1 for i in range(CHECKPOINTS)]
+    baseline_load = load1()
     t0 = time.perf_counter()
     for _ in range(200):
         forward_once(torch, juggler, template, x)
     torch.cuda.synchronize()
     baseline = time.perf_counter() - t0
+    zipf_load = load1()
     t0 = time.perf_counter()
     switches_before = juggler.switches
     for _ in range(200):
@@ -411,16 +423,23 @@ def leg_f_numbers(torch: Any, juggler: Any, template: Any) -> Dict[str, Any]:
     out = {
         "lane_backed_bytes": lane_bytes,
         "h2d_floor_gbps": round(floor_gbps, 2),
+        "h2d_floor_load1": floor_load,
         "warm_switch_median_s": round(warm_median, 4),
+        "warm_switch_rows": wall_rows,
         "warm_switch_gbps": round(warm_gbps, 2),
         "warm_vs_floor": round(warm_gbps / floor_gbps, 3) if floor_gbps else None,
         "serving_noop_s": round(noop.wall_s, 6),
         "cold_rebuild_switch_s": round(cold_rebuild_wall, 4),
+        "cold_rebuild_load1": cold_rebuild_load,
         "cold_disk_direct_switch_s": round(cold_direct_wall, 4),
+        "cold_direct_load1": cold_direct_load,
         "zipf_200req_s": round(juggled, 3),
+        "zipf_load1": zipf_load,
         "zipf_switches": zipf_switches,
         "single_ck_200req_s": round(baseline, 3),
+        "baseline_load1": baseline_load,
         "zipf_overhead": round(juggled / baseline, 3) if baseline else None,
+        "end_load1": load1(),
     }
     loud(f"leg F: {json.dumps(out)}")
     return out

--- a/benchmarks/checkpoint_juggle_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pgw1607.py
@@ -64,10 +64,15 @@ def loud(msg: str) -> None:
     print(f"[pgw1607] {msg}", flush=True)
 
 
-def load_gate() -> None:
+def load_gate(limit: float = 24.0) -> None:
+    """Refuse above the limit. A raised limit is DELIBERATE and printed —
+    only the load-insensitive correctness arms may run over it (the
+    coordinator's window grant, 2026-08-20); arm F stays behind 24."""
     load1 = os.getloadavg()[0]
-    if load1 > 24:
-        raise SystemExit(f"load gate: 1-min load {load1:.1f} > 24; refusing to start")
+    if load1 > limit:
+        raise SystemExit(f"load gate: 1-min load {load1:.1f} > {limit}; refusing to start")
+    if limit > 24:
+        loud(f"load gate RAISED to {limit} for correctness arms (1-min {load1:.1f})")
     loud(f"load gate ok (1-min {load1:.1f}); uptime: "
          f"{subprocess.run(['uptime'], capture_output=True, text=True).stdout.strip()}")
 
@@ -264,13 +269,20 @@ def leg_d_franken_fence(torch: Any, juggler: Any, template: Any) -> Dict[str, An
     from gen_worker.models.checkpoint_juggle import RegionInvalid
 
     real = juggler._refill_backed
+    residency = juggler.residency
+    backed_count = sum(
+        1 for r in residency.layout.regions if residency.is_resident(r.name)
+    )
+    assert backed_count >= 1, "no backed regions; nothing to kill"
+    # Die on the LAST backed refill: everything before it (and every unbacked
+    # free-swap) has already moved to the target — the franken shape — while
+    # this region dies with some bytes possibly moved.
+    kill_at = backed_count
     calls = {"n": 0}
 
     def dying_refill(region: Any, image: Any, manifest: Any, stream: Any) -> int:
         calls["n"] += 1
-        if calls["n"] == 2:
-            # First region lands (state: valid@target); the second dies with
-            # SOME of its bytes possibly moved — the franken shape.
+        if calls["n"] == kill_at:
             raise RuntimeError("injected: H2D died mid-transfer")
         return real(region, image, manifest, stream)
 
@@ -317,6 +329,10 @@ def leg_d_franken_fence(torch: Any, juggler: Any, template: Any) -> Dict[str, An
 def leg_e_teardown(torch: Any, residency: Any) -> Dict[str, Any]:
     stats_before = residency.stats()
     residency.release()
+    # release() unbacks everything; the chunks land in the recycled-idle pool,
+    # still COMMITTED against the budget. Zeroing the budget is the caller's
+    # half of the va#3 teardown discipline — budget-fed to the end.
+    residency.arena.set_budget(0)
     stats = dict(residency.arena.stats())
     committed, mapped = int(stats["committed_bytes"]), int(stats["mapped_bytes"])
     assert committed == 0 and mapped == 0, (
@@ -457,12 +473,18 @@ def main() -> int:
                         help="arena VRAM budget; the whole rig stays under the "
                              "micro-rig 4 GiB device bound")
     parser.add_argument("--out", default=str(SCRATCH / "verdict.json"))
+    parser.add_argument("--load-gate-max", type=float, default=24.0,
+                        help="raise ONLY for the correctness arms (A-E) under "
+                             "an explicit coordinator window grant; arm F "
+                             "refuses above 24 regardless")
     args = parser.parse_args()
+    if "F" in args.arms and args.load_gate_max > 24.0 and os.getloadavg()[0] > 24.0:
+        raise SystemExit("arm F is load-sensitive: run it under a load-24 gate")
 
     from gen_worker.rigcheck import assert_fleet_line
 
     assert_fleet_line("pgw#1607 checkpoint-juggle rig")
-    load_gate()
+    load_gate(args.load_gate_max)
     guard = os.environ.get("GEN_WORKER_HOST_MOVE_GUARD", "1")
     if guard == "0":
         raise SystemExit("GEN_WORKER_HOST_MOVE_GUARD=0: refusing to run")

--- a/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
@@ -155,6 +155,7 @@ def main() -> int:
     parser.add_argument("--requests", type=int, default=24)
     parser.add_argument("--max-hours", type=float, default=2.0)
     parser.add_argument("--host-floor-gib", type=float, default=0.0)
+    parser.add_argument("--target-warm-images", type=int, default=0)
     parser.add_argument("--name", default="")
     parser.add_argument("--retries", type=int, default=3,
                         help="new-host retries for RETRYABLE_HOST failures "
@@ -289,7 +290,8 @@ def run_once(args: argparse.Namespace, api: str, body: dict, name: str,
             f"python pgw/benchmarks/checkpoint_juggle_pod_pgw1607.py "
             f"--arms {shlex.quote(args.arms)} --repos {args.repos} "
             f"--budget-gib {args.budget_gib} --steps {args.steps} "
-            f"--requests {args.requests} --host-floor-gib {args.host_floor_gib}"
+            f"--requests {args.requests} --host-floor-gib {args.host_floor_gib} "
+            f"--target-warm-images {args.target_warm_images}"
         )
         budget_s = int(args.max_hours * 3600)
         log(f"running harness (wall cap {budget_s}s) ...")

--- a/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
@@ -156,7 +156,7 @@ def main() -> int:
     parser.add_argument("--max-hours", type=float, default=2.0)
     parser.add_argument("--name", default="")
     parser.add_argument("--retries", type=int, default=3,
-                        help="new-host retries for HOST_DRIVER_TOO_OLD "
+                        help="new-host retries for RETRYABLE_HOST failures "
                              "(~$0.01 each, terminated with 404 proof)")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
@@ -200,7 +200,7 @@ def main() -> int:
         try:
             return run_once(args, api, body, name, attempt)
         except RuntimeError as exc:
-            if "HOST_DRIVER_TOO_OLD" in str(exc) and attempt + 1 < args.retries:
+            if "RETRYABLE_HOST" in str(exc) and attempt + 1 < args.retries:
                 log(f"attempt {attempt + 1}: {exc}; retrying on a new host")
                 body["name"] = f"{name}-r{attempt + 1}"
                 continue
@@ -224,7 +224,9 @@ def run_once(args: argparse.Namespace, api: str, body: dict, name: str,
     try:
         log("waiting for SSH ...")
         tgt = None
-        deadline = time.time() + 900
+        # 25 min: va#5 measured healthy pods 12+ min into a big image pull —
+        # a 15-min bound tears down working hosts (try 3, $0.09).
+        deadline = time.time() + 1500
         while time.time() < deadline:
             tgt = ssh_target(api, lease)
             if tgt and pod_sh(tgt, "true", 45)[0] == 0:
@@ -232,7 +234,10 @@ def run_once(args: argparse.Namespace, api: str, body: dict, name: str,
             tgt = None
             time.sleep(15)
         if tgt is None:
-            raise RuntimeError("SSH never came up inside 15 min")
+            raise RuntimeError(
+                "RETRYABLE_HOST:ssh-never-up — no SSH inside 25 min; "
+                "terminating and retrying on a different host"
+            )
         log(f"ssh up at {tgt[0]}:{tgt[1]}")
 
         # DRIVER GATE, before any byte of setup: the host must speak CUDA 13
@@ -245,7 +250,7 @@ def run_once(args: argparse.Namespace, api: str, body: dict, name: str,
         log(f"host driver: {drv or 'unreadable'}")
         if major < 580:
             raise RuntimeError(
-                f"HOST_DRIVER_TOO_OLD:{drv} — cannot run the cu130 fleet line; "
+                f"RETRYABLE_HOST:driver-too-old:{drv} — cannot run the cu130 fleet line; "
                 f"terminating and retrying on a different host"
             )
 

--- a/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
@@ -1,0 +1,255 @@
+"""pgw#1607 phase 4: the box-side pod driver.
+
+Rents ONE RunPod GPU pod through podguard (renting and arming teardown are
+one act), bootstraps the fleet line + this branch + the post-va#12 varena
+wheel, runs `checkpoint_juggle_pod_pgw1607.py`, ships the verdicts OFF the
+pod before teardown, and terminates with provider-404 proof. One pod per
+invocation; the matrix is sequential invocations, each gated on the last.
+
+    nice -n 19 .venv/bin/python benchmarks/checkpoint_juggle_pod_driver_pgw1607.py \\
+        --gpu "NVIDIA GeForce RTX 4090" --disk-gb 120 --repos 6 --arms SWCZ
+
+Discipline (the va#5/#1548 shape, reused not reinvented): the pod id is
+BANKED to the ledger file the moment it exists, before any wait loop; every
+exit path runs terminate_and_confirm; results are scp'd out BEFORE teardown;
+the driver refuses to start if a previous pod from this ledger is still
+alive (one heavy thing at a time).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import sys
+import time
+from pathlib import Path
+
+TRACKER_SCRIPTS = Path.home() / "cozy" / "cozy-creator-tracker" / "scripts" / "podguard"
+sys.path.insert(0, str(TRACKER_SCRIPTS))
+
+import podguard  # noqa: E402
+
+LEDGER = Path.home() / ".cache" / "cozy" / "pgw1607" / "pods.jsonl"
+OUT_ROOT = Path.home() / ".cache" / "cozy" / "pgw1607"
+WHEEL = (Path.home() / "cozy" / "varena" / "target" / "wheels" /
+         "varena-0.1.0-cp310-abi3-manylinux_2_34_x86_64.whl")
+FLOORS = Path.home() / "cozy" / "serverless-endpoints" / "fleet-floors.toml"
+BRANCH = "1607-checkpoint-juggle"
+REPO_URL = "https://github.com/cozy-creator/python-gen-worker"
+
+SSH_OPTS = [
+    "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+    "-o", "ConnectTimeout=20", "-o", "LogLevel=ERROR",
+    "-i", str(Path.home() / ".ssh" / "id_ed25519"),
+]
+
+BOOTSTRAP = r"""
+set -euo pipefail
+cd /workspace
+if [ ! -d pgw ]; then
+  git clone --depth 1 -b {branch} {repo} pgw
+fi
+export PATH="$HOME/.local/bin:$PATH"
+command -v uv >/dev/null || (curl -LsSf https://astral.sh/uv/install.sh | sh)
+if [ ! -d venv ]; then
+  uv venv --python 3.11 venv
+fi
+. venv/bin/activate
+python -c "import torch" 2>/dev/null || \
+  uv pip install --python venv/bin/python torch==2.13.0 \
+    --index-url https://download.pytorch.org/whl/cu130
+uv pip install --python venv/bin/python \
+  diffusers transformers accelerate huggingface_hub safetensors numpy msgspec
+uv pip install --python venv/bin/python --force-reinstall --no-deps /workspace/{wheel}
+python - <<'PY'
+import varena
+assert hasattr(varena.Reservation, "page_signatures"), "wheel predates va#12"
+print("varena wheel OK (post-va#12)")
+PY
+"""
+
+
+def log(msg: str) -> None:
+    print(f"[driver {time.strftime('%H:%M:%SZ', time.gmtime())}] {msg}", flush=True)
+
+
+def bank_pod(pod_id: str, note: str, rate: float) -> None:
+    LEDGER.parent.mkdir(parents=True, exist_ok=True)
+    with LEDGER.open("a") as fh:
+        fh.write(json.dumps({
+            "pod_id": pod_id, "note": note, "rate_per_hr": rate,
+            "at": time.strftime("%FT%TZ", time.gmtime()),
+            "kill": f"python3 {TRACKER_SCRIPTS}/podguard.py release {pod_id}",
+        }) + "\n")
+    log(f"BANKED pod {pod_id} rate=${rate}/hr -> {LEDGER}")
+
+
+def any_prior_alive(api: str) -> str | None:
+    if not LEDGER.exists():
+        return None
+    for line in LEDGER.read_text().splitlines():
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if rec.get("released"):
+            continue
+        pod_id = rec["pod_id"]
+        try:
+            podguard.rest(api, "GET", f"/pods/{pod_id}")
+            return pod_id
+        except RuntimeError as exc:
+            if "404" not in str(exc):
+                return pod_id
+    return None
+
+
+def mark_released(pod_id: str) -> None:
+    with LEDGER.open("a") as fh:
+        fh.write(json.dumps({
+            "pod_id": pod_id, "released": True,
+            "at": time.strftime("%FT%TZ", time.gmtime()),
+        }) + "\n")
+
+
+def ssh_target(api: str, lease) -> tuple[str, int] | None:
+    return lease._ssh_target(api)
+
+
+def pod_sh(tgt: tuple[str, int], cmd: str, timeout: int = 1800) -> tuple[int, str]:
+    return podguard._sh(
+        ["ssh", *SSH_OPTS, "-p", str(tgt[1]), f"root@{tgt[0]}", cmd], timeout
+    )
+
+
+def scp_to(tgt: tuple[str, int], src: Path, dst: str) -> None:
+    rc, out = podguard._sh(
+        ["scp", *SSH_OPTS, "-P", str(tgt[1]), str(src), f"root@{tgt[0]}:{dst}"], 300
+    )
+    if rc != 0:
+        raise RuntimeError(f"scp {src} failed: {out[-300:]}")
+
+
+def scp_from(tgt: tuple[str, int], src: str, dst: Path) -> bool:
+    dst.mkdir(parents=True, exist_ok=True)
+    rc, out = podguard._sh(
+        ["scp", *SSH_OPTS, "-P", str(tgt[1]), "-r", f"root@{tgt[0]}:{src}", str(dst)],
+        600,
+    )
+    if rc != 0:
+        log(f"scp-out failed: {out[-300:]}")
+    return rc == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gpu", default="NVIDIA GeForce RTX 4090")
+    parser.add_argument("--disk-gb", type=int, default=120)
+    parser.add_argument("--cloud", default="COMMUNITY")
+    parser.add_argument("--repos", type=int, default=6)
+    parser.add_argument("--arms", default="SWCZ")
+    parser.add_argument("--budget-gib", type=float, default=6.0)
+    parser.add_argument("--steps", type=int, default=28)
+    parser.add_argument("--requests", type=int, default=24)
+    parser.add_argument("--max-hours", type=float, default=2.0)
+    parser.add_argument("--name", default="")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    assert WHEEL.exists(), f"wheel missing: {WHEEL}"
+    assert FLOORS.exists(), f"fleet floors missing: {FLOORS}"
+    api, pub = podguard.creds()
+
+    prior = any_prior_alive(api)
+    if prior:
+        raise SystemExit(
+            f"a prior pgw1607 pod ({prior}) is still alive; release it first — "
+            f"one pod at a time"
+        )
+
+    name = args.name or f"pgw1607-{args.gpu.split()[-1].lower()}-{int(time.time()) % 100000}"
+    body = {
+        "name": name,
+        "imageName": "runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04",
+        "gpuTypeIds": [args.gpu],
+        "gpuCount": 1,
+        "containerDiskInGb": args.disk_gb,
+        "volumeInGb": 0,
+        "cloudType": args.cloud,
+        "supportPublicIp": True,
+        "ports": ["22/tcp"],
+        "env": {"PUBLIC_KEY": pub},
+    }
+    if args.dry_run:
+        print(json.dumps(body, indent=2))
+        return 0
+
+    log(f"renting {args.gpu} ({args.cloud}, {args.disk_gb} GB disk) as {name}")
+    lease = podguard.rent(api, body, lane="pgw1607-juggle",
+                          lease_seconds=900.0)
+    pod_id = lease.pod_id
+    rate = float(lease.rate_per_hr or 0.0)
+    bank_pod(pod_id, f"{name} {args.gpu} arms={args.arms} repos={args.repos}", rate)
+
+    out_dir = OUT_ROOT / f"pod-{pod_id}"
+    started = time.time()
+    ok = False
+    try:
+        log("waiting for SSH ...")
+        tgt = None
+        deadline = time.time() + 900
+        while time.time() < deadline:
+            tgt = ssh_target(api, lease)
+            if tgt and pod_sh(tgt, "true", 45)[0] == 0:
+                break
+            tgt = None
+            time.sleep(15)
+        if tgt is None:
+            raise RuntimeError("SSH never came up inside 15 min")
+        log(f"ssh up at {tgt[0]}:{tgt[1]}")
+
+        scp_to(tgt, WHEEL, f"/workspace/{WHEEL.name}")
+        scp_to(tgt, FLOORS, "/workspace/fleet-floors.toml")
+        rc, out = pod_sh(
+            tgt, BOOTSTRAP.format(branch=BRANCH, repo=REPO_URL, wheel=WHEEL.name),
+            timeout=1800,
+        )
+        log(f"bootstrap rc={rc}; tail: {out[-500:]}")
+        if rc != 0:
+            raise RuntimeError("bootstrap failed")
+
+        harness = (
+            "cd /workspace && . venv/bin/activate && "
+            "export GEN_WORKER_FLEET_LINE_FILE=/workspace/fleet-floors.toml && "
+            "export PYTHONPATH=/workspace/pgw/src && "
+            f"python pgw/benchmarks/checkpoint_juggle_pod_pgw1607.py "
+            f"--arms {shlex.quote(args.arms)} --repos {args.repos} "
+            f"--budget-gib {args.budget_gib} --steps {args.steps} "
+            f"--requests {args.requests}"
+        )
+        budget_s = int(args.max_hours * 3600)
+        log(f"running harness (wall cap {budget_s}s) ...")
+        rc, out = pod_sh(tgt, f"timeout {budget_s} bash -lc {shlex.quote(harness)}",
+                         timeout=budget_s + 300)
+        log(f"harness rc={rc}")
+        print(out[-4000:])
+        got = scp_from(tgt, "/workspace/pgw1607-out", out_dir)
+        ok = rc == 0 and got
+    finally:
+        elapsed_h = (time.time() - started) / 3600
+        log(f"terminating {pod_id} (elapsed {elapsed_h:.2f} h, "
+            f"~${rate * elapsed_h:.2f}) ...")
+        dead = podguard.terminate_and_confirm(api, pod_id)
+        podguard.record_release(pod_id, dead, note="pgw1607 driver finally")
+        mark_released(pod_id)
+        log(f"provider-404 confirmed: {dead}")
+        if not dead:
+            log(f"!! POD MAY BE ALIVE — run: python3 {TRACKER_SCRIPTS}/podguard.py "
+                f"release {pod_id}")
+    log(f"verdicts: {out_dir}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
@@ -60,7 +60,8 @@ python -c "import torch" 2>/dev/null || \
   uv pip install --python venv/bin/python torch==2.13.0 \
     --index-url https://download.pytorch.org/whl/cu130
 uv pip install --python venv/bin/python \
-  diffusers transformers accelerate huggingface_hub safetensors numpy msgspec
+  diffusers transformers accelerate huggingface_hub safetensors numpy msgspec \
+  protobuf grpcio psutil
 uv pip install --python venv/bin/python --force-reinstall --no-deps /workspace/{wheel}
 python - <<'PY'
 import varena

--- a/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
@@ -219,6 +219,23 @@ def main() -> int:
         if rc != 0:
             raise RuntimeError("bootstrap failed")
 
+        # EVIDENCE EGRESS IS PART OF THE SMOKE GATE (coordinator rider,
+        # 2026-08-20; pgw#1568 measured SSH egress dead on raw pods of a
+        # different shape). A full round trip with content verification runs
+        # BEFORE any download or arm — if this fails, abort at ~$0.05 and
+        # wire the publishes channel rather than losing verdicts at the end.
+        canary = f"pgw1607-egress-{pod_id}-{int(time.time())}"
+        rc, _ = pod_sh(tgt, f"mkdir -p /workspace/pgw1607-out && "
+                            f"echo -n {shlex.quote(canary)} "
+                            f"> /workspace/pgw1607-out/egress-canary.txt", 60)
+        if rc != 0 or not scp_from(tgt, "/workspace/pgw1607-out", out_dir):
+            raise RuntimeError("EGRESS UNPROVEN: canary round trip failed — "
+                               "no arm runs without a proven evidence path")
+        got_txt = (out_dir / "pgw1607-out" / "egress-canary.txt")
+        if not got_txt.exists() or got_txt.read_text() != canary:
+            raise RuntimeError("EGRESS UNPROVEN: canary content mismatch")
+        log("evidence egress PROVEN by round trip (canary content verified)")
+
         harness = (
             "cd /workspace && . venv/bin/activate && "
             "export GEN_WORKER_FLEET_LINE_FILE=/workspace/fleet-floors.toml && "

--- a/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
@@ -180,6 +180,11 @@ def main() -> int:
         "supportPublicIp": True,
         "ports": ["22/tcp"],
         "env": {"PUBLIC_KEY": pub},
+        # The fleet line is torch cu13.0; a host driver below the 580 class
+        # cannot init it (measured on pod mrgr6tbpa56k9w: driver 570.172.08 /
+        # CUDA 12.8 -> torch 2.13+cu130 refuses, $0.01 to learn). Filter at
+        # the provider, not after boot.
+        "minCudaVersion": "13.0",
     }
     if args.dry_run:
         print(json.dumps(body, indent=2))
@@ -258,7 +263,7 @@ def main() -> int:
         log(f"terminating {pod_id} (elapsed {elapsed_h:.2f} h, "
             f"~${rate * elapsed_h:.2f}) ...")
         dead = podguard.terminate_and_confirm(api, pod_id)
-        podguard.record_release(pod_id, dead, note="pgw1607 driver finally")
+        podguard.record_release(pod_id, dead, reason="pgw1607 driver finally")
         mark_released(pod_id)
         log(f"provider-404 confirmed: {dead}")
         if not dead:

--- a/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
@@ -154,6 +154,9 @@ def main() -> int:
     parser.add_argument("--requests", type=int, default=24)
     parser.add_argument("--max-hours", type=float, default=2.0)
     parser.add_argument("--name", default="")
+    parser.add_argument("--retries", type=int, default=3,
+                        help="new-host retries for HOST_DRIVER_TOO_OLD "
+                             "(~$0.01 each, terminated with 404 proof)")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
@@ -182,15 +185,32 @@ def main() -> int:
         "env": {"PUBLIC_KEY": pub},
         # The fleet line is torch cu13.0; a host driver below the 580 class
         # cannot init it (measured on pod mrgr6tbpa56k9w: driver 570.172.08 /
-        # CUDA 12.8 -> torch 2.13+cu130 refuses, $0.01 to learn). Filter at
-        # the provider, not after boot.
-        "minCudaVersion": "13.0",
+        # CUDA 12.8 -> torch 2.13+cu130 refuses, $0.01 to learn). The REST
+        # schema rejects `minCudaVersion` (measured, $0); `allowedCudaVersions`
+        # is the surviving spelling, and the post-SSH driver gate below is the
+        # backstop if the provider ignores it.
+        "allowedCudaVersions": ["13.0"],
     }
     if args.dry_run:
         print(json.dumps(body, indent=2))
         return 0
 
-    log(f"renting {args.gpu} ({args.cloud}, {args.disk_gb} GB disk) as {name}")
+    for attempt in range(args.retries):
+        try:
+            return run_once(args, api, body, name, attempt)
+        except RuntimeError as exc:
+            if "HOST_DRIVER_TOO_OLD" in str(exc) and attempt + 1 < args.retries:
+                log(f"attempt {attempt + 1}: {exc}; retrying on a new host")
+                body["name"] = f"{name}-r{attempt + 1}"
+                continue
+            raise
+    return 1
+
+
+def run_once(args: argparse.Namespace, api: str, body: dict, name: str,
+             attempt: int) -> int:
+    log(f"renting {args.gpu} ({args.cloud}, {args.disk_gb} GB disk) as "
+        f"{body['name']} (attempt {attempt + 1})")
     lease = podguard.rent(api, body, lane="pgw1607-juggle",
                           lease_seconds=900.0)
     pod_id = lease.pod_id
@@ -213,6 +233,20 @@ def main() -> int:
         if tgt is None:
             raise RuntimeError("SSH never came up inside 15 min")
         log(f"ssh up at {tgt[0]}:{tgt[1]}")
+
+        # DRIVER GATE, before any byte of setup: the host must speak CUDA 13
+        # or torch cu130 will refuse after minutes of spend.
+        rc, out = pod_sh(
+            tgt, "nvidia-smi --query-gpu=driver_version --format=csv,noheader", 60
+        )
+        drv = out.strip().splitlines()[-1].strip() if rc == 0 and out.strip() else ""
+        major = int(drv.split(".")[0]) if drv.split(".")[:1] and drv.split(".")[0].isdigit() else 0
+        log(f"host driver: {drv or 'unreadable'}")
+        if major < 580:
+            raise RuntimeError(
+                f"HOST_DRIVER_TOO_OLD:{drv} — cannot run the cu130 fleet line; "
+                f"terminating and retrying on a different host"
+            )
 
         scp_to(tgt, WHEEL, f"/workspace/{WHEEL.name}")
         scp_to(tgt, FLOORS, "/workspace/fleet-floors.toml")

--- a/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_driver_pgw1607.py
@@ -154,6 +154,7 @@ def main() -> int:
     parser.add_argument("--steps", type=int, default=28)
     parser.add_argument("--requests", type=int, default=24)
     parser.add_argument("--max-hours", type=float, default=2.0)
+    parser.add_argument("--host-floor-gib", type=float, default=0.0)
     parser.add_argument("--name", default="")
     parser.add_argument("--retries", type=int, default=3,
                         help="new-host retries for RETRYABLE_HOST failures "
@@ -288,7 +289,7 @@ def run_once(args: argparse.Namespace, api: str, body: dict, name: str,
             f"python pgw/benchmarks/checkpoint_juggle_pod_pgw1607.py "
             f"--arms {shlex.quote(args.arms)} --repos {args.repos} "
             f"--budget-gib {args.budget_gib} --steps {args.steps} "
-            f"--requests {args.requests}"
+            f"--requests {args.requests} --host-floor-gib {args.host_floor_gib}"
         )
         budget_s = int(args.max_hours * 3600)
         log(f"running harness (wall cap {budget_s}s) ...")

--- a/benchmarks/checkpoint_juggle_pod_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_pgw1607.py
@@ -98,6 +98,17 @@ def bank(name: str, payload: Dict[str, Any]) -> None:
     print(f"[pgw1607-verdict:{name}] {json.dumps(payload)}", flush=True)
 
 
+def _meminfo(key: str) -> int:
+    try:
+        with open("/proc/meminfo") as fh:
+            for line in fh:
+                if line.startswith(key + ":"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    return 0
+
+
 def gpu_line() -> str:
     try:
         return subprocess.run(
@@ -181,6 +192,7 @@ def make_rig(
     dtype: Any,
     budget_bytes: int,
     admit: List[str],
+    host_floor_gib: float = 0.0,
 ):
     from gen_worker.models.arena_residency import (
         ArenaResidency,
@@ -215,7 +227,13 @@ def make_rig(
         name: read_manifest(d, variant=pick_variant(d))
         for name, d in unet_dirs.items()
     }
-    catalog = CheckpointCatalog(layout, torch_mod=torch, varena_mod=_varena())
+    import gen_worker.models.checkpoint_juggle as cj
+
+    catalog = CheckpointCatalog(
+        layout, torch_mod=torch, varena_mod=_varena(),
+        host_floor_bytes=int(host_floor_gib * GIB) if host_floor_gib
+        else cj.DEFAULT_HOST_FLOOR_BYTES,
+    )
     for name in admit:
         catalog.admit(name, manifests[name])
     image0 = catalog.ensure_warm(serving)
@@ -460,6 +478,9 @@ def arm_z(torch: Any, juggler: Any, template: Any, dtype: Any, ids: List[str],
     zipf_wall = time.perf_counter() - t0
     zipf_per_req = zipf_wall / requests
     out = {
+        "warm_images_end": len(juggler.catalog.images),
+        "evictions_total": juggler.catalog.evictions,
+        "pressure_epoch": juggler.catalog.pressure_epoch,
         "steps_per_request": steps,
         "baseline_s_per_req": round(baseline_per_req, 3),
         "zipf_s_per_req": round(zipf_per_req, 3),
@@ -485,6 +506,10 @@ def main() -> int:
     parser.add_argument("--steps", type=int, default=28)
     parser.add_argument("--requests", type=int, default=24)
     parser.add_argument("--cache", default="/workspace/hf-cache")
+    parser.add_argument("--host-floor-gib", type=float, default=0.0,
+                        help="raise the warm tier's host floor to force real "
+                             "evictions/hysteresis on big-RAM pods (0 = the "
+                             "adaptive default)")
     args = parser.parse_args()
 
     from gen_worker.rigcheck import assert_fleet_line
@@ -507,6 +532,9 @@ def main() -> int:
     bank("meta", {
         "issue": "pgw#1607", "when": time.strftime("%F %T"), "gpu": gpu_line(),
         "arms": args.arms, "repos": repos, "budget_gib": args.budget_gib,
+        "host_floor_gib": args.host_floor_gib,
+        "mem_total_gib": round(_meminfo("MemTotal") / (1 << 30), 1),
+        "mem_available_gib": round(_meminfo("MemAvailable") / (1 << 30), 1),
         "torch": torch.__version__,
     })
 
@@ -520,6 +548,7 @@ def main() -> int:
     template, residency, juggler, _m = make_rig(
         torch, unet_dirs, ids[0],
         dtype=dtype, budget_bytes=int(args.budget_gib * GIB), admit=ids,
+        host_floor_gib=args.host_floor_gib,
     )
     loud(f"rig up: {residency.layout.virtual_bytes / GIB:.2f} GiB virtual, "
          f"resident={len(residency.plan.all_resident)} "

--- a/benchmarks/checkpoint_juggle_pod_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_pgw1607.py
@@ -1,0 +1,551 @@
+"""pgw#1607 phase 4: the checkpoint juggle at SDXL scale, on a rented pod.
+
+Runs ON the pod (weights never transit the box). Downloads K public SDXL
+fine-tune UNets from HF (the 16 header-curated compatible repos), builds ONE
+UNet lane over the arena, and prices the juggle for real: 5 GB-class
+checkpoints, real denoise-shaped requests, a real torch.compile artifact.
+
+Arms (default SWCZ; each banks its verdict before the next runs):
+
+* **S — smoke/correctness** (the spend gate: nothing else runs if S is red).
+  3 checkpoints: distinct outputs at fixed inputs, bitwise round-trip,
+  D2H digests == ingest digests, zero re-arms (pointer + forward identity),
+  and the REAL-COMPILE leg: `torch.compile`d UNet serves distinct outputs
+  across swaps with ZERO recompiles (dynamo counters, not eyeballs).
+* **W — warm matrix.** All K ingested (the warm set sizes itself from the
+  pod's RAM — watching it evict IS the measurement), round-robin warm
+  switches, walls + GB/s against the same-pod pinned H2D floor.
+* **C — cold.** Evict → switch (disk → image → VRAM, the rebuild path) and
+  hysteresis-forced disk-direct, against the pod's measured disk floor.
+* **Z — zipf.** Real ~seconds requests (28 UNet steps, 1024^2-shaped),
+  single-checkpoint baseline FIRST (the phase-3 ordering lesson), then the
+  zipf mix; the honest product is seconds-per-request and switch cost per
+  request, not a toy ratio.
+* **B — cast arm (optional).** The bf16 lane over fp16 files: ingest casts
+  once, warm switches only (disk-direct correctly REFUSES under a cast).
+
+Lane dtype is FP16 by default — the files' native dtype, so disk triples
+are byte-true and disk-direct switching is legal. (fp16 and bf16 are both
+16-bit: raw fp16 bytes in a bf16 slot would pass every length check and be
+silent garbage, which is why the juggler refuses casts outside ingest and
+why this harness loads the template through the IMAGE, never raw triples.)
+
+Overlap, stated honestly: a UNet-only lane has no phase to hide a swap
+under — the bytes cannot be overwritten while any step still reads them, so
+the switch serializes after the request tail and its floor is the transfer
+bound (measured). What CAN overlap is host-side prefetch (disk -> pin under
+compute), which arm Z exercises via hint_next. Phase-overlap (TE/VAE while
+UNet computes) needs a multi-component lane — pgw#1602 integration, not
+this harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+MIB = 1 << 20
+GIB = 1 << 30
+
+#: Header-curated 2026-08-20 ($0, ranged reads; SSD-1B red-armed the check).
+CURATED = [
+    "stabilityai/stable-diffusion-xl-base-1.0",
+    "playgroundai/playground-v2-1024px-aesthetic",
+    "playgroundai/playground-v2.5-1024px-aesthetic",
+    "RunDiffusion/Juggernaut-XL-v9",
+    "SG161222/RealVisXL_V4.0",
+    "SG161222/RealVisXL_V5.0",
+    "cagliostrolab/animagine-xl-3.1",
+    "cagliostrolab/animagine-xl-4.0",
+    "Lykon/dreamshaper-xl-1-0",
+    "Lykon/dreamshaper-xl-v2-turbo",
+    "misri/zavychromaxl_v80",
+    "GraydientPlatformAPI/albedobase2-xl",
+    "fluently/Fluently-XL-v4",
+    "zenless-lab/sdxl-blue-pencil-xl-v7",
+    "dataautogpt3/OpenDalleV1.1",
+    # deliberately NOT ColorfulXL-Lightning here: F32 on disk, it belongs to
+    # arm B (the cast arm), not the byte-true fp16 lane.
+]
+
+OUT_DIR = Path(os.environ.get("PGW1607_POD_OUT", "/workspace/pgw1607-out"))
+
+
+def loud(msg: str) -> None:
+    print(f"[pgw1607-pod] {msg}", flush=True)
+
+
+def bank(name: str, payload: Dict[str, Any]) -> None:
+    """Write the arm's verdict NOW — a later death keeps earlier arms."""
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    path = OUT_DIR / f"{name}.json"
+    path.write_text(json.dumps(payload, indent=2))
+    loud(f"banked {path}")
+
+
+def gpu_line() -> str:
+    try:
+        return subprocess.run(
+            ["nvidia-smi", "--query-gpu=name,memory.total,driver_version",
+             "--format=csv,noheader"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout.strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Downloads — pod-side only
+# ---------------------------------------------------------------------------
+
+
+def fetch_unet(repo: str, cache: Path) -> Path:
+    """The repo's UNet directory only (config + fp16 or main safetensors)."""
+    from huggingface_hub import snapshot_download
+
+    t0 = time.perf_counter()
+    root = snapshot_download(
+        repo,
+        cache_dir=str(cache),
+        allow_patterns=[
+            "unet/config.json",
+            "unet/diffusion_pytorch_model.fp16.safetensors",
+            "unet/diffusion_pytorch_model.safetensors",
+        ],
+    )
+    unet = Path(root) / "unet"
+    files = list(unet.glob("*.safetensors"))
+    if not files:
+        raise RuntimeError(f"{repo}: no unet safetensors landed")
+    loud(f"fetched {repo} unet in {time.perf_counter() - t0:.0f}s "
+         f"({sum(f.stat().st_size for f in files) / GIB:.2f} GiB)")
+    return unet
+
+
+def pick_variant(unet_dir: Path) -> Optional[str]:
+    if (unet_dir / "diffusion_pytorch_model.fp16.safetensors").exists():
+        return "fp16"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rig
+# ---------------------------------------------------------------------------
+
+
+def build_unet(torch: Any, config_dir: Path, dtype: Any) -> Any:
+    from diffusers import UNet2DConditionModel
+
+    with open(config_dir / "config.json") as fh:
+        config = json.load(fh)
+    model = UNet2DConditionModel.from_config(config)
+    return model.to(dtype)
+
+
+def load_template_from_image(torch: Any, template: Any, image: Any) -> None:
+    """Template weights from the NORMALIZED image — never raw triples (the
+    fp16/bf16 same-length hazard)."""
+    with torch.no_grad():
+        state = dict(template.state_dict())
+        for region in image.layout.regions:
+            for slot in region.slots:
+                key = _slot_key_of(slot)
+                state[key].copy_(image.slot_view(slot))
+
+
+def _slot_key_of(slot: Any) -> str:
+    _root, _, rest = slot.leaf.partition(".")
+    return f"{rest}.{slot.attr}" if rest else slot.attr
+
+
+def make_rig(
+    torch: Any,
+    unet_dirs: Dict[str, Path],
+    serving: str,
+    *,
+    dtype: Any,
+    budget_bytes: int,
+    admit: List[str],
+):
+    from gen_worker.models.arena_residency import (
+        ArenaResidency,
+        plan_layout,
+    )
+    from gen_worker.models.checkpoint_juggle import (
+        CheckpointCatalog,
+        CheckpointJuggler,
+        read_manifest,
+    )
+    from gen_worker.models.arena_residency import dlpack_dtype
+    from gen_worker.models.stream_residency import (
+        discover_leaves,
+        own_tensors,
+        tensor_bytes,
+    )
+
+    template = build_unet(torch, unet_dirs[serving], dtype)
+    leaves, _c, _a = discover_leaves([("unet", template)])
+    specs = []
+    for leaf_name, leaf in leaves.items():
+        slots = []
+        for attr, is_param, tensor in own_tensors(leaf):
+            code, bits = dlpack_dtype(torch, tensor.dtype)
+            slots.append(
+                (attr, is_param, tensor_bytes(tensor), tuple(tensor.shape), code, bits)
+            )
+        specs.append((leaf_name, slots))
+    layout = plan_layout(specs, granularity=2 * MIB, min_stream_bytes=8 * MIB)
+
+    manifests = {
+        name: read_manifest(d, variant=pick_variant(d))
+        for name, d in unet_dirs.items()
+    }
+    catalog = CheckpointCatalog(layout, torch_mod=torch, varena_mod=_varena())
+    for name in admit:
+        catalog.admit(name, manifests[name])
+    image0 = catalog.ensure_warm(serving)
+    assert image0 is not None, "the serving checkpoint's image must ingest"
+    load_template_from_image(torch, template, image0)
+    template.to("cuda").eval()
+
+    triples = {
+        k: (s.path, s.offset, s.length) for k, s in manifests[serving].items()
+    }
+    residency = ArenaResidency(
+        [("unet", template)],
+        device="cuda",
+        budget_bytes=budget_bytes,
+        triples=triples,
+        min_stream_bytes=8 * MIB,
+    )
+    residency.engage()
+    juggler = CheckpointJuggler(
+        residency, serving, manifests[serving], catalog=catalog
+    )
+    return template, residency, juggler, manifests
+
+
+def _varena() -> Any:
+    import varena
+
+    return varena
+
+
+def unet_inputs(torch: Any, dtype: Any, *, batch: int = 2) -> Dict[str, Any]:
+    g = torch.Generator().manual_seed(1607)
+    return {
+        "sample": torch.randn(batch, 4, 128, 128, generator=g).to("cuda", dtype),
+        "timestep": torch.tensor(500, device="cuda"),
+        "encoder_hidden_states": torch.randn(batch, 77, 2048, generator=g).to("cuda", dtype),
+        "added_cond_kwargs": {
+            "text_embeds": torch.randn(batch, 1280, generator=g).to("cuda", dtype),
+            "time_ids": torch.randn(batch, 6, generator=g).to("cuda", dtype),
+        },
+    }
+
+
+def one_step(torch: Any, model: Any, inputs: Dict[str, Any]) -> Any:
+    with torch.no_grad():
+        return model(
+            inputs["sample"], inputs["timestep"],
+            encoder_hidden_states=inputs["encoder_hidden_states"],
+            added_cond_kwargs=inputs["added_cond_kwargs"],
+        ).sample
+
+
+def request(torch: Any, juggler: Any, model: Any, inputs: Dict[str, Any], steps: int) -> Any:
+    """A denoise-shaped request: `steps` UNet forwards. Seconds, not ms."""
+    juggler.assert_servable()
+    out = None
+    with torch.no_grad():
+        for _ in range(steps):
+            out = one_step(torch, model, inputs)
+    torch.cuda.synchronize()
+    return out
+
+
+def region_digest(torch: Any, residency: Any, region: Any) -> str:
+    h = hashlib.blake2b(digest_size=16)
+    for slot in region.slots:
+        host = residency._view(slot).detach().to("cpu")
+        h.update(host.view(torch.uint8).view(-1).numpy().tobytes())
+    return h.hexdigest()
+
+
+def measure_h2d_floor(torch: Any, nbytes: int) -> float:
+    src = torch.empty(nbytes, dtype=torch.uint8, pin_memory=True)
+    dst = torch.empty(nbytes, dtype=torch.uint8, device="cuda")
+    dst.copy_(src, non_blocking=True)
+    torch.cuda.synchronize()
+    best = float("inf")
+    for _ in range(3):
+        t0 = time.perf_counter()
+        dst.copy_(src, non_blocking=True)
+        torch.cuda.synchronize()
+        best = min(best, time.perf_counter() - t0)
+    del src, dst
+    torch.cuda.empty_cache()
+    return nbytes / best / 1e9
+
+
+# ---------------------------------------------------------------------------
+# Arms
+# ---------------------------------------------------------------------------
+
+
+def arm_s(torch: Any, juggler: Any, template: Any, dtype: Any, ids: List[str]) -> Dict[str, Any]:
+    """The spend gate. Everything here must be green before matrix money."""
+    inputs = unet_inputs(torch, dtype)
+    a, b = ids[0], ids[1]
+
+    y_a = one_step(torch, template, inputs).clone()
+    juggler.switch_to(b)
+    y_b = one_step(torch, template, inputs).clone()
+    juggler.switch_to(a)
+    y_a2 = one_step(torch, template, inputs).clone()
+    assert not torch.equal(y_a, y_b), "outputs identical across the swap"
+    assert torch.equal(y_a, y_a2), "round trip not bitwise"
+    loud("S: distinct outputs + bitwise round trip GREEN")
+
+    # Digests on every backed region for the serving checkpoint.
+    residency = juggler.residency
+    image = juggler.catalog.warm(a)
+    checked = 0
+    for region in residency.layout.regions:
+        if residency.is_resident(region.name):
+            assert region_digest(torch, residency, region) == \
+                image.region_digests[region.name], region.name
+            checked += 1
+    loud(f"S: {checked} region digests GREEN")
+
+    # THE REAL-COMPILE LEG: torch.compile once, swap, zero recompiles.
+    import torch._dynamo as dynamo
+
+    dynamo.reset()
+    compiled = torch.compile(template)
+    _ = one_step(torch, compiled, inputs)  # compile happens here
+    torch.cuda.synchronize()
+    # The sharpest instrument available: ANY recompile from here on RAISES.
+    dynamo.config.error_on_recompile = True
+    from torch._dynamo.utils import counters as dyn_counters
+
+    frames_before = dict(dyn_counters["stats"])
+    ptrs_before = {
+        (s.leaf, s.attr): int(residency._view(s).data_ptr())
+        for r in residency.layout.regions if residency.is_resident(r.name)
+        for s in r.slots
+    }
+    c_a = one_step(torch, compiled, inputs).clone()
+    juggler.switch_to(b)
+    c_b = one_step(torch, compiled, inputs).clone()
+    juggler.switch_to(a)
+    c_a2 = one_step(torch, compiled, inputs).clone()
+    torch.cuda.synchronize()
+    frames_after = dict(dyn_counters["stats"])
+    dynamo.config.error_on_recompile = False
+    recompiles = frames_after.get("unique_graphs", 0) - frames_before.get("unique_graphs", 0)
+    moved = [
+        k for r in residency.layout.regions if residency.is_resident(r.name)
+        for s in r.slots
+        for k in [(s.leaf, s.attr)]
+        if ptrs_before.get(k) != int(residency._view(s).data_ptr())
+    ]
+    assert not torch.equal(c_a, c_b), "compiled outputs identical across swap"
+    assert torch.equal(c_a, c_a2), "compiled round trip not bitwise"
+    assert recompiles == 0, f"recompiles counted: {recompiles}"
+    assert not moved, f"pointers moved under compiled serve: {moved[:3]}"
+    assert juggler.rearms == 0
+    loud("S: COMPILED serve across swaps GREEN — distinct outputs, "
+         "0 recompiles (counted), pointers fixed")
+    return {
+        "distinct": True, "bitwise_roundtrip": True, "digests_checked": checked,
+        "compiled_distinct": True, "compiled_recompiles": recompiles,
+        "pointers_fixed": len(ptrs_before), "rearms": juggler.rearms,
+    }
+
+
+def arm_w(torch: Any, juggler: Any, ids: List[str]) -> Dict[str, Any]:
+    floor = measure_h2d_floor(torch, 1 * GIB)
+    lane_bytes = sum(
+        r.span for r in juggler.residency.layout.regions
+        if juggler.residency.is_resident(r.name)
+    )
+    for name in ids:
+        juggler.hint_next(name)  # ingest what RAM admits; eviction is data
+    rows = []
+    for name in ids * 2:
+        if name == juggler.serving_id:
+            continue
+        r = juggler.switch_to(name)
+        rows.append({
+            "to": name, "tier": r.tier, "wall_s": round(r.wall_s, 4),
+            "gbps": round(r.bytes_moved / r.wall_s / 1e9, 2) if r.wall_s else 0,
+            "verified": r.backing_verified,
+        })
+    warm = [x["wall_s"] for x in rows if x["tier"] == "host-warm"]
+    out = {
+        "h2d_floor_gbps": round(floor, 2),
+        "lane_backed_bytes": lane_bytes,
+        "warm_images": len(juggler.catalog.images),
+        "evictions": juggler.catalog.evictions,
+        "warm_median_s": round(statistics.median(warm), 4) if warm else None,
+        "warm_bound_s": round(lane_bytes / (floor * 1e9), 4),
+        "rows": rows,
+    }
+    loud(f"W: {json.dumps({k: v for k, v in out.items() if k != 'rows'})}")
+    return out
+
+
+def arm_c(torch: Any, juggler: Any, ids: List[str]) -> Dict[str, Any]:
+    target = next(n for n in ids if n != juggler.serving_id)
+    juggler.catalog.evict(target)
+    t0 = time.perf_counter()
+    r1 = juggler.switch_to(target)
+    rebuild = time.perf_counter() - t0
+    target2 = next(
+        n for n in ids if n not in (juggler.serving_id, target)
+    )
+    juggler.catalog.evict(target2)
+    juggler.catalog._evicted_epoch[target2] = juggler.catalog.pressure_epoch
+    t0 = time.perf_counter()
+    r2 = juggler.switch_to(target2)
+    direct = time.perf_counter() - t0
+    del juggler.catalog._evicted_epoch[target2]
+    out = {
+        "cold_rebuild_s": round(rebuild, 3), "rebuild_tier": r1.tier,
+        "disk_direct_s": round(direct, 3), "direct_tier": r2.tier,
+    }
+    loud(f"C: {json.dumps(out)}")
+    return out
+
+
+def arm_z(torch: Any, juggler: Any, template: Any, dtype: Any, ids: List[str],
+          *, steps: int, requests: int) -> Dict[str, Any]:
+    import random
+
+    inputs = unet_inputs(torch, dtype)
+    # BASELINE FIRST (phase-3 ordering lesson), on a warm-mirrored serving ck.
+    juggler.hint_next(juggler.serving_id)
+    t0 = time.perf_counter()
+    for _ in range(max(4, requests // 4)):
+        request(torch, juggler, template, inputs, steps)
+    base_n = max(4, requests // 4)
+    baseline_per_req = (time.perf_counter() - t0) / base_n
+
+    rng = random.Random(1607)
+    weights = [1.0 / (i + 1) ** 1.1 for i in range(len(ids))]
+    switch_walls: List[float] = []
+    t0 = time.perf_counter()
+    for _ in range(requests):
+        target = rng.choices(ids, weights)[0]
+        if target != juggler.serving_id:
+            r = juggler.switch_to(target)
+            switch_walls.append(r.wall_s)
+        request(torch, juggler, template, inputs, steps)
+    zipf_wall = time.perf_counter() - t0
+    zipf_per_req = zipf_wall / requests
+    out = {
+        "steps_per_request": steps,
+        "baseline_s_per_req": round(baseline_per_req, 3),
+        "zipf_s_per_req": round(zipf_per_req, 3),
+        "zipf_overhead_frac": round(zipf_per_req / baseline_per_req - 1, 4),
+        "switches": len(switch_walls),
+        "switch_median_s": round(statistics.median(switch_walls), 4) if switch_walls else None,
+        "requests": requests,
+    }
+    loud(f"Z: {json.dumps(out)}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--arms", default="SWCZ")
+    parser.add_argument("--repos", type=int, default=6, help="how many curated repos")
+    parser.add_argument("--budget-gib", type=float, default=6.0)
+    parser.add_argument("--steps", type=int, default=28)
+    parser.add_argument("--requests", type=int, default=24)
+    parser.add_argument("--cache", default="/workspace/hf-cache")
+    args = parser.parse_args()
+
+    from gen_worker.rigcheck import assert_fleet_line
+
+    assert_fleet_line("pgw#1607 pod juggle rig")
+    loud(f"gpu: {gpu_line()}")
+
+    import torch
+
+    assert torch.cuda.is_available()
+    dtype = torch.float16
+    ids = [f"ck{i}" for i in range(args.repos)]
+    repos = CURATED[: args.repos]
+    bank("meta", {
+        "issue": "pgw#1607", "when": time.strftime("%F %T"), "gpu": gpu_line(),
+        "arms": args.arms, "repos": repos, "budget_gib": args.budget_gib,
+        "torch": torch.__version__,
+    })
+
+    cache = Path(args.cache)
+    unet_dirs: Dict[str, Path] = {}
+    for name, repo in zip(ids, repos):
+        unet_dirs[name] = fetch_unet(repo, cache)
+    bank("downloads", {"fetched": {n: str(p) for n, p in unet_dirs.items()}})
+
+    smoke_ids = ids[:3]
+    template, residency, juggler, _m = make_rig(
+        torch, unet_dirs, ids[0],
+        dtype=dtype, budget_bytes=int(args.budget_gib * GIB), admit=ids,
+    )
+    loud(f"rig up: {residency.layout.virtual_bytes / GIB:.2f} GiB virtual, "
+         f"resident={len(residency.plan.all_resident)} "
+         f"streamed={len(residency.plan.streamed)}")
+
+    failed = False
+    try:
+        if "S" in args.arms:
+            bank("S", arm_s(torch, juggler, template, dtype, smoke_ids))
+        if "W" in args.arms:
+            bank("W", arm_w(torch, juggler, ids))
+        if "C" in args.arms:
+            bank("C", arm_c(torch, juggler, ids))
+        if "Z" in args.arms:
+            bank("Z", arm_z(torch, juggler, template, dtype, ids,
+                            steps=args.steps, requests=args.requests))
+    except Exception as exc:  # noqa: BLE001
+        failed = True
+        bank("failure", {"error": f"{type(exc).__name__}: {exc}"})
+        loud(f"RED: {type(exc).__name__}: {exc}")
+    finally:
+        try:
+            residency.release()
+            residency.arena.set_budget(0)
+            stats = dict(residency.arena.stats())
+            bank("teardown", {
+                "committed": int(stats["committed_bytes"]),
+                "mapped": int(stats["mapped_bytes"]),
+            })
+            assert int(stats["committed_bytes"]) == 0 and int(stats["mapped_bytes"]) == 0
+            loud("teardown GREEN: committed==mapped==0")
+        except Exception as exc:  # noqa: BLE001
+            failed = True
+            loud(f"RED teardown: {exc}")
+        juggler.catalog.close()
+        gc.collect()
+        torch.cuda.empty_cache()
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/checkpoint_juggle_pod_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_pgw1607.py
@@ -510,6 +510,11 @@ def main() -> int:
                         help="raise the warm tier's host floor to force real "
                              "evictions/hysteresis on big-RAM pods (0 = the "
                              "adaptive default)")
+    parser.add_argument("--target-warm-images", type=int, default=0,
+                        help="compute the host floor pod-side so roughly this "
+                             "many ~5.6 GiB images fit, whatever the pod's "
+                             "RAM — the portable way to force eviction "
+                             "pressure (overrides --host-floor-gib)")
     args = parser.parse_args()
 
     from gen_worker.rigcheck import assert_fleet_line
@@ -537,6 +542,13 @@ def main() -> int:
         "mem_available_gib": round(_meminfo("MemAvailable") / (1 << 30), 1),
         "torch": torch.__version__,
     })
+
+    if args.target_warm_images > 0:
+        avail_gib = _meminfo("MemAvailable") / (1 << 30)
+        args.host_floor_gib = max(2.0, avail_gib - args.target_warm_images * 5.6)
+        loud(f"target_warm_images={args.target_warm_images}: host floor "
+             f"computed at {args.host_floor_gib:.1f} GiB of {avail_gib:.1f} "
+             f"GiB available")
 
     cache = Path(args.cache)
     unet_dirs: Dict[str, Path] = {}

--- a/benchmarks/checkpoint_juggle_pod_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_pgw1607.py
@@ -84,11 +84,18 @@ def loud(msg: str) -> None:
 
 
 def bank(name: str, payload: Dict[str, Any]) -> None:
-    """Write the arm's verdict NOW — a later death keeps earlier arms."""
+    """Write the arm's verdict NOW — a later death keeps earlier arms.
+
+    The payload is ALSO printed inline: the driver captures this stream over
+    SSH, so even a dead scp path leaves every verdict in the box-side
+    transcript (the pgw#1568 lesson: an evidence path that can die must not
+    be the only one)."""
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     path = OUT_DIR / f"{name}.json"
-    path.write_text(json.dumps(payload, indent=2))
+    blob = json.dumps(payload, indent=2)
+    path.write_text(blob)
     loud(f"banked {path}")
+    print(f"[pgw1607-verdict:{name}] {json.dumps(payload)}", flush=True)
 
 
 def gpu_line() -> str:

--- a/benchmarks/checkpoint_juggle_pod_pgw1607.py
+++ b/benchmarks/checkpoint_juggle_pod_pgw1607.py
@@ -495,6 +495,12 @@ def main() -> int:
     import torch
 
     assert torch.cuda.is_available()
+    # FAIL FAST on the whole import closure BEFORE any multi-GB download —
+    # try 2 died on a missing module AFTER 29 GB of fetches ($0.04; this
+    # line makes that class cost $0.01).
+    from gen_worker.models.arena_residency import ArenaResidency  # noqa: F401
+    from gen_worker.models.checkpoint_juggle import CheckpointJuggler  # noqa: F401
+    from diffusers import UNet2DConditionModel  # noqa: F401
     dtype = torch.float16
     ids = [f"ck{i}" for i in range(args.repos)]
     repos = CURATED[: args.repos]

--- a/src/gen_worker/models/arena_residency.py
+++ b/src/gen_worker/models/arena_residency.py
@@ -43,6 +43,34 @@ only decision this module makes is arithmetic. varena's minimalism ruling
 applies to its caller too — the dtype→DLPack table, the layout, the triple
 resolution and the fencing live HERE because they are caller policy, and
 nothing in this lane asked varena to grow.
+
+**Two contracts every caller of this facade inherits** (va#12; varena's
+README carries the same words — this paragraph exists for readers who never
+open it):
+
+* **The arena governs WEIGHTS only.** Activations, VAE workspaces and
+  text-encoder transients live outside it, in torch's allocator, and are the
+  caller's problem — both arms of the ComfyUI floor measurement died at
+  ``VAEDecode``, on memory varena would never have been asked about.
+  "Demand-paged VRAM residency" is a promise about a model's parameters,
+  never about its peak. Weights are immutable and CAS-backed, so demote is
+  unmap-only — parking MUTABLE state would need a write-back leg varena
+  deliberately lacks (refill is one-way disk→pin→VRAM).
+* **The launch window: nothing is unbacked between pre-resident and
+  launch-complete.** The caller is the only party that ever calls
+  ``unback``, so this is a contract to KEEP, not a mechanism varena can
+  enforce or violate on its own. Pre-resident the whole working set, launch,
+  and only then re-budget — the :class:`UnbackRing`'s event gating is this
+  module's implementation of exactly that. It is what makes a stable pointer
+  safe to bake into a compiled artifact or a CUDA graph, and it is universal
+  practice in the field, not a peculiarity of ours: no comparable system
+  pages during a compiled launch.
+
+Residency signatures (scalar ``signature()`` and va#12's per-2 MiB-chunk
+``page_signatures``) are BACKING signatures, never CONTENT signatures: bytes
+changed under an unchanged mapping are invisible to them, and content
+integrity is a caller-side D2H digest (the checkpoint juggle, pgw#1607,
+banks per-region digests at ingest for that reason).
 """
 
 from __future__ import annotations

--- a/src/gen_worker/models/arena_residency.py
+++ b/src/gen_worker/models/arena_residency.py
@@ -972,6 +972,13 @@ class ArenaResidency:
     def _capture_host(self, region: RegionSpec, *, from_live: bool) -> None:
         """Mirror a region into pinned host RAM, unless the RAM half says no."""
         torch = self._torch
+        if self._host.get(region.name) is not None:
+            # A mirror already exists (a prior capture, or the checkpoint
+            # juggle's normalized image, pgw#1607). Weights are immutable so
+            # it cannot be stale: demote is unmap-only, never copy-out (the
+            # va#11 write-back invariant).
+            self._rebind_off_device(region)
+            return
         if not self._host_mirror:
             missing = [
                 self._triple_key(s)

--- a/src/gen_worker/models/checkpoint_juggle.py
+++ b/src/gen_worker/models/checkpoint_juggle.py
@@ -306,7 +306,9 @@ class CheckpointImage:
                 buffer = torch_mod.frombuffer(
                     self._slab.memoryview(), dtype=torch_mod.uint8
                 )
-                self.pinned = bool(self._slab.is_pinned())
+                # pyo3 #[getter]: a property, not a method. The memoryview
+                # does NOT keep the slab alive — self._slab held above does.
+                self.pinned = bool(self._slab.is_pinned)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "checkpoint juggle: pinned image for %s refused (%s: %s); "
@@ -314,6 +316,10 @@ class CheckpointImage:
                     "slower, counted in the switch report",
                     checkpoint_id, type(exc).__name__, exc,
                 )
+                # A buffer built over a slab we are about to drop would be a
+                # view of unmapped memory (measured: EFAULT from the refill
+                # engine) — discard it WITH the slab.
+                buffer = None
                 self._slab = None
                 self._pool = None
         if buffer is None:

--- a/src/gen_worker/models/checkpoint_juggle.py
+++ b/src/gen_worker/models/checkpoint_juggle.py
@@ -1,0 +1,927 @@
+"""The checkpoint juggle: a backing swap under fixed virtual addresses.
+
+pgw#1607, implementing pgw#1602's multi-checkpoint scope addition. Within a
+lane, every admitted checkpoint shares the canonical arena layout — derived
+from the SERVING MODULE TREE by :func:`~gen_worker.models.arena_residency.
+plan_layout`, never from any file — so a checkpoint switch is a backing swap:
+the compiled artifact's pointers, the module's parameter identities and the
+reservation's addresses are all invariant, and the cost is byte transfer only.
+
+Design decisions this module encodes (the tracker section is the argument;
+this is the executable half):
+
+* **D1 admission**: a checkpoint joins a lane's juggle set only after a
+  header-only shape-identity proof against the lane template's slot table.
+  The tensor-layout contract pins keys/dtypes/rank, NOT concrete shapes or
+  file offsets — so identity is proven per checkpoint, and file geometry is
+  normalized away by keying byte ranges to canonical arena offsets.
+* **D3 swap = in-place refill**: regions that are BACKED are overwritten
+  under their fixed addresses (pure H2D; no unmap/map round trip whose chunks
+  would be recycled into an identical mapping). Regions that are UNBACKED
+  swap for free — their refill source repoints.
+* **D5 warm tier**: one pinned host ARENA IMAGE per (lane x checkpoint),
+  laid out exactly as the layout (same offsets), so a swap refill is one
+  contiguous copy per region. The image doubles as the streamed tier's host
+  mirror — no duplicate RAM. Host RAM sizes the warm set adaptively
+  (``MemAvailable`` minus a floor, read at ingest); eviction is LRU with
+  hysteresis (a pressure-evicted image is not rebuilt within the same
+  pressure epoch — the checkpoint still serves, disk-direct).
+* **D7 serving validity** (coordinator requirement, 2026-08-20): every
+  region carries ``valid@X -> refilling(Y) -> valid@Y | INVALID``. A refill
+  that dies partway leaves the region typed-INVALID and serving REFUSES —
+  the franken-weights state (two checkpoints' interleaved bytes under one
+  address) is unreachable, not detected after the fact. Recovery is a
+  re-refill: the source is immutable, so the retry is idempotent.
+* **D6 integrity split** (va#12 coordination): content-level correctness is
+  THIS module's — per-region digests banked at ingest, compared on the test
+  legs. varena's per-page signatures (when adopted) detect backing-level
+  surprises only.
+
+Boundaries, restated once: per-lane only (a cross-lane switch is a different
+layout and a real switch); LoRA variants stay on the fold path (pgw#1571);
+tensors outside the managed regions (non-leaf buffers such as
+``position_ids`` — architecture-derived, not learned) are NOT swapped, and
+the switch report says how many bytes that leaves untouched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import struct
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+
+from .arena_residency import (
+    ArenaLayout,
+    ArenaResidency,
+    RegionSpec,
+    SlotSpec,
+    dlpack_dtype,
+)
+from .safetensors_header import header_len_ok
+
+logger = logging.getLogger(__name__)
+
+#: DLPack uint8, for whole-region byte views.
+_DL_UINT8 = (1, 8)
+
+#: Host RAM the warm tier must always leave for everyone else. The warm
+#: budget is ADAPTIVE, never declared (standing ruling): admit an image only
+#: while MemAvailable minus the image stays above this floor.
+DEFAULT_HOST_FLOOR_BYTES = 4 << 30
+
+#: safetensors dtype spellings this module can place or cast. Closed list —
+#: an unknown spelling is a refusal, never a guess (a wrong size reads the
+#: wrong bytes; a wrong interpretation is a silent numerical fault).
+_SAFETENSORS_DTYPES: Dict[str, Tuple[int, int]] = {
+    "F64": (2, 64),
+    "F32": (2, 32),
+    "F16": (2, 16),
+    "BF16": (4, 16),
+    "I64": (0, 64),
+    "I32": (0, 32),
+    "I16": (0, 16),
+    "I8": (0, 8),
+    "U8": (1, 8),
+    "BOOL": (6, 8),
+}
+
+#: Casts ingest may perform (file dtype -> lane dtype), float-to-float only.
+#: Anything else is an admission refusal: integer/bool weights that disagree
+#: are a different artifact, not a representation choice.
+_CASTABLE = {(2, 16), (2, 32), (2, 64), (4, 16)}
+
+
+class JuggleRefusal(RuntimeError):
+    """Typed refusal: the checkpoint cannot join this lane's juggle set."""
+
+
+class RegionInvalid(RuntimeError):
+    """Typed refusal: a serving region holds no single checkpoint's bytes."""
+
+
+# ---------------------------------------------------------------------------
+# The checkpoint manifest — header-only, $0
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SlotSource:
+    """One tensor's bytes as one checkpoint's files state them."""
+
+    path: Path
+    offset: int
+    length: int
+    dtype_code: int
+    dtype_bits: int
+    shape: Tuple[int, ...]
+
+
+def read_manifest(
+    directory: "str | Path", *, variant: Optional[str] = None
+) -> Dict[str, SlotSource]:
+    """``{tensor key: SlotSource}`` for one component directory.
+
+    The admission input AND the ingest input: shapes and dtypes for the
+    identity proof, byte ranges for the refill. Same file walk as
+    :func:`~gen_worker.models.arena_residency.safetensors_triples`, keeping
+    the header fields that function drops. No tensor is materialised.
+    """
+    root = Path(directory)
+    tail = f".{variant}.safetensors" if variant else ".safetensors"
+    files = sorted(p for p in root.glob("*.safetensors") if p.name.endswith(tail))
+    if not variant:
+        files = [p for p in files if p.name.count(".") == 1]
+    if not files:
+        raise FileNotFoundError(f"no *{tail} weight files under {root}")
+
+    out: Dict[str, SlotSource] = {}
+    for path in files:
+        with path.open("rb") as fh:
+            raw = fh.read(8)
+            if len(raw) != 8:
+                raise ValueError(f"{path}: truncated safetensors header length")
+            (hlen,) = struct.unpack("<Q", raw)
+            if not header_len_ok(hlen):
+                raise ValueError(f"{path}: implausible safetensors header length {hlen}")
+            header = json.loads(fh.read(hlen))
+        base = 8 + hlen
+        for key, meta in header.items():
+            if key == "__metadata__":
+                continue
+            spelling = str(meta["dtype"])
+            code_bits = _SAFETENSORS_DTYPES.get(spelling)
+            if code_bits is None:
+                raise JuggleRefusal(
+                    f"{path}: tensor {key!r} has dtype {spelling!r}, which this "
+                    f"module has no placement for; refusing rather than guessing"
+                )
+            start, end = meta["data_offsets"]
+            out[key] = SlotSource(
+                path=path,
+                offset=base + int(start),
+                length=int(end) - int(start),
+                dtype_code=code_bits[0],
+                dtype_bits=code_bits[1],
+                shape=tuple(int(d) for d in meta["shape"]),
+            )
+    return out
+
+
+def merge_component_manifests(
+    components: Dict[str, "str | Path"], *, variant: Optional[str] = None
+) -> Dict[str, SlotSource]:
+    """Manifests for a multi-component lane, keyed the way the facade keys.
+
+    ``ArenaResidency`` resolves a slot to ``<inner-module-path>.<attr>`` with
+    the root component name stripped (``_triple_key``), and a component's own
+    weight file keys tensors relative to itself — so a single-component lane's
+    keys collide across components. This helper namespaces nothing when there
+    is one component and PREFIXES the component name when there are several;
+    callers juggling multi-component lanes construct their residency triples
+    with the same prefixing.
+    """
+    if len(components) == 1:
+        (directory,) = components.values()
+        return read_manifest(directory, variant=variant)
+    out: Dict[str, SlotSource] = {}
+    for name, directory in components.items():
+        for key, src in read_manifest(directory, variant=variant).items():
+            out[f"{name}.{key}"] = src
+    return out
+
+
+# ---------------------------------------------------------------------------
+# D1 — admission: the header-proven shape-identity check
+# ---------------------------------------------------------------------------
+
+
+def _slot_key(slot: SlotSpec) -> str:
+    """The facade's ``_triple_key``, restated: root component name stripped."""
+    _root, _, rest = slot.leaf.partition(".")
+    return f"{rest}.{slot.attr}" if rest else slot.attr
+
+
+def admission_refusal(
+    layout: ArenaLayout, manifest: Dict[str, SlotSource]
+) -> Optional[str]:
+    """None when the checkpoint is byte-layout-identical to the lane template
+    (up to a float cast); else the first refusal, named.
+
+    The tensor-layout contract guarantees the key set, dtypes and RANK — not
+    concrete shapes. This check is what makes "all checkpoints in a lane share
+    the byte layout" a PROVEN property per checkpoint instead of an assumed
+    one. It reads headers only.
+    """
+    for region in layout.regions:
+        for slot in region.slots:
+            key = _slot_key(slot)
+            src = manifest.get(key)
+            if src is None:
+                return f"tensor {key!r} is absent from the checkpoint"
+            if src.shape != slot.shape:
+                return (
+                    f"tensor {key!r} is shaped {list(src.shape)} in the "
+                    f"checkpoint and {list(slot.shape)} in the lane template — "
+                    f"a different layout, i.e. a cross-lane switch"
+                )
+            same = (src.dtype_code, src.dtype_bits) == (slot.dtype_code, slot.dtype_bits)
+            castable = (
+                (src.dtype_code, src.dtype_bits) in _CASTABLE
+                and (slot.dtype_code, slot.dtype_bits) in _CASTABLE
+            )
+            if not (same or castable):
+                return (
+                    f"tensor {key!r} is dtype ({src.dtype_code},{src.dtype_bits}) "
+                    f"in the checkpoint and ({slot.dtype_code},{slot.dtype_bits}) "
+                    f"in the lane; only float-to-float casts are representation "
+                    f"choices — this is a different artifact"
+                )
+            if same and src.length != slot.nbytes:
+                return (
+                    f"tensor {key!r} states {src.length} bytes for shape "
+                    f"{list(src.shape)}; the lane template holds {slot.nbytes}"
+                )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# D5 — the warm tier: normalized pinned arena images
+# ---------------------------------------------------------------------------
+
+
+def _mem_available_bytes() -> int:
+    try:
+        with open("/proc/meminfo") as fh:
+            for line in fh:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:  # pragma: no cover - /proc always exists on this fleet
+        pass
+    return 0
+
+
+class CheckpointImage:
+    """One checkpoint's bytes, normalized into the canonical arena layout.
+
+    A pinned host buffer of ``layout.virtual_bytes``, every slot at its
+    canonical offset in the LANE dtype (cast once at build, never per swap),
+    per-region digests banked. The buffer serves both as the swap's refill
+    source (one contiguous H2D per region) and as the streamed tier's host
+    mirror (zero-copy per-slot views).
+    """
+
+    def __init__(
+        self,
+        checkpoint_id: str,
+        layout: ArenaLayout,
+        manifest: Dict[str, SlotSource],
+        *,
+        torch_mod: Any,
+        varena_mod: Any = None,
+        engine: Any = None,
+        pin: bool = True,
+    ) -> None:
+        self.checkpoint_id = checkpoint_id
+        self.layout = layout
+        self.manifest = manifest
+        self._torch = torch_mod
+        self.casts = 0
+        self.pinned = False
+        self.region_digests: Dict[str, str] = {}
+
+        n = int(layout.virtual_bytes)
+        self._slab = None
+        self._pool = None
+        buffer = None
+        if pin and varena_mod is not None:
+            try:
+                self._pool = varena_mod.SlabPool(n, pin="require")
+                self._slab = self._pool.alloc(n)
+                buffer = torch_mod.frombuffer(
+                    self._slab.memoryview(), dtype=torch_mod.uint8
+                )
+                self.pinned = bool(self._slab.is_pinned())
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "checkpoint juggle: pinned image for %s refused (%s: %s); "
+                    "degrading to pageable RAM — H2D will be synchronous and "
+                    "slower, counted in the switch report",
+                    checkpoint_id, type(exc).__name__, exc,
+                )
+                self._slab = None
+                self._pool = None
+        if buffer is None:
+            buffer = torch_mod.empty(n, dtype=torch_mod.uint8)
+        self.buffer = buffer
+        self._build(engine)
+
+    # -- construction -------------------------------------------------------
+
+    def _build(self, engine: Any) -> None:
+        """Fill the image: straight reads where dtypes agree, cast where not.
+
+        One engine submit for every straight-read slot (the pgw#1507
+        cold-load lesson: per-slot round trips drain the queue), then the cast
+        slots via torch, then the digests.
+        """
+        torch = self._torch
+        straight: List[Tuple[str, int, int, int, int]] = []
+        casts: List[Tuple[SlotSpec, SlotSource]] = []
+        base_ptr = int(self.buffer.data_ptr())
+        for region in self.layout.regions:
+            for slot in region.slots:
+                src = self.manifest[_slot_key(slot)]
+                if (src.dtype_code, src.dtype_bits) == (slot.dtype_code, slot.dtype_bits):
+                    straight.append(
+                        (str(src.path), src.offset, src.length, base_ptr + slot.offset, 0)
+                    )
+                else:
+                    casts.append((slot, src))
+        if straight:
+            if engine is not None:
+                engine.submit(straight, 0).wait()
+            else:
+                self._pread(straight, base_ptr)
+        for slot, src in casts:
+            file_dtype = _torch_dtype(torch, src.dtype_code, src.dtype_bits)
+            lane_dtype = _torch_dtype(torch, slot.dtype_code, slot.dtype_bits)
+            raw = torch.empty(src.shape, dtype=file_dtype)
+            with open(src.path, "rb") as fh:
+                fh.seek(src.offset)
+                view = raw.view(torch.uint8).view(-1)
+                got = fh.readinto(memoryview(view.numpy()))
+            if got != src.length:
+                raise JuggleRefusal(
+                    f"{self.checkpoint_id}: short read for {_slot_key(slot)!r} "
+                    f"({got} of {src.length} bytes)"
+                )
+            self.slot_view(slot).copy_(raw.to(lane_dtype))
+            self.casts += 1
+        for region in self.layout.regions:
+            self.region_digests[region.name] = self.region_digest(region)
+
+    def _pread(
+        self, requests: Sequence[Tuple[str, int, int, int, int]], base_ptr: int
+    ) -> None:
+        """Engine-less fallback: plain reads into the buffer. Correct, slower."""
+        mv = memoryview(self.buffer.numpy())
+        for path, offset, length, host_ptr, _dev in requests:
+            start = host_ptr - base_ptr
+            with open(path, "rb") as fh:
+                fh.seek(offset)
+                got = fh.readinto(mv[start : start + length])
+            if got != length:
+                raise JuggleRefusal(
+                    f"{self.checkpoint_id}: short read from {path} "
+                    f"({got} of {length} bytes)"
+                )
+
+    # -- views --------------------------------------------------------------
+
+    def region_bytes(self, region: RegionSpec) -> Any:
+        return self.buffer[region.offset : region.offset + region.span]
+
+    def slot_view(self, slot: SlotSpec) -> Any:
+        torch = self._torch
+        dtype = _torch_dtype(torch, slot.dtype_code, slot.dtype_bits)
+        flat = self.buffer[slot.offset : slot.offset + slot.nbytes]
+        return flat.view(dtype).view(slot.shape)
+
+    def region_mirror(self, region: RegionSpec) -> List[Any]:
+        """Per-slot views, in slot order — the facade's ``_host`` shape."""
+        return [self.slot_view(slot) for slot in region.slots]
+
+    def region_digest(self, region: RegionSpec) -> str:
+        """Content digest of the region's WEIGHT bytes (padding excluded).
+
+        Slot-bounded on purpose: padding bytes are whatever the allocator
+        left there and are never read by a kernel, so hashing them would make
+        equal weights hash unequal.
+        """
+        h = hashlib.blake2b(digest_size=16)
+        for slot in region.slots:
+            h.update(memoryview(self.buffer.numpy())[slot.offset : slot.offset + slot.nbytes])
+        return h.hexdigest()
+
+    @property
+    def nbytes(self) -> int:
+        return int(self.buffer.numel())
+
+    def close(self) -> None:
+        self.buffer = None
+        self._slab = None
+        self._pool = None
+
+
+def _torch_dtype(torch: Any, code: int, bits: int) -> Any:
+    for dtype in (
+        torch.float16, torch.bfloat16, torch.float32, torch.float64,
+        torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.bool,
+    ):
+        if dlpack_dtype(torch, dtype) == (code, bits):
+            return dtype
+    raise TypeError(f"no torch dtype for DLPack ({code}, {bits})")
+
+
+# ---------------------------------------------------------------------------
+# The catalog: adaptive warm set, LRU + hysteresis
+# ---------------------------------------------------------------------------
+
+
+class CheckpointCatalog:
+    """The lane's juggle set: admission, warm images, eviction.
+
+    Budget-fed and adaptive: an ingest admits an image only while
+    ``MemAvailable`` minus the image stays above the host floor; under
+    pressure it evicts LRU images first, and an image evicted for pressure is
+    not rebuilt within the same pressure epoch (hysteresis, the pgw#1560
+    rule) — the checkpoint still serves, disk-direct, one tier slower.
+    """
+
+    def __init__(
+        self,
+        layout: ArenaLayout,
+        *,
+        torch_mod: Any,
+        varena_mod: Any = None,
+        engine_factory: Optional[Callable[[], Any]] = None,
+        host_floor_bytes: int = DEFAULT_HOST_FLOOR_BYTES,
+        mem_available: Callable[[], int] = _mem_available_bytes,
+    ) -> None:
+        self.layout = layout
+        self._torch = torch_mod
+        self._varena = varena_mod
+        self._engine_factory = engine_factory
+        self.host_floor_bytes = int(host_floor_bytes)
+        self._mem_available = mem_available
+        self.manifests: Dict[str, Dict[str, SlotSource]] = {}
+        self.images: Dict[str, CheckpointImage] = {}
+        self._lru: List[str] = []  # oldest first
+        #: Ids pressure eviction must skip — the SERVING checkpoint's image
+        #: doubles as the streamed tier's live host mirror, so evicting it
+        #: would pull memory out from under bound views.
+        self.protected: Set[str] = set()
+        self.pressure_epoch = 0
+        self._evicted_epoch: Dict[str, int] = {}
+        self.evictions = 0
+        self.ingests = 0
+
+    # -- admission ----------------------------------------------------------
+
+    def admit(self, checkpoint_id: str, manifest: Dict[str, SlotSource]) -> None:
+        """D1: the shape-identity proof. Refusal is typed and names the key."""
+        refusal = admission_refusal(self.layout, manifest)
+        if refusal is not None:
+            raise JuggleRefusal(
+                f"checkpoint {checkpoint_id!r} refused from the juggle set: {refusal}"
+            )
+        self.manifests[checkpoint_id] = manifest
+
+    def is_admitted(self, checkpoint_id: str) -> bool:
+        return checkpoint_id in self.manifests
+
+    # -- the warm tier ------------------------------------------------------
+
+    def warm(self, checkpoint_id: str) -> Optional[CheckpointImage]:
+        image = self.images.get(checkpoint_id)
+        if image is not None:
+            self._touch(checkpoint_id)
+        return image
+
+    def ensure_warm(self, checkpoint_id: str) -> Optional[CheckpointImage]:
+        """Build the image if RAM admits it; None means SERVE DISK-DIRECT.
+
+        Never raises for capacity: a warm miss is a priced degrade, not a
+        failure. Raises only for admission and integrity refusals.
+        """
+        manifest = self.manifests.get(checkpoint_id)
+        if manifest is None:
+            raise JuggleRefusal(
+                f"checkpoint {checkpoint_id!r} was never admitted to this lane; "
+                f"admit() it (with its manifest) before hinting or switching"
+            )
+        image = self.images.get(checkpoint_id)
+        if image is not None:
+            self._touch(checkpoint_id)
+            return image
+        if self._evicted_epoch.get(checkpoint_id) == self.pressure_epoch:
+            logger.info(
+                "checkpoint juggle: %s stays cold under hysteresis "
+                "(pressure epoch %d); serving disk-direct",
+                checkpoint_id, self.pressure_epoch,
+            )
+            return None
+        need = int(self.layout.virtual_bytes)
+        evictable = [n for n in self._lru if n not in self.protected]
+        while self._mem_available() - need < self.host_floor_bytes and evictable:
+            self._evict(evictable.pop(0), cause="pressure")
+        if self._mem_available() - need < self.host_floor_bytes:
+            self.pressure_epoch += 1
+            self._evicted_epoch[checkpoint_id] = self.pressure_epoch
+            logger.warning(
+                "checkpoint juggle: host RAM cannot admit an image for %s "
+                "(%.2f GiB needed, floor %.2f GiB); serving disk-direct "
+                "(pressure epoch now %d)",
+                checkpoint_id, need / (1 << 30),
+                self.host_floor_bytes / (1 << 30), self.pressure_epoch,
+            )
+            return None
+        engine = self._engine_factory() if self._engine_factory else None
+        image = CheckpointImage(
+            checkpoint_id, self.layout, manifest,
+            torch_mod=self._torch, varena_mod=self._varena, engine=engine,
+        )
+        self.images[checkpoint_id] = image
+        self._lru.append(checkpoint_id)
+        self.ingests += 1
+        logger.info(
+            "checkpoint juggle: ingested %s — %.2f GiB image, pinned=%s, "
+            "casts=%d, %d regions digested",
+            checkpoint_id, image.nbytes / (1 << 30), image.pinned,
+            image.casts, len(image.region_digests),
+        )
+        return image
+
+    def _touch(self, checkpoint_id: str) -> None:
+        try:
+            self._lru.remove(checkpoint_id)
+        except ValueError:
+            pass
+        self._lru.append(checkpoint_id)
+
+    def _evict(self, checkpoint_id: str, *, cause: str) -> None:
+        image = self.images.pop(checkpoint_id, None)
+        if image is None:
+            return
+        try:
+            self._lru.remove(checkpoint_id)
+        except ValueError:
+            pass
+        if cause == "pressure":
+            self.pressure_epoch += 1
+            self._evicted_epoch[checkpoint_id] = self.pressure_epoch
+        image.close()
+        self.evictions += 1
+        logger.info(
+            "checkpoint juggle: evicted %s (%s); demote is free/unpin only — "
+            "weights are immutable, refill comes from disk",
+            checkpoint_id, cause,
+        )
+
+    def evict(self, checkpoint_id: str) -> None:
+        self._evict(checkpoint_id, cause="explicit")
+
+    def close(self) -> None:
+        for checkpoint_id in list(self.images):
+            self._evict(checkpoint_id, cause="teardown")
+
+
+# ---------------------------------------------------------------------------
+# D7 — the serving-validity ledger
+# ---------------------------------------------------------------------------
+
+
+class RegionValidity(Enum):
+    VALID = "valid"
+    REFILLING = "refilling"
+    INVALID = "invalid"
+
+
+@dataclass
+class _RegionState:
+    validity: RegionValidity
+    checkpoint_id: str  # the checkpoint whose bytes the region holds/held
+
+
+class ValidityLedger:
+    """Per-region serving validity. The franken-weights fence.
+
+    ``valid@X -> refilling(Y) -> valid@Y | INVALID``. Serving asks
+    :meth:`assert_servable`; a region mid-refill or invalid is a typed
+    refusal, never a serve of mixed bytes.
+    """
+
+    def __init__(self, layout: ArenaLayout, checkpoint_id: str) -> None:
+        self._state: Dict[str, _RegionState] = {
+            r.name: _RegionState(RegionValidity.VALID, checkpoint_id)
+            for r in layout.regions
+        }
+
+    def begin(self, region: str, target: str) -> None:
+        st = self._state[region]
+        st.validity = RegionValidity.REFILLING
+        st.checkpoint_id = target
+
+    def complete(self, region: str) -> None:
+        self._state[region].validity = RegionValidity.VALID
+
+    def poison(self, region: str) -> None:
+        self._state[region].validity = RegionValidity.INVALID
+
+    def of(self, region: str) -> Tuple[RegionValidity, str]:
+        st = self._state[region]
+        return st.validity, st.checkpoint_id
+
+    def assert_servable(self, expected_checkpoint: str) -> None:
+        for name, st in self._state.items():
+            if st.validity is not RegionValidity.VALID:
+                raise RegionInvalid(
+                    f"region {name!r} is {st.validity.value} "
+                    f"(target {st.checkpoint_id!r}); refusing to serve — "
+                    f"re-run the switch to recover (the refill is idempotent)"
+                )
+            if st.checkpoint_id != expected_checkpoint:
+                raise RegionInvalid(
+                    f"region {name!r} holds {st.checkpoint_id!r} while the lane "
+                    f"claims to serve {expected_checkpoint!r}; refusing mixed "
+                    f"checkpoints"
+                )
+
+
+# ---------------------------------------------------------------------------
+# The juggler
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SwitchReport:
+    """One switch, priced. Every field lands on the loud line."""
+
+    from_id: str
+    to_id: str
+    tier: str  # serving | host-warm | disk-cold
+    wall_s: float
+    bytes_moved: int
+    regions_refilled: int
+    regions_unbacked: int  # swapped for free (source repointed)
+    transfer_gbps: float
+    residue_bytes: int  # managed by nobody, NOT swapped (non-leaf buffers)
+    pinned_source: bool
+
+    def loud(self) -> str:
+        return (
+            f"checkpoint switch {self.from_id!r} -> {self.to_id!r}: tier={self.tier} "
+            f"wall={self.wall_s * 1000:.1f}ms bytes={self.bytes_moved} "
+            f"({self.transfer_gbps:.2f} GB/s) refilled={self.regions_refilled} "
+            f"free-swapped={self.regions_unbacked} residue_untouched={self.residue_bytes} "
+            f"pinned_source={self.pinned_source}"
+        )
+
+
+class CheckpointJuggler:
+    """The lane's switch engine over one :class:`ArenaResidency`.
+
+    The residency owns the layout, the reservation and the paging machinery;
+    the juggler owns WHICH checkpoint's bytes those fixed addresses hold. It
+    is driven at request boundaries (the launch-window contract: nothing here
+    runs concurrently with a forward on the same regions — the caller's
+    quiesce; the compute-stream event wait below covers the prior request's
+    still-executing tail).
+    """
+
+    def __init__(
+        self,
+        residency: ArenaResidency,
+        serving_id: str,
+        serving_manifest: Dict[str, SlotSource],
+        *,
+        catalog: Optional[CheckpointCatalog] = None,
+    ) -> None:
+        self.residency = residency
+        self.layout = residency.layout
+        self.catalog = catalog or CheckpointCatalog(
+            self.layout,
+            torch_mod=residency._torch,
+            varena_mod=residency._varena,
+            engine_factory=residency._engine_for,
+        )
+        if not residency.adopted:
+            raise ValueError(
+                "checkpoint juggle: the residency is not engaged; call "
+                "engage() before constructing the juggler — the swap protocol "
+                "assumes the arena already holds the serving checkpoint"
+            )
+        self.catalog.admit(serving_id, serving_manifest)
+        self.catalog.protected.add(serving_id)
+        self.serving_id = serving_id
+        self.ledger = ValidityLedger(self.layout, serving_id)
+        self.switches = 0
+        self.rearms = 0  # incremented by NOTHING here; the zero is the proof
+        self.reports: List[SwitchReport] = []
+        self._residue_bytes = self._count_residue()
+
+    # -- the public seam ----------------------------------------------------
+
+    def admit(self, checkpoint_id: str, manifest: Dict[str, SlotSource]) -> None:
+        self.catalog.admit(checkpoint_id, manifest)
+
+    def hint_next(self, checkpoint_id: str) -> bool:
+        """Warm the image CPU-side while the current checkpoint serves.
+
+        GPU-untouched by construction — safe at any moment, not only at
+        request boundaries. True = warm; False = will serve disk-direct.
+        """
+        return self.catalog.ensure_warm(checkpoint_id) is not None
+
+    def assert_servable(self) -> None:
+        self.ledger.assert_servable(self.serving_id)
+
+    def switch_to(self, checkpoint_id: str) -> SwitchReport:
+        """The backing swap. Fixed addresses; in-place refill; zero re-arms."""
+        torch = self.residency._torch
+        if checkpoint_id == self.serving_id:
+            report = SwitchReport(
+                from_id=checkpoint_id, to_id=checkpoint_id, tier="serving",
+                wall_s=0.0, bytes_moved=0, regions_refilled=0,
+                regions_unbacked=0, transfer_gbps=0.0,
+                residue_bytes=self._residue_bytes, pinned_source=True,
+            )
+            logger.info(report.loud())
+            return report
+        image = self.catalog.ensure_warm(checkpoint_id)
+        manifest = self.catalog.manifests[checkpoint_id]
+        tier = "host-warm" if image is not None else "disk-cold"
+        if image is None:
+            # A disk-cold switch streams file bytes straight into the arena,
+            # so it cannot cast. Refuse BEFORE any region transitions — the
+            # lane keeps serving the current checkpoint, validly.
+            for region in self.layout.regions:
+                for slot in region.slots:
+                    src = manifest[_slot_key(slot)]
+                    if (src.dtype_code, src.dtype_bits) != (
+                        slot.dtype_code, slot.dtype_bits,
+                    ):
+                        raise JuggleRefusal(
+                            f"disk-cold switch to {checkpoint_id!r} would need "
+                            f"a cast for {_slot_key(slot)!r}; warm it first "
+                            f"(casts happen at ingest, once) — still serving "
+                            f"{self.serving_id!r}"
+                        )
+
+        started = time.perf_counter()
+        bytes_moved = 0
+        refilled = 0
+        unbacked = 0
+        from_id = self.serving_id
+
+        device = self.residency.device
+        stream = torch.cuda.Stream(device=device)
+        # The prior request's tail may still be executing: the side stream
+        # waits on the compute stream ONCE, then every region refill runs
+        # behind that fence.
+        stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.no_grad():
+            # Retire every deferred unback first: a streamed region pending in
+            # the ring is physically backed with the OLD bytes, and the swap's
+            # "unbacked = free" arm must not run over live physical pages.
+            self.residency.ring.drain()
+            for region in self.layout.regions:
+                if self.residency.is_resident(region.name):
+                    self.ledger.begin(region.name, checkpoint_id)
+                    try:
+                        with torch.cuda.stream(stream):
+                            bytes_moved += self._refill_backed(
+                                region, image, manifest, stream
+                            )
+                    except Exception:
+                        self.ledger.poison(region.name)
+                        logger.error(
+                            "checkpoint juggle: refill of region %r died "
+                            "mid-transfer; region is INVALID and serving will "
+                            "refuse until a switch completes",
+                            region.name,
+                        )
+                        raise
+                    if image is not None:
+                        # The image doubles as this region's host mirror, so a
+                        # later demote is unmap-only (va#11 write-back
+                        # invariant): the facade skips its D2H capture when a
+                        # mirror already exists.
+                        self.residency._host[region.name] = image.region_mirror(region)
+                    self.ledger.complete(region.name)
+                    refilled += 1
+                else:
+                    # Unbacked: free swap. Repoint the host mirror (or leave
+                    # disk-direct) so the next page-in reads the target.
+                    self.ledger.begin(region.name, checkpoint_id)
+                    if image is not None:
+                        self.residency._host[region.name] = image.region_mirror(region)
+                    else:
+                        self.residency._host.pop(region.name, None)
+                    self.residency._rebind_off_device(region)
+                    self.ledger.complete(region.name)
+                    unbacked += 1
+            # Streamed page-ins and any later demote read the new source.
+            self.residency._triples = {
+                key: (src.path, src.offset, src.length)
+                for key, src in manifest.items()
+            }
+            torch.cuda.current_stream(device).wait_stream(stream)
+            torch.cuda.synchronize(device)
+
+        wall = time.perf_counter() - started
+        self.serving_id = checkpoint_id
+        self.catalog.protected = {checkpoint_id}
+        if image is not None:
+            self.catalog._touch(checkpoint_id)
+        self.switches += 1
+        report = SwitchReport(
+            from_id=from_id, to_id=checkpoint_id, tier=tier, wall_s=wall,
+            bytes_moved=bytes_moved, regions_refilled=refilled,
+            regions_unbacked=unbacked,
+            transfer_gbps=(bytes_moved / wall / 1e9) if wall > 0 else 0.0,
+            residue_bytes=self._residue_bytes,
+            pinned_source=bool(image.pinned) if image is not None else False,
+        )
+        self.reports.append(report)
+        logger.info(report.loud())
+        return report
+
+    # -- byte movement ------------------------------------------------------
+
+    def _refill_backed(
+        self,
+        region: RegionSpec,
+        image: Optional[CheckpointImage],
+        manifest: Dict[str, SlotSource],
+        stream: Any,
+    ) -> int:
+        """Overwrite a backed region under its fixed address. Returns bytes.
+
+        No unback, no back, no rebind: the views bound into the modules (and
+        any compiled artifact holding those pointers) read the new bytes the
+        moment the copy lands. That absence IS the zero-re-arm mechanism.
+        """
+        if image is not None:
+            dst = self._device_bytes(region)
+            src = image.region_bytes(region)
+            dst.copy_(src, non_blocking=image.pinned)
+            return region.span
+        base = int(self.residency.reservation.base_ptr)
+        requests = []
+        moved = 0
+        for slot in region.slots:
+            src = manifest[_slot_key(slot)]
+            if (src.dtype_code, src.dtype_bits) != (slot.dtype_code, slot.dtype_bits):
+                raise JuggleRefusal(
+                    f"disk-cold switch cannot cast {_slot_key(slot)!r} in "
+                    f"flight; warm this checkpoint first (the image is where "
+                    f"casts happen, once)"
+                )
+            requests.append(
+                (str(src.path), src.offset, src.length, 0, base + slot.offset)
+            )
+            moved += src.length
+        handle = self.residency._engine_for().submit(
+            requests, int(stream.cuda_stream) if stream is not None else 0
+        )
+        handle.wait()
+        return moved
+
+    def _device_bytes(self, region: RegionSpec) -> Any:
+        torch = self.residency._torch
+        return torch.from_dlpack(
+            self.residency.reservation.tensor(
+                region.offset, [region.span], *_DL_UINT8
+            )
+        )
+
+    def _count_residue(self) -> int:
+        """Bytes on the tree that NO region manages — stated, not swapped."""
+        from .stream_residency import own_tensors, tensor_bytes
+
+        managed = {
+            (slot.leaf, slot.attr)
+            for region in self.layout.regions
+            for slot in region.slots
+        }
+        total = 0
+        for root_name, root in self.residency._roots:
+            for name, module in root.named_modules():
+                qualified = f"{root_name}.{name}" if name else root_name
+                for attr, _is_param, tensor in own_tensors(module):
+                    if (qualified, attr) not in managed and not tensor.is_meta:
+                        total += tensor_bytes(tensor)
+        return total
+
+
+__all__ = [
+    "CheckpointCatalog",
+    "CheckpointImage",
+    "CheckpointJuggler",
+    "JuggleRefusal",
+    "RegionInvalid",
+    "RegionValidity",
+    "SlotSource",
+    "SwitchReport",
+    "ValidityLedger",
+    "admission_refusal",
+    "merge_component_manifests",
+    "read_manifest",
+]

--- a/src/gen_worker/models/checkpoint_juggle.py
+++ b/src/gen_worker/models/checkpoint_juggle.py
@@ -663,6 +663,11 @@ class SwitchReport:
     transfer_gbps: float
     residue_bytes: int  # managed by nobody, NOT swapped (non-leaf buffers)
     pinned_source: bool
+    #: True when every backed region's mapping was checked against the
+    #: DRIVER's truth after the swap (va#12 ``page_signatures(verify=True)``,
+    #: 0.15–0.17 ms/GiB — affordable every swap, so it runs every swap).
+    #: False means the installed varena predates va#12; confessed, not silent.
+    backing_verified: bool = False
 
     def loud(self) -> str:
         return (
@@ -670,7 +675,7 @@ class SwitchReport:
             f"wall={self.wall_s * 1000:.1f}ms bytes={self.bytes_moved} "
             f"({self.transfer_gbps:.2f} GB/s) refilled={self.regions_refilled} "
             f"free-swapped={self.regions_unbacked} residue_untouched={self.residue_bytes} "
-            f"pinned_source={self.pinned_source}"
+            f"pinned_source={self.pinned_source} backing_verified={self.backing_verified}"
         )
 
 
@@ -824,6 +829,7 @@ class CheckpointJuggler:
             }
             torch.cuda.current_stream(device).wait_stream(stream)
             torch.cuda.synchronize(device)
+            backing_verified = self._verify_backing(checkpoint_id)
 
         wall = time.perf_counter() - started
         self.serving_id = checkpoint_id
@@ -838,12 +844,40 @@ class CheckpointJuggler:
             transfer_gbps=(bytes_moved / wall / 1e9) if wall > 0 else 0.0,
             residue_bytes=self._residue_bytes,
             pinned_source=bool(image.pinned) if image is not None else False,
+            backing_verified=backing_verified,
         )
         self.reports.append(report)
         logger.info(report.loud())
         return report
 
     # -- byte movement ------------------------------------------------------
+
+    def _verify_backing(self, checkpoint_id: str) -> bool:
+        """va#12 driver-truth check over every backed region, every swap.
+
+        Priced at 0.15–0.17 ms/GiB (measured under load) — affordable per
+        swap, so it is not rationed. A zero chunk means the mapping is not
+        what this process believes: the region is poisoned and the swap
+        FAILS rather than serving over a lie. Returns False (confessed on
+        the loud line) when the installed varena predates ``page_signatures``.
+        """
+        res = self.residency.reservation
+        if not hasattr(res, "page_signatures"):
+            return False
+        for region in self.layout.regions:
+            if not self.residency.is_resident(region.name):
+                continue
+            sigs = res.page_signatures(region.offset, region.span, True)
+            dead = sum(1 for s in sigs if int(s) == 0)
+            if dead:
+                self.ledger.poison(region.name)
+                raise RegionInvalid(
+                    f"region {region.name!r}: driver disagrees on {dead} of "
+                    f"{len(sigs)} chunks after the swap to {checkpoint_id!r}; "
+                    f"the region is INVALID — residency was lost outside this "
+                    f"process (suspend/reset/external eviction)"
+                )
+        return True
 
     def _refill_backed(
         self,

--- a/tests/test_checkpoint_juggle.py
+++ b/tests/test_checkpoint_juggle.py
@@ -1,0 +1,380 @@
+"""The checkpoint juggle's card-free half: admission, images, validity.
+
+Everything here is decidable without a GPU: the shape-identity admission
+proof, the normalized-image build (bytes, casts, digests), the adaptive
+catalog (pressure eviction, protection, hysteresis) and the serving-validity
+ledger. What is left for the card — the in-place refill, the zero-re-arm
+proof, the mid-refill kill — runs in ``benchmarks/checkpoint_juggle_pgw1607.py``
+under a granted GPU window.
+
+Real ``nn.Module`` trees and real safetensors files throughout — no mocks
+(the test-suite convention): a mocked header would agree with whatever the
+admission check believes about it, which is the one thing worth checking.
+
+# pgw#1607: the checkpoint juggle (implements pgw#1602's multi-checkpoint scope).
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+
+from gen_worker.models.arena_residency import (  # noqa: E402
+    DEFAULT_GRANULARITY,
+    dlpack_dtype,
+    plan_layout,
+)
+from gen_worker.models.checkpoint_juggle import (  # noqa: E402
+    CheckpointCatalog,
+    CheckpointImage,
+    JuggleRefusal,
+    RegionInvalid,
+    RegionValidity,
+    ValidityLedger,
+    admission_refusal,
+    read_manifest,
+)
+from gen_worker.models.stream_residency import (  # noqa: E402
+    discover_leaves,
+    own_tensors,
+    tensor_bytes,
+)
+
+GRAN = DEFAULT_GRANULARITY
+MIB = 1 << 20
+
+_SAFETENSORS_SPELLING = {
+    torch.float32: "F32",
+    torch.float16: "F16",
+    torch.bfloat16: "BF16",
+    torch.int64: "I64",
+}
+
+
+# ---------------------------------------------------------------------------
+# Real trees, real files
+# ---------------------------------------------------------------------------
+
+
+class Net(nn.Module):
+    """A lane template: one streaming-sized leaf, small leaves, a buffer."""
+
+    def __init__(self, seed: int = 0) -> None:
+        super().__init__()
+        g = torch.Generator().manual_seed(seed)
+        self.big = nn.Linear(1024, 1024, bias=False)  # 4 MiB fp32: streams
+        self.small = nn.Linear(16, 16, bias=False)  # core
+        self.norm = nn.LayerNorm(16)  # core
+        with torch.no_grad():
+            for p in self.parameters():
+                p.copy_(torch.randn(p.shape, generator=g))
+
+    def forward(self, x: Any) -> Any:  # pragma: no cover
+        return self.norm(self.small(self.big(x)))
+
+
+def write_safetensors(path: Path, tensors: Dict[str, Any]) -> None:
+    """A real safetensors file, written the way the format states it.
+
+    Deliberately NOT the library writer: the admission check reads headers,
+    so the fixture states its own header and the two implementations must
+    agree from opposite sides.
+    """
+    header: Dict[str, Any] = {}
+    blobs: List[bytes] = []
+    offset = 0
+    for key in sorted(tensors):
+        t = tensors[key].detach().contiguous()
+        raw = t.view(torch.uint8).numpy().tobytes() if t.dtype is torch.bfloat16 else t.numpy().tobytes()
+        header[key] = {
+            "dtype": _SAFETENSORS_SPELLING[t.dtype],
+            "shape": list(t.shape),
+            "data_offsets": [offset, offset + len(raw)],
+        }
+        blobs.append(raw)
+        offset += len(raw)
+    encoded = json.dumps(header).encode()
+    with path.open("wb") as fh:
+        fh.write(struct.pack("<Q", len(encoded)))
+        fh.write(encoded)
+        for blob in blobs:
+            fh.write(blob)
+
+
+def checkpoint_dir(tmp_path: Path, name: str, module: nn.Module, *, dtype: Any = None) -> Path:
+    """One component directory holding the module's weights as a checkpoint."""
+    directory = tmp_path / name
+    directory.mkdir(parents=True, exist_ok=True)
+    tensors = {}
+    for key, tensor in module.state_dict().items():
+        tensors[key] = tensor.to(dtype) if dtype is not None else tensor
+    write_safetensors(directory / "weights.safetensors", tensors)
+    return directory
+
+
+def specs_for(module: nn.Module, name: str = "root") -> List[Tuple[str, List[Any]]]:
+    leaves, _costs, _adapters = discover_leaves([(name, module)])
+    out = []
+    for leaf_name, leaf in leaves.items():
+        slots = []
+        for attr, is_param, tensor in own_tensors(leaf):
+            code, bits = dlpack_dtype(torch, tensor.dtype)
+            slots.append((attr, is_param, tensor_bytes(tensor), tuple(tensor.shape), code, bits))
+        out.append((leaf_name, slots))
+    return out
+
+
+def layout_for(module: nn.Module) -> Any:
+    return plan_layout(specs_for(module), granularity=GRAN, min_stream_bytes=MIB)
+
+
+# ---------------------------------------------------------------------------
+# D1 — admission
+# ---------------------------------------------------------------------------
+
+
+def test_a_checkpoint_of_the_same_architecture_is_admitted(tmp_path: Path) -> None:
+    template = Net(seed=0)
+    other = Net(seed=1)  # a distinct fine-tune, same architecture
+    manifest = read_manifest(checkpoint_dir(tmp_path, "b", other))
+    assert admission_refusal(layout_for(template), manifest) is None
+
+
+def test_a_shape_divergence_is_refused_and_names_the_key(tmp_path: Path) -> None:
+    template = Net(seed=0)
+
+    class Wider(Net):
+        def __init__(self) -> None:
+            super().__init__()
+            self.big = nn.Linear(1024, 2048, bias=False)
+
+    manifest = read_manifest(checkpoint_dir(tmp_path, "wide", Wider()))
+    refusal = admission_refusal(layout_for(template), manifest)
+    assert refusal is not None
+    assert "big.weight" in refusal and "cross-lane" in refusal
+
+
+def test_a_missing_tensor_is_refused(tmp_path: Path) -> None:
+    template = Net(seed=0)
+    directory = checkpoint_dir(tmp_path, "partial", Net(seed=2))
+    manifest = read_manifest(directory)
+    del manifest["norm.bias"]
+    refusal = admission_refusal(layout_for(template), manifest)
+    assert refusal is not None and "norm.bias" in refusal
+
+
+def test_a_float_cast_is_a_representation_choice_not_a_refusal(tmp_path: Path) -> None:
+    """fp16-on-disk in an fp32 lane: admitted; ingest casts once."""
+    template = Net(seed=0)
+    manifest = read_manifest(
+        checkpoint_dir(tmp_path, "half", Net(seed=3), dtype=torch.float16)
+    )
+    assert admission_refusal(layout_for(template), manifest) is None
+
+
+def test_an_integer_dtype_divergence_is_a_different_artifact(tmp_path: Path) -> None:
+    template = Net(seed=0)
+    directory = tmp_path / "intly"
+    directory.mkdir()
+    tensors = {k: t for k, t in Net(seed=4).state_dict().items()}
+    tensors["norm.bias"] = torch.arange(16, dtype=torch.int64)
+    write_safetensors(directory / "weights.safetensors", tensors)
+    refusal = admission_refusal(layout_for(template), read_manifest(directory))
+    assert refusal is not None and "different artifact" in refusal
+
+
+def test_manifest_refuses_unknown_dtype_spellings(tmp_path: Path) -> None:
+    directory = tmp_path / "exotic"
+    directory.mkdir()
+    header = json.dumps(
+        {"x": {"dtype": "F8_E4M3", "shape": [4], "data_offsets": [0, 4]}}
+    ).encode()
+    with (directory / "weights.safetensors").open("wb") as fh:
+        fh.write(struct.pack("<Q", len(header)))
+        fh.write(header)
+        fh.write(b"\x00" * 4)
+    with pytest.raises(JuggleRefusal, match="F8_E4M3"):
+        read_manifest(directory)
+
+
+# ---------------------------------------------------------------------------
+# D5 — the normalized image
+# ---------------------------------------------------------------------------
+
+
+def build_image(
+    tmp_path: Path, name: str, template: nn.Module, module: nn.Module, **kw: Any
+) -> Tuple[Any, CheckpointImage]:
+    layout = layout_for(template)
+    manifest = read_manifest(checkpoint_dir(tmp_path, name, module, **kw))
+    return layout, CheckpointImage(
+        name, layout, manifest, torch_mod=torch, varena_mod=None, engine=None
+    )
+
+
+def test_image_slots_are_bit_exact_with_the_source_tree(tmp_path: Path) -> None:
+    template, other = Net(seed=0), Net(seed=5)
+    layout, image = build_image(tmp_path, "b", template, other)
+    state = other.state_dict()
+    checked = 0
+    for region in layout.regions:
+        for slot in region.slots:
+            key = f"{slot.leaf.partition('.')[2]}.{slot.attr}" if "." in slot.leaf else slot.attr
+            assert torch.equal(image.slot_view(slot), state[key])
+            checked += 1
+    assert checked == len(list(template.state_dict()))
+
+
+def test_image_digests_are_deterministic_and_checkpoint_distinct(tmp_path: Path) -> None:
+    template = Net(seed=0)
+    _, image_b1 = build_image(tmp_path, "b1", template, Net(seed=6))
+    _, image_b2 = build_image(tmp_path, "b2", template, Net(seed=6))
+    _, image_c = build_image(tmp_path, "c", template, Net(seed=7))
+    assert image_b1.region_digests == image_b2.region_digests
+    assert image_b1.region_digests != image_c.region_digests
+
+
+def test_ingest_casts_once_and_values_match(tmp_path: Path) -> None:
+    template = Net(seed=0)
+    other = Net(seed=8)
+    layout, image = build_image(tmp_path, "half", template, other, dtype=torch.float16)
+    assert image.casts == len(list(other.state_dict()))
+    state = other.state_dict()
+    for region in layout.regions:
+        for slot in region.slots:
+            key = f"{slot.leaf.partition('.')[2]}.{slot.attr}" if "." in slot.leaf else slot.attr
+            expected = state[key].to(torch.float16).to(torch.float32)
+            assert torch.equal(image.slot_view(slot), expected)
+
+
+def test_the_image_pays_the_layouts_virtual_bytes(tmp_path: Path) -> None:
+    """The image is the ARENA's shape, alignment tax included — that is what
+    makes the swap one contiguous copy per region."""
+    template = Net(seed=0)
+    layout, image = build_image(tmp_path, "b", template, Net(seed=9))
+    assert image.nbytes == layout.virtual_bytes
+
+
+# ---------------------------------------------------------------------------
+# The catalog — adaptive, protected, hysteretic
+# ---------------------------------------------------------------------------
+
+
+def make_catalog(
+    tmp_path: Path, template: nn.Module, mem: Dict[str, int], floor: int
+) -> Tuple[Any, CheckpointCatalog]:
+    layout = layout_for(template)
+    catalog = CheckpointCatalog(
+        layout,
+        torch_mod=torch,
+        varena_mod=None,
+        host_floor_bytes=floor,
+        mem_available=lambda: mem["available"],
+    )
+    return layout, catalog
+
+
+def admit_real(catalog: CheckpointCatalog, tmp_path: Path, name: str, seed: int) -> None:
+    catalog.admit(name, read_manifest(checkpoint_dir(tmp_path, name, Net(seed=seed))))
+
+
+def test_pressure_evicts_lru_first_and_never_the_protected(tmp_path: Path) -> None:
+    template = Net(seed=0)
+    mem = {"available": 10 << 30}
+    layout, catalog = make_catalog(tmp_path, template, mem, floor=4 << 30)
+    for i, name in enumerate(("a", "b", "c")):
+        admit_real(catalog, tmp_path, name, seed=10 + i)
+        assert catalog.ensure_warm(name) is not None
+    catalog.protected.add("a")
+    # Starve RAM: the next ingest must evict — b (oldest unprotected), not a.
+    mem["available"] = (4 << 30) + layout.virtual_bytes // 2
+    admit_real(catalog, tmp_path, "d", seed=13)
+    catalog.ensure_warm("d")
+    assert catalog.warm("a") is not None
+    assert catalog.images.get("b") is None
+    assert catalog.evictions >= 1
+
+
+def test_hysteresis_a_pressure_evicted_image_stays_cold_this_epoch(tmp_path: Path) -> None:
+    template = Net(seed=0)
+    mem = {"available": 2 << 30}
+    _layout, catalog = make_catalog(tmp_path, template, mem, floor=4 << 30)
+    admit_real(catalog, tmp_path, "a", seed=20)
+    # RAM refuses: disk-direct, a pressure epoch opens, and the SAME id does
+    # not rebuild within it even when RAM returns.
+    assert catalog.ensure_warm("a") is None
+    epoch = catalog.pressure_epoch
+    mem["available"] = 64 << 30
+    assert catalog.ensure_warm("a") is None
+    assert catalog.pressure_epoch == epoch
+    # A different id is not under the epoch's hysteresis.
+    admit_real(catalog, tmp_path, "b", seed=21)
+    assert catalog.ensure_warm("b") is not None
+    # The next epoch releases it.
+    catalog.pressure_epoch += 1
+    assert catalog.ensure_warm("a") is not None
+
+
+def test_an_unadmitted_checkpoint_cannot_be_warmed(tmp_path: Path) -> None:
+    template = Net(seed=0)
+    _layout, catalog = make_catalog(
+        tmp_path, template, {"available": 64 << 30}, floor=4 << 30
+    )
+    with pytest.raises(JuggleRefusal, match="never admitted"):
+        catalog.ensure_warm("ghost")
+
+
+# ---------------------------------------------------------------------------
+# D7 — the serving-validity ledger (the franken-weights fence)
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_happy_path_and_all_three_red_arms(tmp_path: Path) -> None:
+    layout = layout_for(Net(seed=0))
+    ledger = ValidityLedger(layout, "a")
+    ledger.assert_servable("a")
+
+    first = layout.regions[0].name
+    # RED 1: mid-refill is not servable.
+    ledger.begin(first, "b")
+    with pytest.raises(RegionInvalid, match="refilling"):
+        ledger.assert_servable("a")
+    # RED 2: a poisoned region refuses loudly, and names recovery.
+    ledger.poison(first)
+    with pytest.raises(RegionInvalid, match="idempotent"):
+        ledger.assert_servable("a")
+    assert ledger.of(first) == (RegionValidity.INVALID, "b")
+    # Recovery: a completed re-refill serves again.
+    ledger.begin(first, "b")
+    ledger.complete(first)
+    # RED 3: mixed checkpoints — region 0 holds b, the rest hold a.
+    if len(layout.regions) > 1:
+        with pytest.raises(RegionInvalid, match="mixed"):
+            ledger.assert_servable("b")
+    for region in layout.regions[1:]:
+        ledger.begin(region.name, "b")
+        ledger.complete(region.name)
+    ledger.assert_servable("b")
+
+
+def test_a_partial_switch_is_never_servable_under_either_identity(tmp_path: Path) -> None:
+    """The exact franken state the coordinator's requirement names: some
+    regions swapped to B, one died mid-refill. Neither A nor B may serve."""
+    layout = layout_for(Net(seed=0))
+    if len(layout.regions) < 2:
+        pytest.skip("needs two regions to interleave")
+    ledger = ValidityLedger(layout, "a")
+    ledger.begin(layout.regions[0].name, "b")
+    ledger.complete(layout.regions[0].name)
+    ledger.begin(layout.regions[1].name, "b")
+    ledger.poison(layout.regions[1].name)
+    for identity in ("a", "b"):
+        with pytest.raises(RegionInvalid):
+            ledger.assert_servable(identity)


### PR DESCRIPTION
Within a lane every admitted checkpoint shares the canonical arena layout (derived from the serving module tree, never from files), so a checkpoint switch is an in-place refill under fixed addresses: zero re-arms, zero pointer rewrites, cost = byte transfer only.

- `models/checkpoint_juggle.py`: header-only shape-identity admission (the tensor-layout contract pins keys/dtypes/rank, NOT shapes/offsets — proven per checkpoint); normalized pinned arena images as the warm tier (ingest casts once, per-region digests banked); adaptive budget-fed catalog (LRU + hysteresis + serving-image protection); per-region serving-validity ledger (valid@X → refilling → valid@Y | INVALID — the franken-weights state is unreachable); switch engine with per-region in-place refill on a side stream, va#12 `page_signatures(verify=True)` after every swap (confessed-absent on older wheels), disk-direct fallback, priced loud SwitchReport.
- `arena_residency.py`: \_capture_host early-returns when a mirror exists (demote = unmap-only, the va#11 write-back invariant) + the va#12 mirror paragraph (weights-only scope, launch-window contract).
- 15 card-free tests, green first run; **card-proven on the 4070 in a granted window**: both arms (full-resident + 1-backed/5-streamed) green on all five correctness legs incl. the mid-refill kill red leg; warm switch = 97.7% of the same-window pinned H2D floor (P1: switch wall IS the transfer bound); serving no-op 0; streamed-tail swap free.
- `benchmarks/`: local window battery, pod-side SDXL battery (smoke gate + warm/cold/zipf), box-side podguard driver, $0 HF header-curation preflight (16 compatible fine-tunes; SSD-1B red-arms the check).

Tracker: pgw#1607 (implements pgw#1602's multi-checkpoint scope addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)