### PR TITLE
pgw#1623: the streamed load lands the LANE's dtype — sdxl's `c10::Half` vs `float` was two loaders disagreeing

### DIFF
--- a/changelog.d/pgw1623.md
+++ b/changelog.d/pgw1623.md
@@ -1,0 +1,20 @@
+- **pgw#1623: the streamed load lands the LANE's dtype, so sdxl serves again.** The streaming
+  engine passed container dtypes through verbatim while the eager `from_pretrained` bridge has
+  applied `torch_dtype=<the lane's>` since pgw#1447 — two loaders in one platform disagreeing
+  about the dtype of the same lane. Measured, not inferred: the hub's own catalog says
+  `wai-illustrious@prod-fp16vae` carries `{unet: fp16, text_encoder: fp16, text_encoder_2: fp16,
+  vae: fp32}` from its safetensors headers, on a lane declaring **bfloat16**. The streamed
+  pipeline came back heterogeneous and died `RuntimeError: Input type (c10::Half) and bias type
+  (float) should be the same` in the VAE's first conv — `boot_warmup_failed`, then a real
+  request burned on a rented A4500. The skeleton is now built at the lane's dtype (so buffers
+  and anything no container names are the lane too), and a wide-float tensor whose stored dtype
+  is not the lane's is cast to it after it lands. fp8/fp4, integer and bool containers are never
+  touched: quantized bytes ARE the lane, and `lane_materialize` owns those modules.
+- **pgw#1623: the repair is counted, and the result is asserted.** A tree whose containers are
+  not its lane's bytes is still a store defect, so the cast is confessed — a
+  `container_dtype_off_lane` `serve_degrade` event plus `cast_to_lane` on the load report — and
+  "which deployments serve bytes their own lane does not name" stays one query rather than
+  something a pod's lost stdout knew. `StreamingLoader._assert_lane_dtype` then proves the
+  loaded pipeline is one dtype and refuses by name if it is not: the sibling bug on the eager
+  bridge does not crash — it upcasts per op and serves correct images 20-40x slow — so this one
+  crashing was luck, not design.

--- a/src/gen_worker/serving/streaming/engine.py
+++ b/src/gen_worker/serving/streaming/engine.py
@@ -19,11 +19,23 @@ Four properties, each load-bearing:
    consecutive file bytes; the tensors that overlap it are scattered out of
    it. Small tensors coalesce into one read for free (SDXL has ~2.5k of
    them), and a tensor larger than the window simply spans several.
-3. **dtype passthrough.** Bytes land verbatim in the container's own dtype —
-   bf16 stays bf16, fp8 stays fp8 with its scale tensors beside it. Any
-   conversion is the STORE's contract-negotiation job (the lane IS a tensorfs
-   layout contract), never load time. A container that disagrees with the
-   active lane is reported, not silently repaired.
+3. **One pipeline, one dtype: the LANE's** (pgw#1623). Bytes land verbatim —
+   the read is always a byte copy, fp8 stays fp8 with its scale tensors beside
+   it, ints and bools are never touched. But a WIDE FLOAT container whose
+   stored dtype is not the lane's declared one is cast to it after it lands,
+   which is the identical rule the eager ``from_pretrained(torch_dtype=…)``
+   bridge has applied since pgw#1447. Two loaders in one platform disagreeing
+   about the dtype of the same lane is not a passthrough property, it is a
+   fork: measured on a rented A4500, the `wai-illustrious@prod-fp16vae`
+   checkpoint (unet/text encoders fp16, VAE fp32 — the hub's own catalog says
+   so, from safetensors headers) came back as a HETEROGENEOUS pipeline and
+   died `Input type (c10::Half) and bias type (float)` inside the VAE's first
+   conv, on a lane declaring bfloat16. A tree whose containers disagree with
+   its lane is still a STORE defect and is still reported — but it is reported
+   AND served, never passed through into a pipeline that cannot run a forward.
+   :meth:`StreamingLoader._assert_lane_dtype` then proves the result, because
+   the sibling bug on the eager bridge is silent (20-40x slow, correct images)
+   and only this one crashed.
 4. **Nothing survives on meta.** Every parameter and buffer is accounted for
    by name. A missing name would serve uninitialized memory on the first
    request, so it is a typed refusal naming the names.
@@ -65,8 +77,30 @@ _TORCH_DTYPE: Mapping[str, str] = {
 }
 
 
+#: The dtypes a lane cast is defined over. A quantized or sub-byte container
+#: is the lane's OWN bytes when the lane is quantized (`lane_materialize` owns
+#: those modules), so nothing here ever touches one; integer and bool tensors
+#: are not precision at all. Same set `Module.to(dtype)` moves.
+_WIDE_FLOATS = ("float64", "float32", "float16", "bfloat16")
+
+
+def _is_wide_float(dtype: Any) -> bool:
+    import torch
+
+    return any(dtype is getattr(torch, name, None) for name in _WIDE_FLOATS)
+
+
 class LoadError(RuntimeError):
     """A streamed load could not be completed as specified."""
+
+
+class LaneDtypeUnmet(LoadError):
+    """The loaded pipeline is not the dtype its lane declares.
+
+    A structural refusal, not a numerics opinion: it can only fire when the
+    cast above missed something, which means a tensor reached the card by a
+    path this engine does not know about.
+    """
 
 
 class NameMismatch(LoadError):
@@ -89,6 +123,9 @@ class LoadReport:
     windows: int = 0
     seconds: float = 0.0
     dtypes: Tuple[str, ...] = ()
+    #: Tensors whose stored wide-float dtype was not the lane's and were cast
+    #: to it at install (pgw#1623). 0 means the tree WAS the contract's bytes.
+    cast_to_lane: int = 0
 
     def attributes(self) -> Dict[str, object]:
         return {
@@ -99,6 +136,7 @@ class LoadReport:
             "io": self.io,
             "containers": self.containers,
             "tensors": self.tensors,
+            "cast_to_lane": self.cast_to_lane,
         }
 
 
@@ -228,11 +266,18 @@ class StreamingLoader:
 
         started = time.perf_counter()
         device = torch.device(self._device)
-        built = _skeleton.build(pipeline_cls, Path(checkpoint_dir))
+        compute_dtype = _lane_compute_dtype(lane)
+        built = _skeleton.build(
+            pipeline_cls, Path(checkpoint_dir), compute_dtype=compute_dtype)
         report = LoadReport(
             io=self._io,
             source=str(getattr(self._store, "KIND", type(self._store).__name__)),
         )
+        #: (slot, name, stored dtype) for every tensor the lane cast covers.
+        #: Collected during the walk, applied AFTER the pool has finished, so a
+        #: cast never reads a buffer whose copy is still in flight on the
+        #: staging stream.
+        recasts: List[Tuple[_Slot, str, Any]] = []
 
         with StagingPool(
             device,
@@ -248,8 +293,11 @@ class StreamingLoader:
                     pool=pool,
                     device=device,
                     report=report,
+                    compute_dtype=compute_dtype,
+                    recasts=recasts,
                 )
             report.containers = len(self._planned)
+        self._cast_to_lane(recasts, compute_dtype, report)
 
         for component, module in built.modules.items():
             survivors = _skeleton.meta_survivors(module)
@@ -269,7 +317,7 @@ class StreamingLoader:
             )
         self.last_report = report
         self._place_uninstalled(built.pipeline, device)
-        self._warn_on_lane(lane, report)
+        self._assert_lane_dtype(built.modules, compute_dtype)
         logger.info(
             "ctx.load: %s resident on %s — %.2f GiB streamed in %.2fs "
             "(%.2f GB/s, staging=%s io=%s, %d tensors over %d windows)",
@@ -372,6 +420,8 @@ class StreamingLoader:
         pool: StagingPool,
         device: Any,
         report: LoadReport,
+        compute_dtype: Any = None,
+        recasts: Optional[List[Tuple[_Slot, str, Any]]] = None,
     ) -> None:
         import torch
 
@@ -417,6 +467,9 @@ class StreamingLoader:
                 )
             pool.track(destination)
             _install(slot, destination)
+            if (recasts is not None and compute_dtype is not None
+                    and dtype is not compute_dtype and _is_wide_float(dtype)):
+                recasts.append((slot, f"{component}/{entry.name}", dtype))
             seen.add(entry.name)
             placements.append(
                 _Placement(
@@ -510,37 +563,115 @@ class StreamingLoader:
     # -- the lane contract -------------------------------------------------
 
     @staticmethod
-    def _warn_on_lane(lane: Any, report: LoadReport) -> None:
-        """The lane IS the dtype (there is no ``torch_dtype=`` to pass).
+    def _cast_to_lane(
+        recasts: List[Tuple[_Slot, str, Any]],
+        compute_dtype: Any,
+        report: LoadReport,
+    ) -> None:
+        """Land every off-lane wide-float tensor at the lane's dtype, and SAY
+        SO — the tree not being the contract's bytes is a store defect that
+        this repair must not erase (pgw#1623).
 
-        A container whose floating dtype is not the lane's means the tree was
-        not converted through the active contract before it reached this pod.
-        That is a STORE defect — reported here, never repaired here, because
-        a load-time conversion is exactly the byte-rewriting this whole
-        design deleted.
+        One tensor at a time, replacing in place: the pre-cast tensor's only
+        remaining holder is the slot being overwritten, so the peak cost of
+        the whole pass is one tensor, not a second copy of the checkpoint.
         """
-        declared = getattr(lane, "dtype", None)
-        if declared is None or not report.dtypes:
+        if not recasts:
             return
-        spelling = str(declared).rsplit(".", 1)[-1].upper()
-        floating = {
-            name for name in report.dtypes if name.startswith(("F", "BF"))
-        }
-        aliases = {spelling, {"BFLOAT16": "BF16", "FLOAT16": "F16",
-                              "FLOAT32": "F32"}.get(spelling, spelling)}
-        if floating and not (floating & aliases):
-            logger.warning(
-                "ctx.load: the active lane declares dtype %s but this "
-                "checkpoint's containers carry %s — the tree was not "
-                "converted through the lane's layout contract before it "
-                "reached this pod; loading verbatim (conversion is the "
-                "store's job, never the loader's)",
-                declared,
-                ", ".join(sorted(floating)),
+        counts: Dict[str, int] = {}
+        # Reverse order so the list can be truncated as it drains: the tuple
+        # holds no tensor, but the caller's list would otherwise pin nothing
+        # and the ordering keeps the trace readable (last container first).
+        while recasts:
+            slot, name, stored = recasts.pop()
+            held = (
+                slot.owner._parameters.get(slot.leaf) if slot.parameter
+                else slot.owner._buffers.get(slot.leaf)
+            )
+            if held is None:  # pragma: no cover — defensive
+                continue
+            _install(slot, held.to(compute_dtype))
+            key = str(stored).rsplit(".", 1)[-1]
+            counts[key] = counts.get(key, 0) + 1
+            report.cast_to_lane += 1
+        rendered = ", ".join(
+            f"{count} {dtype}" for dtype, count in sorted(counts.items()))
+        sentence = (
+            f"{report.cast_to_lane} tensor(s) were stored off-lane "
+            f"({rendered}) and were cast to the lane's "
+            f"{str(compute_dtype).rsplit('.', 1)[-1]} at load; the tree was "
+            f"not converted through the lane's layout contract before it "
+            f"reached this pod"
+        )
+        logger.warning("ctx.load: %s", sentence)
+        # A pod's stdout does not survive the pod (RunPod has no logs API), and
+        # "which deployments are serving bytes their own lane does not name" is
+        # a fleet question. Typed, so it is one query hub-side.
+        try:
+            from ... import activity
+
+            activity.emit_event(
+                activity.KIND_SERVE_DEGRADE, sentence,
+                phase="container_dtype_off_lane", step=report.cast_to_lane,
+            )
+        except Exception:  # noqa: BLE001 — a confession never fails a load
+            logger.debug("ctx.load: could not emit the off-lane dtype event",
+                         exc_info=True)
+
+    @staticmethod
+    def _assert_lane_dtype(modules: Mapping[str, Any], compute_dtype: Any) -> None:
+        """Every wide-float tensor in the loaded modules IS the lane's dtype.
+
+        The instrument the eager sibling never had. pgw#1447 fixed the same
+        class on `from_pretrained` and could only fix it by inspection, because
+        a pipeline that is half fp16 and half fp32 there does not crash — it
+        upcasts per op and serves correct images 20-40x slow. This one crashed,
+        which is luck, not design; so the invariant is asserted rather than
+        left to whichever component happens to hold a conv.
+        """
+        if compute_dtype is None:
+            return
+        offenders: List[str] = []
+        for component, module in modules.items():
+            held = list(module.named_parameters(remove_duplicate=False))
+            held += list(module.named_buffers(remove_duplicate=False))
+            for name, tensor in held:
+                if tensor is None or not _is_wide_float(tensor.dtype):
+                    continue
+                if tensor.dtype is not compute_dtype:
+                    offenders.append(f"{component}/{name}={tensor.dtype}")
+                    if len(offenders) >= 8:
+                        break
+            if len(offenders) >= 8:
+                break
+        if offenders:
+            raise LaneDtypeUnmet(
+                f"the loaded pipeline is not the lane's {compute_dtype}: "
+                f"{', '.join(offenders)}. A tensor reached the module by a "
+                f"path this engine did not install and so was never cast — "
+                f"serving it would mix dtypes inside one forward"
             )
 
 
+def _lane_compute_dtype(lane: Any) -> Any:
+    """The lane's declared dtype, when it is one this cast is defined over.
+
+    Reads the lane through the SAME resolver both eager bridges use, so the
+    streaming loader cannot come to a different conclusion about the same
+    contract than `from_pretrained(torch_dtype=…)` does. A quantized lane
+    (fp8/fp4) answers a narrow dtype and is returned as ``None``: its bytes ARE
+    the lane, and `serving.lane_materialize` owns those modules.
+    """
+    if lane is None:
+        return None
+    from ..context import _lane_torch_dtype
+
+    dtype = _lane_torch_dtype(lane)
+    return dtype if _is_wide_float(dtype) else None
+
+
 __all__ = [
+    "LaneDtypeUnmet",
     "LoadError",
     "LoadReport",
     "NameMismatch",

--- a/src/gen_worker/serving/streaming/skeleton.py
+++ b/src/gen_worker/serving/streaming/skeleton.py
@@ -17,6 +17,18 @@ after ``from_pretrained``, minus the weights, which arrive next.
 Symmetry with the publish moment (pgw#1370): the SAME construction on meta,
 with nothing streamed into it, is what the derive traces. One surface, two
 moments — the ``ctx.compile`` duality, for weights.
+
+pgw#1623: THE SKELETON IS BUILT AT THE LANE'S DTYPE. A config-built module
+lands at whatever ``torch.get_default_dtype()`` and its own config say —
+float32 for a diffusers ``from_config``, the config's ``torch_dtype`` for some
+transformers classes — and NOTHING here used to name a dtype at all. Every
+tensor a container carries is then overwritten by the stream, so the skeleton's
+dtype survives only on what the container does NOT name: real (non-meta)
+buffers, non-persistent buffers, and any optional component. That residue is
+enough to kill a request: measured on a rented A4500, sdxl reached
+``RuntimeError: Input type (c10::Half) and bias type (float)`` inside a conv.
+The eager ``from_pretrained`` bridge has always applied ``torch_dtype=`` the
+lane declares; this is the same rule, on the other loader.
 """
 
 from __future__ import annotations
@@ -119,24 +131,37 @@ def _is_module(cls: type) -> bool:
     return issubclass(cls, torch.nn.Module)
 
 
-def _build_on_meta(cls: type, directory: Path, component: str) -> Any:
-    """Construct one nn.Module component from its config, on meta."""
+def _build_on_meta(
+    cls: type, directory: Path, component: str, compute_dtype: Any = None,
+) -> Any:
+    """Construct one nn.Module component from its config, on meta.
+
+    ``compute_dtype`` is the LANE's declared dtype. Applied after construction
+    with ``Module.to(dtype)`` — which casts floating parameters and buffers and
+    leaves ints and bools alone, exactly what ``from_pretrained(torch_dtype=)``
+    does on the eager bridge — rather than by setting a default dtype around
+    the constructor, because a class that reads ``config.torch_dtype`` itself
+    would ignore the default and land somewhere else again.
+    """
     load_config = getattr(cls, "load_config", None)
     from_config = getattr(cls, "from_config", None)
+    built: Any = None
     if callable(load_config) and callable(from_config):
         # diffusers ConfigMixin: the config is a plain dict on disk.
         config = load_config(str(directory))
         if isinstance(config, tuple):
             config = config[0]
         with init_empty_weights():
-            return from_config(config)
-
-    config_class = getattr(cls, "config_class", None)
-    if config_class is not None and hasattr(config_class, "from_pretrained"):
-        # transformers PreTrainedModel: the config is a typed object.
-        config = config_class.from_pretrained(str(directory))
-        with init_empty_weights():
-            return cls(config)
+            built = from_config(config)
+    else:
+        config_class = getattr(cls, "config_class", None)
+        if config_class is not None and hasattr(config_class, "from_pretrained"):
+            # transformers PreTrainedModel: the config is a typed object.
+            config = config_class.from_pretrained(str(directory))
+            with init_empty_weights():
+                built = cls(config)
+    if built is not None:
+        return built if compute_dtype is None else built.to(compute_dtype)
 
     raise SkeletonError(
         f"component {component!r} ({cls.__module__}.{cls.__name__}) exposes "
@@ -151,8 +176,14 @@ def build(
     checkpoint_dir: Path,
     *,
     extra_kwargs: Optional[Mapping[str, Any]] = None,
+    compute_dtype: Any = None,
 ) -> Skeleton:
-    """Build ``pipeline_cls`` from configs only. Reads no tensor bytes."""
+    """Build ``pipeline_cls`` from configs only. Reads no tensor bytes.
+
+    ``compute_dtype`` is the lane's declared dtype; every module component is
+    built at it (pgw#1623). ``None`` keeps each config's own, which is the
+    laneless case (a fixture, a derive) and nothing else.
+    """
     index_path = Path(checkpoint_dir) / MODEL_INDEX
     if not index_path.is_file():
         raise SkeletonError(
@@ -245,7 +276,7 @@ def build(
             )
         cls = _resolve(str(library), str(class_name))
         if _is_module(cls):
-            components[name] = _build_on_meta(cls, directory, name)
+            components[name] = _build_on_meta(cls, directory, name, compute_dtype)
             modules[name] = components[name]
         else:
             # PASSTHROUGH: a non-`nn.Module` component (tokenizer, scheduler,

--- a/tests/test_lane_dtype_pgw1623.py
+++ b/tests/test_lane_dtype_pgw1623.py
@@ -1,0 +1,212 @@
+"""pgw#1623: the streamed load lands the LANE's dtype, or it says why not.
+
+The article is the production layout, measured off the hub's own catalog rather
+than invented: `tensorhub/wai-illustrious@prod-fp16vae`, the checkpoint sdxl
+0.4.1 bound on pod `xvuc95yqw6buzz`, carries
+
+    component_dtypes {text_encoder: fp16, text_encoder_2: fp16,
+                      unet: fp16, vae: fp32}   (source: safetensors-headers)
+
+on a lane (`sdxl.diffusers-bf16@1`) that declares **bfloat16**. Three dtypes,
+one pipeline. The eager `from_pretrained(torch_dtype=…)` bridge flattens that
+to the lane's dtype and always has; the streaming engine passed it through, and
+the result died `Input type (c10::Half) and bias type (float) should be the
+same` in the VAE's first conv — a real request, burned on a rented card.
+
+No mocks: a real diffusers pipeline saved per-component at those dtypes, into a
+real chunked CAS, projected the way the chokepoint projects it, and loaded
+through the production `StreamingLoader.build`. The forward arm runs the
+mismatch that actually killed the request — the unet's own output dtype into
+`vae.decode` — so the fix is proven by serving, not only by inspection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+pytest.importorskip("safetensors")
+
+from cas_fixture import ingest_repository  # noqa: E402
+from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
+from gen_worker.serving.streaming import (  # noqa: E402
+    BridgeWeightStore,
+    StreamingLoader,
+)
+from gen_worker.serving.streaming.engine import LaneDtypeUnmet  # noqa: E402
+from streaming_fixture import Lane, tiny_pipeline_class  # noqa: E402
+
+#: What the pod's checkpoint carries, component for component.
+STORED: Dict[str, Any] = {
+    "unet": torch.float16,
+    "vae": torch.float32,
+    "text_encoder": torch.float16,
+    "text_encoder_2": torch.float16,
+}
+
+
+def _heterogeneous_source(target: Path) -> type:
+    """A real pipeline saved at wai-illustrious' own per-component dtypes."""
+    from diffusers import AutoencoderKL, DDIMScheduler, UNet2DConditionModel
+    from transformers import CLIPTextConfig, CLIPTextModel
+
+    torch.manual_seed(1623)
+    unet = UNet2DConditionModel(
+        sample_size=16, in_channels=4, out_channels=4, layers_per_block=1,
+        block_out_channels=(32, 64), norm_num_groups=4, cross_attention_dim=32,
+        attention_head_dim=4,
+        down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+        up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
+    )
+    vae = AutoencoderKL(
+        in_channels=3, out_channels=3, latent_channels=4, norm_num_groups=4,
+        block_out_channels=(32,), down_block_types=("DownEncoderBlock2D",),
+        up_block_types=("UpDecoderBlock2D",),
+    )
+    text_config = CLIPTextConfig(
+        hidden_size=32, intermediate_size=64, num_hidden_layers=2,
+        num_attention_heads=4, vocab_size=256, max_position_embeddings=32,
+        projection_dim=32,
+    )
+    pipeline_cls = tiny_pipeline_class()
+    def at(module: Any, dtype: Any) -> Any:
+        module.to(dtype)
+        return module
+
+    pipeline = pipeline_cls(
+        unet=at(unet, STORED["unet"]),
+        vae=at(vae, STORED["vae"]),
+        text_encoder=at(CLIPTextModel(text_config), STORED["text_encoder"]),
+        text_encoder_2=at(CLIPTextModel(text_config), STORED["text_encoder_2"]),
+        scheduler=DDIMScheduler(),
+    )
+    pipeline.save_pretrained(str(target), safe_serialization=True)
+    return pipeline_cls
+
+
+def _project(base: Path, source: Path, key: str) -> Path:
+    cas = LocalCAS(base)
+    manifest = ingest_repository(cas, source)
+    cas.compare_and_swap_ref(
+        REF_PREFIX + key, cas.store_manifest(manifest), expected=None
+    )
+    tree = base / SNAPSHOTS_DIR / key
+    project_snapshot(cas, manifest, tree)
+    return tree
+
+
+def _cas_manifest(tree: Path) -> Tuple[Any, Any]:
+    from gen_worker.models import projection
+
+    projected = projection.resolve_projection(tree)
+    assert projected is not None, f"{tree} has no chunk store behind it"
+    return projected.cas, projected.manifest
+
+
+@pytest.fixture(scope="module")
+def loaded(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    """The production load: heterogeneous tree, bf16 lane, real engine."""
+    base = tmp_path_factory.mktemp("pgw1623")
+    source = base / "source-model"
+    pipeline_cls = _heterogeneous_source(source)
+    tree = _project(base, source, key="c" * 64)
+    loader = StreamingLoader(
+        BridgeWeightStore(*_cas_manifest(tree)), device="cpu", buffer_bytes=4096
+    )
+    pipeline = loader.build(pipeline_cls, checkpoint_dir=tree, lane=Lane)
+    return {"pipeline": pipeline, "report": loader.last_report, "tree": tree,
+            "source": source, "pipeline_cls": pipeline_cls}
+
+
+def _wide_floats(module: Any) -> Dict[str, Any]:
+    held = dict(module.named_parameters(remove_duplicate=False))
+    held.update(dict(module.named_buffers(remove_duplicate=False)))
+    return {
+        name: tensor.dtype for name, tensor in held.items()
+        if tensor is not None
+        and tensor.dtype in (torch.float64, torch.float32,
+                             torch.float16, torch.bfloat16)
+    }
+
+
+def test_the_article_really_is_three_dtypes_on_disk(loaded: Dict[str, Any]) -> None:
+    """The control arm: without it a green suite proves only that the fixture
+    is uniform, which is the fixture bug this whole class hides behind."""
+    from safetensors import safe_open
+
+    # The projected tree holds POINTER STUBS, so the dtypes are read off the
+    # source the CAS ingested — which is the bytes the store serves.
+    stored: Dict[str, set] = {}
+    source = loaded["source"]
+    for container in sorted(source.rglob("*.safetensors")):
+        with safe_open(str(container), framework="pt") as handle:
+            for name in handle.keys():
+                stored.setdefault(container.parent.name, set()).add(
+                    handle.get_slice(name).get_dtype()
+                )
+    assert stored["unet"] == {"F16"}, stored
+    assert stored["vae"] == {"F32"}, stored
+    assert stored["text_encoder"] == {"F16"}, stored
+
+
+def test_the_loaded_pipeline_is_one_dtype_and_it_is_the_lanes(
+    loaded: Dict[str, Any],
+) -> None:
+    """RED before pgw#1623: unet/text encoders come back fp16 and the vae fp32,
+    on a lane that declares bf16."""
+    pipeline = loaded["pipeline"]
+    for component in STORED:
+        dtypes = set(_wide_floats(getattr(pipeline, component)).values())
+        assert dtypes == {Lane.dtype}, (
+            f"{component} came back {sorted(str(d) for d in dtypes)} on a lane "
+            f"declaring {Lane.dtype}"
+        )
+
+
+def test_the_repair_is_counted_not_silent(loaded: Dict[str, Any]) -> None:
+    """A store defect that is repaired and NOT reported is the same defect one
+    layer down. The count is on the load report, so a fleet query can find
+    every deployment serving bytes its own lane does not name."""
+    report = loaded["report"]
+    assert report.cast_to_lane > 0
+    assert report.attributes()["cast_to_lane"] == report.cast_to_lane
+
+
+def test_the_unet_output_survives_the_vae_pgw1623(loaded: Dict[str, Any]) -> None:
+    """THE REQUEST THAT BURNED. `pipeline_stable_diffusion_xl` reaches the VAE
+    only through `vae.decode(latents)`, with latents carrying the denoiser's
+    own dtype — so a pipeline whose unet and vae disagree dies exactly here,
+    after the whole denoise loop has been paid for."""
+    pipeline = loaded["pipeline"]
+    latents = torch.randn(
+        1, 4, 8, 8, dtype=next(pipeline.unet.parameters()).dtype)
+    decoded = pipeline.vae.decode(latents, return_dict=False)[0]
+    assert decoded.dtype == Lane.dtype
+
+
+def test_a_tensor_that_dodges_the_cast_refuses_by_name(
+    loaded: Dict[str, Any],
+) -> None:
+    """The fence can go RED. An instrument that cannot fail is not one — and
+    this fence's whole job is to catch the sibling bug that does NOT crash."""
+    pipeline = loaded["pipeline"]
+    module = pipeline.vae
+    leaf = next(name for name, _ in module.named_parameters())
+    owner = module.get_submodule(leaf.rpartition(".")[0]) if "." in leaf else module
+    key = leaf.rpartition(".")[2]
+    held = owner._parameters[key]
+    owner._parameters[key] = torch.nn.Parameter(
+        held.to(torch.float32), requires_grad=False)
+    try:
+        with pytest.raises(LaneDtypeUnmet) as caught:
+            StreamingLoader._assert_lane_dtype({"vae": module}, Lane.dtype)
+        assert leaf in str(caught.value)
+        assert "float32" in str(caught.value)
+    finally:
+        owner._parameters[key] = held


### PR DESCRIPTION
## The separating measurement, run before any fix (pgw#1623 asked for exactly this)

The hub's own catalog, for the checkpoint sdxl 0.4.1 bound on pod `xvuc95yqw6buzz`
(`tensorhub/wai-illustrious@prod-fp16vae`, `sha256:55c20c66…`):

```
component_dtypes {text_encoder: fp16, text_encoder_2: fp16, unet: fp16, vae: fp32}
component_dtypes_source: safetensors-headers
```

on a lane — `sdxl.diffusers-bf16@1` — declaring **bfloat16**. Three dtypes, one pipeline.

That separates the filing's two candidates and names a third it did not list: **not** contract
COVERAGE (mechanism 1), and **not** a lane-vs-checkpoint disagreement on its own (mechanism 2) —
the tree is HETEROGENEOUS, and only one of this platform's two loaders flattens it.

`ctx.load`'s eager `from_pretrained` bridge has passed `torch_dtype=<the lane's dtype>` since
pgw#1447. The streaming engine documented "dtype passthrough" as a property and honoured it, so
the same checkpoint came back fp16 unet + fp32 VAE and died in the VAE's first conv:
`RuntimeError: Input type (c10::Half) and bias type (float) should be the same`. A passthrough
that only one of two loaders implements is not a property, it is a fork.

## The fix, at the class

- `skeleton.build(..., compute_dtype=)` — components are built at the lane's dtype. The skeleton
  named no dtype at all, so it landed at `torch.get_default_dtype()` or at `config.torch_dtype`,
  and that residue survives on everything no container names (real buffers, non-persistent
  buffers, optional components).
- `StreamingLoader` casts a wide-float tensor whose stored dtype is not the lane's after it
  lands — one tensor at a time, in place, after the staging pool has finished. fp8/fp4, int and
  bool are never touched: quantized bytes ARE the lane, and `lane_materialize` owns those modules.
- The repair is **confessed**: `cast_to_lane` on the load report + a typed
  `container_dtype_off_lane` `serve_degrade` event. A store defect silently repaired is the same
  defect one layer down.
- `_assert_lane_dtype` proves the loaded pipeline is one dtype and refuses by name. The sibling
  bug on the eager bridge does *not* crash — it upcasts per op and serves correct images 20-40x
  slow — so this one crashing was luck, not design.

## Red/green, through the production entry point, $0 and local

A real diffusers pipeline saved per-component at the pod's own dtypes → a real chunked CAS →
projected by the same `project_snapshot` the chokepoint calls → `StreamingLoader.build`.

On master the forward arm reproduces the pod's failure **byte for byte**:

```
E  RuntimeError: Input type (c10::Half) and bias type (float) should be the same
E  AssertionError: unet came back ['torch.float16'] on a lane declaring torch.bfloat16
```

4 failed / 1 passed before, 5 passed after. The one that passes before is the control arm
asserting the article really is three dtypes on disk — without it a green suite would only prove
the fixture is uniform. The fence arm proves the new refusal can go red.

`mypy` + `ruff` clean; `tests/test_weight_streaming.py` and five sibling load suites (77 tests)
unchanged and green — the byte-equality article is bf16 on disk under a bf16 lane, so nothing is
cast, which is the point.