### PR TITLE
pgw#1618: a SCALAR model_index.json entry is pipeline CONFIG — the streaming skeleton refused a CANONICAL diffusers checkpoint

### DIFF
--- a/changelog.d/pgw1618.md
+++ b/changelog.d/pgw1618.md
@@ -1,0 +1,8 @@
+- **A scalar `model_index.json` entry is pipeline CONFIG, not an unreadable component.**
+  pgw#1481 turned `continue` into a refusal for every entry that is not
+  `[library, class_name]` — which is correct for a LIST-shaped entry the walker
+  cannot read, and wrong for the two scalars a canonical diffusers index ships
+  (`force_zeros_for_empty_prompt`, `add_watermarker`). sdxl on a rented RTX 4090
+  fetched its 6.7 GB checkpoint and then died `SkeletonError: … is True, which
+  is not [library, class_name]`, fatally. Scalars are skipped; list-shaped
+  refusals are unchanged.

--- a/src/gen_worker/serving/streaming/skeleton.py
+++ b/src/gen_worker/serving/streaming/skeleton.py
@@ -172,11 +172,32 @@ def build(
     for name, spec in sorted(index.items()):
         if name.startswith("_"):
             continue
-        # pgw#1481: an entry this walker cannot read is REFUSED BY NAME, never
-        # skipped. `continue` here collapsed nine specific failures into one
-        # "declares no nn.Module component" that named none of them — and that
-        # sentence is false when the index declares nine.
-        if not isinstance(spec, (list, tuple)) or len(spec) < 2:
+        # pgw#1618: A SCALAR ENTRY IS PIPELINE CONFIG, NOT A COMPONENT, and a
+        # CANONICAL diffusers index carries several. SDXL's ships
+        # `"force_zeros_for_empty_prompt": true` and `"add_watermarker": null`
+        # right beside its eight component pairs; neither starts with `_`, so
+        # the `_`-prefix skip above does not cover them. Diffusers itself
+        # treats exactly this shape as config — anything that is not a
+        # (library, class_name) pair is handed to the pipeline's `__init__`,
+        # never resolved as a module.
+        #
+        # MEASURED ON A RENTED POD, not reasoned about: sdxl 0.4.0 on an
+        # RTX 4090 (pod cwnu3dyz72c1wn, se#819) fetched its 6.7 GB checkpoint,
+        # then died `SkeletonError: … entry 'force_zeros_for_empty_prompt' is
+        # True, which is not [library, class_name]` — first as
+        # `boot_warmup_failed`, then as a FATAL request result that the blame
+        # ladder burned the worker on. Every diffusers-family endpoint on the
+        # streaming loader is exposed to this.
+        if not isinstance(spec, (list, tuple)):
+            continue
+        # pgw#1481 is UNCHANGED for the case it was actually about: an entry
+        # that IS list-shaped but that this walker cannot read is REFUSED BY
+        # NAME, never skipped. A bare `continue` over those collapsed nine
+        # specific failures into one "declares no nn.Module component" that
+        # named none of them — and that sentence is false when the index
+        # declares nine. A scalar is not that case; it is not a component at
+        # all, and refusing it made a correct index unloadable.
+        if len(spec) < 2:
             raise SkeletonError(
                 f"{index_path} entry {name!r} is {spec!r}, which is not "
                 f"[library, class_name]"

--- a/tests/test_modular_model_index.py
+++ b/tests/test_modular_model_index.py
@@ -120,10 +120,9 @@ def test_pinned_variant_or_revision_is_refused_by_name(
     "bad",
     [
         ["diffusers"],
-        "nonsense",
         ["diffusers", "AutoencoderKL", "not-a-dict", "extra"],
     ],
-    ids=["one-element", "scalar", "no-metadata-object"],
+    ids=["one-element", "no-metadata-object"],
 )
 def test_unreadable_entry_names_itself(tmp_path: Path, bad: object) -> None:
     """An entry the walker cannot read is refused, and the message names it.
@@ -143,3 +142,52 @@ def test_unreadable_entry_names_itself(tmp_path: Path, bad: object) -> None:
     with pytest.raises(SkeletonError) as excinfo:
         sk.build(pipeline_cls, source)
     assert "vae" in str(excinfo.value)
+
+
+# ── pgw#1618: a SCALAR entry is pipeline CONFIG ─────────────────────────────
+#
+# The `scalar` case was removed from `test_unreadable_entry_names_itself`
+# above, and that removal is the point rather than a concession. It asserted
+# that a non-list entry is unreadable; a CANONICAL diffusers index carries two
+# of them, so the assertion made a correct checkpoint unloadable. pgw#1481's
+# real subject — a LIST-shaped entry the walker cannot read — is untouched and
+# still covered by the two surviving ids.
+
+
+def test_canonical_diffusers_scalars_are_config_not_components(tmp_path: Path) -> None:
+    """SDXL's own `model_index.json` must build.
+
+    MEASURED, from the tree `tensorhub/wai-illustrious@prod-fp16vae`
+    materialises on a pod:
+
+        "force_zeros_for_empty_prompt": true,
+        "add_watermarker": null,
+
+    Neither starts with `_`, so the prefix skip does not cover them. Before
+    this fix, sdxl 0.4.0 on a rented RTX 4090 (pod cwnu3dyz72c1wn, se#819)
+    fetched 6.7 GB of weights and then died
+    `SkeletonError: … entry 'force_zeros_for_empty_prompt' is True, which is
+    not [library, class_name]` — as `boot_warmup_failed` first, then as a
+    FATAL request result the blame ladder burned the worker on.
+
+    THE RED ARM: restore `not isinstance(spec, (list, tuple)) or len(spec) < 2`
+    as one refusal in `skeleton.build` and this fails on the first scalar.
+    """
+    source = tmp_path / "canonical-scalars"
+    pipeline_cls = build_source(source)
+    index_path = source / "model_index.json"
+    index = json.loads(index_path.read_text())
+    declared = {k for k in index if not k.startswith("_")}
+    index["force_zeros_for_empty_prompt"] = True
+    index["add_watermarker"] = None
+    index_path.write_text(json.dumps(index))
+
+    built = sk.build(pipeline_cls, source)
+
+    reached = set(built.modules) | set(built.passthrough)
+    assert reached == declared, (
+        f"scalars must be skipped as config and every real component still "
+        f"reached: declared {sorted(declared)}, reached {sorted(reached)}"
+    )
+    assert "force_zeros_for_empty_prompt" not in reached
+    assert "add_watermarker" not in reached


### PR DESCRIPTION
FOUND ON A RENTED POD, not in review. sdxl 0.4.0 (se#819) booted on an
RTX 4090 (pod cwnu3dyz72c1wn), pulled 6.7 GB of
`tensorhub/wai-illustrious@prod-fp16vae`, and died:

  SkeletonError: /tmp/tensorhub-cache/cas/snapshots/sha256:55c20c66…/
  model_index.json entry 'force_zeros_for_empty_prompt' is True,
  which is not [library, class_name]

First as `serve_degrade/boot_warmup_failed`, then as a FATAL request result the
blame ladder burned the worker on (`request_burned_on_worker`, request
`0d4143a4-…` failed `error_type=fatal` after 137.8s and $0.34/hr of pod).

THE INDEX IS CORRECT. SDXL's own `model_index.json`, verbatim:

  "_class_name": "StableDiffusionXLPipeline",
  "force_zeros_for_empty_prompt": true,
  "add_watermarker": null,
  "scheduler": ["diffusers", "EulerDiscreteScheduler"],
  ...

Two scalar PIPELINE-CONFIG values sitting beside eight component pairs. Neither
starts with `_`, so the prefix skip does not cover them, and diffusers itself
treats exactly this shape as config — anything that is not a (library,
class_name) pair goes to the pipeline's `__init__`, never to a module resolver.

pgw#1481 is UNCHANGED FOR WHAT IT WAS ABOUT. Its subject was a LIST-shaped entry
the walker cannot read — nine of them collapsing into one "declares no
nn.Module component" that named none. That refusal stays, by name. What splits
off is the case that is not a component at all:

    if not isinstance(spec, (list, tuple)):
        continue                      # config
    if len(spec) < 2:
        raise SkeletonError(...)      # unreadable component, by name

VERIFIED AGAINST A REAL TREE, not a fixture: `skeleton.build` over
`~/.cache/cozy/pgw1587-accept/sdxl-bf16-tree` with this change reaches
modules ['text_encoder', 'text_encoder_2', 'unet', 'vae'] and passthrough
['scheduler', 'tokenizer', 'tokenizer_2'], with the two scalars correctly
absent from both.

TEST: `test_canonical_diffusers_scalars_are_config_not_components` adds the two
real keys to the fixture index and asserts every declared component still
reaches the skeleton and neither scalar does. Its red arm is the exact revert.
The `scalar` id is REMOVED from `test_unreadable_entry_names_itself` — it
asserted that a non-list entry is unreadable, which is the defect, and the two
surviving list-shaped ids keep pgw#1481's guarantee.

BLAST RADIUS: every diffusers-family endpoint served through the streaming
loader. It was invisible until now only because the fleet's canary could not
buy a pod at all (e2e#1928).

🤖 Generated with [Claude Code](https://claude.com/claude-code)