### PR TITLE
pgw#1619: partial_resident refuses to park a component it cannot ENTER

### DIFF
--- a/changelog.d/pgw1619.md
+++ b/changelog.d/pgw1619.md
@@ -1,0 +1,20 @@
+- **pgw#1619: `partial_resident` no longer parks a component it cannot enter.** The rung arms
+  each parked component with `register_forward_pre_hook`, which fires on `__call__`/`forward`
+  and on nothing else — while diffusers reaches the VAE only as `self.vae.decode(latents, ...)`.
+  A parked VAE therefore never onloaded, and the decode died against host weights: *"Input type
+  (CUDABFloat16Type) and weight type (CPUBFloat16Type) should be the same"* — **observed, not
+  predicted.** Two things broke, not one: the same hooks enforce the rung's *"at most one parked
+  component on the card"* invariant, so the siblings' eviction did not happen either, and the
+  admission arithmetic assumed both. Latent since pgw#1577 only because a `force_upcast` VAE is
+  force-pinned for unrelated reasons (gw#441/gw#469) — and the minimum-byte planner already
+  selected the VAE when it was not forced.
+- **pgw#1619: the guard REFUSES rather than hooking `decode` too, and detects structurally.**
+  Hooking `decode` would fix the instance and leave the class; the mechanism's real assumption
+  is *"a component is entered through `forward`"*, false for anything diffusers drives by name.
+  A component the rung cannot enter is now forced resident, turning a silent correctness bug
+  into a slightly more expensive plan. Detection is by capability, not by name — `AutoencoderKL`
+  exposes `decode`/`encode` while `UNet2DConditionModel`, `CLIPTextModel` and
+  `CLIPTextModelWithProjection` expose only `forward` — so it keeps working for families nobody
+  has written yet. Scoped to this rung's planner rather than the shared
+  `unhookable_components`, because "this mechanism cannot enter it" is a fact about the
+  mechanism, not about the component.

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -1506,6 +1506,7 @@ def _plan_partial_resident(
     try:
         from .partial_resident import (
             PARTIAL_RESIDENT_RESERVE_GB,
+            method_driven_components,
             plan_for_pipeline,
         )
 
@@ -1552,7 +1553,15 @@ def _plan_partial_resident(
             budget_bytes=int(max(0.0, free_gb - reserve_gb) * _GIB),
             free_bytes=int(free_gb * _GIB),
             sizer=lambda m: module_storage_bytes(m),
-            forced_resident=unhookable_components(pipeline),
+            # pgw#1619: the union of "must not move" (dtype-fragile,
+            # content-shared) and "CANNOT BE ENTERED by this rung's hooks".
+            # The second is this module's own defect and is scoped HERE rather
+            # than added to `unhookable_components`, because it is a fact about
+            # partial_resident's mechanism, not about the component.
+            forced_resident=(
+                list(unhookable_components(pipeline))
+                + list(method_driven_components(pipeline))
+            ),
             min_moved_bytes=min_moved_bytes,
         )
     except Exception as exc:

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -311,6 +311,66 @@ def _pipeline_component_names(pipeline: Any) -> List[str]:
     return names
 
 
+#: Entry points diffusers drives BY NAME rather than through ``__call__``. A
+#: module exposing one of these is reached without ever running ``forward``, so
+#: a ``register_forward_pre_hook`` on it never fires.
+_METHOD_ENTRY_POINTS = ("decode", "encode")
+
+
+def method_driven_components(pipeline: Any) -> List[str]:
+    """Components this rung CANNOT ENTER, and must therefore never park.
+
+    pgw#1619, and it is a defect this module shipped. ``_install_residency_hooks``
+    arms each parked component with ``register_forward_pre_hook``, which fires on
+    ``__call__``/``forward`` and on **nothing else** — while diffusers reaches the
+    VAE only as ``self.vae.decode(latents, ...)``. A parked VAE therefore never
+    onloads, and the decode dies against host weights:
+
+        Input type (CUDABFloat16Type) and weight type (CPUBFloat16Type)
+        should be the same
+
+    **Two things break, not one.** The onload never fires, AND the same hooks
+    enforce this rung's *"at most one parked component on the card"* invariant —
+    so the siblings' eviction does not happen either, and the admission
+    arithmetic assumed both.
+
+    **Why REFUSE rather than "also hook decode".** Hooking ``decode`` fixes the
+    instance and leaves the class: the mechanism's real assumption is *"a
+    component is entered through forward"*, and that is false for anything
+    diffusers drives by name. A component the mechanism cannot enter belongs
+    with the other unhookables, where the planner simply does not choose it —
+    turning a silent correctness bug into a slightly more expensive plan. The
+    detection is STRUCTURAL rather than a name list: ``AutoencoderKL`` exposes
+    ``decode``/``encode`` while ``UNet2DConditionModel``, ``CLIPTextModel`` and
+    ``CLIPTextModelWithProjection`` expose only ``forward``, so the capability
+    separates them without hardcoding ``"vae"`` and keeps working for families
+    nobody has written yet.
+
+    THE LESSON THIS COST: the mechanism was validated on ``text_encoder_2``,
+    the one component whose call shape it happens to support, and shipped as if
+    that generalised.
+    """
+    out: List[str] = []
+    for name, comp in _named_components_of(pipeline):
+        if comp is None or not hasattr(comp, "parameters"):
+            continue
+        if any(callable(getattr(comp, m, None)) for m in _METHOD_ENTRY_POINTS):
+            out.append(name)
+    return sorted(out)
+
+
+def _named_components_of(pipeline: Any) -> List[Tuple[str, Any]]:
+    try:
+        comps = dict(getattr(pipeline, "components", {}) or {})
+    except Exception:  # noqa: BLE001
+        comps = {}
+    pairs = [(n, c) for n, c in comps.items()]
+    for n in _pipeline_component_names(pipeline):
+        if n not in comps:
+            pairs.append((n, getattr(pipeline, n, None)))
+    return pairs
+
+
 def _denoiser_name(pipeline: Any, names: Sequence[str]) -> str:
     """The component whose residency is the point. Named by attribute, in the
     order diffusers itself uses across families."""
@@ -731,6 +791,7 @@ __all__ = [
     "apply_component_residency",
     "parks_module",
     "plan_component_residency",
+    "method_driven_components",
     "plan_for_pipeline",
     "probe_plan",
 ]

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -638,3 +638,137 @@ def test_EVERY_rung_confesses_the_decision_time_free_vram_not_a_re_read():
         f"{len(missing)} rung(s) still confess a post-placement re-read as the "
         f"decision's input: {missing}"
     )
+
+
+# --------------------------------------------------------------------------
+# pgw#1619 — a component this rung cannot ENTER must never be parked
+# --------------------------------------------------------------------------
+
+
+class _MethodDrivenBlock(_Block):
+    """Reached the way diffusers reaches a VAE: by name, never via ``__call__``."""
+
+    def decode(self, x: Any) -> Any:
+        return self.lin(x)
+
+    def encode(self, x: Any) -> Any:
+        return self.lin(x)
+
+
+class _PipelineWithMethodDrivenComponent(DiffusionPipeline):
+    model_cpu_offload_seq = "text_encoder->unet->vae"
+    text_encoder: Any
+    unet: Any
+    vae: Any
+
+    def __init__(self, text_encoder: Any, unet: Any, vae: Any) -> None:
+        super().__init__()
+        cast(Any, self).register_modules(
+            text_encoder=text_encoder, unet=unet, vae=vae
+        )
+
+
+def test_a_forward_pre_hook_does_NOT_fire_on_a_named_method():
+    """THE DEFECT ITSELF, asserted so it cannot silently stop being true.
+
+    pgw#1619: `_install_residency_hooks` arms every parked component with
+    `register_forward_pre_hook`, and diffusers reaches the VAE only as
+    `self.vae.decode(...)`. If this ever starts firing, the refusal below
+    becomes unnecessary — and if it stops being asserted, the reason for the
+    refusal is lost.
+    """
+    m = _MethodDrivenBlock(8)
+    fired: List[str] = []
+    m.register_forward_pre_hook(lambda mod, a: fired.append("forward"))
+    m(torch.zeros(1, 8))
+    assert fired == ["forward"], "the hook does not even fire on __call__"
+    fired.clear()
+    m.decode(torch.zeros(1, 8))
+    assert fired == [], (
+        "a forward pre-hook fired on a named method — if torch changed this, "
+        "pgw#1619's refusal can be revisited"
+    )
+
+
+def test_a_component_this_rung_cannot_enter_is_never_parked():
+    """RED ARM for pgw#1619. Before the fix the minimum-byte planner selects the
+    method-driven component — it is small and evicting it is cheap — and the
+    request then dies at decode against host weights:
+
+        Input type (CUDABFloat16Type) and weight type (CPUBFloat16Type)
+        should be the same
+
+    (observed by the pgw#1548 lane, not predicted). After the fix it is forced
+    resident and the planner simply chooses a more expensive plan.
+    """
+    from gen_worker.models.partial_resident import method_driven_components
+
+    pipe = _PipelineWithMethodDrivenComponent(_Block(8), _Block(16), _MethodDrivenBlock(4))
+    assert method_driven_components(pipe) == ["vae"], (
+        "the structural check did not spot the method-driven component"
+    )
+
+    sizer = lambda m: sum(p.numel() * p.element_size() for p in m.parameters())
+    plan = plan_for_pipeline(
+        pipe, budget_bytes=1200, free_bytes=64 * _MIB,
+        sizer=sizer, transient_reserve_bytes=0,
+        forced_resident=method_driven_components(pipe),
+    )
+    assert plan.fits, plan.refusal
+    assert "vae" not in plan.offloaded, (
+        "a component whose onload hook can never fire was selected for parking"
+    )
+
+
+def test_the_PRODUCTION_planner_refuses_to_park_what_it_cannot_enter():
+    """THE ONE THAT GUARDS THE FIX, through `_plan_partial_resident`.
+
+    The tests above call `plan_for_pipeline` and pass `forced_resident`
+    themselves, so they assert the HELPER and would pass with the production
+    wiring torn out — verified, they did. That is the same tautology this lane
+    already shipped once for the reserve invariant, so it is checked here rather
+    than trusted: sizes are chosen so the minimum-byte search WANTS the
+    method-driven component (it is the cheapest subset that clears the budget),
+    and only the guard stops it.
+    """
+    import gen_worker.models.memory as m
+
+    # unet 1088 B forced; vae 360 B is the cheapest way to clear the budget;
+    # text_encoder 1680 B is the next-cheapest and is what the guard forces.
+    pipe = _PipelineWithMethodDrivenComponent(
+        _Block(20), _Block(16), _MethodDrivenBlock(9)
+    )
+    total = 1680 + 1088 + 360
+    free_bytes = int(PARTIAL_RESIDENT_RESERVE_GB * _GIB) + (total - 328)
+
+    real_free, real_unhook = m.get_available_vram_gb, m.unhookable_components
+    m.get_available_vram_gb = lambda *a, **k: free_bytes / _GIB
+    m.unhookable_components = lambda *a, **k: []
+    try:
+        plan = m._plan_partial_resident(pipe, logging.getLogger("t"))
+    finally:
+        m.get_available_vram_gb, m.unhookable_components = real_free, real_unhook
+
+    assert plan is not None and plan.fits, "the planner admitted nothing"
+    assert "vae" not in plan.offloaded, (
+        "the production planner parked a component whose onload hook can NEVER "
+        "fire — this is the pgw#1619 decode-against-host-weights death"
+    )
+    assert "text_encoder" in plan.offloaded, (
+        "the guard did not merely refuse the vae, it broke the plan"
+    )
+
+
+def test_the_structural_check_does_not_over_refuse_the_denoiser_or_encoders():
+    """The guard must cost only what it has to. `UNet2DConditionModel`,
+    `CLIPTextModel` and `CLIPTextModelWithProjection` expose only `forward`, so
+    a capability test separates them from `AutoencoderKL` without hardcoding
+    `"vae"` — and without refusing to park the components this rung exists to
+    park."""
+    from gen_worker.models.partial_resident import method_driven_components
+
+    pipe = _PipelineWithMethodDrivenComponent(_Block(8), _Block(16), _MethodDrivenBlock(4))
+    refused = method_driven_components(pipe)
+    assert "unet" not in refused and "text_encoder" not in refused, (
+        f"the guard over-refused: {refused}"
+    )


### PR DESCRIPTION
## The defect, observed rather than predicted

The rung arms each parked component with `register_forward_pre_hook`, which fires on `__call__`/`forward` and **nothing else** — while diffusers reaches the VAE only as `self.vae.decode(latents, ...)`. A parked VAE never onloads and the decode dies against host weights:

```
Input type (CUDABFloat16Type) and weight type (CPUBFloat16Type) should be the same
```

Observed by the #1548 lane. I filed this as "latent"; **it had already happened**, and the issue now says so rather than keeping my weaker framing.

Minimal repro of the mechanism:

```
m.register_forward_pre_hook(...)
m(x)          -> hook fires
m.decode(x)   -> HOOK DID NOT FIRE
```

## Two things broke, not one

The same hooks enforce this rung's *"at most one parked component on the card"* invariant. For a method-driven component **neither the onload nor its siblings' eviction fired** — and the admission arithmetic assumed both.

Latent since #1577 only because a `force_upcast` VAE is force-pinned for unrelated reasons (gw#441/gw#469). That's luck, and thin: the minimum-byte planner **already selects the VAE when it isn't forced** — a #1586 sweep with `forced_resident=()` returned `offloaded=('text_encoder_2', 'vae')`.

## Refuse, don't also-hook-decode

Hooking `decode` fixes the instance and leaves the class; the mechanism's real assumption is *"a component is entered through `forward`"*, false for anything diffusers drives by name. A component the rung cannot enter is now **forced resident** — a silent correctness bug becomes a slightly more expensive plan.

Detection is **structural, not a name list**: `AutoencoderKL` exposes `decode`/`encode` while `UNet2DConditionModel`, `CLIPTextModel` and `CLIPTextModelWithProjection` expose only `forward` (verified against the real classes), so it separates them without hardcoding `"vae"` and keeps working for families nobody has written yet. Scoped to this rung's planner rather than the shared `unhookable_components`, because *"this mechanism cannot enter it"* is a fact about the mechanism, not the component.

## The guard test caught my third tautology of the day

My first three tests passed `forced_resident` themselves — so they asserted the **helper** and **passed with the production wiring torn out**. I verified that rather than assuming it. The replacement drives `_plan_partial_resident` with sizes chosen so the minimum-byte search *wants* the method-driven component and only the guard stops it; reverting the wiring now turns it red.

The rule this lane keeps re-learning: **a test that constructs the same arithmetic the production path constructs proves nothing — enter through the production entry point.**

29 tests green, mypy clean, ruff clean.