### PR TITLE
pgw#1620: the lane that SERVED is reported again — by the ladder that decided it

### DIFF
--- a/changelog.d/pgw1620.md
+++ b/changelog.d/pgw1620.md
@@ -1,0 +1,25 @@
+- **pgw#1620: a completed request names the lane that served it again.** `metrics.lane` is
+  `JobResult.metrics.lane` (proto field 13), which the v1 executor stamped from its
+  `ServedIdentity`; the v1 hardcut deleted the executor and the v2 worker built a `JobMetrics`
+  of two numbers, so `payload.metrics.lane` and `request_state.execution_lane` were
+  **structurally absent for every pgw#1599-surface endpoint**. Measured on a COMPLETED
+  production request — anima 0.5.0, real image, rented A4500, 24.666 s — and nothing was red,
+  because an absent metric reads exactly like "not measured yet". Under the measurement law that
+  run proved nothing about which lane executed, which made every lane claim on every migrated
+  endpoint unfalsifiable from the hub. The successor producer is strictly better than v1's: the
+  value now comes from the **ladder that decided the lane** (`serve_loop`'s `ResolvedLane`,
+  stamped on the request context so a FAILED request reports it too) rather than from an
+  endpoint remembering to call `report_applied_lane()` after `quantize_()`.
+- **pgw#1620: the ladder's confession leaves the pod.** `resolved.confession()` — `LANE=…
+  contract=… card=… reason=… rejected=…`, the audit line pgw#1606 wrote precisely so a ladder
+  that reports only its winner cannot exist — was a `logger.info` on a RunPod pod, which has no
+  logs API: measured appearing ZERO times in the hub log and in zero `worker_activity_events`
+  rows. It now rides the `applied_lane` typed event, once per (model class, checkpoint), with
+  the ranked lane body as `phase` (a closed vocabulary, countable hub-side) and the tensorfs
+  contract id as `family`.
+- **pgw#1620: the eager/compiled half is MEASURED, not assumed.** The regime comes from
+  pgw#1491's dispatch counter — the instrument that caught twelve "compiled" images being served
+  entirely eager — re-armed per request so a pod that mints mid-life stops reporting eager. A
+  window shared with a concurrent request cannot say which one entered a compiled graph, so the
+  regime is then reported as unmeasured rather than guessed, and a lane that never resolved
+  reports absent rather than a plausible default.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -138,12 +138,25 @@ KIND_OUTPUT_INTEGRITY = "output_integrity"
 KIND_ROTATION_PRELOAD = "rotation_preload"
 KIND_CAPABILITY_RENEWAL = "capability_renewal"
 KIND_RESIDENCY_FAULT = "residency_fault"
-# pgw#1104: a serve-time recipe reported the lane it APPLIED to the weights
-# (`gen_worker.report_applied_lane`), and `metrics.lane` now follows it instead
-# of the binding. `phase` is the component, `detail` carries the applied lane
-# body, the module counts and the BOUND lane it diverged from — so "which pods
-# serve a lane their checkpoint does not name" is one query, not an inference
-# from allocated-bytes rows.
+# THE LANE THE PLATFORM RESOLVED, emitted once per (model class, checkpoint)
+# by `serving.serve_loop._resolve_for` — the one moment both facts are in hand,
+# the card and what the deploy staged.
+#
+# pgw#1620 REWROTE THIS PRODUCER, and the correction matters more than the
+# field: pgw#1104's emitter was `gen_worker.report_applied_lane()`, an ENDPOINT
+# calling in after `quantize_()` to say what it had done. pgw#1599 retired that
+# call ("the lane is the Model's declared contract") and gave the job to
+# nothing, so every migrated endpoint went silent — no `applied_lane` row, and
+# `metrics.lane` absent, on real completed production requests. The successor
+# is strictly better than what v1 had: the report now comes from the ladder
+# that DECIDED the lane, not from an endpoint remembering to say so.
+#
+# `phase` is the ranked lane BODY (`bf16-w16a16`), a closed fleet vocabulary
+# and therefore countable hub-side; `family` carries the tensorfs contract id
+# (`sdxl.diffusers-bf16@1`); `detail` is the ladder's whole confession — card,
+# reason, and every rejected rung with its numbers. That last part is the point:
+# a ladder that reports only its winner cannot be audited, and its confession
+# was a `logger.info` on a pod with no logs API, which is to say nowhere.
 KIND_APPLIED_LANE = "applied_lane"
 # pgw#1043 §PRODUCTIZATION: the ATTENTION path setup() actually installed
 # (`gen_worker.report_applied_attention`). A third axis beside `lane` and

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -285,6 +285,15 @@ class RequestContext(Generic[D]):
         self._canceled = False
         self._boot_warmup = bool(boot_warmup)
         self._execution_lane = ""  # executing lane, set by the executor
+        #: pgw#1620: the ladder's own `ResolvedLane` for this request's PRIMARY
+        #: model slot — the platform's decision record, not an author surface
+        #: and never read by author code. It rides the context because the
+        #: context is the one object the dispatcher holds on EVERY terminal
+        #: path: a request that failed inside the handler is exactly the one
+        #: whose lane is worth reporting, and `InvokeOutcome` does not exist
+        #: for it. `None` until the serve loop resolves one (a weightless
+        #: entrypoint never does), which is UNPROVEN and is reported as such.
+        self._resolved_lane: Any = None
         # th#2049/pgw#1294: the executing function DECLARED `publishes=True`,
         # so it may write tensors/repos to the hub. Kind stops implying write
         # authority; this declaration is the one justification. Stamped from
@@ -419,6 +428,11 @@ class RequestContext(Generic[D]):
 
     def _set_execution_lane(self, execution_lane: str) -> None:
         self._execution_lane = str(execution_lane or "").strip()
+
+    def _set_resolved_lane(self, resolved: Any) -> None:
+        """Worker-internal (pgw#1620): the boot ladder's pick for this
+        request's primary slot, stamped by the serve loop."""
+        self._resolved_lane = resolved
 
     @property
     def config(self) -> Dict[str, Any]:

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -384,8 +384,41 @@ class ServeLoop:
         )
         if resolved is not None:
             logger.info("lane ladder: %s", resolved.confession())
+            # pgw#1620: THE CONFESSION HAS TO LEAVE THE POD. This line is the
+            # audit record pgw#1606 wrote so a ladder that only reports its
+            # winner cannot exist — and it was a `logger.info` on a RunPod pod,
+            # which has no logs API, so it was measured appearing ZERO times in
+            # the hub log and in zero `worker_activity_events` rows. Once per
+            # (class, checkpoint), because this method is the cache.
+            #
+            # `phase` is the ranked lane BODY, which is a closed fleet
+            # vocabulary and therefore countable hub-side; the contract, the
+            # card, the reason and every rejected rung ride `detail`.
+            try:
+                from .. import activity
+
+                activity.emit_event(
+                    activity.KIND_APPLIED_LANE,
+                    f"{model_cls.__name__} <- {binding.checkpoint_ref}: "
+                    f"{resolved.confession()}",
+                    phase=str(resolved.body or "?"),
+                    family=str(resolved.contract_id or ""),
+                )
+            except Exception:  # noqa: BLE001 — a confession never fails a boot
+                logger.debug("lane ladder: could not emit applied_lane",
+                             exc_info=True)
             self._resolved[key] = resolved
         return resolved
+
+    def resolved_lane_for(self, model_cls: type, binding: DeployBinding) -> Any:
+        """The ladder's pick for this (class, binding), if it has run.
+
+        Read-only: the ladder runs at instance build (`_backend_factory`), so
+        by the time a request holds a live instance this is populated. It
+        answers ``None`` for a model whose instance this process never built,
+        which is UNPROVEN and must be reported as absent rather than guessed.
+        """
+        return self._resolved.get((model_cls, str(binding.checkpoint_ref)))
 
     def _lane_of(self, model_cls: type) -> Tuple[Any, str]:
         lane = self.lanes[model_cls]
@@ -640,9 +673,18 @@ class ServeLoop:
             # The executing lane is the PRIMARY slot's; a weightless entrypoint
             # has none and keeps the default.
             if spec.model_params:
-                primary_lane, primary_handle = self._lane_of(spec.model_params[0][1])
+                primary_cls = spec.model_params[0][1]
+                primary_lane, primary_handle = self._lane_of(primary_cls)
                 if primary_lane is not None:
                     ctx._set_execution_lane(primary_handle)
+                # pgw#1620: and the LADDER's own answer, which is the one the
+                # request metric reports. `_lane_of` above reads the deploy's
+                # per-class pick and is `None` for a multi-lane model; the
+                # resolved lane is never None once an instance exists, and it
+                # carries the contract, the body and the reason together.
+                if primary_binding is not None:
+                    ctx._set_resolved_lane(
+                        self.resolved_lane_for(primary_cls, primary_binding))
 
             # The author's own span. Everything outside it — envelope decode,
             # input fetch, admission, weight load — is platform time, and

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -811,6 +811,9 @@ class Worker:
         self.drained = asyncio.Event()
         self._jobs: Dict[Tuple[str, int], asyncio.Task[None]] = {}
         self._canceled: set[Tuple[str, int]] = set()
+        #: pgw#1620's compiled-vs-eager witness; built on first use, because
+        #: it can only attach to modules an adopt has already produced.
+        self._dispatch: Optional[Any] = None
         self._drain_task: Optional[asyncio.Task[None]] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._stop_requested = False
@@ -1340,6 +1343,61 @@ class Worker:
                 f"{sorted(self.lanes) or '[]'} — never a silent fallback"
             )
 
+    def _dispatch_counter(self) -> Any:
+        """The compiled-vs-eager witness, attached to whatever this boot
+        adopted (pgw#1620).
+
+        `install` is idempotent per module and `rearm` wraps anything the
+        BACKGROUND MINT armed since the last request — which is the whole
+        reason it is re-asked here rather than once at boot: a pod that adopts
+        nothing and mints for ten minutes flips from eager to compiled
+        mid-life, and a counter wired only at boot would report eager forever.
+        Safe on a worker that adopted nothing: it then reports `armed_modules=0`
+        and the regime is `eager` by measurement rather than by assumption.
+        """
+        # `getattr` rather than the attribute: several suites drive `_run_one`
+        # on an `object.__new__(Worker)` skeleton (the runner's real catch site
+        # is the subject, the collaborators are not), and a witness must not be
+        # the thing that decides whether a terminal ships.
+        counter = getattr(self, "_dispatch", None)
+        if counter is None:
+            from .serving.dispatch_counter import DispatchCounter
+
+            counter = DispatchCounter()
+            self._dispatch = counter
+        counter.install(self)
+        return counter
+
+    def _served_lane(self, ctx_box: List[Any], *, solo: bool) -> str:
+        """`JobMetrics.lane` — the concrete lane that served this request.
+
+        The hub's field (proto 13) is the th#1050 DESCRIPTOR vocabulary
+        (`bf16-w16a16+eager`), and it stays that: `reduce.go` groups the
+        measurement relation on `split_part(lane,'+',1)`, so spelling the new
+        surface's tensorfs CONTRACT here instead would fork that relation by
+        surface and make every historical row incomparable for the same
+        numerics. The contract id is not lost — it rides the `applied_lane`
+        event the ladder emits, beside the reason and the rejected rungs.
+
+        `""` when no lane was resolved (a weightless entrypoint, or a request
+        that died before it held an instance). Absent means UNPROVEN, and the
+        hub stores it as omitted rather than as an empty claim.
+        """
+        ctx = ctx_box[0] if ctx_box else None
+        resolved = getattr(ctx, "_resolved_lane", None) if ctx is not None else None
+        body = str(getattr(resolved, "body", "") or "")
+        if not body:
+            return ""
+        if not solo or len(self._jobs) > 1:
+            return body
+        counts = self._dispatch_counter().take()
+        if counts.armed_modules == 0:
+            return f"{body}+eager"
+        return (
+            f"{body}+compiled" if counts.compiled_graph_calls > 0
+            else f"{body}+eager"
+        )
+
     async def _run_one(self, run: pb.RunJob, key: Tuple[str, int]) -> None:
         accepted_at = time.monotonic()
         if key in self._canceled:
@@ -1358,6 +1416,17 @@ class Worker:
         adjustments: Tuple[Dict[str, str], ...] = ()
         stages: Optional[Any] = None
         started = accepted_at
+        # Hoisted out of the try (pgw#1620): the context is how the lane report
+        # reaches the terminal, and a request that died before the handler ran
+        # must still produce a metrics stamp rather than a NameError.
+        ctx_box: List[Any] = []
+        #: Was this request the only one in flight for its whole window? The
+        #: dispatch counter is per-PROCESS, so a blended window cannot say
+        #: which of two concurrent requests entered a compiled graph. Solo is
+        #: the normal shape of a GPU pod; when it does not hold, the regime is
+        #: reported as UNMEASURED (no `+` suffix) rather than guessed.
+        solo = len(self._jobs) <= 1
+        self._dispatch_counter().reset()
         try:
             self._check_lane(run)
             envelope = self._envelope_of(run)
@@ -1380,7 +1449,6 @@ class Worker:
             # on a worker thread; `on_context` is how it reaches the context
             # object that holds the token.
             renew: Optional[asyncio.Task[None]] = None
-            ctx_box: List[Any] = []
 
             def _bind_context(ctx: Any, box: List[Any] = ctx_box) -> None:
                 box.append(ctx)
@@ -1481,6 +1549,19 @@ class Worker:
             runtime_ms=runtime_ms,
             queue_ms=int((started - accepted_at) * 1000),
         )
+        # pgw#1620: THE LANE THAT SERVED, on every terminal path. The v1
+        # executor stamped this from `ServedIdentity` and died with the v1
+        # hardcut; the v2 worker built a `JobMetrics` of two numbers, so
+        # `payload.metrics.lane` and `request_state.execution_lane` were
+        # STRUCTURALLY ABSENT for every pgw#1599-surface endpoint — measured on
+        # a completed production request (anima 0.5.0, pod qj555emwwvaw03).
+        # Nothing was red: absence reads exactly like "not measured yet", which
+        # is why it survived a full deployment.
+        #
+        # A failed request's lane is the sample most worth having, so this is
+        # read off the CONTEXT (which exists on every path) rather than off the
+        # invoke outcome (which does not).
+        metrics.lane = self._served_lane(ctx_box, solo=solo)
         # pgw#1425: the per-stage breakdown, closed against `runtime_ms` so
         # every emitted stage plus `resid.unattributed` sums to it. Before this
         # the `JobResult.metrics` of every v2 request carried two numbers and

--- a/tests/test_metrics_lane_pgw1620.py
+++ b/tests/test_metrics_lane_pgw1620.py
@@ -1,0 +1,177 @@
+"""pgw#1620: a completed request NAMES the lane that served it.
+
+THE DEFECT WAS A SILENCE. anima 0.5.0 completed a real request on a rented
+A4500 — real image, real card, real money — and `payload.metrics.lane` was
+absent, `request_state.execution_lane` was empty, and no `applied_lane` row
+existed. Nothing failed. Under the measurement law an absent metric is
+UNPROVEN, so that run proved nothing about which lane executed, and every lane
+claim on every pgw#1599-surface endpoint was unfalsifiable from the hub.
+
+Root cause: `metrics.lane` is `JobResult.metrics.lane` (proto field 13), which
+the v1 executor stamped from `ServedIdentity`. The v1 hardcut deleted the
+executor and the v2 worker built a `JobMetrics` of two numbers.
+
+THE CALLER HERE IS THE POD'S (pgw#1551's lesson, and tonight's): the object
+under test is a REAL `ServeLoop` over a REAL projected tensorfs tree, driven
+through the REAL `Worker._run_one` — the same except chain, the same
+`pb.JobResult` construction, the same wire bound. Only the socket is captured.
+A test that stamped a context itself and then read it back would prove the
+getter and nothing else, which is exactly how this hole opened.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+
+from gen_worker import activity  # noqa: E402
+from gen_worker.models.store import ModelStore  # noqa: E402
+from gen_worker.pb import worker_scheduler_pb2 as pb  # noqa: E402
+from gen_worker.worker import Worker  # noqa: E402
+
+# The pod-shaped fixture: a real ServeLoop, a real CAS, a real projected tree.
+# Re-exported under the fixture names pytest resolves by, aliased on import so
+# the test signatures below are parameters rather than redefinitions.
+from test_pod_serve_loop_streams import LANE, REF, pod_serve_loop  # noqa: E402
+from test_pod_serve_loop_streams import bound_store as _bound_store  # noqa: E402
+from test_pod_serve_loop_streams import projected as _projected  # noqa: E402
+
+projected = _projected
+bound_store = _bound_store
+
+#: `sdxl.diffusers-bf16@1` and the fixture's `fixture.diffusers-bf16@1` both
+#: declare bfloat16, and `lane_ladder.dtype_body` maps that to ONE ranked body.
+#: This is the hub's own vocabulary (proto 13: "fp8-w8a8-dynamic+compiled"),
+#: which is what old-surface endpoints report today — so old and new surfaces
+#: stay comparable in the measurement relation instead of forking by spelling.
+EXPECTED = "bf16-w16a16+eager"
+
+
+class _PodWorker:
+    """`Worker._run_one` over the REAL pod serve loop, with the socket captured.
+
+    Everything that produces the lane is production code: the ladder resolves
+    it inside the instance build, `ServeLoop.invoke` stamps it on the request
+    context, and `Worker._served_lane` reads it at the terminal.
+    """
+
+    def __init__(self, loop: Any) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        w = object.__new__(Worker)
+        w._jobs = {}
+        w._canceled = set()
+        w._dispatch = None
+        w.draining = False
+        w.lanes = frozenset({LANE})
+        w.file_base_url = ""
+        w.serve = loop  # type: ignore[assignment]
+        w.loaded = loop.loaded  # type: ignore[assignment]
+        w.adoption = None  # type: ignore[attr-defined]
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        w._send = _send  # type: ignore[method-assign]
+        self.w = w
+
+    def run(self, job_id: str = "lane-1") -> pb.JobResult:
+        run = pb.RunJob(request_id=job_id, attempt=1, function_name="probe")
+        run.models.add(slot="model", ref=REF)
+        asyncio.run(self.w._run_one(run, (job_id, 1)))
+        results = [m.job_result for m in self.sent if m.HasField("job_result")]
+        assert len(results) == 1, self.sent
+        return results[0]
+
+
+@pytest.fixture()
+def emitted(monkeypatch: pytest.MonkeyPatch) -> List[Dict[str, str]]:
+    """Every typed activity event this process emits, captured at the seam."""
+    rows: List[Dict[str, str]] = []
+    real = activity.emit_event
+
+    def _capture(kind: str, detail: str, phase: str = "", *args: Any,
+                 **kwargs: Any) -> None:
+        rows.append({"kind": kind, "detail": detail, "phase": phase,
+                     "family": str(kwargs.get("family", ""))})
+        real(kind, detail, phase, *args, **kwargs)
+
+    monkeypatch.setattr(activity, "emit_event", _capture)
+    return rows
+
+
+def test_a_completed_request_carries_the_lane_that_served_it(
+    projected: Dict[str, Any], bound_store: ModelStore, tmp_path: Path,
+) -> None:
+    """RED before pgw#1620: `metrics.lane` is the empty string on a COMPLETED
+    request from an endpoint that declares a lane — which the hub omits from
+    the payload entirely, and which every dashboard reads exactly the way it
+    reads 'not measured yet'."""
+    result = _PodWorker(pod_serve_loop(projected, tmp_path)).run()
+
+    assert result.status == pb.JOB_STATUS_OK, result.safe_message
+    assert result.metrics.lane == EXPECTED, (
+        f"a completed request on a lanes-declaring endpoint reported "
+        f"lane={result.metrics.lane!r}; absent means UNPROVEN, so this run "
+        f"would prove nothing about which lane executed"
+    )
+
+
+def test_the_regime_is_MEASURED_not_assumed(
+    projected: Dict[str, Any], bound_store: ModelStore, tmp_path: Path,
+) -> None:
+    """`+eager` here is the dispatch counter's answer, not a default: this
+    fixture adopts nothing, so `armed_modules == 0` and the pod says eager
+    because it counted, which is the same instrument that caught twelve
+    'compiled' images being served entirely eager (pgw#1491)."""
+    result = _PodWorker(pod_serve_loop(projected, tmp_path)).run()
+    assert result.metrics.lane.endswith("+eager")
+    body, _, regime = result.metrics.lane.partition("+")
+    # `reduce.go` groups the measurement relation on `split_part(lane,'+',1)`,
+    # so the body half must stay a member of the fleet's ranked table.
+    from gen_worker.models.execution_lanes import known_execution_lane_bodies
+
+    assert body in known_execution_lane_bodies(), body
+    assert regime in ("eager", "compiled")
+
+
+def test_the_ladders_confession_leaves_the_pod(
+    projected: Dict[str, Any], bound_store: ModelStore, tmp_path: Path,
+    emitted: List[Dict[str, str]],
+) -> None:
+    """The other half of the filing. `resolved.confession()` — the audit line
+    pgw#1606 wrote so a ladder that reports only its winner cannot exist — was
+    a `logger.info` on a RunPod pod, which has no logs API: measured ZERO times
+    in the hub log and in zero `worker_activity_events` rows."""
+    _PodWorker(pod_serve_loop(projected, tmp_path)).run()
+
+    lanes = [row for row in emitted if row["kind"] == activity.KIND_APPLIED_LANE]
+    assert lanes, (
+        "no `applied_lane` event: the platform resolved a lane and forwarded "
+        "it nowhere that survives the pod"
+    )
+    row = lanes[0]
+    assert row["phase"] == "bf16-w16a16", row
+    assert row["family"] == LANE, row
+    # The confession names what it did NOT do, or it is not an audit line.
+    assert "LANE=" in row["detail"] and "rejected=" in row["detail"], row
+    assert "contract=" in row["detail"], row
+
+
+def test_a_lane_that_was_never_resolved_is_reported_ABSENT(tmp_path: Path) -> None:
+    """Absence must stay possible and stay honest: a weightless entrypoint
+    resolves no lane, and inventing one would be the worse failure. `""` is
+    what the hub stores as omitted rather than as an empty claim."""
+    w = object.__new__(Worker)
+    w._jobs = {}
+    w._dispatch = None
+    assert w._served_lane([], solo=True) == ""
+    ctx = types.SimpleNamespace(_resolved_lane=None)
+    assert w._served_lane([ctx], solo=True) == ""


### PR DESCRIPTION
## The defect was a silence

anima 0.5.0 completed a real request on a rented A4500 (pod `qj555emwwvaw03`) — real image, real
card, 24.666 s — and `payload.metrics.lane` was absent, `request_state.execution_lane` empty,
zero `applied_lane` rows. Nothing was red: an absent metric reads exactly like "not measured
yet". Under the standing measurement law that run is UNPROVEN, so every lane claim on every
pgw#1599-surface endpoint was unfalsifiable from the hub — while pgw#1600's `demand_miss` and
pgw#1586's coefficient ledger both key on knowing which lane served.

## One correction to the filing, checked against tensorhub rather than inherited

`metrics.lane` does **not** follow the `applied_lane` activity event. The hub reads
`JobResult.metrics.lane` (proto field 13) at `grpc/connect_worker.go:3042` and writes
`request_state.execution_lane` from the same value at `job_result_transition.go:151`. The single
mention of `applied_lane` in the whole hub is a comment in `measurement/reduce.go` saying that
population is deliberately *not* parsed. The real producer was
`executor.py`'s `metrics.lane = self._served_execution_lane(...)`, deleted with the v1 hardcut;
the v2 worker built a `JobMetrics` of two numbers. The activity kind is still worth having — see
below — but it was never the wire.

## The producer is now the decider

`serve_loop` already holds the authoritative `ResolvedLane` at the one moment both facts are in
hand (the card, and what the deploy staged). It stamps it on the request **context**, the one
object that exists on every terminal path — a request that failed inside the handler is exactly
the one whose lane is worth having, and `InvokeOutcome` does not exist for it. Strictly better
than v1, whose value was self-reported by endpoint code after `quantize_()`.

`metrics.lane` keeps the hub's th#1050 vocabulary (`bf16-w16a16+eager`) rather than the new
surface's tensorfs contract id: `reduce.go` groups the measurement relation on
`split_part(execution_lane,'+',1)`, so spelling the contract there would fork that relation by
SURFACE and make every historical row incomparable for the same numerics. The contract rides the
`applied_lane` event as `family` instead — nothing is lost. **Easy to overrule if you want the
contract in the metric; say so and it is a one-line change.**

## And the confession leaves the pod

`resolved.confession()` — `LANE=… contract=… card=… reason=… rejected=…`, written by pgw#1606 so
a ladder that reports only its winner cannot exist — was a `logger.info` on a RunPod pod, which
has no logs API: measured ZERO times in the hub log and in zero `worker_activity_events` rows.
It now rides the `applied_lane` typed event, once per (model class, checkpoint), `phase` = the
ranked lane body (closed vocabulary, countable hub-side), `detail` = the whole confession.

## The regime is measured, not assumed

`+eager`/`+compiled` comes from pgw#1491's dispatch counter — the instrument that caught twelve
"compiled" images being served entirely eager — installed on whatever the boot adopted and
**re-armed per request**, so a pod that adopts nothing and mints for ten minutes stops reporting
eager when the mint lands. The counter is per-process: a window shared with a concurrent request
cannot say which one entered a compiled graph, so the regime is then reported as unmeasured (no
suffix) rather than guessed. A lane that never resolved reports ABSENT.

## The guard, and its caller is the pod's

A REAL `ServeLoop` over a REAL projected tensorfs tree, driven through the REAL
`Worker._run_one` — same except chain, same `pb.JobResult` construction, same wire bound, only
the socket captured (pgw#1551's lesson: *a unit test is a caller the production path is not*).
On master it goes red the way production did:

```
E  AssertionError: a completed request on a lanes-declaring endpoint reported lane='';
   absent means UNPROVEN
E  AssertionError: no `applied_lane` event: the platform resolved a lane and forwarded it
   nowhere that survives the pod
```

4 failed before, 4 passed after. `mypy` + `ruff` clean; six sibling suites (77 tests) green.