### PR TITLE
pgw#1614: cut 0.127.2 — sdxl can serve on the lane-declaration surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.127.1"
+version = "0.127.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -573,7 +573,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.127.1"
+version = "0.127.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Cut because a POD RUN needs one (`docs/releasing.md` rule 1): se#819's sdxl deployment is blocked
on both P0s below, and sdxl is `access_policy=private` until a real invoke proves them on a card.
7 commits since `v0.127.1`, counted not estimated.

**Must-ride, ancestor-verified against this tree:**

| commit | issue | why it must ride |
|---|---|---|
| `8ed6b388` | pgw#1623 | the streamed load lands the lane's dtype — without it sdxl cannot produce an image at all |
| `cb85607a` | pgw#1620 | `metrics.lane` has a producer again — without it a successful invoke proves nothing about which lane executed |
| `ceed0806` | pgw#1619 | `partial_resident` refuses to park a component it cannot enter |
| `fa5ed7b8` | pgw#1622 | ruff debt from pgw#1606 |

## Step 0 was not run, and this PR says so rather than passing over it

`scripts/assemble_changelog.py --version 0.127.2 --headline …` dies
`FileNotFoundError: CHANGELOG.md` — **reproduced on this exact tree**, not recalled from the
filing. pgw#1582 deleted the file and left the cut path reading it unguarded; that is
**pgw#1615**, still open on a Paul ruling (is `CHANGELOG.md` dead, or was its deletion a
mistake?). This cut therefore ships with no assembled section, and the `changelog.d/` fragments
for pgw#1620 and pgw#1623 join the seven the 0.127.0 cut already left `pending`. Nothing is
worked around: the fragments are written, and whichever way the ruling goes they are
attributable to this tag by the tree that contains them.

Merges as a **true merge** (the queue's method) so the tag stays an ancestor of `master`.