### PR TITLE
pgw#1627: regime-split headroom admission + cache release at the park→compiled seam

### DIFF
--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -2725,6 +2725,11 @@ def apply_low_vram_config(
                              ("attr_ctx_bytes", "attr_ctx_gb")):
                 if _k in probe_facts:
                     applied[_lbl] = float(probe_facts[_k]) / _GIB
+            if "headroom_basis" in probe_facts:
+                # pgw#1627: the regime-split admit names its budget basis
+                # (driver_free vs free+cache) on the loud line, so the hub can
+                # see WHICH arithmetic admitted without the code in hand.
+                applied["headroom_basis"] = str(probe_facts["headroom_basis"])
             probe_free = probe_facts.get("probe_free_bytes")
             if probe_free is not None:
                 # Probe SUCCESS was `log.info` and therefore inaudible, which

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -537,6 +537,7 @@ def _install_residency_hooks(
             log.debug("partial_resident: %s could not carry the park mark", name)
 
     seen_parked = False
+    released_confessed: List[bool] = []
     for name in order:
         if name in parked:
             seen_parked = True
@@ -549,6 +550,30 @@ def _install_residency_hooks(
 
         def _release(_m: Any, _a: Any) -> None:
             _park_all_but()
+            # pgw#1627, THE PARK→COMPILED SEAM. Parking strands the parked
+            # components' device blocks in the caching allocator (~1.3 GiB
+            # measured on the 8 GiB death), where eager can spend them and
+            # AOTI — which allocates its first-call pool OUTSIDE the torch
+            # allocator — cannot. So when THIS module's forward is about to
+            # be a compiled call, hand the cache back to the driver first;
+            # when it is eager, keep it (that cache is eager's activation
+            # money, pgw#1586). The gate is read HERE, per request, and
+            # deliberately not at install time: adopt arms the dispatcher
+            # AFTER these hooks are installed (death-log ordering), so an
+            # install-time gate would always read "not compiled" and the
+            # release would never fire — the pgw#1587 wrong-moment shape.
+            if compiled_dispatch_armed(_m):
+                from .memory import release_cached_vram
+
+                release_cached_vram()
+                if not released_confessed:
+                    released_confessed.append(True)
+                    log.info(
+                        "partial_resident: released allocator cache after "
+                        "park — %s carries an armed compiled dispatcher, and "
+                        "AOTI spends driver_free, not cache (pgw#1627)",
+                        type(_m).__name__,
+                    )
 
         module.register_forward_pre_hook(_release)
         break
@@ -608,11 +633,45 @@ def _placement_attribution(torch_mod: Any) -> Dict[str, int]:
     return out
 
 
+def headroom_admits(
+    *, regime: str, free_bytes: int, cache_bytes: int,
+    floor_bytes: int = _PROBE_FLOOR_BYTES, demand_bytes: int = 0,
+) -> tuple[bool, str]:
+    """(admitted, budget basis). THE headroom predicate, REGIME-SPLIT
+    (pgw#1627, implementing pgw#1601's banked ruling).
+
+    * ``eager`` — the budget is ``driver_free + reusable cache`` against the
+      floor. The allocator's cache is spendable by the torch allocator and by
+      NOTHING else, and eager activations come out of that allocator, so
+      counting it is right (pgw#1586: the bug that term fixed was a SPURIOUS
+      REFUSAL, and past the probe the failure mode is retries-and-serve).
+    * ``compiled`` — the budget is ``driver_free`` ONLY, against
+      ``demand + floor``. AOTI's first-call pool (+1154 MiB measured on sdxl
+      sm_89, 4/4 runs, batch-invariant) allocates OUTSIDE the torch allocator
+      and cannot spend the cache. Counting cache here is the arithmetic that
+      killed every 8 GiB compiled-SDXL leg: admitted on ``free+cache`` =
+      2.2 GiB against a real budget of ``driver_free`` = 1.18 GiB, process
+      death at step 0, no traceback — and a mid-graph OOM on the compiled
+      path is uncatchable (pgw#1255 leg 2), so admission is the ONLY safety.
+
+    ``demand_bytes`` is the compiled artifact's out-of-allocator first-call
+    demand — pgw#1601's mint-time stamp once it lands; 0 until a caller has
+    one. The basis string goes on the confession line so a reader of the
+    admit can see WHICH budget the split used without the code in hand.
+    """
+    if regime == "compiled":
+        ok = int(free_bytes) >= int(demand_bytes) + int(floor_bytes)
+        return ok, "driver_free"
+    return int(free_bytes) + int(cache_bytes) >= int(floor_bytes), "free+cache"
+
+
 def probe_plan(
     parked: Dict[str, ParkedComponent], *, free_bytes_now: Any,
     floor_bytes: int = _PROBE_FLOOR_BYTES,
-) -> tuple[bool, int]:
-    """DO the worst onload once and read what is left. Returns (ok, free_bytes).
+    regime: str = "eager", demand_bytes: int = 0,
+) -> tuple[bool, int, str]:
+    """DO the worst onload once and read what is left. Returns
+    (ok, free_bytes, budget_basis).
 
     The planner's transient ceiling is arithmetic over numbers it can read, and
     on the campaign card that arithmetic admitted a plan whose onload then died
@@ -620,9 +679,21 @@ def probe_plan(
     neither the component sizes nor the free-VRAM probe. This is the same
     question asked of the card instead of of a constant, and it costs one copy
     at load.
+
+    The floor check is :func:`headroom_admits` and is REGIME-SPLIT (pgw#1627):
+    eager counts ``free + reusable cache``, compiled counts ``driver_free``
+    only — see that function for why each side is right and what believing
+    the eager arithmetic on a compiled leg cost.
     """
     if not parked:
-        return True, int(free_bytes_now())
+        free = int(free_bytes_now())
+        if regime == "compiled":
+            ok, basis = headroom_admits(
+                regime=regime, free_bytes=free, cache_bytes=0,
+                floor_bytes=floor_bytes, demand_bytes=demand_bytes,
+            )
+            return ok, free, basis
+        return True, free, "free+cache"
     worst = max(parked.values(), key=lambda c: c.bytes)
     worst.onload()
     free = int(free_bytes_now())
@@ -635,24 +706,54 @@ def probe_plan(
         cache = 0
     worst.park()
     # pgw#1586. THE FLOOR IS CHECKED AGAINST WHAT ACTIVATIONS CAN ACTUALLY HAVE,
-    # WHICH IS NOT DRIVER-FREE. A parked component's blocks stay in the caching
-    # allocator's pool: `park()` drops the reference, the allocator keeps the
-    # block, and `mem_get_info` never sees it return. So the same bytes were
-    # counted as freed by the plan and as used by this probe. Measured on the
-    # card: driver_free 0.45 + reusable cache 1.56 = 2.01 GiB against a 2.00 GiB
-    # reserve — the reserve was honoured all along and the probe was reading a
-    # number 1.56 GiB too small.
+    # WHICH FOR THE *EAGER* REGIME IS NOT DRIVER-FREE. A parked component's
+    # blocks stay in the caching allocator's pool: `park()` drops the
+    # reference, the allocator keeps the block, and `mem_get_info` never sees
+    # it return. So the same bytes were counted as freed by the plan and as
+    # used by this probe. Measured on the card: driver_free 0.45 + reusable
+    # cache 1.56 = 2.01 GiB against a 2.00 GiB reserve — the reserve was
+    # honoured all along and the probe was reading a number 1.56 GiB too small.
     #
     # ⚠️ CACHE IS *SOFT* AVAILABILITY, NOT A HARD BUDGET TERM. 1.56 GiB of
     # cached blocks is not 1.56 GiB of CONTIGUOUS space, and the 214 allocator
     # retries this leg logged ARE that discount showing up at runtime — the
     # allocator freeing and remapping segments that do not fit the requested
-    # activation. Counting it here is right because the bug being fixed is a
-    # SPURIOUS REFUSAL and the failure mode past the probe is retries-and-serve,
-    # not a fatal (degrade-never-OOM holds). Do NOT promote this term into a
-    # hard budget: the measured-placement work should treat it as soft, with the
-    # retry count as the natural signal for how soft.
-    return (free + cache) >= floor_bytes, free
+    # activation. Counting it for EAGER is right because the bug being fixed
+    # was a SPURIOUS REFUSAL and the failure mode past the probe is
+    # retries-and-serve, not a fatal (degrade-never-OOM holds). Do NOT promote
+    # this term into a hard budget: the measured-placement work should treat it
+    # as soft, with the retry count as the natural signal for how soft.
+    #
+    # ⚠️ AND IT IS EAGER-ONLY MONEY (pgw#1627). The compiled regime's demand
+    # lands outside the torch allocator, where the cache is not spendable at
+    # all and the failure mode past the probe is process death, not retries.
+    # `headroom_admits` holds the split; do not re-merge the terms.
+    ok, basis = headroom_admits(
+        regime=regime, free_bytes=free, cache_bytes=cache,
+        floor_bytes=floor_bytes, demand_bytes=demand_bytes,
+    )
+    return ok, free, basis
+
+
+def compiled_dispatch_armed(module: Any) -> bool:
+    """Is ``module``'s next forward a COMPILED call? (pgw#1627)
+
+    torchcg's adopt path installs its dispatcher as an INSTANCE attribute —
+    ``module.forward = dispatcher`` (adopt.py) — which is why the read goes
+    through ``__dict__`` rather than ``getattr``: a bare class ``forward``
+    means no dispatcher was ever installed. Duck-typed on the dispatcher's
+    ``armed_graphs()`` (its own arming signal) instead of an isinstance
+    against the vendored class, so a torchcg the release env pins itself
+    still answers. An armed dispatcher can still fall through to eager on a
+    shape miss, so this can over-release — one spare ``empty_cache`` — but
+    never under-protect the compiled call.
+    """
+    try:
+        fwd = getattr(module, "__dict__", {}).get("forward")
+        armed = getattr(fwd, "armed_graphs", None)
+        return bool(callable(armed) and armed())
+    except Exception:  # noqa: BLE001 — a gate that raises would cost the request
+        return False
 
 
 def parks_module(target: Any) -> bool:
@@ -739,28 +840,34 @@ def apply_component_residency(
             )
             return False
         if free_bytes_now is not None:
-            ok, free = probe_plan(parked, free_bytes_now=free_bytes_now)
+            ok, free, basis = probe_plan(parked, free_bytes_now=free_bytes_now)
             # The probe's MEASUREMENT, handed back so the caller can put it on
             # the loud line. pgw#1595: success was `log.info` and inaudible at
             # the endpoint's WARNING level, which makes "probe passed" and
             # "probe never ran" the same picture (pgw#1559 class).
             if facts is not None:
                 facts["probe_free_bytes"] = int(free)
+                # pgw#1627: WHICH budget the admit used (driver_free vs
+                # free+cache), so the regime split is visible from the
+                # confession rather than from the code.
+                facts["headroom_basis"] = str(basis)
                 facts.update(_placement_attribution(torch))
             if not ok:
                 log.warning(
-                    "partial_resident: PROBE REFUSED %s — onloading the largest "
-                    "evicted component left %.2f GiB free, under the %.2f GiB "
-                    "floor. The plan's arithmetic said %.2f GiB peak of %.2f "
-                    "free; the card disagrees, and the card is right.",
-                    ",".join(plan.offloaded), free / _GIB,
+                    "partial_resident: PROBE REFUSED %s (budget basis: %s) — "
+                    "onloading the largest evicted component left %.2f GiB "
+                    "free, under the %.2f GiB floor. The plan's arithmetic "
+                    "said %.2f GiB peak of %.2f free; the card disagrees, and "
+                    "the card is right.",
+                    ",".join(plan.offloaded), basis, free / _GIB,
                     _PROBE_FLOOR_BYTES / _GIB,
                     plan.transient_peak_bytes / _GIB, plan.free_bytes / _GIB,
                 )
                 return False
             log.info(
-                "partial_resident: probe OK — %.2f GiB still free with %s "
-                "onloaded", free / _GIB, ",".join(plan.offloaded),
+                "partial_resident: probe OK (budget basis: %s) — %.2f GiB "
+                "still free with %s onloaded",
+                basis, free / _GIB, ",".join(plan.offloaded),
             )
         _install_residency_hooks(
             pipeline, parked, _pipeline_component_names(pipeline), log
@@ -789,6 +896,8 @@ __all__ = [
     "ParkedComponent",
     "ResidencyPlan",
     "apply_component_residency",
+    "compiled_dispatch_armed",
+    "headroom_admits",
     "parks_module",
     "plan_component_residency",
     "method_driven_components",

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -593,7 +593,7 @@ def test_the_probe_counts_the_reusable_allocator_pool_as_available():
     real_attr = pr._placement_attribution
     pr._placement_attribution = lambda torch_mod: {"attr_cache_bytes": cache}
     try:
-        ok, reported = pr.probe_plan(
+        ok, reported, basis = pr.probe_plan(
             parked, free_bytes_now=lambda: driver_free, floor_bytes=floor)
     finally:
         pr._placement_attribution = real_attr
@@ -605,6 +605,217 @@ def test_the_probe_counts_the_reusable_allocator_pool_as_available():
     assert reported == driver_free, (
         "the reported number must stay the DRIVER-free figure — the soft cache "
         "term belongs in the decision, not in what the log claims is free"
+    )
+    assert basis == "free+cache", (
+        "an eager admit must confess the free+cache basis (pgw#1627)"
+    )
+
+
+# --------------------------------------------------------------------------
+# pgw#1627 — the headroom split: allocator cache is EAGER-ONLY money
+# --------------------------------------------------------------------------
+
+# The 8 GiB death, as measured (arm-static-c51ba51f/up.log): driver_free at the
+# compiled first call, the dead cache parking stranded in the allocator, and
+# AOTI's out-of-allocator first-call demand (sdxl sm_89, 4/4, batch-invariant).
+_DEATH_FREE = int(1.18 * _GIB)
+_DEATH_CACHE = int(1.02 * _GIB)
+_AOTI_DEMAND = int(1.15 * _GIB)
+
+
+def test_the_death_shape_numbers_refuse_compiled_and_admit_eager():
+    """pgw#1627, the RED arm of the regime split, on the exact numbers that
+    killed the process. Counting cache for a compiled admit said 2.2 GiB
+    against a real budget of 1.18 — AOTI allocates outside the torch
+    allocator, so the cache was money the compiled call could not spend, and
+    the process died at step 0 with no traceback."""
+    from gen_worker.models.partial_resident import headroom_admits
+
+    ok, basis = headroom_admits(
+        regime="compiled", free_bytes=_DEATH_FREE, cache_bytes=_DEATH_CACHE,
+        demand_bytes=_AOTI_DEMAND,
+    )
+    assert not ok, (
+        "the compiled predicate admitted the death shape — 1.18 GiB of "
+        "driver_free cannot cover a 1.15 GiB out-of-allocator demand plus "
+        "the floor, and the 1.02 GiB of cache is not compiled money"
+    )
+    assert basis == "driver_free"
+
+    ok, basis = headroom_admits(
+        regime="eager", free_bytes=_DEATH_FREE, cache_bytes=_DEATH_CACHE,
+    )
+    assert ok, (
+        "the same numbers must ADMIT eager — the cache is spendable by the "
+        "torch allocator, and refusing here would be the pgw#1586 spurious "
+        "refusal all over again"
+    )
+    assert basis == "free+cache"
+
+
+def test_post_release_driver_free_admits_compiled():
+    """The other half of the fix: `release_cached_vram()` hands the parked
+    cache back to the driver, and THEN the same card admits the compiled
+    call. 4782 weights + 371 ctx + 1154 AOTI pool + 450 activations = 6757 of
+    7808 MiB — fits with ~1 GiB spare, which is what the on-card TEST 1
+    validates against this predicate."""
+    from gen_worker.models.partial_resident import headroom_admits
+
+    ok, basis = headroom_admits(
+        regime="compiled", free_bytes=_DEATH_FREE + _DEATH_CACHE,
+        cache_bytes=0, demand_bytes=_AOTI_DEMAND,
+    )
+    assert ok, (
+        "post-release driver_free (2.20 GiB) covers demand+floor (1.40 GiB) "
+        "and must admit — a split that refuses this is a cliff, not a guard"
+    )
+    assert basis == "driver_free"
+
+
+def test_probe_plan_itself_refuses_a_compiled_leg_the_cache_would_admit():
+    """The split through `probe_plan`'s real code path — the mirror image of
+    `test_the_probe_counts_the_reusable_allocator_pool_as_available` above:
+    the SAME reusable-pool term that rightly rescues an eager admit must be
+    invisible to a compiled one."""
+    import gen_worker.models.partial_resident as pr
+
+    pipe = _pipeline()
+    _, armed = _arm(pipe)
+    assert armed
+    parked = getattr(pipe, PARKED_COMPONENTS_ATTR)
+
+    real_attr = pr._placement_attribution
+    pr._placement_attribution = (
+        lambda torch_mod: {"attr_cache_bytes": _DEATH_CACHE})
+    try:
+        ok, reported, basis = pr.probe_plan(
+            parked, free_bytes_now=lambda: _DEATH_FREE,
+            regime="compiled", demand_bytes=_AOTI_DEMAND,
+        )
+        eager_ok, _, _ = pr.probe_plan(
+            parked, free_bytes_now=lambda: _DEATH_FREE,
+        )
+    finally:
+        pr._placement_attribution = real_attr
+
+    assert not ok and basis == "driver_free", (
+        "probe_plan admitted a compiled leg on cache the compiled call "
+        "cannot spend — the exact death arithmetic"
+    )
+    assert reported == _DEATH_FREE
+    assert eager_ok, "the eager reading of the same card must stay admitted"
+
+
+def test_the_admit_confesses_which_budget_basis_it_used():
+    """Acceptance (c): the confession carries `headroom_basis`, so the hub can
+    see the split executing rather than trusting that it does."""
+    pipe = _pipeline()
+    plan = plan_for_pipeline(
+        pipe, budget_bytes=1200, free_bytes=64 * _MIB,
+        transient_reserve_bytes=0,
+        sizer=lambda m: sum(p.numel() * p.element_size() for p in m.parameters()),
+    )
+    facts: dict = {}
+    armed = apply_component_residency(
+        pipe, plan, device="cpu", log=logging.getLogger("t"),
+        free_bytes_now=lambda: 4 * _GIB, facts=facts,
+    )
+    assert armed
+    assert facts.get("headroom_basis") == "free+cache", (
+        "the probe admitted and did not say which budget arithmetic it used"
+    )
+
+
+# --------------------------------------------------------------------------
+# pgw#1627 — the park→compiled seam releases the cache, and ONLY for compiled
+# --------------------------------------------------------------------------
+
+
+class _FakeDispatcher:
+    """torchcg's adopt shape (adopt.py:551): an INSTANCE `forward` shadowing
+    the class one, exposing `armed_graphs()`. Duck-typed exactly like the real
+    `_ForwardDispatcher` so the seam's gate reads it the same way."""
+
+    def __init__(self, module: Any, events: List[str]) -> None:
+        self.eager_forward = module.forward
+        self._events = events
+
+    def armed_graphs(self) -> tuple:
+        return ("graph-1",)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self._events.append("compiled_call")
+        return self.eager_forward(*args, **kwargs)
+
+
+def _seam_events(adopt: bool) -> List[str]:
+    """Arm the rung, THEN (optionally) adopt, then serve one request —
+    recording park / release / compiled-call order.
+
+    The adopt-AFTER-hook-install ordering is the death log's own
+    (residency confession before `adopt: … armed`), and it is load-bearing:
+    a gate evaluated at hook-install time reads "not compiled" forever and
+    this test's `released` event never appears."""
+    import gen_worker.models.memory as m
+    import gen_worker.models.partial_resident as pr
+
+    events: List[str] = []
+    pipe = _pipeline()
+    _, armed = _arm(pipe)
+    assert armed
+
+    if adopt:
+        pipe.unet.forward = _FakeDispatcher(pipe.unet, events)
+
+    real_park = pr.ParkedComponent.park
+    real_release = m.release_cached_vram
+
+    def counted_park(self: Any) -> None:
+        if self.on_device:
+            events.append("parked")
+        real_park(self)
+
+    pr.ParkedComponent.park = counted_park  # type: ignore[method-assign]
+    m.release_cached_vram = lambda: events.append("released")
+    try:
+        # One request, the pipeline's own call order: the parked encoder
+        # onloads via its pre-hook; the resident unet's pre-hook parks it and
+        # sits exactly at the park→compiled seam.
+        pipe.text_encoder(torch.randn(2, 8))
+        pipe.unet(torch.randn(2, 16))
+    finally:
+        pr.ParkedComponent.park = real_park  # type: ignore[method-assign]
+        m.release_cached_vram = real_release
+    return events
+
+
+def test_the_seam_releases_the_cache_between_park_and_the_compiled_call():
+    """Acceptance (b): parked → released → first compiled call, in that
+    order. The dispatcher is installed AFTER the hooks (adopt runs after the
+    rung arms, per the death log), so a release gated at install time — the
+    pgw#1587 wrong-moment shape — fails here by never firing."""
+    events = _seam_events(adopt=True)
+    assert "parked" in events, "the seam never parked — the instrument is blind"
+    assert "released" in events, (
+        "the park→compiled seam never released the allocator cache; either "
+        "the gate was read at install time (before adopt) or it does not "
+        "recognise an armed dispatcher"
+    )
+    assert "compiled_call" in events
+    assert events.index("parked") < events.index("released") < events.index(
+        "compiled_call"
+    ), f"wrong order at the seam: {events}"
+
+
+def test_the_seam_keeps_the_cache_for_an_eager_denoiser():
+    """The split's other half: no armed dispatcher means the cache is the
+    eager regime's activation money (pgw#1586) and must NOT be released."""
+    events = _seam_events(adopt=False)
+    assert "parked" in events
+    assert "released" not in events, (
+        "the seam released the allocator cache under an EAGER denoiser — "
+        "that cache is eager's activation money, and this empty_cache is a "
+        "per-request tax the regime split exists to avoid"
     )
 
 


### PR DESCRIPTION
Fixes the bug that killed every compiled-SDXL leg on 8 GiB (death receipt `arm-static-c51ba51f/up.log`: attr_alloc_gb=4.78, attr_cache_gb=1.30, attr_ctx_gb=0.35, drv_min_free_mib=1182).

**The bug.** Parking components strands ~1.3 GiB of dead device cache in the torch allocator, and `probe_plan` admitted on `(free + cache) >= floor`. Correct for eager (torch can spend its own cache), false for compiled: AOTI's first-call demand (+1154 MiB measured 4/4 on sdxl sm_89, batch-invariant) allocates OUTSIDE the torch allocator, so the compiled budget is `driver_free` alone. Admitted against 2.2 GiB, had 1.18 → process death at step 0, no traceback.

**The fix** (pgw#1601's banked REGIME-SPLIT ruling, implemented early — tracker pgw#1627):
1. `headroom_admits()`: compiled counts `driver_free` only against `demand + floor`; eager keeps `free + reusable cache`. `probe_plan` routes through it; the admit confesses `headroom_basis` (`driver_free` vs `free+cache`).
2. `_install_residency_hooks::_release` (the seam that strands the cache) calls `release_cached_vram()` after `_park_all_but()`, gated at REQUEST time on an armed torchcg dispatcher on the module — adopt runs after hook install, so an install-time gate would never fire. Eager keeps its cache.

**Tests** (logic-level; the on-card proof is the forensics lane's TEST 1, which validates this landed path — predicted fit with ~1 GiB spare): death-shape numbers refuse compiled + admit eager through both the predicate and `probe_plan`'s real path; post-release admits compiled; call-order test proves parked → released → first compiled call with adopt AFTER hook install; eager keeps the cache. Both guards proven red-able before trusting green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)