### PR TITLE
pgw#1622: clear two ruff findings from pgw#1606 (lint debt — master was NOT blocked)

### DIFF
--- a/src/gen_worker/serving/lane_materialize.py
+++ b/src/gen_worker/serving/lane_materialize.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from ..models import execution_lanes as el
 from .lane_ladder import ResolvedLane, is_baseline

--- a/src/gen_worker/serving/loader.py
+++ b/src/gen_worker/serving/loader.py
@@ -117,7 +117,7 @@ class LoadedEndpoint:
                 raise EndpointLoadError(
                     f"{self.module_name}.{model_cls.__name__}: no lane "
                     f"{contract!r} to pin (declared: "
-                    f"{sorted(lane_handle(l) for l in self.lanes_of(model_cls))})"
+                    f"{sorted(lane_handle(row) for row in self.lanes_of(model_cls))})"
                 )
         # pgw#1599's DeclaredLane rows, filtered to the (possibly pinned)
         # candidate set. Read, never rebuilt: the stamp is not re-parsed and


### PR DESCRIPTION
Two findings in `ruff check src/gen_worker`, both introduced by pgw#1606:

```
F401  src/gen_worker/serving/lane_materialize.py:21   `typing.Optional` imported but unused
E741  src/gen_worker/serving/loader.py:120            Ambiguous variable name: `l`
```

Drop the import; rename the comprehension variable to `row` (it iterates lane rows, so it is also the better name). Gate command clean after, 38 lane tests green, mypy clean on both files.

## ⚠️ Also: this lane first filed itself as pgw#1617, which is another lane'''s id

Taking an id from the allocator is the first step of the lane lifecycle, and the hotfix framing skipped it. **#1617 already belongs to the pgw#1548 benchmark lane** (a live-pod ops defect). Re-filed as **pgw#1622** from `scripts/take-id.sh`. The workspace policy warns about exactly this — pgw#1163 was taken twice on 2026-08-12 by a lane that ran the protocol by hand under time pressure. Urgency is when the allocator matters most, not least. (The branch name still reads `1617-ruff-red`; it dies on merge.)

## ⚠️ The urgent framing this arrived with is wrong, and the correction matters more than the two lines

This was reported to me as *"master is RUFF-RED and it fails the required fast-gates for EVERY PR branched since 21:16."* It does not, and it **cannot**:

- **`ci.yaml:214-216` — the `Lint` step is `continue-on-error: true`**, with the reason inline (*"Lint debt (mostly worker.py, being rewritten) — visible in logs, doesn't block CI"*) and restated at `ci.yaml:60`. Ruff findings are **structurally incapable** of failing `fast gates`.
- **Empirically nothing is blocked.** Every PR opened after pgw#1606 landed is green: pgw#1618 (`55cbb02b`), pgw#1613 (`652ad96a`), pgw#1616 (`b8a12152`). The only red in that window was pgw#1616's own import bug, already fixed.

So this lands as **ordinary debt-clearing, not a hotfix**, and no `--admin` is warranted or used. The findings are real and mine, and lint debt shouldn't accumulate silently — that part of the request stands on its own.

## Two things checked while verifying, both worth keeping

**`ruff check .` reports 88 findings tree-wide**, because the gate lints `src/gen_worker` only — `tests/` is not linted at all. Fixing to that signal would have touched ~30 unrelated files on what was presented as an emergency. Verify against the command the gate actually runs, not the tool's default.

**`ci.yaml` triggers are `workflow_dispatch` / `merge_group` / `schedule` / `pull_request` — still no `push`.** So the earlier "pgw has no push-triggered post-merge CI" note stands; the push-event run sitting on master tip is `Publish to PyPI`, a different workflow.
