### PR TITLE
pgw#1614: cut 0.127.0 — the lane declaration surface, published

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.126.0"
+version = "0.127.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -573,7 +573,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.126.0"
+version = "0.127.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Pinned cut commit 392b7154 (origin/master tip at cut time), tagged after
merge so the tag stays an ancestor of master (docs/releasing.md).

Cut BECAUSE A POD RUN NEEDS ONE (releasing.md rule 1): se#819 moves sdxl and
anima onto the pgw#1599/#1606 surface and deploys them on the standing master
stack. 0.126.0 predates the whole surface — it has no `gen_worker/demand.py`,
no `lane()`, no `ctx.load_pipeline`, so every v2 endpoint in the fleet is on a
git COMMIT pin today and the platform has no released SDK that can build one.

Must-ride, ancestor-verified against the cut commit:
  d782ea5e  pgw#1599  the lane declaration surface; five vocabularies die
  93e06f9e  pgw#1606  ctx.load_pipeline + the boot lane-selection ladder
  c26427ae  pgw#1590  admission charges the LANE'S DECLARATION
  4e01bd0c  pgw#1609  the DERIVE meets projected trees too
  667af708  pgw#1591  a WRAPPED dispatcher is not a DISPLACED one

528 commits since v0.126.0 (git rev-list --count v0.126.0..392b7154).

DEFECT, filed as pgw#1615 and NOT worked around silently: docs/releasing.md
step 0 ("assemble the CHANGELOG section") CANNOT RUN on this tree. pgw#1582
deleted CHANGELOG.md as Paul deleted it locally and checked only that
`assemble_changelog.py --check` (which reads changelog.d/ alone) still passes
fast gates. The cut path reads `root / "CHANGELOG.md"` unguarded at line 394,
so `--version 0.127.0` dies with FileNotFoundError. Seven fragments stay
pending; this cut ships with no assembled section, and that is a hole in the
release procedure, not a decision made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)