### PR TITLE
pgw#1627 follow-up: thread compile intent into the probe — the regime split was dead code in production

### DIFF
--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -2421,8 +2421,21 @@ def apply_low_vram_config(
     offload_to_disk_path: Optional[str] = None,
     stream_budget_bytes: int = 0,
     stream_ram_budget_bytes: int = 0,
+    regime: str = "eager",
+    compiled_demand_bytes: int = 0,
 ) -> Dict[str, Any]:
     """Apply a low-VRAM configuration to a diffusers pipeline.
+
+    ``regime`` is the caller's COMPILE INTENT — "will this load serve
+    compiled" (``ctx.load`` derives it from whether a graph-adoption sink is
+    bound). It reaches the `partial_resident` probe's REGIME-SPLIT floor
+    (pgw#1627: compiled counts ``driver_free`` only; eager keeps
+    ``free + reusable cache``). ``compiled_demand_bytes`` is the compiled
+    artifact's out-of-allocator first-call demand — pgw#1601's mint-time
+    stamp once it lands. Until a caller has a stamp it is 0, which makes the
+    compiled REFUSAL inert by design; the park→compiled-seam cache release is
+    the active protection meanwhile, and the confession's
+    ``headroom_basis``/``headroom_demand_gb`` pair says so out loud.
 
     ``mode="auto"`` runs :func:`select_auto_mode` against free VRAM. Returns a
     dict describing what was applied. Idempotent per pipeline object.
@@ -2698,6 +2711,10 @@ def apply_low_vram_config(
                 pipeline, plan, device=_execution_device(), log=log,
                 free_bytes_now=lambda: int(get_available_vram_gb() * _GIB),
                 facts=probe_facts,
+                # pgw#1627 follow-up: the regime split shipped first as a
+                # probe_plan parameter THIS call never passed — dead code on
+                # the exact path that produced the death log's probe line.
+                regime=regime, demand_bytes=int(compiled_demand_bytes),
             )
             if armed:
                 break
@@ -2728,8 +2745,13 @@ def apply_low_vram_config(
             if "headroom_basis" in probe_facts:
                 # pgw#1627: the regime-split admit names its budget basis
                 # (driver_free vs free+cache) on the loud line, so the hub can
-                # see WHICH arithmetic admitted without the code in hand.
+                # see WHICH arithmetic admitted without the code in hand —
+                # plus the demand it was checked against, so `driver_free`
+                # with demand 0 reads as "split WIRED, stamp pending
+                # (pgw#1601), refusal inert" rather than as protection.
                 applied["headroom_basis"] = str(probe_facts["headroom_basis"])
+                applied["headroom_demand_gb"] = (
+                    float(probe_facts.get("headroom_demand_bytes", 0)) / _GIB)
             probe_free = probe_facts.get("probe_free_bytes")
             if probe_free is not None:
                 # Probe SUCCESS was `log.info` and therefore inaudible, which

--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -538,6 +538,14 @@ def _install_residency_hooks(
 
     seen_parked = False
     released_confessed: List[bool] = []
+    # pgw#1627 follow-up: the gate below interrogates the DENOISER, resolved
+    # by name, NOT whichever module the release hook happens to ride. The hook
+    # sits on the first resident module after the parked chain — for SDXL that
+    # IS the unet, but only by execution-order coincidence: a family whose
+    # first post-parked resident is not the denoiser would have gated on a
+    # module no one compiles, and the release would silently never fire.
+    _gate_name = _denoiser_name(pipeline, list(order))
+    _gate_module = getattr(pipeline, _gate_name, None) if _gate_name else None
     for name in order:
         if name in parked:
             seen_parked = True
@@ -554,7 +562,7 @@ def _install_residency_hooks(
             # components' device blocks in the caching allocator (~1.3 GiB
             # measured on the 8 GiB death), where eager can spend them and
             # AOTI — which allocates its first-call pool OUTSIDE the torch
-            # allocator — cannot. So when THIS module's forward is about to
+            # allocator — cannot. So when the DENOISER's forward is about to
             # be a compiled call, hand the cache back to the driver first;
             # when it is eager, keep it (that cache is eager's activation
             # money, pgw#1586). The gate is read HERE, per request, and
@@ -562,7 +570,9 @@ def _install_residency_hooks(
             # AFTER these hooks are installed (death-log ordering), so an
             # install-time gate would always read "not compiled" and the
             # release would never fire — the pgw#1587 wrong-moment shape.
-            if compiled_dispatch_armed(_m):
+            if compiled_dispatch_armed(
+                _gate_module if _gate_module is not None else _m
+            ):
                 from .memory import release_cached_vram
 
                 release_cached_vram()
@@ -570,9 +580,12 @@ def _install_residency_hooks(
                     released_confessed.append(True)
                     log.info(
                         "partial_resident: released allocator cache after "
-                        "park — %s carries an armed compiled dispatcher, and "
-                        "AOTI spends driver_free, not cache (pgw#1627)",
-                        type(_m).__name__,
+                        "park — the denoiser (%s) carries an armed compiled "
+                        "dispatcher, and AOTI spends driver_free, not cache "
+                        "(pgw#1627)",
+                        type(
+                            _gate_module if _gate_module is not None else _m
+                        ).__name__,
                     )
 
         module.register_forward_pre_hook(_release)
@@ -793,6 +806,8 @@ def apply_component_residency(
     log: logging.Logger,
     free_bytes_now: Any = None,
     facts: Optional[Dict[str, Any]] = None,
+    regime: str = "eager",
+    demand_bytes: int = 0,
 ) -> bool:
     """Arm ``plan`` on ``pipeline``, PROBING it on the card first. Returns
     whether it armed.
@@ -800,6 +815,18 @@ def apply_component_residency(
     A False return means nothing was armed and the caller either asks for a
     more expensive plan or falls to the next rung — never that a partial
     arrangement was left behind.
+
+    ``regime`` is the caller's COMPILE INTENT — "will this load serve
+    compiled" — and reaches :func:`probe_plan`'s regime-split floor check
+    (pgw#1627 follow-up: the split shipped first as a parameter no production
+    caller passed, i.e. dead code on the exact path that produced the death
+    log). It is intent, deliberately not :func:`compiled_dispatch_armed`:
+    adopt arms the dispatcher AFTER load, so at admission time there is
+    nothing armed to interrogate. ``demand_bytes`` is the compiled artifact's
+    out-of-allocator first-call demand — pgw#1601's mint-time stamp once it
+    lands; until then it is 0 and the compiled refusal is INERT BY DESIGN
+    (the seam release in ``_install_residency_hooks`` is the active
+    protection meanwhile).
     """
     if not plan.fits:
         return False
@@ -840,7 +867,10 @@ def apply_component_residency(
             )
             return False
         if free_bytes_now is not None:
-            ok, free, basis = probe_plan(parked, free_bytes_now=free_bytes_now)
+            ok, free, basis = probe_plan(
+                parked, free_bytes_now=free_bytes_now,
+                regime=regime, demand_bytes=demand_bytes,
+            )
             # The probe's MEASUREMENT, handed back so the caller can put it on
             # the loud line. pgw#1595: success was `log.info` and inaudible at
             # the endpoint's WARNING level, which makes "probe passed" and
@@ -849,25 +879,31 @@ def apply_component_residency(
                 facts["probe_free_bytes"] = int(free)
                 # pgw#1627: WHICH budget the admit used (driver_free vs
                 # free+cache), so the regime split is visible from the
-                # confession rather than from the code.
+                # confession rather than from the code — and the demand it was
+                # checked against, so demand=0 reads as "split wired, stamp
+                # pending (pgw#1601)" rather than as protection.
                 facts["headroom_basis"] = str(basis)
+                facts["headroom_demand_bytes"] = int(demand_bytes)
                 facts.update(_placement_attribution(torch))
             if not ok:
                 log.warning(
-                    "partial_resident: PROBE REFUSED %s (budget basis: %s) — "
-                    "onloading the largest evicted component left %.2f GiB "
-                    "free, under the %.2f GiB floor. The plan's arithmetic "
-                    "said %.2f GiB peak of %.2f free; the card disagrees, and "
-                    "the card is right.",
-                    ",".join(plan.offloaded), basis, free / _GIB,
-                    _PROBE_FLOOR_BYTES / _GIB,
+                    "partial_resident: PROBE REFUSED %s (budget basis: %s, "
+                    "demand %.2f GiB) — onloading the largest evicted "
+                    "component left %.2f GiB free, under the %.2f GiB floor. "
+                    "The plan's arithmetic said %.2f GiB peak of %.2f free; "
+                    "the card disagrees, and the card is right.",
+                    ",".join(plan.offloaded), basis, demand_bytes / _GIB,
+                    free / _GIB, _PROBE_FLOOR_BYTES / _GIB,
                     plan.transient_peak_bytes / _GIB, plan.free_bytes / _GIB,
                 )
                 return False
             log.info(
-                "partial_resident: probe OK (budget basis: %s) — %.2f GiB "
-                "still free with %s onloaded",
-                basis, free / _GIB, ",".join(plan.offloaded),
+                "partial_resident: probe OK (budget basis: %s, demand %.2f "
+                "GiB%s) — %.2f GiB still free with %s onloaded",
+                basis, demand_bytes / _GIB,
+                (", INERT until pgw#1601's stamp lands"
+                 if regime == "compiled" and demand_bytes <= 0 else ""),
+                free / _GIB, ",".join(plan.offloaded),
             )
         _install_residency_hooks(
             pipeline, parked, _pipeline_component_names(pipeline), log

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -942,6 +942,18 @@ class LoadContext(Generic[MT_co]):
                 pipeline,
                 mode="auto",
                 stream_budget_bytes=self._weight_budget_bytes,
+                # pgw#1627: COMPILE INTENT, for the regime-split headroom
+                # probe. A bound compile sink is what makes `ctx.compile`
+                # consult the graph store at all, so it IS "this load may
+                # serve compiled" — and it is the only signal available at
+                # admission: adopt arms dispatchers AFTER load, so there is
+                # nothing armed to interrogate yet (the forensics ordering
+                # proof). The compiled demand stamp (pgw#1601) is not wired
+                # yet; until it is, the compiled refusal is inert and the
+                # basis confession says which arithmetic ran.
+                regime=(
+                    "compiled" if self._compile_sink is not None else "eager"
+                ),
             )
         except HostRamMoveRefusedError:
             # The guard did its job: this host cannot hold what the rung wanted

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -706,9 +706,13 @@ def test_probe_plan_itself_refuses_a_compiled_leg_the_cache_would_admit():
     assert eager_ok, "the eager reading of the same card must stay admitted"
 
 
-def test_the_admit_confesses_which_budget_basis_it_used():
-    """Acceptance (c): the confession carries `headroom_basis`, so the hub can
-    see the split executing rather than trusting that it does."""
+def _admit_through_production_path(*, regime, free_bytes, cache_bytes,
+                                   demand_bytes=0):
+    """Arm through `apply_component_residency` — the ONLY production caller of
+    `probe_plan`, and the call the first #1627 PR left unpassed (dead code on
+    the exact path that produced the death log's probe line)."""
+    import gen_worker.models.partial_resident as pr
+
     pipe = _pipeline()
     plan = plan_for_pipeline(
         pipe, budget_bytes=1200, free_bytes=64 * _MIB,
@@ -716,13 +720,89 @@ def test_the_admit_confesses_which_budget_basis_it_used():
         sizer=lambda m: sum(p.numel() * p.element_size() for p in m.parameters()),
     )
     facts: dict = {}
-    armed = apply_component_residency(
-        pipe, plan, device="cpu", log=logging.getLogger("t"),
-        free_bytes_now=lambda: 4 * _GIB, facts=facts,
-    )
+    real_attr = pr._placement_attribution
+    pr._placement_attribution = (
+        lambda torch_mod: {"attr_cache_bytes": cache_bytes})
+    try:
+        armed = apply_component_residency(
+            pipe, plan, device="cpu", log=logging.getLogger("t"),
+            free_bytes_now=lambda: free_bytes, facts=facts,
+            regime=regime, demand_bytes=demand_bytes,
+        )
+    finally:
+        pr._placement_attribution = real_attr
+    return armed, facts
+
+
+def test_an_eager_load_admits_and_confesses_free_plus_cache():
+    """Acceptance (c), eager half — through the production path."""
+    armed, facts = _admit_through_production_path(
+        regime="eager", free_bytes=_DEATH_FREE, cache_bytes=_DEATH_CACHE)
     assert armed
     assert facts.get("headroom_basis") == "free+cache", (
         "the probe admitted and did not say which budget arithmetic it used"
+    )
+
+
+def test_a_compiled_load_refuses_the_death_shape_THROUGH_the_production_path():
+    """The wiring test the first #1627 PR was missing: `regime` existed on
+    `probe_plan` while its only production caller never passed it, so the
+    compiled branch was UNREACHABLE in production and `headroom_basis` was a
+    constant "free+cache" — a confession that could not go red. This drives
+    the death-shape numbers through `apply_component_residency` itself and
+    demands the driver_free basis AND the refusal."""
+    armed, facts = _admit_through_production_path(
+        regime="compiled", free_bytes=_DEATH_FREE, cache_bytes=_DEATH_CACHE,
+        demand_bytes=_AOTI_DEMAND)
+    assert facts.get("headroom_basis") == "driver_free", (
+        "a compiled load's probe still confesses the eager basis — the "
+        "regime never reached the predicate (the dead-plumbing finding)"
+    )
+    assert facts.get("headroom_demand_bytes") == _AOTI_DEMAND, (
+        "the demand the admit was checked against must be in the confession, "
+        "or demand=0 inertness is indistinguishable from a real guard"
+    )
+    assert not armed, (
+        "the death shape was admitted compiled through the production path — "
+        "1.02 GiB of allocator cache is not money AOTI can spend"
+    )
+
+
+def test_a_compiled_load_with_no_stamp_is_wired_but_inert():
+    """Honesty pin: until pgw#1601's mint-time demand stamp lands, production
+    passes demand_bytes=0 and the compiled refusal DOES NOT bite (1.18 GiB >=
+    0 + floor admits). The split is WIRED — the basis reads driver_free — and
+    the seam release is the only active protection. If this test fails on
+    `armed`, a demand source was wired in: move the death-shape refusal
+    expectation to that source's tests and delete this pin."""
+    armed, facts = _admit_through_production_path(
+        regime="compiled", free_bytes=_DEATH_FREE, cache_bytes=_DEATH_CACHE)
+    assert armed, "demand=0 admits — the refusal is inert until the stamp"
+    assert facts.get("headroom_basis") == "driver_free"
+    assert facts.get("headroom_demand_bytes") == 0
+
+
+def test_the_load_path_threads_compile_intent_into_the_probe():
+    """The chain above `apply_component_residency`, pinned at the source level
+    so the dead-plumbing class cannot re-open silently: `ctx.load`'s fit-rung
+    call derives `regime` from its compile sink (intent — adopt arms AFTER
+    load, so `compiled_dispatch_armed` is unusable at admission), and
+    `apply_low_vram_config` hands regime + demand to the probe call."""
+    import inspect
+
+    import gen_worker.models.memory as m
+    import gen_worker.serving.context as c
+
+    fit = inspect.getsource(c.LoadContext._fit_rung)
+    assert "_compile_sink" in fit and "regime=" in fit, (
+        "ctx.load no longer derives the probe regime from its compile intent"
+    )
+    low_vram = inspect.getsource(m.apply_low_vram_config)
+    idx = low_vram.index("apply_component_residency(")
+    call = low_vram[idx:idx + 600]  # the call site plus its kwargs window
+    assert "regime=regime" in call and "demand_bytes=" in call, (
+        "apply_low_vram_config's probe call dropped regime/demand — the "
+        "regime split is dead code in production again"
     )
 
 
@@ -816,6 +896,75 @@ def test_the_seam_keeps_the_cache_for_an_eager_denoiser():
         "the seam released the allocator cache under an EAGER denoiser — "
         "that cache is eager's activation money, and this empty_cache is a "
         "per-request tax the regime split exists to avoid"
+    )
+
+
+class _MidStagePipeline(DiffusionPipeline):
+    """A family whose first resident module AFTER the parked chain is NOT the
+    denoiser. On SDXL the two coincide (encoders park, the unet is next), so
+    a gate that interrogates the hook's own module is right there by
+    execution-order coincidence only — this shape is where that gate goes
+    silently blind."""
+
+    model_cpu_offload_seq = "text_encoder->mid->unet->vae"
+    text_encoder: Any
+    mid: Any
+    unet: Any
+    vae: Any
+
+    def __init__(self, text_encoder: Any, mid: Any, unet: Any, vae: Any) -> None:
+        super().__init__()
+        cast(Any, self).register_modules(
+            text_encoder=text_encoder, mid=mid, unet=unet, vae=vae
+        )
+
+
+def test_the_seam_gate_reads_the_DENOISER_not_whichever_module_holds_the_hook():
+    """pgw#1627 follow-up, finding 3: the release hook rides the first
+    resident module after the parked chain, and the gate must still ask the
+    DENOISER — the compile target — whether a compiled call is coming. Here
+    that first module is `mid` (never compiled) while the dispatcher sits on
+    `unet`: a gate keyed to the hook's own module never releases, and this
+    test goes red."""
+    import gen_worker.models.memory as m
+    import gen_worker.models.partial_resident as pr
+
+    events: List[str] = []
+    pipe = _MidStagePipeline(_Block(8), _Block(12), _Block(16), _Block(4))
+    sizer = lambda mod: sum(  # noqa: E731
+        p.numel() * p.element_size() for p in mod.parameters())
+    total = sum(sizer(c) for c in pipe.components.values())
+    plan = plan_for_pipeline(
+        pipe,
+        # Room for everything but the text encoder: the cheapest legal plan
+        # parks exactly `text_encoder`, so `mid` is the first post-parked
+        # resident and carries the release hook.
+        budget_bytes=total - sizer(pipe.text_encoder) + 8,
+        free_bytes=64 * _MIB,
+        transient_reserve_bytes=0,
+        sizer=sizer,
+    )
+    assert plan.fits and plan.offloaded == ("text_encoder",)
+    armed = apply_component_residency(
+        pipe, plan, device="cpu", log=logging.getLogger("t"))
+    assert armed
+
+    pipe.unet.forward = _FakeDispatcher(pipe.unet, events)
+    real_release = m.release_cached_vram
+    m.release_cached_vram = lambda: events.append("released")
+    try:
+        pipe.text_encoder(torch.randn(2, 8))
+        pipe.mid(torch.randn(2, 12))
+        pipe.unet(torch.randn(2, 16))
+    finally:
+        m.release_cached_vram = real_release
+
+    assert "released" in events, (
+        "no release before the compiled denoiser call — the gate asked the "
+        "hook's own module (mid) instead of resolving the denoiser"
+    )
+    assert events.index("released") < events.index("compiled_call"), (
+        f"the release must precede the compiled call: {events}"
     )
 
 

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -933,7 +933,7 @@ def test_the_seam_gate_reads_the_DENOISER_not_whichever_module_holds_the_hook():
     pipe = _MidStagePipeline(_Block(8), _Block(12), _Block(16), _Block(4))
     sizer = lambda mod: sum(  # noqa: E731
         p.numel() * p.element_size() for p in mod.parameters())
-    total = sum(sizer(c) for c in pipe.components.values())
+    total = sum(sizer(c) for c in cast(Any, pipe).components.values())
     plan = plan_for_pipeline(
         pipe,
         # Room for everything but the text encoder: the cheapest legal plan


### PR DESCRIPTION
Re-opened by the forensics lane's $0 finding against b8ef5b52 (PR #1169): `probe_plan` gained `regime` but its only production caller never passed it — the compiled branch of `headroom_admits` was unreachable, `headroom_basis` was a constant `free+cache`, and pgw#1601's demand stamp had no consumer. Test :724 pinned the bug. The green-test-on-an-unreached-seam class.

**Plumbing (tracker pgw#1627):**
1. `ctx.load::_fit_rung` passes `regime="compiled"` iff its compile sink is bound — the caller's COMPILE INTENT, the only signal available at admission (adopt arms dispatchers AFTER load, so `compiled_dispatch_armed` is unusable there).
2. `apply_low_vram_config(regime=, compiled_demand_bytes=)` → `apply_component_residency(regime=, demand_bytes=)` → `probe_plan`. Confession now carries `headroom_demand_gb` beside `headroom_basis`.
3. **Inert-by-design, stated out loud:** production demand is 0 until pgw#1601's mint-time stamp lands, so the compiled refusal does not bite yet (1.18 GiB ≥ 0 + 0.25 floor admits); the park→compiled seam release remains the active protection. The probe log says "INERT until pgw#1601's stamp lands" on that exact case.
4. The seam gate resolves the DENOISER explicitly instead of interrogating whichever module carries the release hook (SDXL-only ordering coincidence).

**Tests:** death shape refuses compiled THROUGH `apply_component_residency` (basis `driver_free`, with stamp) and admits eager; wired-but-inert pin for demand=0; source-level wiring guard on the ctx.load → probe chain; mid-stage pipeline proves the gate reads the denoiser. All three new guards proven red-able by sabotage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)