### PR TITLE
pgw#1614: cut 0.127.1 — the hotfix that lets a diffusers endpoint serve at all

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.127.0"
+version = "0.127.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -573,7 +573,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.127.0"
+version = "0.127.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Pinned cut commit ff60d6ae (origin/master tip at cut time).

CUT BECAUSE A POD RUN NEEDS ONE, and this time literally: on 0.127.0 the
streaming skeleton refuses a CANONICAL diffusers `model_index.json`, so sdxl
booted on a rented RTX 4090, pulled 6.7 GB, and died fatally
(`SkeletonError: entry 'force_zeros_for_empty_prompt' is True, which is not
[library, class_name]`). Every diffusers-family endpoint on the streaming
loader is exposed.

Must-ride, ancestor-verified against the cut commit:
  55cbb02b  pgw#1618  a SCALAR model_index.json entry is pipeline CONFIG
                      — THE reason for this cut

Also carried, because they merged into master between the two tags and a cut
ships the tree it tags rather than a curated subset:
  b350ca2d  pgw#1616  a serve lane declares its QUANTIZATION; vendor tensorfs
                      51adc50; refuse the floor-losing nvfp4 spelling
  b8a12152  pgw#1616  the guard asks THIS module, not a package path
  84f29b6c  pgw#1613  the boot fetch opens an ACTIVITY, because the watchdog
                      kills what declares nothing
  652ad96a  pgw#1613  strict-mypy on the verdict stand-in

Six commits since v0.127.0. `CHANGELOG.md` is still absent (pgw#1615), so this
cut assembles no section and the fragments stay pending — stated, not hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)