### PR TITLE
pgw#1613: the boot fetch opens an ACTIVITY, because the watchdog kills what declares nothing

### DIFF
--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -319,6 +319,20 @@ KIND_ENGINE_BOOT = "engine_boot"
 # `model_download_pending` decline explain (th#2191). Phases are a closed
 # vocabulary (`weight_position.PHASE_*`).
 KIND_WEIGHT_FETCH = "weight_fetch"
+# pgw#1613: the boot materialization SPAN — one open activity for the whole
+# fetch loop, from the first ref to the last byte. It is not telemetry: the
+# compute-child watchdog (`procsplit/parent.py` `_hang_verdict`) arms on a
+# silent event loop and then decides by what is OPEN, so a fill that declares
+# nothing takes the `loop_wedged_no_activity` branch and is SIGKILLed while it
+# is provably burning CPU. Measured twice on minimax-h3 (~105 GB) at two
+# different pins: killed at 356 s and 687 s, `cause=watchdog_hang`, oom_kill=0.
+# Its OWN kind, deliberately NOT `weight_fetch`: that kind's rows are the
+# closed-vocabulary BYTE POSITIONS (`weight_position._emit`, fire-and-forget
+# `emit_event` — which is exactly why nothing was ever open), and a span with
+# an empty phase mixed into them would corrupt the one signal th#2191 reads.
+# Nothing hub-side keys on this kind; like `warmup_summary` before it, a new
+# kind is stored and served generically and needs no hub change.
+KIND_BOOT_MATERIALIZE = "boot_materialize"
 # th#1322: the roll-up phase both mint routes report their TOTAL under. A
 # reader groups on (kind, phase) and must never sum a roll-up together with
 # its own children.

--- a/src/gen_worker/boot_materialize.py
+++ b/src/gen_worker/boot_materialize.py
@@ -69,6 +69,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, Mapping, Optional, Tuple
 
+from . import activity
 from . import boot_phases
 from . import weight_position
 from .models.refs import WireRef
@@ -279,9 +280,49 @@ class CheckpointMaterialization:
         Order is the config's own order: a pod that fetched the 22 MB
         interpolator before the 134 GB checkpoint would finish the cheap half
         first and still not be able to serve.
+
+        pgw#1613: THE FETCH RUNS UNDER AN OPEN ACTIVITY, and that is load-
+        bearing, not bookkeeping. A cold multi-hundred-GB fill saturates the
+        container's cores and holds this process's event loop quiet for
+        minutes. The compute-child watchdog arms on that silence and then asks
+        what is OPEN (`procsplit/parent.py` `_hang_verdict`): with nothing
+        declared it returns `loop_wedged_no_activity` and SIGKILLs a child that
+        is provably burning CPU. Its `held` branch — "the child's event loop is
+        starved by accounted work, not hung" — exists for exactly this case and
+        can only fire when an activity is open. Measured twice on minimax-h3
+        (~105 GB), at two different pins, killed at 356 s and 687 s.
+
+        Scoped to the FETCH ONLY: `_warm()` opens its own `warmup` activity and
+        must not nest inside this one.
         """
+        with activity.running(activity.KIND_BOOT_MATERIALIZE) as fetch:
+            if not await self._fetch_refs(config, fetch):
+                await self._announce()
+                return
+
+        # pgw#1584: WEIGHTS ARE DOWN, NOTHING IS SERVABLE YET. The warm pass
+        # goes exactly here — after the last byte and before the state flips —
+        # so the first synthetic forward happens while this worker is still
+        # advertising `loading_functions`. It never raises (see `_warm`).
+        await self._warm()
+
+        self.state = STATE_READY
+        self.failure = ""
+        logger.info(
+            "checkpoint config version=%d MATERIALIZED (%d ref(s)); this "
+            "worker is now ready and routable",
+            config.version, len(config.refs),
+        )
+        await self._announce()
+
+    async def _fetch_refs(
+        self, config: CheckpointConfig, fetch: "activity.Activity",
+    ) -> bool:
+        """Put every configured ref on disk. ``False`` when one of them did not
+        land, with `state`/`failure` already set by the caller's contract."""
         for ref in config.refs:
             snapshot = config.snapshots.get(ref)
+            fetch.note(f"ref={ref}")
             try:
                 # pgw#1555: TIMED, because a `resident` verdict deletes the
                 # only other row this ref would have produced. The check is a
@@ -316,24 +357,13 @@ class CheckpointMaterialization:
                     "and not routable; nothing retries this in the background.",
                     ref, type(exc).__name__, exc,
                 )
-                await self._announce()
-                return
+                # The activity's terminal is FAILED, not COMPLETED: a silent
+                # death is a bug by this module's own contract. `failed()` and
+                # the `running` exit are both idempotent through `_done`.
+                fetch.failed(exc)
+                return False
             logger.info("checkpoint %s materialized at %s", ref, path)
-
-        # pgw#1584: WEIGHTS ARE DOWN, NOTHING IS SERVABLE YET. The warm pass
-        # goes exactly here — after the last byte and before the state flips —
-        # so the first synthetic forward happens while this worker is still
-        # advertising `loading_functions`. It never raises (see `_warm`).
-        await self._warm()
-
-        self.state = STATE_READY
-        self.failure = ""
-        logger.info(
-            "checkpoint config version=%d MATERIALIZED (%d ref(s)); this "
-            "worker is now ready and routable",
-            config.version, len(config.refs),
-        )
-        await self._announce()
+        return True
 
     # ---- the boot warm pass ------------------------------------------------
 

--- a/tests/test_boot_materialize.py
+++ b/tests/test_boot_materialize.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, cast
 
 import pytest
 
@@ -715,6 +715,9 @@ def _hang_verdict(*, activity_kind: str, now: float = 100.0) -> str | None:
 
     from gen_worker.procsplit.parent import _ChildSlot
 
+    # A structural stand-in for the four attributes the verdict reads. `cast`
+    # rather than a real `_ChildSlot`: constructing one needs a live parent, a
+    # spawned subprocess and a socket, none of which this decision touches.
     slot = SimpleNamespace(
         # evidence is FRESH: the child's tree is accruing kernel-accounted work,
         # which is what a CAS fill looks like from the parent's /proc sampler.
@@ -723,7 +726,7 @@ def _hang_verdict(*, activity_kind: str, now: float = 100.0) -> str | None:
         liveness_activity=activity_kind,
         p=SimpleNamespace(_evidence_hold_window=15.0),
     )
-    return _ChildSlot._hang_verdict(slot, now)
+    return _ChildSlot._hang_verdict(cast(Any, slot), now)
 
 
 def test_the_watchdog_HOLDS_a_cpu_burning_child_only_because_an_activity_is_open() -> None:

--- a/tests/test_boot_materialize.py
+++ b/tests/test_boot_materialize.py
@@ -696,3 +696,135 @@ def test_an_ABSENT_ref_records_the_check_it_lost_before_the_fetch_it_starts(
             "and the fetch it fell through to must be its own row")
     finally:
         origin.close()
+
+
+# ---------------------------------------------------------------------------
+# pgw#1613 — the fetch must be an OPEN ACTIVITY, because the compute-child
+# watchdog decides a silent event loop by what is open
+# ---------------------------------------------------------------------------
+
+
+def _hang_verdict(*, activity_kind: str, now: float = 100.0) -> str | None:
+    """Run the REAL `_ChildSlot._hang_verdict` against a slot that is burning
+    CPU (fresh evidence) with a silent loop, and `activity_kind` open.
+
+    Called unbound on a stand-in so the assertion is about the production
+    decision function itself, not a copy of its logic.
+    """
+    from types import SimpleNamespace
+
+    from gen_worker.procsplit.parent import _ChildSlot
+
+    slot = SimpleNamespace(
+        # evidence is FRESH: the child's tree is accruing kernel-accounted work,
+        # which is what a CAS fill looks like from the parent's /proc sampler.
+        liveness_evidence=1234.5,
+        liveness_evidence_at=now - 0.5,
+        liveness_activity=activity_kind,
+        p=SimpleNamespace(_evidence_hold_window=15.0),
+    )
+    return _ChildSlot._hang_verdict(slot, now)
+
+
+def test_the_watchdog_HOLDS_a_cpu_burning_child_only_because_an_activity_is_open() -> None:
+    """The two halves of pgw#1613, asserted against the real verdict function.
+
+    A child mid-materialization is burning CPU with a starved event loop. What
+    decides its life is whether anything is OPEN. This is the RED ARM for the
+    fix below: delete the `activity.running(...)` scope in `_materialize` and
+    the second assertion is what production does instead — SIGKILL on a live
+    pull.
+    """
+    assert _hang_verdict(activity_kind=activity.KIND_BOOT_MATERIALIZE) == "held", (
+        "a fetch that declares itself must survive a starved event loop"
+    )
+    assert _hang_verdict(activity_kind="") == "loop_wedged_no_activity", (
+        "with nothing open the same child is killed — this is the defect, and "
+        "it is why the fetch has to open an activity at all"
+    )
+
+
+def test_a_cold_fetch_holds_a_weight_fetch_activity_OPEN_for_its_whole_pull(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """Measured on minimax-h3 twice, at two pins: a ~105 GB fill silenced the
+    child's loop and the watchdog killed it at 356 s / 687 s with `cause=
+    watchdog_hang`, no OOM, while the process burned CPU. Nothing was open.
+
+    So: while the pull is in flight, `activity.current()` must be the fetch.
+    The observation is taken from INSIDE the funnel — the store's own byte
+    callback — because that is the only place that is provably mid-pull.
+    """
+    origin = _Origin()
+    try:
+        snapshot = _blobs(origin)
+        wire = _Wire()
+        seen: List[Any] = []
+
+        async def boot() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            store = _store(wire, tmp_path / "cas")
+            inner = store.ensure_local
+
+            async def watched(*a: Any, **kw: Any) -> Any:
+                # mid-pull, by construction: the funnel has been entered and
+                # has not returned.
+                seen.append(activity.current())
+                return await inner(*a, **kw)
+
+            store.ensure_local = watched  # type: ignore[method-assign]
+            mat = CheckpointMaterialization(store)
+            mat.configure(_config(1, _REF, snapshot))
+            await _settle(mat)
+            assert mat.state == STATE_READY
+
+        asyncio.run(boot())
+
+        assert seen, "the cold path never entered the funnel; test proves nothing"
+        kinds = [getattr(a, "kind", None) for a in seen]
+        assert all(k == activity.KIND_BOOT_MATERIALIZE for k in kinds), (
+            "the pull must run under an open weight_fetch activity or the "
+            f"compute-child watchdog SIGKILLs it (pgw#1613); saw {kinds}"
+        )
+    finally:
+        origin.close()
+
+
+def test_a_failed_fetch_ends_the_activity_FAILED_not_completed(
+    tmp_path: Path, _fine_cadence: Any
+) -> None:
+    """`activity.py`'s contract: a silent death is a bug. A materialization
+    that dies must not leave a COMPLETED fetch behind for the hub to read as a
+    successful pull."""
+    origin = _Origin()
+    try:
+        snapshot = _blobs(origin)
+        wire = _Wire()
+
+        async def boot() -> None:
+            activity.bind_sink(wire.send, asyncio.get_running_loop())
+            store = _store(wire, tmp_path / "cas")
+
+            async def boom(*a: Any, **kw: Any) -> Any:
+                raise RuntimeError("origin went away mid-pull")
+
+            store.ensure_local = boom  # type: ignore[method-assign]
+            mat = CheckpointMaterialization(store)
+            mat.configure(_config(1, _REF, snapshot))
+            await _settle(mat)
+            assert mat.state == STATE_FAILED
+            assert activity.current() is None, "the fetch activity outlived its pull"
+
+        asyncio.run(boot())
+
+        fetches = [
+            u for u in wire.updates
+            if u.kind == activity.KIND_BOOT_MATERIALIZE
+        ]
+        assert fetches, "no weight_fetch activity was reported at all"
+        assert fetches[-1].state == pb.ActivityState.ACTIVITY_STATE_FAILED, (
+            "a dead pull must terminate FAILED, not COMPLETED; last state was "
+            f"{fetches[-1].state}"
+        )
+    finally:
+        origin.close()


### PR DESCRIPTION
A cold multi-hundred-GB materialization saturates the container's cores and
holds the compute child's event loop quiet for minutes. The child watchdog
(`procsplit/parent.py` `_hang_verdict`) arms on that silence and then decides
by what is OPEN:

    liveness_evidence is None              -> "no_evidence_source"       KILL
    evidence stale > hold window           -> "no_work_accrued"          KILL
    not self.liveness_activity             -> "loop_wedged_no_activity"  KILL
    else                                   -> "held"

`boot_materialize` declared nothing, so a fill that was provably burning CPU
took the third branch and was SIGKILLed. The `held` branch exists for exactly
this case — `child.py` says so itself: "Loop silence may only ARM the verdict;
the open activity DECIDES it" — and could never fire.

MEASURED TWICE, at two different pins, on minimax-h3 (~105 GB fp8te tree):

    pod 6uneiwhdl7fz8u  pin fe035d0c  watchdog_hang  exit 137  lifetime 686.8s
    pod t9r8rcxpixkn0a  pin bf6c3bbb  watchdog_hang  exit 137  lifetime 356.0s

Neither was an OOM (oom_kill=0; 110/234 GiB and 124/234 GiB). `git diff
fe035d0c..bf6c3bbb -- src/gen_worker/procsplit/` is one file and four cosmetic
lines, so this is not a regression — it is the long-standing shape. Both pods
then retired `all_declared_functions_disabled` and took their rental with them.

Why `weight_position` did not already cover it: it reports byte positions
through `activity_mod.emit_event(...)`, a fire-and-forget terminal event that
never sets `_current`. `KIND_WEIGHT_FETCH`'s own comment had already noticed
the hole from the other side — "`warmup`'s byte counter rides whichever
activity happens to be open, which for a steady-state materialization is none".

THE FIX: wrap the fetch loop in `activity.running(KIND_BOOT_MATERIALIZE)`.
Scoped to the FETCH only — `_warm()` opens its own `warmup` activity and must
not nest. A failed pull terminates the activity FAILED, not COMPLETED, per this
module's "a silent death is a bug" contract.

Its OWN kind, deliberately not `weight_fetch`: that kind's rows are the
closed-vocabulary byte positions th#2191 reads, and a span with an empty phase
mixed into them would corrupt the one signal that separates "downloading" from
"downloading is PROGRESSING". Like `warmup_summary` before it, a new kind needs
no hub change — kinds are stored and served generically.

TESTS (`tests/test_boot_materialize.py`), all RED-ARMED — removing the scope
fails the last two, verified:
  * the real `_ChildSlot._hang_verdict`, called on a stand-in that is burning
    CPU with a silent loop, returns "held" with the activity open and
    "loop_wedged_no_activity" without it. This is the defect, asserted against
    the production decision function rather than a copy of its logic.
  * a cold pull observed from INSIDE the funnel holds the activity open.
  * a pull that dies mid-flight ends FAILED and leaves no current activity.

Not fixed here, filed separately: th#2249 (the hub dispatches on a checkpoint
config `version=2` that names no refs, 117 ms before `version=3` names the real
ones — the `attempt=1 unplaceable` that puts the idle job on the child in the
first place). pgw#1596's disk-headroom fix remains untested by these two runs:
both died before headroom was ever consulted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)