### PR TITLE
pgw#1632: two store fences — the ensure_* idempotence harness and the counter-source lint

### DIFF
--- a/changelog.d/pgw1632.md
+++ b/changelog.d/pgw1632.md
@@ -1,0 +1,45 @@
+- **pgw#1632: every `ensure_*` on the weight path now has to PROVE it is idempotent.**
+  A fill is supposed to be a pure function of (manifest, store) — objects the CAS holds
+  are skipped, progress IS bytes-present, and re-entry is free. That property had no
+  instrument, which is why pgw#1596 (a headroom gate that demanded the whole tree while
+  82% of it was resident) reached a $2/hr H200 before anything went red, and why
+  th#2246's tier-3 view wrote a second 57.7 GB copy of a tree the disk was bought to
+  hold once. The harness drives the real `ModelStore.ensure_local` /
+  `_materialize_local`, the real `download.ensure_local` and the real
+  `ensure_snapshot_async` against a real HTTP origin and a real `LocalCAS`, and asserts
+  three properties on each: **called twice** moves zero network bytes and returns the
+  same path; **killed at k% (k ∈ 10/50/80/99) then re-entered** fetches EXACTLY the
+  bytes the first pass did not bank — not approximately, since every object either
+  landed or did not; and the **disk high-water never exceeds one tree** plus the
+  fan-out's in-flight temporaries. The only injected part is the origin's byte fuse,
+  which is what "the fetcher raised" means, and `ModelStore`'s own
+  `disk_free_bytes_fn` parameter, which expresses "this volume holds one copy of the
+  tree" as arithmetic over the real files the fill really wrote. The pre-`d2e31047`
+  gate is reconstructed in a red arm and fails, so the harness is known to be able to
+  go red.
+
+- **pgw#1632: the gate and the fill are made to agree by MEASUREMENT, not by review.**
+  The named anti-pattern is *a precondition computed from a stale view of state the
+  operation itself changes* — the gate asks the REQUEST what it costs while the fill
+  asks the DELTA. Both layers now run against one partially-filled store and their
+  numbers are compared: what the gate's refusal quotes as `required_bytes` against what
+  the origin then really serves. pgw#1596 is precisely the case where those disagreed
+  by 86 GB. A cheap structural twin backs it up — `_ensure_disk_headroom` may not read
+  a file size or `sum()` anything, because a gate that can re-derive its cost is a gate
+  that can disagree.
+
+- **pgw#1632: a byte counter cannot exist without declaring the instrument it was read
+  off, and `load:staged_bytes` becomes `load:ingested_bytes`.** That counter samples
+  `/proc/self/io` **read_bytes** plus anon-RSS growth — a READ meter wearing a WRITE
+  verb. Nothing about the number was wrong; th#2246's first mechanism lane believed the
+  name and spent a pass hunting a per-child write that does not exist in this repo.
+  `gen_worker.byte_sources` declares a `Source` for every byte counter and position
+  (`PROC_READ_IO`, `PROC_WRITE_IO`, `NET_SOCKET_RECV`, `NET_SOCKET_SEND`,
+  `STATVFS_DELTA`, `RSS_GROWTH`, `CAS_ACCOUNTED`), and a registry-driven table test
+  enforces that the verb suits the direction: `staged`/`written`/`flushed`/`uploaded`
+  need a write instrument, `read`/`ingested`/`pulled` a read one, `freed`/`consumed`
+  the filesystem. An AST scan over `src/` — not a grep, because the names are built at
+  the call site — refuses any byte counter the registry does not classify, and refuses
+  a registry entry no site creates, so a half-done rename fails on both halves rather
+  than neither. The rename is wire-safe: the hub's stall clock keys on advancement, not
+  on the name, and no repository in the workspace greps the literal.

--- a/src/gen_worker/byte_sources.py
+++ b/src/gen_worker/byte_sources.py
@@ -1,0 +1,156 @@
+"""pgw#1632(b): every byte counter declares HOW it was measured.
+
+`load:staged_bytes` sampled `/proc/self/io` **read_bytes** plus anonymous-RSS
+growth — a READ meter wearing a WRITE verb. th#2246's first mechanism lane read
+the name, went looking for a per-child write that does not exist, and spent a
+pass on it. The number was never wrong; the name was, and a name is the only
+thing a reader has.
+
+So a byte counter is not just a name and a unit. It is a name, a unit, and the
+INSTRUMENT it was read off. Once the instrument is declared, the admissible
+verbs follow from it mechanically, and `tests/test_counter_source_lint_pgw1632.py`
+enforces both halves: the verb must suit the source, and a counter that names no
+source cannot be created at all.
+
+The design review's ``NET_SOCKET`` is split by direction here. A socket meter is
+a read instrument on the way in and a write instrument on the way out, so an
+undirected socket source would make the lint vacuous for the network path —
+which is the largest byte mover in the repo and the one most worth naming
+correctly.
+
+``CAS_ACCOUNTED`` is the honest source for the aggregate positions: they credit
+bytes that are PRESENT for a manifest regardless of whether they arrived over a
+socket, came off a volume, or were already banked. It admits no directional verb
+at all, which is the correct outcome — `weight_position`'s own docstring already
+warns that its position is "bytes accounted for the snapshot, not bytes off the
+wire", and no read verb or write verb can say that truthfully.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Mapping
+
+
+class Direction(Enum):
+    """What class of verb a source can honestly wear."""
+
+    READ = "read"
+    WRITE = "write"
+    #: Free/used space on a filesystem — neither a read nor a write.
+    SPACE = "space"
+    #: Bytes credited against a plan, from any of several instruments.
+    ACCOUNTED = "accounted"
+
+
+class Source(Enum):
+    """The instrument a byte counter is sampled from."""
+
+    #: `/proc/<pid>/io` read_bytes — bytes this process pulled off block devices.
+    PROC_READ_IO = (Direction.READ,)
+    #: `/proc/<pid>/io` write_bytes — bytes this process pushed to block devices.
+    PROC_WRITE_IO = (Direction.WRITE,)
+    #: Bytes arriving over a socket.
+    NET_SOCKET_RECV = (Direction.READ,)
+    #: Bytes leaving over a socket.
+    NET_SOCKET_SEND = (Direction.WRITE,)
+    #: A `statvfs` delta on a mount — space freed or consumed.
+    STATVFS_DELTA = (Direction.SPACE,)
+    #: Anonymous resident-set growth — an inference about staging, from memory.
+    RSS_GROWTH = (Direction.READ,)
+    #: Bytes present for a manifest, whatever instrument proved they are there.
+    CAS_ACCOUNTED = (Direction.ACCOUNTED,)
+
+    @property
+    def direction(self) -> Direction:
+        return self.value[0]
+
+
+#: Verb -> the direction a counter wearing it must have been measured with.
+#: Extend it freely; the cost of a new verb is one line, and the cost of an
+#: unclassified one is th#2246's wasted pass.
+VERB_DIRECTIONS: Mapping[str, Direction] = {
+    "staged": Direction.WRITE,
+    "written": Direction.WRITE,
+    "flushed": Direction.WRITE,
+    "uploaded": Direction.WRITE,
+    "read": Direction.READ,
+    "ingested": Direction.READ,
+    "pulled": Direction.READ,
+    "freed": Direction.SPACE,
+    "consumed": Direction.SPACE,
+}
+
+
+#: THE REGISTRY. Every byte counter and byte position in `src/gen_worker`,
+#: keyed by its literal name or — for counters keyed per subject — by the
+#: literal PREFIX before the interpolation. The lint refuses any byte counter
+#: whose name is not resolvable here, so a new one cannot be added unclassified.
+BYTE_COUNTERS: Mapping[str, Source] = {
+    # `/proc/self/io` read_bytes, with RSS growth as the alternate when the
+    # load is page-cache warm. Both read-side; the name says `ingested` for
+    # exactly that reason (pgw#1632's seed fix, was `staged`).
+    "load:ingested_bytes": Source.PROC_READ_IO,
+    # `_progress(done, total)` where `done` = resident + volume-filled +
+    # fetched. Bytes accounted for the snapshot, from three instruments.
+    "download:": Source.CAS_ACCOUNTED,
+    # Bytes pushed through the presigned PUT.
+    "upload:bytes": Source.NET_SOCKET_SEND,
+}
+
+
+#: Byte POSITIONS — the durable per-object aggregates that ride the event
+#: stream rather than the beat. Keyed by qualified class name; each class also
+#: carries the same value as a ``SOURCE`` attribute, and the lint asserts the
+#: two agree so a site cannot drift from the registry.
+BYTE_POSITIONS: Mapping[str, Source] = {
+    # Same quantity as `download:` — bytes accounted for the snapshot, from
+    # residency, volume fill and the wire together.
+    "gen_worker.weight_position.FetchPosition": Source.CAS_ACCOUNTED,
+}
+
+
+def verbs_in(name: str) -> set[str]:
+    """The classified verbs a counter name wears."""
+
+    tokens = {
+        token
+        for token in "".join(c if c.isalnum() else " " for c in name).split()
+    }
+    return tokens & set(VERB_DIRECTIONS)
+
+
+def source_of(name: str) -> Source | None:
+    """The declared source for a counter name, resolving prefix keys."""
+
+    if name in BYTE_COUNTERS:
+        return BYTE_COUNTERS[name]
+    for key, source in BYTE_COUNTERS.items():
+        if key.endswith(":") and name.startswith(key):
+            return source
+    return None
+
+
+def misclassified(name: str, source: Source) -> str:
+    """Why ``name`` may not wear its verbs given ``source``, or ``""``."""
+
+    for verb in sorted(verbs_in(name)):
+        want = VERB_DIRECTIONS[verb]
+        if source.direction is not want:
+            return (
+                f"{name!r} carries the {want.value}-side verb {verb!r} but is "
+                f"measured with {source.name} ({source.direction.value}-side)"
+            )
+    return ""
+
+
+__all__ = [
+    "BYTE_COUNTERS",
+    "BYTE_POSITIONS",
+    "Direction",
+    "Source",
+    "VERB_DIRECTIONS",
+    "misclassified",
+    "source_of",
+    "verbs_in",
+]

--- a/src/gen_worker/models/load_progress.py
+++ b/src/gen_worker/models/load_progress.py
@@ -42,13 +42,23 @@ from pathlib import Path
 from typing import Optional
 
 from .. import activity as activity_mod
+from .. import byte_sources
 from .. import postmortem
 
 logger = logging.getLogger(__name__)
 
 #: One counter name for the whole load path; the hub's stall clock runs on
 #: non-advancement of whatever counter is freshest, not on the name.
-COUNTER_NAME = "load:staged_bytes"
+#:
+#: pgw#1632: was ``load:staged_bytes``. It is sampled from ``/proc/self/io``
+#: read_bytes (with anon-RSS growth as the page-cache-warm alternate) — a READ
+#: meter that wore a WRITE verb, and th#2246's first mechanism lane spent a pass
+#: hunting the per-child write it implied. The rename is wire-safe because the
+#: hub keys on advancement, not on the name (see the module docstring).
+COUNTER_NAME = "load:ingested_bytes"
+#: How :data:`COUNTER_NAME` is measured. `byte_sources` holds the registry the
+#: pgw#1632 lint reads; this is the declaration at the site that produces it.
+COUNTER_SOURCE = byte_sources.Source.PROC_READ_IO
 
 #: A load phase STARTED (``duration_ms`` 0 — nothing is measured yet). This
 #: is the row that names the component a hung load is hung on.
@@ -374,7 +384,7 @@ class LoadProgressReporter:
                 "phase": self._phase,
                 "read_bytes": read,
                 "rss_anon_kb": rss_anon_kb,
-                "staged_bytes": done,
+                "ingested_bytes": done,
                 "total_bytes": self.total_bytes,
                 "started_unix": self._started_unix,
                 "ts_unix": time.time(),
@@ -406,6 +416,7 @@ def thrash_verdict() -> str:
 
 __all__ = [
     "COUNTER_NAME",
+    "COUNTER_SOURCE",
     "EVENT_PHASE",
     "EVENT_PHASE_DONE",
     "EVENT_PHASE_THRASH",

--- a/src/gen_worker/weight_position.py
+++ b/src/gen_worker/weight_position.py
@@ -52,6 +52,8 @@ import logging
 import time
 from typing import Any, Iterator, Optional
 
+from . import byte_sources
+
 logger = logging.getLogger(__name__)
 
 MIB = 1024 * 1024
@@ -92,6 +94,14 @@ class FetchPosition:
     download layer already calls, so the reporter is wired by handing this
     method to the same callback chain rather than by threading a second one.
     """
+
+    #: pgw#1632 — HOW this number is measured, declared at the site that
+    #: produces it. `CAS_ACCOUNTED`, not a wire meter: the position credits
+    #: bytes that are PRESENT for the manifest whether they came off a socket,
+    #: off the endpoint volume, or were already banked (see the module
+    #: docstring's "what the position MEANS"). No read verb and no write verb
+    #: can say that truthfully, which is why the source admits neither.
+    SOURCE = byte_sources.Source.CAS_ACCOUNTED
 
     def __init__(self, ref: str, total_bytes: int = 0) -> None:
         self.ref = str(ref or "")

--- a/tests/fill_fixture.py
+++ b/tests/fill_fixture.py
@@ -1,0 +1,420 @@
+"""The real fill path, driven from a test, with a fault-injectable origin.
+
+pgw#1632. Every `ensure_*` on the weight path is supposed to be a pure function
+of (manifest, store): present objects are skipped, absent ones are fetched, and
+a second call — or a re-entry after a kill — costs nothing but the scan. That
+property has never had an instrument, which is why pgw#1596 (a headroom gate
+that demanded the whole tree while 82% of it was resident) reached a $2/hr H200
+before anything noticed.
+
+Everything here is the production code path. The only injected part is the
+BYTES' ORIGIN: a real HTTP server that answers real grant URLs and can be told
+to stop answering after N bytes, which is how "the fetcher raised at k%" is
+expressed without mocking a single one of the functions under test.
+
+The disk budget is injected the same way production allows it to be —
+:class:`ModelStore`'s own ``disk_free_bytes_fn`` constructor parameter — over a
+REAL measurement of the REAL files the fill wrote, so "the tmpfs is 1x the tree"
+is enforced arithmetic rather than a mounted filesystem no CI runner can create.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import http.server
+import shutil
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Awaitable, Iterable, Optional, Sequence
+
+from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+from gen_worker.models.refs import TensorhubRef, WireRef
+from gen_worker.models.store import ModelStore
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+
+def sha(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+class _Refused(Exception):
+    pass
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_args: object) -> None:
+        pass
+
+    def do_GET(self) -> None:  # noqa: N802
+        origin: "Origin" = self.server.origin  # type: ignore[attr-defined]
+        key = self.path.rsplit("/", 1)[-1]
+        body = origin.blobs.get(key)
+        if body is None:
+            self.send_error(404)
+            return
+        try:
+            origin.charge(len(body))
+        except _Refused:
+            # 410 GONE is TERMINAL in `transfer.grants._retry` (any 4xx that is
+            # not 408/425/429 refuses without retrying), so the fault surfaces
+            # as one immediate failure instead of five backoffs. That is the
+            # shape a kill has: the fetch stops, it does not grind.
+            self.send_error(410)
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class Origin:
+    """A real HTTP origin for CAS objects, with a byte fuse.
+
+    ``wire_bytes`` is what actually left it — the independent check on every
+    claim a fill makes about what it fetched. ``cutoff_bytes`` arms the fuse:
+    once serving one more object would cross it, every further GET is refused
+    terminally. That is the fault injection, and it is at the only layer this
+    harness is allowed to fake.
+    """
+
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+        self.lock = threading.Lock()
+        self.served = 0
+        self.cutoff_bytes: Optional[int] = None
+        self.refusals = 0
+        self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.server.origin = self  # type: ignore[attr-defined]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def charge(self, n: int) -> None:
+        with self.lock:
+            if self.cutoff_bytes is not None and self.served + n > self.cutoff_bytes:
+                self.refusals += 1
+                raise _Refused
+            self.served += n
+
+    def put(self, data: bytes) -> str:
+        digest = sha(data)
+        self.blobs[digest] = data
+        host, port = self.server.server_address[0], self.server.server_address[1]
+        return f"http://{host!s}:{port!s}/{digest}"
+
+    @property
+    def wire_bytes(self) -> int:
+        with self.lock:
+            return int(self.served)
+
+    def arm(self, cutoff_bytes: Optional[int]) -> None:
+        with self.lock:
+            self.cutoff_bytes = cutoff_bytes
+
+    def reset(self) -> None:
+        with self.lock:
+            self.served = 0
+            self.refusals = 0
+            self.cutoff_bytes = None
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join()
+
+
+@dataclass(frozen=True)
+class Tree:
+    """A synthetic checkpoint: distinct objects, known sizes, real URLs."""
+
+    files: tuple[tuple[str, bytes, str], ...]
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(len(body) for _p, body, _u in self.files)
+
+    @property
+    def object_bytes(self) -> int:
+        return len(self.files[0][1])
+
+    def resolved(self) -> WorkerResolvedRepo:
+        fingerprint = hashlib.sha256(
+            b"|".join(f"{p}:{sha(b)}".encode() for p, b, _u in self.files)
+        ).hexdigest()
+        return WorkerResolvedRepo(
+            snapshot_digest="sha256:" + fingerprint,
+            files=[
+                WorkerResolvedRepoFile(p, len(b), url, digest=sha(b))
+                for p, b, url in self.files
+            ],
+        )
+
+    def snapshot(self) -> pb.Snapshot:
+        resolved = self.resolved()
+        return pb.Snapshot(
+            digest=resolved.snapshot_digest,
+            files=[
+                pb.SnapshotFile(
+                    path=f.path, size_bytes=f.size_bytes, digest=f.digest, url=f.url,
+                )
+                for f in resolved.files
+            ],
+        )
+
+
+def build_tree(origin: Origin, *, objects: int = 32, object_bytes: int = 256 * 1024) -> Tree:
+    """A tree of distinct, incompressible-enough objects on a real origin.
+
+    Sized so per-object granularity (1/objects) resolves every k the harness
+    asks for, and so the whole matrix stays inside a CI test budget. The ratios
+    that decide pass/fail — resident vs missing, high-water vs tree — are size
+    independent.
+    """
+
+    files: list[tuple[str, bytes, str]] = []
+    for i in range(objects):
+        body = hashlib.sha256(f"object-{i}".encode()).digest() * (object_bytes // 32)
+        assert len(body) == object_bytes
+        path = f"component-{i % 4}/shard-{i:03d}.safetensors"
+        files.append((path, body, origin.put(body)))
+    return Tree(tuple(files))
+
+
+def disk_used(root: Path) -> int:
+    """Bytes the fill has actually put on this disk, counted from the files.
+
+    ``st_blocks`` would count sparseness and symlink targets twice; the
+    question here is "how many bytes of tree does this pod hold", which the
+    apparent sizes of the regular files answer exactly. Symlinks (the
+    projection's publish form) are deliberately not followed — a projected tree
+    that points into the CAS is not a second copy, and counting it as one would
+    make the high-water assertion unfalsifiable.
+    """
+
+    total = 0
+    for path in root.rglob("*"):
+        try:
+            status = path.lstat()
+        except OSError:
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        total += int(status.st_size)
+    return total
+
+
+class HighWater:
+    """Samples real on-disk bytes while an operation runs."""
+
+    def __init__(self, root: Path, interval_s: float = 0.01) -> None:
+        self.root = root
+        self.interval_s = interval_s
+        self.peak = 0
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.interval_s):
+            self.sample()
+
+    def sample(self) -> int:
+        try:
+            now = disk_used(self.root)
+        except OSError:
+            return self.peak
+        self.peak = max(self.peak, now)
+        return now
+
+    def __enter__(self) -> "HighWater":
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._thread = threading.Thread(target=self._run, name="high-water", daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self.sample()
+
+
+class Wire:
+    """A bound sink collecting the envelopes a real fill emits."""
+
+    def __init__(self) -> None:
+        self.messages: list[pb.WorkerMessage] = []
+
+    async def send(self, msg: pb.WorkerMessage) -> None:
+        self.messages.append(msg)
+
+    @property
+    def model_events(self) -> list[Any]:
+        return [
+            m.model_event for m in self.messages
+            if m.WhichOneof("msg") == "model_event"
+        ]
+
+
+def reset_fill_memos() -> None:
+    """Forget every in-process memo, so the next pass is a fresh PROCESS.
+
+    A re-entry that is only re-entering an in-memory cache proves nothing about
+    resumability. The trusted-snapshot set and the in-flight builder map are
+    module state; a real pod restart has neither.
+    """
+
+    from gen_worker.models import cozy_snapshot
+
+    cozy_snapshot._TRUSTED_SNAPSHOTS.clear()
+    with cozy_snapshot._SNAP_LOCK:
+        cozy_snapshot._SNAP_ENTRIES.clear()
+
+
+@dataclass
+class FillContext:
+    cache_dir: Path
+    tree: Tree
+    origin: Origin
+    ref: WireRef = field(default=WireRef("acme/harness-model"))
+    disk_free_bytes_fn: Optional[Callable[[], int]] = None
+    wire: Wire = field(default_factory=Wire)
+
+    def store(self) -> ModelStore:
+        return ModelStore(
+            self.wire.send,
+            cache_dir=self.cache_dir,
+            disk_free_bytes_fn=self.disk_free_bytes_fn,
+        )
+
+    def budget_fn(self, budget_bytes: int) -> Callable[[], int]:
+        """Free space on a volume of exactly ``budget_bytes``, measured for real.
+
+        This is the 1x-tree tmpfs, expressed as arithmetic over the bytes the
+        fill has genuinely written. A gate that charges for the whole tree on a
+        re-entry cannot satisfy it; a gate that charges for the remainder can.
+        """
+
+        cache_dir = self.cache_dir
+
+        def free() -> int:
+            return max(0, budget_bytes - disk_used(cache_dir))
+
+        return free
+
+
+#: One fill entry point, as the harness drives it.
+@dataclass(frozen=True)
+class Op:
+    name: str
+    run: Callable[[FillContext], Awaitable[Path]]
+
+
+async def _op_store_ensure_local(ctx: FillContext) -> Path:
+    return await ctx.store().ensure_local(ctx.ref, ctx.tree.snapshot())
+
+
+async def _op_store_materialize_local(ctx: FillContext) -> Path:
+    return (
+        await ctx.store()._materialize_local(ctx.ref, ctx.tree.snapshot())
+    ).path
+
+
+async def _op_download_ensure_local(ctx: FillContext) -> Path:
+    from gen_worker.models import download as download_mod
+    from gen_worker.models.store import _snapshot_to_resolved
+
+    return await download_mod.ensure_local(
+        str(ctx.ref),
+        provider="tensorhub",
+        snapshot=_snapshot_to_resolved(ctx.tree.snapshot()),
+        cache_dir=ctx.cache_dir,
+    )
+
+
+async def _op_ensure_snapshot_async(ctx: FillContext) -> Path:
+    from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+
+    return await ensure_snapshot_async(
+        base_dir=ctx.cache_dir,
+        ref=TensorhubRef(owner="acme", repo="harness-model", release="latest"),
+        resolved=ctx.tree.resolved(),
+        progress=None,
+        fill_source_dir=None,
+    )
+
+
+#: THE COVERED SET. `tests/test_ensure_idempotence_pgw1632.py` asserts every
+#: byte-moving `ensure_*` in `models/` is either here or classified as moving
+#: no bytes — a new fill cannot be added without answering the question.
+FILL_OPS: tuple[Op, ...] = (
+    Op("ModelStore.ensure_local", _op_store_ensure_local),
+    Op("ModelStore._materialize_local", _op_store_materialize_local),
+    Op("download.ensure_local", _op_download_ensure_local),
+    Op("cozy_snapshot.ensure_snapshot_async", _op_ensure_snapshot_async),
+)
+
+
+def run_fill(ctx: FillContext, op: Op) -> Path:
+    """One pass of ``op`` on a fresh process view of the store."""
+
+    reset_fill_memos()
+
+    async def go() -> Path:
+        from gen_worker import activity
+
+        activity.bind_sink(ctx.wire.send, asyncio.get_running_loop())
+        path = await op.run(ctx)
+        for _ in range(8):
+            await asyncio.sleep(0)
+        return path
+
+    return asyncio.run(go())
+
+
+def resident_bytes(cache_dir: Path, tree: Tree) -> int:
+    """Bytes of ``tree`` the pod's CAS actually holds — the fill's own predicate."""
+
+    from gen_worker.models.cache_paths import open_worker_cas
+
+    cas = open_worker_cas(cache_dir)
+    total = 0
+    for _path, body, _url in tree.files:
+        if cas.contains(sha(body), size=len(body)):
+            total += len(body)
+    return total
+
+
+def free_disk_bytes(path: Path) -> int:
+    return int(shutil.disk_usage(path).free)
+
+
+def wait_for(predicate: Callable[[], bool], *, timeout_s: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+__all__ = [
+    "FILL_OPS",
+    "FillContext",
+    "HighWater",
+    "Op",
+    "Origin",
+    "Tree",
+    "Wire",
+    "build_tree",
+    "disk_used",
+    "free_disk_bytes",
+    "reset_fill_memos",
+    "resident_bytes",
+    "run_fill",
+    "sha",
+    "wait_for",
+]

--- a/tests/test_counter_source_lint_pgw1632.py
+++ b/tests/test_counter_source_lint_pgw1632.py
@@ -1,0 +1,298 @@
+"""pgw#1632(b): a byte counter cannot exist without declaring its instrument.
+
+`load:staged_bytes` measured `/proc/self/io` **read_bytes** plus anon-RSS
+growth. Nothing about the NUMBER was wrong. The NAME said a write had happened,
+th#2246's first mechanism lane believed it, and went looking for a per-child
+write that does not exist anywhere in this repo.
+
+The fence is two rules over one registry (`gen_worker.byte_sources`):
+
+* **classification** — every byte counter created in `src/` resolves to a
+  declared `Source`, and a registry entry nothing creates is deleted rather
+  than left as decoration;
+* **admissibility** — a counter's verb must suit the direction of its source.
+  `staged`/`written`/`flushed`/`uploaded` need a write-side instrument;
+  `read`/`ingested`/`pulled` need a read-side one; `freed`/`consumed` need the
+  filesystem.
+
+The scan is over the AST, not over a grep, because the names are built at the
+call site (`f"download:{ref}"`) and a grep for the literal would miss exactly
+the counters that are keyed per subject.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import gen_worker
+from gen_worker import byte_sources
+from gen_worker.byte_sources import (
+    BYTE_COUNTERS,
+    BYTE_POSITIONS,
+    Direction,
+    Source,
+    misclassified,
+    source_of,
+    verbs_in,
+)
+
+#: The factories that mint a counter. Matched on the ATTRIBUTE/function name,
+#: because every one of them is reached under several import spellings
+#: (`activity.scoped_counter`, `activity_mod.scoped_counter`, `act.counter`,
+#: `progress_mod.counter`).
+COUNTER_FACTORIES = {"scoped_counter", "counter"}
+
+#: How the unit argument spells "bytes".
+BYTE_UNITS = {"bytes", "UNIT_BYTES"}
+
+SRC = Path(gen_worker.__file__).parent
+
+
+def _source_files() -> list[Path]:
+    """Every module the worker actually ships, minus vendored trees.
+
+    `_vendor` is other repos' code, snapshot-pinned; a lint that fails on a
+    vendor bump is a lint nobody keeps.
+    """
+
+    return [
+        path
+        for path in sorted(SRC.rglob("*.py"))
+        if "_vendor" not in path.parts
+    ]
+
+
+def _module_string_constants(module: ast.Module) -> dict[str, str]:
+    """Module-level ``NAME = "literal"`` bindings.
+
+    Declaring the name once as a constant is the GOOD pattern — it is what
+    `load_progress.COUNTER_NAME` does — so the lint has to follow it rather
+    than punish it.
+    """
+
+    constants: dict[str, str] = {}
+    for node in module.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+            continue
+        if not isinstance(node.value.value, str):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                constants[target.id] = node.value.value
+    return constants
+
+
+def _all_string_constants() -> dict[str, str]:
+    """Every module-level string constant in `src/`, by name.
+
+    Cross-module references (`load_progress.COUNTER_NAME`) resolve through
+    this. A name bound to two different strings resolves to neither, which
+    reports as unclassifiable rather than silently picking one.
+    """
+
+    seen: dict[str, set[str]] = {}
+    for path in _source_files():
+        module = ast.parse(path.read_text(), filename=str(path))
+        for name, value in _module_string_constants(module).items():
+            seen.setdefault(name, set()).add(value)
+    return {name: next(iter(v)) for name, v in seen.items() if len(v) == 1}
+
+
+def _literal_prefix(node: ast.expr, constants: dict[str, str]) -> str | None:
+    """The literal part of a counter-name expression.
+
+    A plain string is its own name; a module constant resolves through
+    ``constants``. An f-string contributes the literal head before the first
+    interpolation, which is what the registry's prefix keys (`"download:"`)
+    are for. Anything with no literal head at all cannot be classified and is
+    reported as such.
+    """
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
+    if isinstance(node, ast.Attribute):
+        return constants.get(node.attr)
+    if isinstance(node, ast.JoinedStr):
+        head = node.values[0] if node.values else None
+        if isinstance(head, ast.Constant) and isinstance(head.value, str):
+            return head.value
+        return ""
+    return None
+
+
+def _unit_is_bytes(call: ast.Call) -> bool:
+    args = list(call.args[1:2])
+    args += [kw.value for kw in call.keywords if kw.arg == "unit"]
+    for arg in args:
+        if isinstance(arg, ast.Constant) and arg.value in BYTE_UNITS:
+            return True
+        if isinstance(arg, ast.Attribute) and arg.attr in BYTE_UNITS:
+            return True
+        if isinstance(arg, ast.Name) and arg.id in BYTE_UNITS:
+            return True
+    return False
+
+
+def _factory_name(call: ast.Call) -> str:
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def _byte_counter_sites() -> list[tuple[Path, int, str | None]]:
+    """Every byte-counter creation in `src/`, as (file, line, literal prefix)."""
+
+    shared = _all_string_constants()
+    found: list[tuple[Path, int, str | None]] = []
+    for path in _source_files():
+        module = ast.parse(path.read_text(), filename=str(path))
+        constants = {**shared, **_module_string_constants(module)}
+        # The module that DEFINES the factories is not a call site.
+        if path.name in ("progress.py", "activity.py") and path.parent == SRC:
+            defined = {
+                node.name for node in ast.walk(module)
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+            if COUNTER_FACTORIES & defined and path.name == "progress.py":
+                continue
+        for node in ast.walk(module):
+            if not isinstance(node, ast.Call):
+                continue
+            if _factory_name(node) not in COUNTER_FACTORIES:
+                continue
+            if not node.args or not _unit_is_bytes(node):
+                continue
+            found.append(
+                (path, node.lineno, _literal_prefix(node.args[0], constants))
+            )
+    return found
+
+
+def test_the_registry_never_puts_a_verb_on_the_wrong_instrument() -> None:
+    """THE TABLE TEST. Registry-driven, so it grows with the registry."""
+
+    for name, source in BYTE_COUNTERS.items():
+        problem = misclassified(name, source)
+        assert not problem, problem
+
+
+def test_every_byte_counter_in_src_is_classified() -> None:
+    """A counter with no declared source cannot be created.
+
+    The failure message names the file and line, because the fix is one line in
+    `byte_sources.BYTE_COUNTERS` and the person adding the counter is the only
+    one who knows which instrument they read.
+    """
+
+    sites = _byte_counter_sites()
+    assert sites, "the AST scan found no byte counters at all — it is broken"
+
+    unclassified: list[str] = []
+    for path, line, prefix in sites:
+        where = f"{path.relative_to(SRC.parent.parent)}:{line}"
+        if prefix is None:
+            unclassified.append(f"{where}: counter name is not a literal")
+            continue
+        if not prefix:
+            unclassified.append(f"{where}: counter name has no literal prefix")
+            continue
+        if source_of(prefix) is None:
+            unclassified.append(f"{where}: {prefix!r} is in no source registry")
+    assert not unclassified, (
+        "byte counters with no declared measurement source:\n  "
+        + "\n  ".join(unclassified)
+        + "\nAdd each to gen_worker.byte_sources.BYTE_COUNTERS with the "
+          "instrument it is read off."
+    )
+
+
+def test_the_registry_has_no_dead_entries() -> None:
+    """A registry entry nothing creates is decoration, and decoration rots.
+
+    This is the arm that would have caught the rename going half-done: the old
+    key stays in the table, the new counter is unclassified, and BOTH halves
+    fail rather than neither.
+    """
+
+    prefixes = {p for _f, _l, p in _byte_counter_sites() if p}
+    for key in BYTE_COUNTERS:
+        assert any(
+            name == key or (key.endswith(":") and name.startswith(key))
+            for name in prefixes
+        ), f"{key!r} is registered but no site in src/ creates it"
+
+
+def test_every_byte_position_declares_the_same_source_it_is_registered_with() -> None:
+    """A position's site declaration and the registry cannot drift apart."""
+
+    import importlib
+
+    for qualname, source in BYTE_POSITIONS.items():
+        module_name, _, class_name = qualname.rpartition(".")
+        cls = getattr(importlib.import_module(module_name), class_name)
+        declared = getattr(cls, "SOURCE", None)
+        assert declared is source, (
+            f"{qualname}.SOURCE is {declared!r}, registered as {source!r}"
+        )
+        assert not misclassified(class_name, source)
+
+
+def test_the_seed_fix_landed_and_the_read_meter_reads() -> None:
+    """pgw#1632's seed: `load:staged_bytes` was a READ meter with a WRITE verb.
+
+    Both halves are asserted, because renaming without reclassifying just moves
+    the lie: the name must be read-side AND the declared instrument must be the
+    `/proc` read counter the sampler genuinely uses.
+    """
+
+    from gen_worker.models import load_progress
+
+    assert load_progress.COUNTER_NAME == "load:ingested_bytes"
+    assert load_progress.COUNTER_SOURCE is Source.PROC_READ_IO
+    assert BYTE_COUNTERS[load_progress.COUNTER_NAME] is Source.PROC_READ_IO
+    assert "staged" not in load_progress.COUNTER_NAME
+
+    # The sampler really does read `/proc/self/io` read_bytes — the fact the
+    # classification asserts. A rename with no producer behind it is worse
+    # than the wrong verb.
+    source = ast.parse(Path(load_progress.__file__).read_text())
+    reads = [
+        node for node in ast.walk(source)
+        if isinstance(node, ast.Constant) and node.value == "read_bytes:"
+    ]
+    assert reads, "COUNTER_SOURCE claims PROC_READ_IO with no /proc read behind it"
+
+
+def test_a_write_verb_on_a_read_source_is_rejected() -> None:
+    """RED ARM. The exact pre-fix pair must fail the rule that now exists."""
+
+    assert misclassified("load:staged_bytes", Source.PROC_READ_IO), (
+        "the original defect must be rejected by the rule written to catch it"
+    )
+    assert misclassified("cas:written_bytes", Source.RSS_GROWTH)
+    assert misclassified("volume:freed_bytes", Source.NET_SOCKET_RECV)
+    # ...and the honest pairings pass.
+    assert not misclassified("load:ingested_bytes", Source.PROC_READ_IO)
+    assert not misclassified("upload:bytes", Source.NET_SOCKET_SEND)
+    assert not misclassified("disk:freed_bytes", Source.STATVFS_DELTA)
+
+
+@pytest.mark.parametrize("source", list(Source))
+def test_every_source_has_a_direction(source: Source) -> None:
+    assert isinstance(source.direction, Direction)
+
+
+def test_no_verb_is_classified_two_ways() -> None:
+    """The table is a function, not a suggestion."""
+
+    assert len(byte_sources.VERB_DIRECTIONS) == len(set(byte_sources.VERB_DIRECTIONS))
+    assert verbs_in("load:staged_bytes") == {"staged"}
+    assert verbs_in("download:acme/model@prod") == set()

--- a/tests/test_ensure_idempotence_pgw1632.py
+++ b/tests/test_ensure_idempotence_pgw1632.py
@@ -1,0 +1,481 @@
+"""pgw#1632(a): the `ensure_*` idempotence harness — the fence pgw#1596 needed.
+
+A fill on the weight path is supposed to be a pure function of (manifest,
+store): objects the CAS already holds are skipped, the rest are fetched, and
+progress IS bytes-present. Three consequences follow and NONE of them had an
+instrument before this file:
+
+1. **Called twice** — the second call moves zero network bytes and hands back
+   the same path.
+2. **Killed at k%, then re-entered** — the second pass fetches exactly the
+   bytes the first did not bank. Not "approximately": every object either
+   landed or did not, so the arithmetic is exact and any restart-from-zero is
+   a numeric failure, not a judgement call.
+3. **Disk high-water ≤ 1x tree + the fan-out's in-flight files** — a resumable
+   fill never needs a second copy of the tree, which is the property pgw#1596
+   violated in the GATE (it demanded 2x) and th#2246 violated in the WRITER
+   (it wrote 2x).
+
+Plus the cross-layer property that was the actual defect: **the headroom gate
+and the fill loop must agree about what is missing.** Proven here by running
+both and comparing numbers — the gate's refusal quotes `required_bytes`, the
+origin counts what the fill then really fetched, and pgw#1596 is the case where
+those two disagreed by 86 GB.
+
+Everything runs the production code path against a real HTTP origin and a real
+`LocalCAS`. The only injected pieces are the origin's byte fuse (that is what
+"the fetcher raised" MEANS) and `ModelStore`'s own `disk_free_bytes_fn`
+constructor parameter, which expresses "this volume holds one copy of the tree"
+as arithmetic over the real files the fill really wrote.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from gen_worker import activity
+from gen_worker.capability import InsufficientDiskError
+from gen_worker.models import store as store_mod
+from gen_worker.models.refs import WireRef
+from gen_worker.models.store import _DISK_GC_MARGIN_BYTES, ModelStore
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.transfer.grants import DEFAULT_PARALLEL
+
+from fill_fixture import (
+    FILL_OPS,
+    FillContext,
+    HighWater,
+    Op,
+    Origin,
+    Tree,
+    build_tree,
+    disk_used,
+    resident_bytes,
+    run_fill,
+)
+
+#: 32 objects resolves every k the design asks for (3.1% granularity) and keeps
+#: the whole 4-op x 4-k matrix inside a CI budget. The RATIOS that decide
+#: pass/fail are size independent — this is the pgw#1596 test's own scaling
+#: trick, and the incident it descends from was 105 GB.
+OBJECTS = 32
+OBJECT_BYTES = 256 * 1024
+
+#: What a fill legitimately holds ABOVE the tree: the fan-out's in-flight
+#: temporaries, one per worker. Bounded by the transfer width, never by the
+#: tree size — which is exactly why a 2x-tree requirement is a bug and not a
+#: bigger constant.
+INFLIGHT_SLACK = DEFAULT_PARALLEL * OBJECT_BYTES
+
+K_PERCENTS = (10, 50, 80, 99)
+
+
+@pytest.fixture(autouse=True)
+def _clean_activity() -> Iterator[None]:
+    activity.reset_for_tests()
+    yield
+    activity.reset_for_tests()
+
+
+@pytest.fixture(scope="module")
+def origin() -> Iterator[Origin]:
+    served = Origin()
+    try:
+        yield served
+    finally:
+        served.close()
+
+
+@pytest.fixture(scope="module")
+def tree(origin: Origin) -> Tree:
+    return build_tree(origin, objects=OBJECTS, object_bytes=OBJECT_BYTES)
+
+
+@pytest.fixture
+def one_tree_budget(tree: Tree) -> int:
+    """A volume that holds exactly ONE copy of the tree, plus production margin.
+
+    `_DISK_GC_MARGIN_BYTES` is the gate's own reserve, so a disk sized without
+    it would refuse every fill for reasons that have nothing to do with
+    re-entry. What this budget deliberately does NOT have room for is a SECOND
+    copy of the tree.
+    """
+
+    return tree.total_bytes + _DISK_GC_MARGIN_BYTES + INFLIGHT_SLACK
+
+
+def _ctx(tmp_path: Path, tree: Tree, origin: Origin, budget: int | None = None) -> FillContext:
+    ctx = FillContext(cache_dir=tmp_path / "cas", tree=tree, origin=origin)
+    if budget is not None:
+        ctx.disk_free_bytes_fn = ctx.budget_fn(budget)
+    return ctx
+
+
+def _no_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A kill is one interruption, not a retry storm.
+
+    `ModelStore` retries a failed download three times with backoff, and that
+    inner retry is itself a re-entry — which is real behaviour but a different
+    test, and paying its 5 s of `asyncio.sleep` in all sixteen cells buys
+    nothing this file is measuring. The property under test is what happens
+    when the operation is ENTERED AGAIN, so the first entry is made to stop.
+    """
+
+    monkeypatch.setattr(store_mod, "_DOWNLOAD_RETRIES", 1)
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — called twice
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", FILL_OPS, ids=lambda o: o.name)
+def test_called_twice_moves_zero_network_bytes(
+    tmp_path: Path, tree: Tree, origin: Origin, op: Op
+) -> None:
+    """The second call is free, and it is the SAME answer.
+
+    An `ensure_*` that re-fetches what it already holds is not an ensure at
+    all; it is a download with an optimistic name. The origin's own counter is
+    the check, because it is the only number no layer under test computed.
+    """
+
+    ctx = _ctx(tmp_path, tree, origin)
+    origin.reset()
+
+    first_path = run_fill(ctx, op)
+    first_wire = origin.wire_bytes
+    assert first_wire == tree.total_bytes, "the cold pass fetches the whole tree"
+
+    origin.reset()
+    second_path = run_fill(ctx, op)
+
+    assert origin.wire_bytes == 0, (
+        f"{op.name} re-fetched {origin.wire_bytes} bytes it already held"
+    )
+    assert second_path == first_path
+    assert disk_used(ctx.cache_dir) <= tree.total_bytes + INFLIGHT_SLACK, (
+        "a second call must not leave a second copy behind"
+    )
+
+
+def test_a_second_call_leaves_no_open_download_record(
+    tmp_path: Path, tree: Tree, origin: Origin
+) -> None:
+    """th#2204/th#2205's LIABILITY, as a property of the fill.
+
+    A hub-side `model_download` row is opened by `DOWNLOADING` and only
+    `ON_DISK`/`FAILED`/`EVICTED` closes it; while it is open the hub vetoes
+    idle retirement and parks placement (th#2205: 179 minutes at $1.59/hr).
+    So the fence on a re-entry is not "say nothing" — it is "leave nothing
+    open", on a call that moved no bytes at all.
+
+    MEASURED HERE, and deliberately recorded rather than tightened: a FRESH
+    PROCESS over a warm CAS does still emit one `DOWNLOADING`, because the
+    identity bank that suppresses it (`_disk_identities`) is in-memory and a
+    restart has none. It closes within the same materialization, so it is a
+    brief honest "verifying" row and not the immortal one th#2204 cost a rental
+    to — but a change that makes it stop closing fails right here.
+    """
+
+    ctx = _ctx(tmp_path, tree, origin)
+    origin.reset()
+    run_fill(ctx, FILL_OPS[0])
+
+    origin.reset()
+    ctx.wire = type(ctx.wire)()
+    run_fill(ctx, FILL_OPS[0])
+
+    assert origin.wire_bytes == 0
+    events = ctx.wire.model_events
+    opened = sum(1 for e in events if e.state == pb.MODEL_STATE_DOWNLOADING)
+    closed = sum(
+        1 for e in events
+        if e.state in (
+            pb.MODEL_STATE_ON_DISK, pb.MODEL_STATE_FAILED, pb.MODEL_STATE_EVICTED,
+        )
+    )
+    assert closed >= opened, (
+        f"{opened} download record(s) opened, {closed} closed: "
+        f"{[e.state for e in events]}"
+    )
+    moved = [e.bytes_done for e in events if e.state == pb.MODEL_STATE_DOWNLOADING]
+    assert all(int(b) == 0 for b in moved), (
+        f"a fully resident re-entry reported bytes moving: {moved}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — killed at k%, re-entered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", FILL_OPS, ids=lambda o: o.name)
+@pytest.mark.parametrize("k", K_PERCENTS)
+def test_killed_at_k_percent_resumes_without_refetching(
+    tmp_path: Path,
+    tree: Tree,
+    origin: Origin,
+    monkeypatch: pytest.MonkeyPatch,
+    op: Op,
+    k: int,
+) -> None:
+    """THE REGRESSION, generalized. Interrupt the fill, re-enter, and the second
+    pass must fetch exactly the remainder — never the tree.
+
+    The pre-`d2e31047` gate fails this at every k (proven by
+    `test_the_harness_is_red_against_the_pre_pgw1596_gate` below); a fill that
+    restarted from zero would fail it by fetching `total` again.
+    """
+
+    _no_retry(monkeypatch)
+    ctx = _ctx(tmp_path, tree, origin)
+    total = tree.total_bytes
+
+    origin.reset()
+    origin.arm(total * k // 100)
+    with HighWater(ctx.cache_dir) as killed_pass:
+        with pytest.raises(BaseException):
+            run_fill(ctx, op)
+
+    banked = resident_bytes(ctx.cache_dir, tree)
+    assert 0 < banked < total, (
+        f"k={k} must interrupt the fill mid-flight; banked {banked} of {total}"
+    )
+    assert origin.wire_bytes == banked, (
+        "every byte the origin served must be a byte the CAS banked — anything "
+        "else is a partial object the resume will have to pay for again"
+    )
+
+    origin.reset()
+    origin.arm(None)
+    with HighWater(ctx.cache_dir) as resume_pass:
+        path = run_fill(ctx, op)
+
+    assert path.exists()
+    assert origin.wire_bytes == total - banked, (
+        f"{op.name} re-entered at {100 * banked // total}% and fetched "
+        f"{origin.wire_bytes} bytes; exactly {total - banked} were missing"
+    )
+    peak = max(killed_pass.peak, resume_pass.peak)
+    assert peak <= total + INFLIGHT_SLACK, (
+        f"disk high-water {peak} exceeded one tree ({total}) plus the "
+        f"fan-out's in-flight files ({INFLIGHT_SLACK}) — a resumable fill "
+        f"never needs a second copy"
+    )
+
+
+def test_the_harness_is_red_against_the_pre_pgw1596_gate(
+    tmp_path: Path,
+    tree: Tree,
+    origin: Origin,
+    one_tree_budget: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED ARM. Restore the pre-`d2e31047` precondition and the harness fails.
+
+    Before pgw#1596 the gate compared free space against the ENTIRE manifest
+    with nothing subtracting the resident part. On a disk that fits exactly one
+    copy of the tree that is unsatisfiable the moment anything has landed —
+    which is what killed a 105 GB pull 157 MB from the end on a real H200.
+
+    A harness that cannot go red proves nothing, so the pre-fix behaviour is
+    reconstructed exactly (`resident = 0`) and the resume is asserted to
+    REFUSE.
+    """
+
+    _no_retry(monkeypatch)
+    ctx = _ctx(tmp_path, tree, origin, budget=one_tree_budget)
+    total = tree.total_bytes
+
+    origin.reset()
+    origin.arm(total * 80 // 100)
+    with pytest.raises(BaseException):
+        run_fill(ctx, FILL_OPS[0])
+    banked = resident_bytes(ctx.cache_dir, tree)
+    assert banked > INFLIGHT_SLACK
+
+    # The post-fix gate lets the resume through on the same disk.
+    origin.reset()
+    origin.arm(None)
+    run_fill(ctx, FILL_OPS[0])
+    assert origin.wire_bytes == total - banked
+
+    # Now the pre-fix gate, on the same state: it demands the whole tree free.
+    monkeypatch.setattr(ModelStore, "_already_resident_bytes", lambda self, files: 0)
+    fresh = _ctx(tmp_path, tree, origin, budget=one_tree_budget)
+    with pytest.raises(InsufficientDiskError) as caught:
+        run_fill(fresh, FILL_OPS[0])
+    assert caught.value.required_bytes == total, (
+        "the reconstructed pre-fix gate must charge for the whole manifest — "
+        "if it does not, this arm is not proving the harness can go red"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — precondition consistency
+# ---------------------------------------------------------------------------
+
+
+def test_the_gate_and_the_fill_agree_about_what_is_missing(
+    tmp_path: Path,
+    tree: Tree,
+    origin: Origin,
+    one_tree_budget: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE NAMED ANTI-PATTERN: *a precondition computed from a stale view of
+    state the operation itself changes.*
+
+    Both layers are run against one partially-filled store and their numbers
+    are compared: what the gate says is still needed, and what the fill then
+    actually pulls off the wire. pgw#1596 is precisely the case where those
+    disagreed — the gate said 105 GB, the fill needed 157 MB.
+
+    This is the structural form of the check. Its cheap twin (the gate may not
+    re-derive a size at all) is `test_the_gate_derives_its_cost_from_the_one_predicate`.
+    """
+
+    _no_retry(monkeypatch)
+    ctx = _ctx(tmp_path, tree, origin, budget=one_tree_budget)
+    total = tree.total_bytes
+
+    origin.reset()
+    origin.arm(total * 50 // 100)
+    with pytest.raises(BaseException):
+        run_fill(ctx, FILL_OPS[0])
+    banked = resident_bytes(ctx.cache_dir, tree)
+    assert 0 < banked < total
+
+    # What the GATE says is still required, taken from its own refusal on a
+    # disk with nothing free.
+    starved = FillContext(cache_dir=ctx.cache_dir, tree=tree, origin=origin)
+    starved.disk_free_bytes_fn = lambda: 0
+    snapshot = tree.snapshot()
+    import asyncio
+
+    with pytest.raises(InsufficientDiskError) as caught:
+        asyncio.run(
+            starved.store()._ensure_disk_headroom(
+                WireRef("acme/harness-model"),
+                total,
+                files=list(snapshot.files),
+            )
+        )
+    gate_says = caught.value.required_bytes
+
+    # What the FILL actually moves, from the origin's own counter.
+    origin.reset()
+    origin.arm(None)
+    run_fill(ctx, FILL_OPS[0])
+    fill_moved = origin.wire_bytes
+
+    assert gate_says == fill_moved == total - banked, (
+        f"the gate required {gate_says} bytes and the fill moved {fill_moved}; "
+        "a gate that does not share the fill's skip predicate is the pgw#1596 "
+        "defect regardless of which direction it is wrong in"
+    )
+
+
+def _gate_source() -> ast.FunctionDef:
+    source = inspect.getsource(ModelStore._ensure_disk_headroom)
+    tree_ = ast.parse(re.sub(r"^\s{4}", "", source, flags=re.MULTILINE))
+    node = tree_.body[0]
+    assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    return node  # type: ignore[return-value]
+
+
+def test_the_gate_derives_its_cost_from_the_one_predicate() -> None:
+    """THE LINT. The gate may not compute a size; it may only be handed one.
+
+    Every instance of this bug class looks the same in source: a precondition
+    that re-derives its cost from the REQUEST (walk the manifest, sum the
+    sizes) instead of from the DELTA (ask the store what it already holds). So
+    the rule is structural and cheap — inside `_ensure_disk_headroom` there is
+    no size arithmetic over files, and the resident figure comes from the same
+    content-addressed predicate the fill skips on.
+
+    A rewrite that feeds the gate the fill's PLAN satisfies this by
+    construction: a plan is a delta, so there is nothing left to re-derive.
+    """
+
+    node = _gate_source()
+    names = {
+        n.attr for n in ast.walk(node) if isinstance(n, ast.Attribute)
+    } | {
+        n.id for n in ast.walk(node) if isinstance(n, ast.Name)
+    }
+
+    assert "size_bytes" not in names, (
+        "`_ensure_disk_headroom` reads a file size directly. That is the "
+        "pgw#1596 shape: the gate is re-deriving cost from the request instead "
+        "of from what the store is missing."
+    )
+    assert not any(
+        isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "sum"
+        for n in ast.walk(node)
+    ), "the gate must be HANDED its cost, never sum one"
+    assert {"_already_resident_bytes", "_missing_bytes", "plan"} & names, (
+        "the gate must consume the fill's own skip predicate (or the plan it "
+        "produced); nothing else can be proven to agree with it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The coverage fence
+# ---------------------------------------------------------------------------
+
+#: `ensure_*` functions in `models/` that move no bytes, with the reason. The
+#: point of naming them is that a NEW `ensure_*` belongs in one list or the
+#: other, and cannot quietly belong to neither.
+NON_FILL_ENSURES = {
+    "_ensure_objects": "the fill's inner loop; driven through every op above",
+    "ensure_snapshot": "the method behind `ensure_snapshot_async`, covered by it",
+    "_ensure_disk_headroom": "a gate — it moves no bytes, and has its own tests",
+    "ensure_pinned": "writes one manifest pin, not tree bytes (pgw#1526)",
+    "ensure_resident": "a VRAM lease scope; no disk fill",
+    "ensure_warm": "checkpoint juggle over already-materialized trees",
+}
+
+#: `ensure_*` functions the harness drives, by the name in `FILL_OPS`.
+COVERED_ENSURES = {"ensure_local", "_materialize_local", "ensure_snapshot_async"}
+
+
+def test_every_fill_in_models_is_covered_or_classified() -> None:
+    """A new `ensure_*` cannot be added without answering "is it idempotent?".
+
+    The design's whole point is that this property belongs to the CLASS, not to
+    whichever function last had an incident. So the fence enumerates the class.
+    """
+
+    root = Path(store_mod.__file__).parent
+    found: dict[str, str] = {}
+    for path in sorted(root.glob("*.py")):
+        module = ast.parse(path.read_text())
+        for node in ast.walk(module):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name.lstrip("_").startswith("ensure_") or node.name == "_materialize_local":
+                found[node.name] = path.name
+
+    unclassified = {
+        name: where
+        for name, where in found.items()
+        if name not in COVERED_ENSURES and name not in NON_FILL_ENSURES
+    }
+    assert not unclassified, (
+        f"unclassified fill/ensure functions: {unclassified}. Add each to "
+        f"FILL_OPS (and prove it idempotent) or to NON_FILL_ENSURES with the "
+        f"reason it moves no bytes."
+    )
+    assert COVERED_ENSURES <= set(found), (
+        f"the harness claims to cover {COVERED_ENSURES - set(found)}, which no "
+        f"longer exists in models/"
+    )
+    assert {op.name for op in FILL_OPS} and len(FILL_OPS) >= 4


### PR DESCRIPTION
Closes pgw#1632.

## (a) The `ensure_*` idempotence harness

A fill on the weight path is supposed to be a pure function of (manifest, store). Nothing measured that, which is why pgw#1596 — a headroom gate that demanded the whole tree while 82% of it was resident — reached a $2/hr H200 before anything went red.

`tests/fill_fixture.py` drives the **real** `ModelStore.ensure_local` / `_materialize_local`, the **real** `download.ensure_local` and the **real** `ensure_snapshot_async` against a real HTTP origin and a real `LocalCAS`. Three properties per op:

| property | assertion |
|---|---|
| called twice | 0 network bytes, same path, no second copy, no open download record |
| killed at k% (k ∈ 10/50/80/99), re-entered | second pass fetches **exactly** `total − banked` |
| disk high-water | ≤ 1× tree + `DEFAULT_PARALLEL × object_bytes` |

The exactness matters: every object either landed or did not, so a restart-from-zero is a numeric failure rather than a judgement call. 16 (op × k) cells, all exact.

The only injected pieces are the origin's byte fuse (that is what "the fetcher raised" MEANS) and `ModelStore`'s own `disk_free_bytes_fn` constructor parameter, which states "this volume holds one copy of the tree" as arithmetic over the real files the fill really wrote — rather than a mounted tmpfs no CI runner can create.

**Red arm**: the pre-`d2e31047` gate is reconstructed (`_already_resident_bytes → 0`) and the resume is asserted to refuse with `required_bytes == whole tree`. A harness that cannot go red proves nothing.

**Precondition-consistency** is proven by measurement, not review: the gate's refusal quotes `required_bytes`, the origin counts what the fill then really fetched, and they must be equal. pgw#1596 is exactly the case where those disagreed by 86 GB. A structural twin backs it up — `_ensure_disk_headroom` may not read a `size_bytes` or `sum()` anything.

**Coverage fence**: every `ensure_*` in `models/` is either driven by the harness or classified as moving no bytes, with the reason.

## (b) The counter-source lint, and the seed rename

`load:staged_bytes` samples `/proc/self/io` **read_bytes** plus anon-RSS growth — a READ meter wearing a WRITE verb. The number was never wrong; th#2246's first mechanism lane believed the name and spent a pass hunting a per-child write that does not exist in this repo.

`gen_worker.byte_sources` declares a `Source` for every byte counter and position; a registry-driven table test enforces verb/direction admissibility (`staged|written|flushed|uploaded` → write-side, `read|ingested|pulled` → read-side, `freed|consumed` → `STATVFS_DELTA`). An AST scan over `src/` — not a grep, since names are built at the call site (`f"download:{ref}"`) — refuses any byte counter the registry does not classify **and** any registry entry no site creates, so a half-done rename fails on both halves rather than neither.

`load:staged_bytes` → `load:ingested_bytes`. Wire-safe: the hub's stall clock keys on advancement, not on the name, and the literal appears in **no other repository in the workspace** — grepped across tensorhub, e2e, serverless-endpoints, jobs and cozy-local *before* the rename.

Two documented refinements of the review's enum: undirected `NET_SOCKET` is split `RECV`/`SEND` (an undirected socket source makes the lint vacuous for the biggest byte mover in the repo), and `CAS_ACCOUNTED` is added for the aggregate positions, which credit bytes that are PRESENT for a manifest whatever instrument proved it — it admits no directional verb at all, which is the honest outcome for a number `weight_position`'s own docstring already warns is "not bytes off the wire".

## Recorded, not chased

A **fresh process** over a warm CAS still emits one `DOWNLOADING` before discovering the tree is resident, because the identity bank that suppresses it (`ModelStore._disk_identities`) is in-memory and a restart has none. It closes within the same materialization, so it is a brief honest "verifying" row and not th#2204's immortal one — but `test_a_second_call_leaves_no_open_download_record` fails the moment it stops closing.

## Verification

- `tests/test_ensure_idempotence_pgw1632.py` — 25 passed
- `tests/test_counter_source_lint_pgw1632.py` — 11 passed
- neighbours (`pgw1596`, `weight_position`, `pgw1351`, `gw621`, `pgw1263`) — 33 passed
- `mypy src/gen_worker tests` — clean, 627 files
- `ruff check src/gen_worker` — clean