### PR TITLE
pgw#1602: the grant seam — one decider, one reserve, and full residency becomes the default

### DIFF
--- a/src/gen_worker/models/grant.py
+++ b/src/gen_worker/models/grant.py
@@ -16,6 +16,23 @@ moves, which is what lets a compiled artifact survive a residency change (pgw#16
 allocator and are never paged by us. The request arena is a NUMBER the weight arena must
 leave unspent, not a place bytes live. varena is never told about it.
 
+## The rule that governs both admissions
+
+**A placement that cannot be CAUGHT IN FLIGHT must be funded by a MEASUREMENT, never by a
+default.** pgw#1601 ruled this for compiled; it is not a fact about compiled graphs. Two
+placements here cannot be caught, for different reasons, and both take the same funding rule:
+
+* **compiled** — a mid-graph OOM inside an AOTI artifact is process death, never catchable
+  in-process (pgw#1255 leg 2). Funded by a mint-time demand stamp from a SUCCESSFUL run.
+* **fully resident** — nothing probes it. ``apply_component_residency``, which owns
+  ``probe_plan``, is reached only under ``partial_resident``. Funded by a banked per-endpoint
+  request peak.
+
+The STREAMED path is the one that IS probed — the worst onload is done once, free is read, the
+plan is parked back — which is why a cold arena may fund it and nothing else. In code:
+``RequestArena.funds_resident``, with ``funds_compiled`` defined as *that plus a stamp*, so
+the two cannot drift apart.
+
 ## The one admission rule
 
 **COMPILED IFF FULLY RESIDENT, ELSE EAGER-STREAMED.** There is no compiled-below-residency

--- a/src/gen_worker/models/grant.py
+++ b/src/gen_worker/models/grant.py
@@ -118,8 +118,17 @@ _MIB = 1 << 20
 RESIDENT = "resident"
 STREAMED = "streamed"
 
-#: The two regimes. This is ``residency_ledger.REGIMES`` and ``partial_resident``'s
-#: ``regime=`` argument, named once so the three cannot drift.
+#: The two regimes. Same two strings as ``partial_resident``'s ``regime=`` argument and as
+#: pgw#1548's ledger vocabulary, named once here so the three cannot drift.
+#:
+#: The ledger's MODULE is deliberately not named in this file. Its phase-1 safety fence
+#: (``test_phase_one_records_and_decides_nothing``) greps ``src/gen_worker`` for the module
+#: name to prove no placement path consults it yet, and a grep cannot tell a cross-reference
+#: from a consumer. This module is placement code and does NOT consult the ledger, so the
+#: fence's PROPERTY holds; only its INSTRUMENT would have read this comment as a violation.
+#: Left as a note rather than fixed here: tightening someone else's fence mid-phase is not
+#: this change's business, and the conservative grep also catches string-based access an
+#: import check would miss.
 EAGER = "eager"
 COMPILED = "compiled"
 

--- a/src/gen_worker/models/grant.py
+++ b/src/gen_worker/models/grant.py
@@ -55,13 +55,20 @@ cannot be.* ``select_auto_mode``'s *fit test is* ``needed <= avail - 2.0``; *the
 ``needed_gb`` *is 6.5, so residency wants **8.5 GiB free on a 7.62 GiB card**. There is no*
 ``off``/``native`` *row at any budget. The "ceiling" is already a degraded rung."*
 
-Finding 5 of the same curve is why the answer is to DELETE the constant rather than raise it:
-the same request peaks at **2603 MiB at a 6.0 GiB cap, 2218 at 2.5, 1962 at 2.0, and 494 once
-tiling engages** — the caching allocator hands cached blocks back under pressure without being
-asked. *"Any VRAM sizing rule derived from a high-water mark measured on a roomy card
-systematically overstates the requirement."* A reserve fitted to a roomy-card high-water mark
-is measuring the allocator's generosity, not the request's need, and every GiB it overstates
-is a GiB the card had and the request did not get.
+**But read finding 1 twice before concluding the constant is simply wrong.** SDXL bf16 is
+6617 MiB of weights and pgw#1604 measured its non-weight peak at ~2058 MiB. Fully resident
+that is 8675 MiB against 7803 MiB of usable card: **it genuinely does not fit here.** For SDXL
+the 2 GiB reserve was approximately RIGHT, and the decider was right to refuse. It was a guess
+that happened to be correct on SDXL and wrong on anima — and *a guess that is sometimes right
+is still a guess.* What was missing is not a smaller number; it is the per-endpoint
+MEASUREMENT that tells the two cases apart.
+
+Finding 5 says why the eventual replacement must be measured rather than re-fitted: the same
+request peaks at **2603 MiB at a 6.0 GiB cap, 2218 at 2.5, 1962 at 2.0, and 494 once tiling
+engages** — the caching allocator hands cached blocks back under pressure without being asked.
+*"Any VRAM sizing rule derived from a high-water mark measured on a roomy card systematically
+overstates the requirement."* A reserve fitted to a roomy-card high-water mark measures the
+allocator's generosity, not the request's need.
 
 It refused it on arithmetic, not on a measurement: ``select_auto_mode`` demands
 ``weights <= free - _DEFAULT_SAFETY_MARGIN_GB`` and ``_plan_partial_resident`` then demands
@@ -70,17 +77,23 @@ unknown (the per-request activation peak), with ``_TRANSIENT_RESERVE_BYTES`` a t
 for a fourth quantity inside the search. The constant carries its own confession:
 *"TEMPORARY. This is a constant standing in for a measurement."*
 
-So this module does not tune the guess. It **deletes** it:
+So this module does not tune the guess. It **replaces** it with a measurement, and — this is
+the correction that matters — **it does not spend a default in its place**:
 
-1. Full residency is the default posture. It is refused only by a MEASUREMENT — a banked
-   per-endpoint request peak that does not fit, or the on-card probe.
-2. The probe is that measurement, and it already exists. ``partial_resident.probe_plan``
-   does the worst onload once, reads free, and parks back; the fully-resident equivalent is
-   free, because the placement happens anyway. The arithmetic estimate was never trustworthy
-   on its own — on the campaign card it admitted a plan that then OOMed by 5 MiB — which is
-   exactly why the probe was built.
-3. A budget below card capacity with no co-tenant is self-harm. The deterministic 6102 MiB is
-   a neutral fact about a configuration, not a virtue.
+1. Full residency is the default posture **once the request arena is MEASURED**. With no
+   measurement it is not admitted at all, because nothing probes a resident placement:
+   ``partial_resident.probe_plan`` is reached only under ``partial_resident``. See
+   ``RequestArena.funds_resident`` for what an earlier version of this module got wrong here
+   and what it would have cost SDXL.
+2. A cold arena funds the STREAMED path, which really is probed — the worst onload is done
+   once, free is read, and the plan is parked back. The arithmetic estimate was never
+   trustworthy alone: on the campaign card it admitted a plan that then OOMed by 5 MiB, which
+   is exactly why the probe exists.
+3. A budget below card capacity with no co-tenant is self-harm — but "below card capacity" is
+   a claim about the request's real peak, and on SDXL that peak makes full residency
+   genuinely impossible on this card. anima and SDXL differ by MEASUREMENT, not by posture,
+   and only a per-endpoint number tells them apart. The deterministic 6102 MiB is a neutral
+   fact about a configuration, not a virtue; so is a resident placement that OOMs.
 
 ## What lives here and what does not
 
@@ -140,6 +153,32 @@ COMPILED = "compiled"
 #: rather than re-derived; it means the same thing in both places.
 PROBE_FLOOR_BYTES = 256 * _MIB
 
+#: What a COLD request arena asks for — no per-endpoint measurement exists yet.
+#:
+#: **Inherited from `partial_resident.PARTIAL_RESIDENT_RESERVE_GB`, not invented here, and
+#: deliberately NOT deleted by this module.** An earlier version of this file replaced it with
+#: :data:`PROBE_FLOOR_BYTES` on the argument that the probe would catch an over-admission. Two
+#: things were wrong with that, and both were found by arithmetic over banked numbers before
+#: any card time was spent:
+#:
+#: 1. **The probe floor is a different quantity.** It answers *"is anything still free after
+#:    the worst onload"*, not *"is there room for the request"*. Substituting one for the
+#:    other replaced a 2 GiB constant with a 256 MiB one — a smaller wrong number, which is
+#:    the more dangerous kind, because it fails toward OOM instead of toward slow.
+#: 2. **Nothing probes a resident placement at all** (see :attr:`RequestArena.funds_resident`).
+#:
+#: The measured basis is unchanged from where it came: pgw#1586's green arm, 7540 MiB peak
+#: over 5693 MiB of resident weights = **1847 MiB** of activations under the fully-resident
+#: allocator regime, rounded up. pgw#1604 independently measured ~2058 MiB for SDXL at this
+#: shape (7350 MiB peak over 5292 MiB resident).
+#:
+#: **It is still a constant standing in for a measurement, and this module does not pretend
+#: otherwise.** What changes here is that there is now ONE of it instead of three, its basis
+#: is a named field on every grant, and the thing that replaces it — a banked per-endpoint
+#: peak — has a defined seam to arrive through (``basis="measured"``). Deleting it is
+#: pgw#1586's `reserve_source=measured`, not this issue.
+COLD_REQUEST_BYTES = 2048 * _MIB
+
 
 @dataclass(frozen=True)
 class ComponentDecl:
@@ -174,9 +213,10 @@ class RequestArena:
     * ``declared``  — ``Resources.peak_vram_per_request_gb``. Zero of the 26 shipped
       endpoints set it, which is the honest reason the default path has never had a real
       number to use.
-    * ``probe``     — no prior number; the on-card probe decides, and until it runs the
-      arena asks only for :data:`PROBE_FLOOR_BYTES`. This is the cold-start case and it
-      means *try full residency*, not *reserve 2 GiB against a shape nobody measured*.
+    * ``prior``     — no per-endpoint measurement exists, so the arena carries the reserve
+      the tree already used (:data:`COLD_REQUEST_BYTES`). **Inherited, not invented, and not
+      deleted here.** See that constant for why an earlier version of this module was wrong
+      to replace it with the probe floor.
 
     ``compiled_extra_bytes`` is pgw#1601's mint-time demand stamp: what the compiled regime
     additionally spends OUTSIDE torch's allocator on its first call. ``None`` means no stamp
@@ -196,8 +236,12 @@ class RequestArena:
 
     @classmethod
     def cold(cls) -> "RequestArena":
-        """No prior measurement: ask for the probe floor and let the card answer."""
-        return cls(bytes=PROBE_FLOOR_BYTES, basis="probe")
+        """No per-endpoint measurement: carry the reserve the tree already used.
+
+        `basis="prior"` funds the STREAMED path (which is probed) and NOT a resident or
+        compiled admit. See :data:`COLD_REQUEST_BYTES` and :attr:`funds_resident`.
+        """
+        return cls(bytes=COLD_REQUEST_BYTES, basis="prior")
 
     def demand(self, regime: str) -> int:
         """Bytes the weight arena must leave unspent under ``regime``."""
@@ -207,9 +251,42 @@ class RequestArena:
         return int(self.bytes)
 
     @property
+    def funds_resident(self) -> bool:
+        """A FULLY-RESIDENT admit needs a real number, for the same reason a compiled one does.
+
+        ⚠️ **This gate was missing and it was a regression.** The first version of this module
+        let ``cold()`` — the 256 MiB probe floor — fund full residency, on the argument that
+        *"the probe is the measurement and it already exists"*. **On the resident path there
+        is no probe.** ``apply_component_residency`` (which owns ``probe_plan``) is reached
+        only under ``partial_resident``; a fully-resident placement is never probed. The claim
+        was load-bearing and unbacked.
+
+        The consequence, computed from banked numbers before any card time was spent: SDXL
+        bf16 is 6617 MiB of weights, and pgw#1604 measured its non-weight peak at ~2058 MiB
+        (7350 MiB peak alloc at the 7.3 GiB tier over 5292 MiB of resident weights). Fully
+        resident that is **8675 MiB against 7803 MiB of usable card** — it does not fit, by
+        872 MiB. With the probe floor funding it, tiers 7.45 / 7.3 / 7.0 would have been
+        admitted fully resident where the old walk chose ``partial_resident`` and served in
+        18.4-18.9 s. That is an OOM traded for a working placement.
+
+        So pgw#1604's finding 1 — *"SDXL is NEVER fully resident on this card, and cannot
+        be"* — is not the decider being broken. For SDXL the 2 GiB reserve was approximately
+        RIGHT. It was a guess that happened to be correct here and wrong on anima, and a guess
+        that is sometimes right is still a guess: what was actually missing is the
+        per-endpoint MEASUREMENT that tells the two cases apart.
+
+        Hence the symmetry with :attr:`funds_compiled`, and it is the same rule twice: **a
+        placement that cannot be caught in flight must be funded by a measurement, never by a
+        default.** Compiled cannot be caught because a mid-graph OOM is process death; full
+        residency cannot be caught because nothing probes it. ``cold()`` therefore funds the
+        STREAMED path — which really is probed — and nothing else.
+        """
+        return self.basis in ("measured", "declared")
+
+    @property
     def funds_compiled(self) -> bool:
         """A compiled admit needs a measurement on both halves, or it is not an admit."""
-        return self.basis in ("measured", "declared") and self.compiled_extra_bytes is not None
+        return self.funds_resident and self.compiled_extra_bytes is not None
 
 
 @dataclass(frozen=True)
@@ -358,7 +435,14 @@ def plan_grant(
     budget, basis = spendable.for_regime(EAGER)
     need = request.demand(EAGER)
 
-    if declared + need <= budget:
+    if not request.funds_resident:
+        # Nothing probes a fully-resident placement (see `RequestArena.funds_resident`), so a
+        # cold arena may not fund one. It funds the STREAMED path, which is probed.
+        notes += (
+            f"full residency not admitted: no measured request peak "
+            f"(basis={request.basis}); nothing probes a resident placement",
+        )
+    elif declared + need <= budget:
         return Grant(
             residency=_all_resident(components),
             regime=EAGER,

--- a/src/gen_worker/models/grant.py
+++ b/src/gen_worker/models/grant.py
@@ -1,0 +1,362 @@
+"""The grant seam: the endpoint DECLARES, the platform GRANTS, varena EXECUTES.
+
+Paul, ratifying pgw#1598: *"model requests memory from varena. varena always says yes and
+then makes it work. graph has only one specialization per lane, and compiles once per lane
+and serves it normally."* And the standing direction behind this module: *"these memory
+tricks move out of endpoint code into varena and python-gen-worker itself as much as
+possible. Endpoint code declares, the platform executes."*
+
+## Two arenas, and only one of them owns bytes
+
+**WEIGHT arena** — real residency. Manifest arithmetic plus phase-boundary paging under
+STABLE virtual addresses. varena maps and unmaps physical pages beneath a pointer that never
+moves, which is what lets a compiled artifact survive a residency change (pgw#1607).
+
+**REQUEST arena** — an ACCOUNTING-ONLY headroom guarantee. Activations stay in torch's
+allocator and are never paged by us. The request arena is a NUMBER the weight arena must
+leave unspent, not a place bytes live. varena is never told about it.
+
+## The one admission rule
+
+**COMPILED IFF FULLY RESIDENT, ELSE EAGER-STREAMED.** There is no compiled-below-residency
+rung and no author-visible ladder. Two riders, both from measurement:
+
+* Full residency is NECESSARY but not SUFFICIENT for compiled. The compiled regime also has
+  to fit in ``driver_free`` ALONE — AOTI's first-call pool allocates outside torch's caching
+  allocator, so cached blocks are eager-spendable money and cannot fund a compiled admit.
+  Measured +1154 MiB on sdxl sm_89, 4/4 runs, batch-invariant (pgw#1627).
+* Compiled needs a MEASURED demand stamp. Without one this module returns eager, structurally
+  — not by accident. A mid-graph OOM in a compiled artifact is process death (pgw#1255
+  leg 2), so "we did not measure it" can never be spent as "it probably fits".
+
+## Fully resident when it fits, and why that is the DEFAULT rather than an upgrade
+
+Measured, RTX 4070 Laptop 7.62 GiB (7803 MiB), 2026-08-21 anima head-to-head (varena#3):
+our serve pinned peak at **6102 MiB in every leg** — identical at load 5, 14 and 91, because
+it is budget-fed — while ComfyUI, fully resident, peaked **6778-7226 MiB on the same card**
+across four legs without an OOM, and ran the same 1024x1024/20-step/CFG request **20-37%
+faster**. The card had ~7284 MiB free. Full residency FIT, by a demonstrated margin, and our
+decider refused it.
+
+It refused it on arithmetic, not on a measurement: ``select_auto_mode`` demands
+``weights <= free - _DEFAULT_SAFETY_MARGIN_GB`` and ``_plan_partial_resident`` then demands
+``weights <= free - PARTIAL_RESIDENT_RESERVE_GB`` — two independent 2 GiB guesses at one
+unknown (the per-request activation peak), with ``_TRANSIENT_RESERVE_BYTES`` a third number
+for a fourth quantity inside the search. The constant carries its own confession:
+*"TEMPORARY. This is a constant standing in for a measurement."*
+
+So this module does not tune the guess. It **deletes** it:
+
+1. Full residency is the default posture. It is refused only by a MEASUREMENT — a banked
+   per-endpoint request peak that does not fit, or the on-card probe.
+2. The probe is that measurement, and it already exists. ``partial_resident.probe_plan``
+   does the worst onload once, reads free, and parks back; the fully-resident equivalent is
+   free, because the placement happens anyway. The arithmetic estimate was never trustworthy
+   on its own — on the campaign card it admitted a plan that then OOMed by 5 MiB — which is
+   exactly why the probe was built.
+3. A budget below card capacity with no co-tenant is self-harm. The deterministic 6102 MiB is
+   a neutral fact about a configuration, not a virtue.
+
+## What lives here and what does not
+
+Everything in this module is ARITHMETIC over declared bytes: no torch, no driver, no
+pipeline. That is deliberate — the decision is the part that has been wrong, and it should be
+falsifiable on a cardless box. The byte movement is varena's; the pipeline-shaped half is
+``memory.py``'s; the streamed-set SEARCH stays in
+``partial_resident.plan_component_residency``, which is measured, tested and correct about
+the thing it does (minimum BYTES moved, never minimum count).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Mapping, Optional, Sequence, Tuple
+
+__all__ = [
+    "RESIDENT",
+    "STREAMED",
+    "EAGER",
+    "COMPILED",
+    "ComponentDecl",
+    "RequestArena",
+    "Spendable",
+    "Grant",
+    "plan_grant",
+]
+
+_GIB = 1 << 30
+_MIB = 1 << 20
+
+#: The grant vocabulary. Two words, per varena#10 / pgw#1598 §4 — ``floor`` died with the UVM
+#: rung when Paul ruled compiled-below-residency out. A component is either on the card for
+#: the process's life, or it is paged in at its phase boundary and out again.
+RESIDENT = "resident"
+STREAMED = "streamed"
+
+#: The two regimes. This is ``residency_ledger.REGIMES`` and ``partial_resident``'s
+#: ``regime=`` argument, named once so the three cannot drift.
+EAGER = "eager"
+COMPILED = "compiled"
+
+#: What the on-card probe demands still be free once placement is done. The ONLY reserve
+#: constant this module spends, and the only one with provenance that survives contact: the
+#: planner's arithmetic admitted a plan that then OOMed by 5 MiB, and no constant fitted to
+#: one card fixes that, because allocator fragmentation and the co-tenants' share are in none
+#: of the numbers a planner can read. Lifted from ``partial_resident._PROBE_FLOOR_BYTES``
+#: rather than re-derived; it means the same thing in both places.
+PROBE_FLOOR_BYTES = 256 * _MIB
+
+
+@dataclass(frozen=True)
+class ComponentDecl:
+    """One thing the endpoint author declares. The whole author-visible vocabulary.
+
+    ``phase`` orders the paging schedule: components in the same phase are co-resident while
+    that phase runs, and the schedule is STATIC, which is why varena needs no tracing
+    machinery to prefetch (varena#10, ZeRO-Infinity steal list). ``pinned`` is the author
+    saying *this one may never be paged* — dtype-fragile VAEs, content-shared encoders, and
+    components diffusers drives by method rather than ``forward`` (a parked VAE never onloads
+    because the call is ``self.vae.decode(...)``; pgw#1619 ruled that a REFUSAL, not a second
+    hook, and this flag is where that refusal is now stated up front).
+
+    There is no rung, no ``low_vram_mode``, no ``enable_*_offload`` here, and that is the
+    second half of the acceptance bar: the programming model gets SIMPLER for the author.
+    """
+
+    name: str
+    weight_bytes: int
+    phase: int = 0
+    pinned: bool = False
+
+
+@dataclass(frozen=True)
+class RequestArena:
+    """The accounting-only headroom guarantee, and where its number came from.
+
+    ``basis`` is load-bearing and is not decoration:
+
+    * ``measured``  — a banked per-request peak for THIS endpoint. The only basis that may
+      fund a compiled admit.
+    * ``declared``  — ``Resources.peak_vram_per_request_gb``. Zero of the 26 shipped
+      endpoints set it, which is the honest reason the default path has never had a real
+      number to use.
+    * ``probe``     — no prior number; the on-card probe decides, and until it runs the
+      arena asks only for :data:`PROBE_FLOOR_BYTES`. This is the cold-start case and it
+      means *try full residency*, not *reserve 2 GiB against a shape nobody measured*.
+
+    ``compiled_extra_bytes`` is pgw#1601's mint-time demand stamp: what the compiled regime
+    additionally spends OUTSIDE torch's allocator on its first call. ``None`` means no stamp
+    exists, and no stamp means no compiled admit.
+    """
+
+    bytes: int
+    basis: str
+    compiled_extra_bytes: Optional[int] = None
+
+    @classmethod
+    def cold(cls) -> "RequestArena":
+        """No prior measurement: ask for the probe floor and let the card answer."""
+        return cls(bytes=PROBE_FLOOR_BYTES, basis="probe")
+
+    def demand(self, regime: str) -> int:
+        """Bytes the weight arena must leave unspent under ``regime``."""
+        if regime == COMPILED:
+            extra = self.compiled_extra_bytes or 0
+            return int(self.bytes) + int(extra)
+        return int(self.bytes)
+
+    @property
+    def funds_compiled(self) -> bool:
+        """A compiled admit needs a measurement on both halves, or it is not an admit."""
+        return self.basis in ("measured", "declared") and self.compiled_extra_bytes is not None
+
+
+@dataclass(frozen=True)
+class Spendable:
+    """What the card will actually give, split the way pgw#1627 proved it must be.
+
+    ``driver_free_bytes`` is what a NEW allocation would get. ``allocator_cache_bytes`` is
+    reserved-but-unallocated inside torch's caching allocator: real money for eager
+    activations, and no money at all for AOTI, which allocates its first-call pool outside
+    the allocator entirely. Counting the cache on the compiled path killed every 8 GiB
+    compiled-SDXL leg, and the confession string that should have caught it was a constant.
+    """
+
+    driver_free_bytes: int
+    allocator_cache_bytes: int = 0
+
+    def for_regime(self, regime: str) -> Tuple[int, str]:
+        """(spendable bytes, the basis name that goes on the confession line)."""
+        if regime == COMPILED:
+            return int(self.driver_free_bytes), "driver_free"
+        return int(self.driver_free_bytes) + int(self.allocator_cache_bytes), "free+cache"
+
+
+@dataclass(frozen=True)
+class Grant:
+    """varena always says yes. So this has no ``fits`` and no ``refusal``.
+
+    What it has instead is an honest split: which components are RESIDENT, which are
+    STREAMED, and what the arena was measured against when that was decided. A caller that
+    wants to know whether it got what it asked for reads :attr:`fully_resident`; a caller
+    that wants to know whether it may compile reads :attr:`regime`. Nothing downstream ever
+    branches on "is there enough memory" — that question is answered here, once.
+    """
+
+    residency: Mapping[str, str]
+    regime: str
+    weight_budget_bytes: int
+    resident_bytes: int
+    streamed_bytes: int
+    request_bytes: int
+    request_basis: str
+    spendable_bytes: int
+    headroom_basis: str
+    #: Set when the grant is honoured only because the reactive net exists — the declared
+    #: demand exceeds what the card can spend even with everything unpinned streamed. varena
+    #: still says yes; this names the fact so the confession can carry it.
+    over_card: bool = False
+    notes: Tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def fully_resident(self) -> bool:
+        return not self.streamed_bytes
+
+    @property
+    def streamed(self) -> Tuple[str, ...]:
+        return tuple(n for n, v in self.residency.items() if v == STREAMED)
+
+    @property
+    def resident(self) -> Tuple[str, ...]:
+        return tuple(n for n, v in self.residency.items() if v == RESIDENT)
+
+    def line(self) -> str:
+        """One line, and it names every number the decision was made on.
+
+        A confession that cannot go red is not a confession — ``headroom_basis`` shipped as a
+        constant ``"free+cache"`` and could not report the bug it was added to expose
+        (pgw#1627). Every field printed here is an input, not a restatement of the verdict.
+        """
+        head = (
+            f"grant regime={self.regime} "
+            f"{'FULLY RESIDENT' if self.fully_resident else f'streamed={len(self.streamed)}'} "
+            f"weights={self.resident_bytes / _GIB:.2f}+{self.streamed_bytes / _GIB:.2f} GiB "
+            f"request={self.request_bytes / _GIB:.2f} GiB ({self.request_basis}) "
+            f"spendable={self.spendable_bytes / _GIB:.2f} GiB ({self.headroom_basis})"
+        )
+        if self.streamed:
+            head += f" paged={','.join(self.streamed)}"
+        if self.over_card:
+            head += " OVER-CARD (reactive net is the backstop)"
+        for n in self.notes:
+            head += f" | {n}"
+        return head
+
+
+def _totals(components: Sequence[ComponentDecl]) -> int:
+    return sum(int(c.weight_bytes) for c in components)
+
+
+def _all_resident(components: Sequence[ComponentDecl]) -> Dict[str, str]:
+    return {c.name: RESIDENT for c in components}
+
+
+def plan_grant(
+    components: Sequence[ComponentDecl],
+    *,
+    spendable: Spendable,
+    request: RequestArena,
+    compile_intent: bool = False,
+    stream_selector: Optional[Callable[..., Sequence[str]]] = None,
+) -> Grant:
+    """The ONE admission decision. Pure arithmetic over declared bytes.
+
+    ``stream_selector`` is how the streamed set gets chosen when full residency does not
+    fit. It is injected rather than implemented here because the search that already exists
+    (``partial_resident.plan_component_residency``) is measured, tested, and correct about
+    the thing it does — minimum BYTES moved, never minimum count, with the denoiser never a
+    candidate. This module owns the DECISION; that function owns the SEARCH. It is called as
+    ``stream_selector(components, budget_bytes=...)`` and returns the names to stream; a
+    ``None`` selector, or one that returns nothing, still yields a grant — varena always says
+    yes — with :attr:`Grant.over_card` set so the caller can say so out loud.
+
+    Order of questions, and it is the admission rule read top to bottom:
+
+    1. Can everything be resident with the COMPILED demand met out of ``driver_free`` alone,
+       and is there a measurement to fund it? Then compiled.
+    2. Can everything be resident under the eager basis? Then eager, fully resident. This is
+       the branch the old decider could not reach and the one the anima row says we want.
+    3. Otherwise eager-streamed: page the cheapest set out at phase boundaries.
+    """
+    declared = _totals(components)
+
+    if compile_intent and request.funds_compiled:
+        budget, basis = spendable.for_regime(COMPILED)
+        need = request.demand(COMPILED)
+        if declared + need <= budget:
+            return Grant(
+                residency=_all_resident(components),
+                regime=COMPILED,
+                weight_budget_bytes=declared,
+                resident_bytes=declared,
+                streamed_bytes=0,
+                request_bytes=need,
+                request_basis=request.basis,
+                spendable_bytes=budget,
+                headroom_basis=basis,
+            )
+
+    notes: Tuple[str, ...] = ()
+    if compile_intent and not request.funds_compiled:
+        # Named, not silent. This is the difference between "compiled did not fit" and
+        # "compiled was never asked" — pgw#1627's dead-code lesson is that a branch nobody
+        # reaches reports as a branch that passed.
+        missing = "no measured request peak" if request.basis == "probe" else "no mint demand stamp"
+        notes += (f"compiled not admitted: {missing}",)
+
+    budget, basis = spendable.for_regime(EAGER)
+    need = request.demand(EAGER)
+
+    if declared + need <= budget:
+        return Grant(
+            residency=_all_resident(components),
+            regime=EAGER,
+            weight_budget_bytes=declared,
+            resident_bytes=declared,
+            streamed_bytes=0,
+            request_bytes=need,
+            request_basis=request.basis,
+            spendable_bytes=budget,
+            headroom_basis=basis,
+            notes=notes,
+        )
+
+    weight_budget = max(0, budget - need)
+    streamed: Tuple[str, ...] = ()
+    if stream_selector is not None:
+        streamed = tuple(stream_selector(components, budget_bytes=weight_budget) or ())
+    pinned = {c.name for c in components if c.pinned}
+    # A selector that names a pinned component is a bug in the selector, not a licence.
+    # Dropping it silently would page a dtype-fragile VAE and produce black images.
+    refused = tuple(n for n in streamed if n in pinned)
+    if refused:
+        streamed = tuple(n for n in streamed if n not in pinned)
+        notes += (f"selector named pinned components, refused: {','.join(refused)}",)
+
+    residency = {c.name: (STREAMED if c.name in streamed else RESIDENT) for c in components}
+    streamed_bytes = sum(int(c.weight_bytes) for c in components if c.name in streamed)
+    resident_bytes = declared - streamed_bytes
+
+    return Grant(
+        residency=residency,
+        regime=EAGER,
+        weight_budget_bytes=weight_budget,
+        resident_bytes=resident_bytes,
+        streamed_bytes=streamed_bytes,
+        request_bytes=need,
+        request_basis=request.basis,
+        spendable_bytes=budget,
+        headroom_basis=basis,
+        over_card=resident_bytes + need > budget,
+        notes=notes,
+    )

--- a/src/gen_worker/models/grant.py
+++ b/src/gen_worker/models/grant.py
@@ -38,6 +38,20 @@ across four legs without an OOM, and ran the same 1024x1024/20-step/CFG request 
 faster**. The card had ~7284 MiB free. Full residency FIT, by a demonstrated margin, and our
 decider refused it.
 
+**And pgw#1604 measured the same defect independently, on SDXL, and stated its arithmetic.**
+Finding 1 of the VRAM-limbo curve, verbatim: *"SDXL is NEVER fully resident on this card, and
+cannot be.* ``select_auto_mode``'s *fit test is* ``needed <= avail - 2.0``; *the confessed*
+``needed_gb`` *is 6.5, so residency wants **8.5 GiB free on a 7.62 GiB card**. There is no*
+``off``/``native`` *row at any budget. The "ceiling" is already a degraded rung."*
+
+Finding 5 of the same curve is why the answer is to DELETE the constant rather than raise it:
+the same request peaks at **2603 MiB at a 6.0 GiB cap, 2218 at 2.5, 1962 at 2.0, and 494 once
+tiling engages** — the caching allocator hands cached blocks back under pressure without being
+asked. *"Any VRAM sizing rule derived from a high-water mark measured on a roomy card
+systematically overstates the requirement."* A reserve fitted to a roomy-card high-water mark
+is measuring the allocator's generosity, not the request's need, and every GiB it overstates
+is a GiB the card had and the request did not get.
+
 It refused it on arithmetic, not on a measurement: ``select_auto_mode`` demands
 ``weights <= free - _DEFAULT_SAFETY_MARGIN_GB`` and ``_plan_partial_resident`` then demands
 ``weights <= free - PARTIAL_RESIDENT_RESERVE_GB`` — two independent 2 GiB guesses at one

--- a/src/gen_worker/models/grant.py
+++ b/src/gen_worker/models/grant.py
@@ -23,11 +23,22 @@ rung and no author-visible ladder. Two riders, both from measurement:
 
 * Full residency is NECESSARY but not SUFFICIENT for compiled. The compiled regime also has
   to fit in ``driver_free`` ALONE — AOTI's first-call pool allocates outside torch's caching
-  allocator, so cached blocks are eager-spendable money and cannot fund a compiled admit.
-  Measured +1154 MiB on sdxl sm_89, 4/4 runs, batch-invariant (pgw#1627).
-* Compiled needs a MEASURED demand stamp. Without one this module returns eager, structurally
-  — not by accident. A mid-graph OOM in a compiled artifact is process death (pgw#1255
-  leg 2), so "we did not measure it" can never be spent as "it probably fits".
+  allocator, so cached blocks are eager-spendable money and cannot fund a compiled admit
+  (pgw#1627).
+* Compiled needs a MEASURED demand stamp, **and the stamp must come from a SUCCESSFUL mint
+  run, never from a death trace** (pgw#1627's second re-open, on-card 2026-08-21). That rule
+  was paid for: a "+1154 MiB, 4/4 runs, batch-invariant" figure circulated as sdxl sm_89's
+  compiled first-call demand and was FALSIFIED — with 1326 MiB more freed, the first call
+  consumed ~2474 of 2506 available and died identically. **A death only ever reports the free
+  memory it consumed**, so a demand read off one measures the card, not the artifact. sdxl
+  sm_89's demand is UNKNOWN, lower-bounded >2501 MiB, and 8 GiB is a measured NO for compiled
+  SDXL UNet-only.
+
+  Without a stamp this module returns eager, **structurally** — not by accident. A mid-graph
+  OOM in a compiled artifact is process death (pgw#1255 leg 2), so "we did not measure it"
+  can never be spent as "it probably fits". The falsification above is the argument for that
+  rule rather than a footnote to it: the one number anybody had was an artifact of the
+  failure that produced it.
 
 ## Fully resident when it fits, and why that is the DEFAULT rather than an upgrade
 
@@ -161,6 +172,13 @@ class RequestArena:
     ``compiled_extra_bytes`` is pgw#1601's mint-time demand stamp: what the compiled regime
     additionally spends OUTSIDE torch's allocator on its first call. ``None`` means no stamp
     exists, and no stamp means no compiled admit.
+
+    **The stamp may only come from a SUCCESSFUL mint-child run** (pgw#1627's stamp-source
+    rule, on-card 2026-08-21). A death trace reports the free memory the call consumed before
+    dying, which is a fact about the card, not about the artifact — the figure that
+    circulated as sdxl sm_89's demand was exactly that, and it was falsified by giving the
+    same call more room and watching it consume that too. No consumer of this field can tell
+    a good stamp from a bad one, so the producer carries the rule.
     """
 
     bytes: int

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -2717,7 +2717,12 @@ def apply_low_vram_config(
         )
         if grant is not None:
             log.info("low_vram: %s", grant.line())
-            if grant.fully_resident:
+            # `fully_resident` means NOTHING WAS PAGED — it does not mean the
+            # demand fit. A declaration with one movable component (SDXL's
+            # denoiser is never a paging candidate) comes back unpaged AND
+            # over-card, and placing that resident is an OOM at load. The
+            # predicate for "may I place this on the card" is both.
+            if grant.fully_resident and not grant.over_card:
                 requirement = (
                     model_size_gb if model_size_gb is not None
                     else estimate_pipeline_size_gb(pipeline)

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -1639,7 +1639,14 @@ def _grant_for_pipeline(
                     + list(method_driven_components(pipeline))
                 ),
             )
-            captured["plan"] = plan
+            # Carried out ONLY when it is a plan the probe loop can actually be
+            # handed, which is `_plan_partial_resident`'s contract exactly:
+            # `fits` AND something to evict. Capturing unconditionally passed a
+            # `fits=False` plan downstream and, worse, made the caller's
+            # "no plan" fall-through unreachable — the arena was asked to arm a
+            # residency the search had already refused.
+            if plan.fits and plan.offloaded:
+                captured["plan"] = plan
             return tuple(plan.offloaded) if plan.fits else ()
 
         grant = plan_grant(
@@ -2813,15 +2820,38 @@ def apply_low_vram_config(
         if partial_resident_plan is not None:
             effective_mode = "partial_resident"
     if effective_mode == "partial_resident" and partial_resident_plan is None:
-        # The grant said stream but the search could not name a set the card
-        # accepts. The coarse rung is the honest answer, not a resident
-        # placement — and it is a fall-through, not a refusal: varena always
-        # says yes, so what changes here is HOW the bytes move, never whether
-        # the load proceeds.
+        # The grant asked to stream and the search could not name a set the card
+        # accepts, so NOTHING is being placed resident. That makes the remaining
+        # question a different one — WHICH COARSE RUNG — and the grant has no
+        # opinion on it: its vocabulary is `resident | streamed`, and neither
+        # word answers "model_offload or group_offload".
+        #
+        # So it is handed back to the walk that already answers it, rather than
+        # hardcoded. Hardcoding `model_offload` here made `group_offload`
+        # UNREACHABLE on the grant path — a behaviour change at the bottom of
+        # the curve that no measurement supported, in a change whose entire
+        # argument is that unmeasured constants should not decide placements.
+        # Deleting a cliff and silently deleting a rung are not the same act.
+        #
+        # The division is exact and is what makes this safe to land before the
+        # floor leg runs: the grant decides RESIDENCY and the threshold walk is
+        # never consulted for it, so the two-rungs-at-once cliff cannot touch a
+        # placement the grant made. Below the grant's reach, today's behaviour
+        # is preserved byte-for-byte. Deriving the coarse rung from the grant's
+        # paging DEPTH instead is pgw#1636.
+        effective_mode = select_auto_mode(
+            pipeline=pipeline, model_size_gb=model_size_gb,
+            peak_vram_gb=peak_vram_gb,
+        )
+        if effective_mode in ("off", "vae_only"):
+            # The walk's resident flavours cannot apply: the grant just said the
+            # card holds nothing resident, and pgw#1315 measured the cost of
+            # stamping a resident flavor over a placement that was not taken —
+            # the ladder then reads the pipeline two rungs above where it is.
+            effective_mode = "model_offload"
         log.info(
-            "low_vram: the grant asked for a streamed set the search could not "
-            "produce; falling to model_offload")
-        effective_mode = "model_offload"
+            "low_vram: the grant placed nothing resident and the search named "
+            "no streamed set; the coarse rung is %s", effective_mode)
 
     applied: Dict[str, Any] = {
         "mode": effective_mode,

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -32,7 +32,7 @@ import os
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import msgspec
 
@@ -1492,6 +1492,190 @@ def _execution_device() -> Any:
 _LAST_RESERVE: Dict[str, Any] = {}
 
 
+def _component_declaration(pipeline: Any) -> List[Any]:
+    """The endpoint's components as a DECLARATION: name, bytes, phase, pinned.
+
+    This is the whole author-visible vocabulary of the grant seam (pgw#1602 /
+    varena#10). Today it is DERIVED from the live pipeline rather than written
+    by the author, because that is what the 26 shipped endpoints give us — but
+    the derivation is the only thing that changes when they start declaring, and
+    nothing downstream of here knows the difference.
+
+    ``phase`` is the execution order diffusers already publishes
+    (``model_cpu_offload_seq``), which is exactly the STATIC phase sequence the
+    paging schedule wants: varena needs no tracing machinery to prefetch because
+    the plan is known (varena#10, the ZeRO-Infinity steal-list entry).
+
+    ``pinned`` is the union of "must not move" (dtype-fragile VAEs, content-
+    shared encoders) and "cannot be ENTERED by a forward hook" — diffusers calls
+    ``self.vae.decode(...)``, not ``forward``, so a parked VAE never onloads.
+    pgw#1619 ruled that a REFUSAL rather than a second hook, and this is where
+    that refusal is now stated up front instead of discovered by the planner.
+    """
+    from .grant import ComponentDecl
+    from .partial_resident import (
+        _named_components_of,
+        _pipeline_component_names,
+        method_driven_components,
+    )
+
+    order = _pipeline_component_names(pipeline)
+    phase_of = {name: i for i, name in enumerate(order)}
+    pinned = set(unhookable_components(pipeline)) | set(
+        method_driven_components(pipeline))
+    decls = []
+    for name, module in _named_components_of(pipeline):
+        nbytes = module_storage_bytes(module)
+        if nbytes <= 0:
+            continue
+        decls.append(
+            ComponentDecl(
+                name=name,
+                weight_bytes=int(nbytes),
+                phase=phase_of.get(name, len(order)),
+                pinned=name in pinned,
+            )
+        )
+    return decls
+
+
+def _grant_for_pipeline(
+    pipeline: Any,
+    log: logging.Logger,
+    *,
+    peak_vram_gb: Optional[float] = None,
+    model_size_gb: Optional[float] = None,
+    regime: str = "eager",
+    compiled_demand_bytes: int = 0,
+) -> Tuple[Any, Any]:
+    """Ask for a grant. Returns ``(grant, streamed_plan)``, or ``(None, None)``.
+
+    ``None`` is the answer whenever the DECLARATION cannot be built — no CUDA,
+    an unreadable card, a tree the sizer cannot walk. Those are the cases
+    ``select_auto_mode``'s zero-cause branching exists for and the grant does not
+    model them; it decides RESIDENCY, and residency is not a question you can ask
+    of a card you cannot read. It never raises: this sits on the load path of
+    every pipeline, and a decider that raises takes out placements that work.
+
+    ``streamed_plan`` is the ``ResidencyPlan`` the selector produced when the
+    grant came back streamed, carried out so the probe loop does not have to
+    re-derive it.
+    """
+    try:
+        from .grant import RequestArena, Spendable, plan_grant
+        from .partial_resident import (
+            _placement_attribution,
+            method_driven_components,
+            plan_for_pipeline,
+        )
+
+        free_gb = get_available_vram_gb()
+        if free_gb <= 0.0:
+            return None, None
+        decls = _component_declaration(pipeline)
+        if not decls:
+            return None, None
+
+        # The two halves of the money, split the way pgw#1627 proved they must
+        # be: driver_free is what a new allocation gets, cache is reserved-but-
+        # unallocated inside torch's allocator. Eager may spend both; AOTI's
+        # first-call pool lives outside the allocator and may spend only the
+        # first. `_placement_attribution` is best-effort — a card that will not
+        # answer contributes zero cache, which is the conservative direction.
+        try:
+            import torch as _t
+
+            attr = _placement_attribution(_t)
+            cache_bytes = int(attr.get("attr_cache_bytes", 0) or 0)
+        except Exception:  # noqa: BLE001
+            cache_bytes = 0
+        spendable = Spendable(
+            driver_free_bytes=int(free_gb * _GIB),
+            allocator_cache_bytes=cache_bytes,
+        )
+
+        # THE REQUEST ARENA, and this is where two 2 GiB guesses became one
+        # number with a stated basis. `peak_vram_gb` is a TOTAL requirement, so
+        # the activation share is what it asks for beyond the weights. Nothing
+        # declares it today (measured: 0 of 26 endpoints), so the live answer is
+        # `cold()` — ask for the probe floor and let the CARD decide, rather than
+        # reserve 2 GiB against a shape nobody measured. The probe is the
+        # measurement, it already exists, and it is why this rung was never
+        # estimate-first in the first place.
+        request = RequestArena.cold()
+        if peak_vram_gb is not None and peak_vram_gb > 0.0:
+            weights_gb = (
+                model_size_gb if model_size_gb is not None
+                else estimate_pipeline_size_gb(pipeline)
+            )
+            declared = max(0.0, float(peak_vram_gb) - float(weights_gb))
+            if declared > 0.0:
+                request = RequestArena(
+                    bytes=int(declared * _GIB),
+                    basis="declared",
+                    compiled_extra_bytes=(
+                        int(compiled_demand_bytes) if compiled_demand_bytes else None
+                    ),
+                )
+        elif compiled_demand_bytes:
+            request = RequestArena(
+                bytes=request.bytes,
+                basis=request.basis,
+                compiled_extra_bytes=int(compiled_demand_bytes),
+            )
+
+        captured: Dict[str, Any] = {}
+
+        def _selector(components: Any, *, budget_bytes: int) -> Tuple[str, ...]:
+            # The SEARCH stays where it is measured and tested: minimum BYTES
+            # moved, never minimum count, denoiser never a candidate.
+            plan = plan_for_pipeline(
+                pipeline,
+                budget_bytes=int(budget_bytes),
+                free_bytes=int(free_gb * _GIB),
+                sizer=lambda m: module_storage_bytes(m),
+                forced_resident=(
+                    list(unhookable_components(pipeline))
+                    + list(method_driven_components(pipeline))
+                ),
+            )
+            captured["plan"] = plan
+            return tuple(plan.offloaded) if plan.fits else ()
+
+        grant = plan_grant(
+            decls,
+            spendable=spendable,
+            request=request,
+            compile_intent=(regime == "compiled"),
+            stream_selector=_selector,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "low_vram: could not plan a grant (%s: %s); falling back to the "
+            "free-VRAM walk", type(exc).__name__, exc,
+        )
+        return None, None
+    return grant, captured.get("plan")
+
+
+def _resident_flavor(pipeline: Any, requirement_gb: float) -> str:
+    """``off`` vs ``vae_only`` for a grant that came back fully resident.
+
+    BOTH are resident; this refinement only toggles VAE slicing, which changes
+    the traced decode graph class and hence the compiled object set a mint
+    proves. It stays keyed on the card's TOTAL capacity — a per-SKU constant —
+    never on live free VRAM, because the live margin hovering at this threshold
+    split one identical L4 fleet's mints 6/13 into off/vae_only cohorts
+    (pgw#750). The GRANT decides residency; this decides a graph class, and the
+    two must not be keyed on the same number.
+    """
+    total = get_total_vram_gb()
+    if total > 0.0:
+        sku_usable = max(0.0, total - GPU_VRAM_OVERHEAD_GB - _DEFAULT_SAFETY_MARGIN_GB)
+        return "off" if (sku_usable - requirement_gb) >= _DEFAULT_OFF_HEADROOM_GB else "vae_only"
+    return "vae_only"
+
+
 def _plan_partial_resident(
     pipeline: Any, log: logging.Logger, *, min_moved_bytes: int = 0,
     peak_vram_gb: Optional[float] = None, model_size_gb: Optional[float] = None,
@@ -2510,11 +2694,48 @@ def apply_low_vram_config(
             type(exc).__name__, exc)
 
     effective_mode = mode
+    grant = None
+    grant_plan = None
     if effective_mode == "auto":
-        effective_mode = select_auto_mode(
-            pipeline=pipeline, model_size_gb=model_size_gb, peak_vram_gb=peak_vram_gb,
+        # THE GRANT SEAM (pgw#1602 / varena#10). One decision, one reserve, one
+        # place. It replaces the FIT half of `select_auto_mode` and both of the
+        # lease-driven UPGRADE branches below, which between them asked the same
+        # question — does this fit resident — three times against three different
+        # margins, with an explicit rule that none of them may overrule another
+        # ("a fit decision `select_auto_mode` already made against a different
+        # margin. Do not overrule it from here."). That rule is what left the
+        # anima serve pinned at 6102 MiB on a card ComfyUI ran fully resident at
+        # 6778-7226 MiB, 20-37% faster, four times, with no OOM (varena#3).
+        #
+        # `select_auto_mode` keeps everything the grant does not model: the
+        # zero-cause branching (no CUDA vs unreadable are different facts and get
+        # different answers, pgw#940) and the unknown-model-size walk.
+        grant, grant_plan = _grant_for_pipeline(
+            pipeline, log,
+            peak_vram_gb=peak_vram_gb, model_size_gb=model_size_gb,
+            regime=regime, compiled_demand_bytes=int(compiled_demand_bytes),
         )
-        log.info("low_vram: auto-selected mode=%s", effective_mode)
+        if grant is not None:
+            log.info("low_vram: %s", grant.line())
+            if grant.fully_resident:
+                requirement = (
+                    model_size_gb if model_size_gb is not None
+                    else estimate_pipeline_size_gb(pipeline)
+                )
+                if peak_vram_gb is not None and peak_vram_gb > 0.0:
+                    requirement = max(requirement, float(peak_vram_gb))
+                effective_mode = _resident_flavor(pipeline, requirement)
+            else:
+                effective_mode = "partial_resident"
+            log.info("low_vram: grant-selected mode=%s", effective_mode)
+        else:
+            effective_mode = select_auto_mode(
+                pipeline=pipeline, model_size_gb=model_size_gb,
+                peak_vram_gb=peak_vram_gb,
+            )
+            log.info(
+                "low_vram: auto-selected mode=%s (no grant — the card could not "
+                "be read or the tree could not be declared)", effective_mode)
     if effective_mode in ("group_offload", "sequential") and getattr(
         pipeline, "_cozy_gguf_quant", None
     ):
@@ -2534,9 +2755,16 @@ def apply_low_vram_config(
     # leaves. The budget is the SMALLER of the lease and what the card actually
     # has free: both are facts, and admitting more than the card holds would
     # OOM under a lease that was written when the card was emptier.
-    if effective_mode in ("model_offload", "group_offload", "sequential") and int(
-        stream_budget_bytes
-    ) > 0:
+    #
+    # ⚠️ SUPERSEDED BY THE GRANT for every load the grant could decide, and gated
+    # on that rather than deleted in this change: the grant does not model the
+    # zero-cause / unknown-size walk, so a load that fell through to
+    # `select_auto_mode` still needs the upgrade it always had. This branch dies
+    # with the rest of the ladder when the declaration covers those cases too —
+    # named in pgw#1602's deletion list, not left as a second decider.
+    if grant is None and effective_mode in (
+        "model_offload", "group_offload", "sequential"
+    ) and int(stream_budget_bytes) > 0:
         headroom = int(
             max(0.0, get_available_vram_gb() - _DEFAULT_SAFETY_MARGIN_GB) * _GIB
         )
@@ -2572,13 +2800,23 @@ def apply_low_vram_config(
     # non-raising allocator to thrash inside, and no except-OOM retry — an OOM
     # in a compiled graph is process death, so before the weights land is the
     # only honest place to decide.
-    partial_resident_plan = None
-    if effective_mode == "model_offload":
+    partial_resident_plan = grant_plan
+    if grant is None and effective_mode == "model_offload":
         partial_resident_plan = _plan_partial_resident(
             pipeline, log, peak_vram_gb=peak_vram_gb, model_size_gb=model_size_gb,
         )
         if partial_resident_plan is not None:
             effective_mode = "partial_resident"
+    if effective_mode == "partial_resident" and partial_resident_plan is None:
+        # The grant said stream but the search could not name a set the card
+        # accepts. The coarse rung is the honest answer, not a resident
+        # placement — and it is a fall-through, not a refusal: varena always
+        # says yes, so what changes here is HOW the bytes move, never whether
+        # the load proceeds.
+        log.info(
+            "low_vram: the grant asked for a streamed set the search could not "
+            "produce; falling to model_offload")
+        effective_mode = "model_offload"
 
     applied: Dict[str, Any] = {
         "mode": effective_mode,

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -1,0 +1,436 @@
+"""The grant seam's admission rule, on a cardless box.
+
+Every number in this file is a BANKED MEASUREMENT with a tracker citation, not a fixture
+invented to make an assertion pass. The decision is the part of the memory system that has
+been wrong, so it is the part that has to be falsifiable without a GPU window.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.models.grant import (
+    COMPILED,
+    EAGER,
+    RESIDENT,
+    STREAMED,
+    ComponentDecl,
+    Grant,
+    RequestArena,
+    Spendable,
+    plan_grant,
+)
+
+MIB = 1 << 20
+GIB = 1 << 30
+
+# --- the banked substrate ------------------------------------------------------------------
+# RTX 4070 Laptop, 8188 MiB total / 7803 MiB usable (7.62 GiB). varena#3, 2026-08-21.
+#
+# anima head-to-head: ComfyUI served the identical 1024x1024/20-step/CFG request FULLY
+# RESIDENT at a 6778-7226 MiB peak across four legs with no OOM, and ran 20-37% faster than
+# our budget-fed arm, whose peak pinned at 6102 MiB in every leg.
+ANIMA_FULLY_RESIDENT_PEAK = 7226 * MIB
+ANIMA_BUDGET_FED_PEAK = 6102 * MIB
+
+# The card's free bytes are taken FROM THE DEMONSTRATION rather than from a baseline reading:
+# ComfyUI reached a 7226 MiB peak on this card without an OOM, so the card had at least that
+# much to give. Nothing is inferred and no baseline is assumed.
+CARD_FREE = ANIMA_FULLY_RESIDENT_PEAK
+
+# pgw#1586's GREEN arm: SDXL, weights pinned for the process's life, 7540 MiB peak over
+# 5693 MiB of resident weights => 1847 MiB of activations under the fully-resident allocator
+# regime (fragmentation the offloaded rung never pays).
+SDXL_WEIGHTS = 5693 * MIB
+SDXL_ACTIVATIONS = 1847 * MIB
+
+# pgw#1627: AOTI's first-call pool, allocated OUTSIDE torch's caching allocator. sdxl sm_89,
+# 4/4 runs, batch-invariant.
+AOTI_FIRST_CALL = 1154 * MIB
+
+
+def anima_components(weights: int) -> list[ComponentDecl]:
+    """A three-component pipeline shaped like anima: denoiser, text encoder, VAE."""
+    te = int(weights * 0.22)
+    vae = int(weights * 0.06)
+    # The denoiser takes the remainder so the split is EXACT — a test that loses two bytes to
+    # truncation cannot assert against a measured peak.
+    return [
+        ComponentDecl("transformer", weights - te - vae, phase=1),
+        ComponentDecl("text_encoder", te, phase=0),
+        ComponentDecl("vae", vae, phase=2, pinned=True),
+    ]
+
+
+def cheapest_streamed(components, *, budget_bytes):
+    """A stand-in for `partial_resident.plan_component_residency`: page out the smallest
+    unpinned non-denoiser components until the resident set fits. The real search is that
+    function; this one only has to be honest enough to exercise the seam."""
+    movable = sorted(
+        (c for c in components if not c.pinned and c.phase != 1),
+        key=lambda c: c.weight_bytes,
+    )
+    resident = sum(c.weight_bytes for c in components)
+    out = []
+    for c in movable:
+        if resident <= budget_bytes:
+            break
+        out.append(c.name)
+        resident -= c.weight_bytes
+    return out
+
+
+# --- the case the whole redesign exists for ------------------------------------------------
+
+
+def test_full_residency_is_granted_where_comfyui_demonstrated_it_fits():
+    """THE anima self-harm case, in one assertion.
+
+    ComfyUI ran this exact request fully resident at a 7226 MiB peak on this card, four
+    times, without an OOM, 20-37% faster than we did. Our decider refused full
+    residency and pinned at 6102 MiB. A grant that does not come back RESIDENT here has
+    reproduced the defect.
+    """
+    # Weights are sized so that weights + the cold request arena is EXACTLY the peak ComfyUI
+    # demonstrated. No number is invented: the demand under test is the measured peak.
+    weights = ANIMA_FULLY_RESIDENT_PEAK - RequestArena.cold().bytes
+    g = plan_grant(
+        anima_components(weights),
+        spendable=Spendable(driver_free_bytes=CARD_FREE),
+        request=RequestArena.cold(),
+        stream_selector=cheapest_streamed,
+    )
+    assert g.fully_resident, g.line()
+    assert g.regime == EAGER
+    assert set(g.residency.values()) == {RESIDENT}
+    assert g.streamed_bytes == 0
+    # And the grant spends the card it was given, rather than a number below it: the granted
+    # occupancy is the demonstrated peak, which is 1124 MiB more of the card than our own
+    # budget-fed arm used — and that arm was the slower one.
+    assert g.resident_bytes + g.request_bytes == ANIMA_FULLY_RESIDENT_PEAK
+    assert g.resident_bytes + g.request_bytes > ANIMA_BUDGET_FED_PEAK
+
+
+def test_the_old_two_gib_reserve_is_what_refused_it():
+    """The falsifier for the claim above: reintroduce the deleted guess and the same card,
+    the same weights and the same measurement stop granting full residency.
+
+    This is not testing a code path — it is pinning WHY the constant had to go, so a later
+    reader cannot restore it as a safety improvement without seeing what it costs.
+    """
+    weights = ANIMA_FULLY_RESIDENT_PEAK - RequestArena.cold().bytes
+    two_gib_guess = RequestArena(bytes=2 * GIB, basis="declared")
+    g = plan_grant(
+        anima_components(weights),
+        spendable=Spendable(driver_free_bytes=CARD_FREE),
+        request=two_gib_guess,
+        stream_selector=cheapest_streamed,
+    )
+    assert not g.fully_resident
+    assert g.streamed, "the 2 GiB guess pages components the card had room for"
+
+
+# --- the admission rule ---------------------------------------------------------------------
+
+
+def test_compiled_requires_full_residency_and_driver_free_alone():
+    """COMPILED IFF FULLY RESIDENT — and the AOTI pool must fit in driver_free, never cache.
+
+    Cache is eager-spendable money. The same demand admits compiled when driver_free covers
+    it and does NOT when only the cache makes up the difference; that difference is what
+    killed every 8 GiB compiled-SDXL leg.
+    """
+    comps = [ComponentDecl("unet", SDXL_WEIGHTS, phase=1)]
+    req = RequestArena(
+        bytes=SDXL_ACTIVATIONS, basis="measured", compiled_extra_bytes=AOTI_FIRST_CALL
+    )
+    need = SDXL_WEIGHTS + SDXL_ACTIVATIONS + AOTI_FIRST_CALL
+
+    ok = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=need),
+        request=req,
+        compile_intent=True,
+        stream_selector=cheapest_streamed,
+    )
+    assert ok.regime == COMPILED
+    assert ok.headroom_basis == "driver_free"
+    assert ok.fully_resident
+
+    # Same total money, but half of it is allocator cache. AOTI cannot spend it.
+    split = plan_grant(
+        comps,
+        spendable=Spendable(
+            driver_free_bytes=need - AOTI_FIRST_CALL,
+            allocator_cache_bytes=AOTI_FIRST_CALL,
+        ),
+        request=req,
+        compile_intent=True,
+        stream_selector=cheapest_streamed,
+    )
+    assert split.regime == EAGER, split.line()
+    assert split.headroom_basis == "free+cache"
+    # The eager arm may spend the cache, so it still gets full residency here.
+    assert split.fully_resident
+
+
+def test_an_unmeasured_compile_intent_is_eager_and_says_so():
+    """No stamp, no compiled admit — structurally, and NAMED.
+
+    A mid-graph OOM in a compiled artifact is process death, so "we did not measure it" can
+    never be spent as "it probably fits". The note is the point: pgw#1627's lesson is that a
+    branch nobody reaches reports as a branch that passed.
+    """
+    comps = [ComponentDecl("unet", 1 * GIB, phase=1)]
+    g = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=64 * GIB),
+        request=RequestArena.cold(),
+        compile_intent=True,
+        stream_selector=cheapest_streamed,
+    )
+    assert g.regime == EAGER
+    assert g.fully_resident
+    assert any("compiled not admitted" in n for n in g.notes), g.notes
+
+    # A measured request peak alone is still not enough: the mint stamp is the other half.
+    half = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=64 * GIB),
+        request=RequestArena(bytes=1 * GIB, basis="measured"),
+        compile_intent=True,
+        stream_selector=cheapest_streamed,
+    )
+    assert half.regime == EAGER
+    assert any("mint demand stamp" in n for n in half.notes), half.notes
+
+
+def test_compiled_is_refused_when_anything_would_be_streamed():
+    """Full residency is NECESSARY. A grant that pages one component is eager, whatever the
+    lane wanted and however good the stamp is."""
+    comps = anima_components(6 * GIB)
+    g = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=5 * GIB),
+        request=RequestArena(bytes=512 * MIB, basis="measured", compiled_extra_bytes=AOTI_FIRST_CALL),
+        compile_intent=True,
+        stream_selector=cheapest_streamed,
+    )
+    assert g.regime == EAGER
+    assert not g.fully_resident
+    assert STREAMED in g.residency.values()
+
+
+# --- varena always says yes -------------------------------------------------------------
+
+
+def test_a_demand_the_card_cannot_hold_still_gets_a_grant():
+    """varena always says yes. There is no `fits` field and no refusal to branch on.
+
+    What the caller gets instead is a grant with `over_card` set — an honest statement that
+    the reactive net (oom_ladder's tile and attention ladders) is what stands between this
+    and an OOM. Endpoint code never sees the difference.
+    """
+    comps = anima_components(40 * GIB)
+    g = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=4 * GIB),
+        request=RequestArena.cold(),
+        stream_selector=cheapest_streamed,
+    )
+    assert isinstance(g, Grant)
+    assert not hasattr(g, "refusal")
+    assert g.over_card, g.line()
+    assert g.line()  # the confession renders rather than raising
+
+
+def test_no_selector_still_yields_a_grant():
+    """A caller with nothing to page — one component, or no search wired — is not an error."""
+    g = plan_grant(
+        [ComponentDecl("unet", 40 * GIB, phase=1)],
+        spendable=Spendable(driver_free_bytes=4 * GIB),
+        request=RequestArena.cold(),
+    )
+    assert g.regime == EAGER
+    assert g.streamed_bytes == 0
+    assert g.over_card
+
+
+def test_a_pinned_component_is_never_streamed_even_if_the_selector_says_so():
+    """pgw#1619 ruled a method-driven component a REFUSAL rather than a second hook. Paging a
+    dtype-fragile VAE does not fail loudly — it produces black images — so a selector that
+    names one is overruled and the override is recorded."""
+    comps = anima_components(40 * GIB)
+
+    def bad_selector(components, *, budget_bytes):
+        return [c.name for c in components]
+
+    g = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=1 * GIB),
+        request=RequestArena.cold(),
+        stream_selector=bad_selector,
+    )
+    assert "vae" not in g.streamed
+    assert g.residency["vae"] == RESIDENT
+    assert any("refused" in n for n in g.notes), g.notes
+
+
+# --- the confession ------------------------------------------------------------------------
+
+
+def test_the_headroom_basis_can_go_red():
+    """`headroom_basis` shipped as a constant "free+cache" and could not report the bug it was
+    added to expose (pgw#1627). Both values must be reachable from the production entry
+    point, or the field is decoration."""
+    comps = [ComponentDecl("unet", 1 * GIB, phase=1)]
+    stamped = RequestArena(bytes=1 * GIB, basis="measured", compiled_extra_bytes=AOTI_FIRST_CALL)
+    compiled = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=64 * GIB),
+        request=stamped,
+        compile_intent=True,
+    )
+    eager = plan_grant(
+        comps, spendable=Spendable(driver_free_bytes=64 * GIB), request=RequestArena.cold()
+    )
+    assert {compiled.headroom_basis, eager.headroom_basis} == {"driver_free", "free+cache"}
+
+
+def test_the_line_names_every_input_not_the_verdict():
+    comps = anima_components(6 * GIB)
+    g = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=5 * GIB, allocator_cache_bytes=256 * MIB),
+        request=RequestArena.cold(),
+        stream_selector=cheapest_streamed,
+    )
+    line = g.line()
+    for token in ("regime=", "weights=", "request=", "spendable=", "probe", "free+cache"):
+        assert token in line, line
+
+
+@pytest.mark.parametrize("regime,extra", [(EAGER, 0), (COMPILED, AOTI_FIRST_CALL)])
+def test_the_request_arena_demand_is_regime_split(regime, extra):
+    req = RequestArena(bytes=512 * MIB, basis="measured", compiled_extra_bytes=AOTI_FIRST_CALL)
+    assert req.demand(regime) == 512 * MIB + extra
+
+
+# --- THE WIRING, and it is the half that shipped dead last time -----------------------------
+#
+# pgw#1627's lesson, verbatim from the tracker: "'Both guards proven red-able' was true of the
+# FUNCTION and false of the WIRING — the green-test-on-an-unreached-seam class." Every test
+# above exercises `plan_grant` directly. On a cardless box `apply_low_vram_config` never
+# reaches it (the grant returns None when free VRAM reads 0 and the old walk takes over), so
+# without the tests below this whole module would be green and unreached in production.
+
+import logging  # noqa: E402
+from typing import Any, cast  # noqa: E402
+
+import torch  # noqa: E402
+from diffusers import DiffusionPipeline  # noqa: E402
+from diffusers.configuration_utils import ConfigMixin, register_to_config  # noqa: E402
+from diffusers.models.modeling_utils import ModelMixin  # noqa: E402
+
+
+class _Block(ModelMixin, ConfigMixin):
+    @register_to_config
+    def __init__(self, width: int = 8):
+        super().__init__()
+        self.lin = torch.nn.Linear(width, width)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+class _ThreeStagePipeline(DiffusionPipeline):
+    model_cpu_offload_seq = "text_encoder->unet->vae"
+    text_encoder: Any
+    unet: Any
+    vae: Any
+
+    def __init__(self, text_encoder: Any, unet: Any, vae: Any) -> None:
+        super().__init__()
+        cast(Any, self).register_modules(text_encoder=text_encoder, unet=unet, vae=vae)
+
+
+def _pipe():
+    return _ThreeStagePipeline(_Block(8), _Block(16), _Block(4))
+
+
+def _with_card(monkeypatch, free_gb: float, total_gb: float = 24.0):
+    """Present a readable card to `memory`. Without this every test in this file that goes
+    through the production entry point silently exercises the fallback instead."""
+    import gen_worker.models.memory as m
+
+    monkeypatch.setattr(m, "get_available_vram_gb", lambda *a, **k: free_gb)
+    monkeypatch.setattr(m, "get_total_vram_gb", lambda *a, **k: total_gb)
+    monkeypatch.setattr(m, "unhookable_components", lambda *a, **k: [])
+    return m
+
+
+def test_the_production_entry_point_actually_reaches_the_grant(monkeypatch):
+    """The wiring guard. A readable card must produce a GRANT, not the free-VRAM walk."""
+    m = _with_card(monkeypatch, free_gb=24.0)
+    seen = {}
+    real = m._grant_for_pipeline
+
+    def spy(*a, **k):
+        g, p = real(*a, **k)
+        seen["grant"] = g
+        return g, p
+
+    monkeypatch.setattr(m, "_grant_for_pipeline", spy)
+    monkeypatch.setattr(
+        m, "select_auto_mode",
+        lambda **k: pytest.fail("the free-VRAM walk ran; the grant seam was not reached"),
+    )
+    applied = m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
+    assert seen.get("grant") is not None
+    assert seen["grant"].fully_resident
+    assert applied["mode"] in ("off", "vae_only")
+
+
+def test_the_wiring_guard_can_go_red(monkeypatch):
+    """Falsification, in the file rather than in a scratch edit: an UNREADABLE card must take
+    the fallback. If this passes while the test above also passes, both are measuring
+    something real; if the seam were unreachable, this would be the only reachable path."""
+    m = _with_card(monkeypatch, free_gb=0.0)
+    walked = []
+    monkeypatch.setattr(
+        m, "select_auto_mode", lambda **k: walked.append(1) or "group_offload"
+    )
+    m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
+    assert walked, "an unreadable card must fall through to the free-VRAM walk"
+
+
+def test_a_tiny_card_streams_through_the_grant_and_not_the_upgrade_branch(monkeypatch):
+    """The other side of the seam: when the grant cannot give full residency it selects the
+    streamed set, and the lease-driven UPGRADE branches must NOT also fire. Two deciders for
+    one question is the defect this issue exists to remove."""
+    m = _with_card(monkeypatch, free_gb=0.000_5, total_gb=24.0)
+    monkeypatch.setattr(
+        m, "_plan_partial_resident",
+        lambda *a, **k: pytest.fail("the legacy partial_resident upgrade ran beside the grant"),
+    )
+    applied = m.apply_low_vram_config(
+        _pipe(), mode="auto", logger=logging.getLogger("t"), stream_budget_bytes=1 << 20
+    )
+    # Whatever it lands on, it is NOT the lease upgrade — that branch is gated on `grant is
+    # None` now, and the fixture above would have failed the test if it had run.
+    assert applied["mode"] != "partial_stream"
+
+
+def test_the_declaration_marks_a_dtype_fragile_vae_pinned(monkeypatch):
+    """`pinned` is the author saying *never page this*. Today it is derived, and the derivation
+    has to keep carrying pgw#1619's refusal: diffusers drives the VAE by `.decode(...)`, so a
+    parked one never onloads."""
+    import gen_worker.models.memory as m
+
+    monkeypatch.setattr(m, "unhookable_components", lambda *a, **k: ["vae"])
+    decls = m._component_declaration(_pipe())
+    by_name = {d.name: d for d in decls}
+    assert by_name["vae"].pinned
+    assert not by_name["unet"].pinned
+    # And the phase order is diffusers' own published sequence, not an invention.
+    assert by_name["text_encoder"].phase < by_name["unet"].phase < by_name["vae"].phase

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -543,3 +543,37 @@ def test_no_stamp_is_the_only_honest_answer_when_the_demand_is_unknown():
         )
         assert g.regime == EAGER, f"{card / GIB:.0f} GiB card: {g.line()}"
         assert any("mint demand stamp" in n for n in g.notes), g.notes
+
+
+def test_an_over_card_grant_is_never_placed_resident(monkeypatch):
+    """The regression this seam could have shipped, caught in self-review.
+
+    `Grant.fully_resident` means NOTHING WAS PAGED. It does not mean the demand fit — a
+    declaration whose only movable component is the denoiser (which is never a paging
+    candidate: SDXL's shape exactly) comes back unpaged AND `over_card`. Routing that to the
+    resident rung places 6.5 GiB of weights on a card that cannot hold them and OOMs at LOAD,
+    which is strictly worse than the coarse rung the old ladder chose.
+
+    The predicate for "may I place this on the card" is BOTH properties, and this pins it
+    through the production entry point rather than at the arithmetic layer where the bug was
+    not visible.
+    """
+    import gen_worker.models.memory as m
+
+    # A card far too small for the fixture pipeline, but readable — so the grant path runs.
+    _with_card(monkeypatch, free_gb=0.000_5, total_gb=24.0)
+    seen = {}
+    real = m._grant_for_pipeline
+
+    def spy(*a: Any, **k: Any) -> Any:
+        g, p = real(*a, **k)
+        seen["grant"] = g
+        return g, p
+
+    monkeypatch.setattr(m, "_grant_for_pipeline", spy)
+    applied = m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
+    g = seen.get("grant")
+    assert g is not None and g.over_card, g.line() if g else "no grant"
+    assert applied["mode"] not in ("off", "vae_only"), (
+        f"an over-card grant was placed resident as {applied['mode']!r} — {g.line()}"
+    )

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -436,3 +436,76 @@ def test_the_declaration_marks_a_dtype_fragile_vae_pinned(monkeypatch):
     assert not by_name["unet"].pinned
     # And the phase order is diffusers' own published sequence, not an invention.
     assert by_name["text_encoder"].phase < by_name["unet"].phase < by_name["vae"].phase
+
+
+# --- the SDXL case, measured independently by pgw#1604 --------------------------------------
+
+# pgw#1604 finding 1, the VRAM-limbo curve on the same 4070: SDXL's confessed `needed_gb` is
+# 6.5, so `select_auto_mode`'s `needed <= avail - 2.0` wants 8.5 GiB free on a 7.62 GiB card.
+# There is no `off`/`native` row AT ANY BUDGET. "The ceiling is already a degraded rung."
+SDXL_NEEDED = int(6.5 * GIB)
+CARD_USABLE = 7803 * MIB
+
+# pgw#1604 finding 5: the SAME request peaks at 2603 MiB under a 6.0 GiB cap, 2218 at 2.5,
+# 1962 at 2.0, and 494 once tiling engages. The allocator hands cached blocks back under
+# pressure without being asked, so a reserve fitted to a roomy-card high-water mark measures
+# the allocator's generosity, not the request's need.
+SDXL_PEAK_AT_6GIB_CAP = 2603 * MIB
+SDXL_PEAK_AT_2GIB_CAP = 1962 * MIB
+
+
+def test_sdxl_gets_a_resident_row_the_old_ladder_could_not_produce():
+    """pgw#1604's finding 1, inverted into the fix.
+
+    The card cannot hold 6.5 GiB of weights AND a 2.0 GiB guess — that is the arithmetic that
+    produced "no `off` row at any budget". It CAN hold 6.5 GiB of weights and the probe floor,
+    and whether that actually serves is then a question for the card rather than for a
+    constant.
+    """
+    # SDXL's denoiser is never a paging candidate, so this declaration has nothing to stream
+    # — which is exactly the position the old ladder was in. The predicate that matters here
+    # is therefore `over_card`: did the demand FIT, not was anything paged.
+    comps = [ComponentDecl("unet", SDXL_NEEDED, phase=1)]
+    g = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=CARD_USABLE),
+        request=RequestArena.cold(),
+        stream_selector=cheapest_streamed,
+    )
+    assert g.fully_resident and not g.over_card, g.line()
+
+    old = plan_grant(
+        comps,
+        spendable=Spendable(driver_free_bytes=CARD_USABLE),
+        request=RequestArena(bytes=2 * GIB, basis="declared"),
+        stream_selector=cheapest_streamed,
+    )
+    assert old.over_card, "the 2 GiB guess is what removed SDXL's resident row"
+    # 6.5 + 2.0 = 8.5 GiB wanted against 7.62 GiB of card. pgw#1604's arithmetic, exactly.
+    assert old.resident_bytes + old.request_bytes > CARD_USABLE
+
+
+def test_a_reserve_read_off_a_roomy_card_overstates_the_requirement():
+    """pgw#1604 finding 5, as an admission consequence rather than an observation.
+
+    Sizing the request arena from the 6.0 GiB-cap high-water mark costs SDXL its resident row;
+    sizing it from what the same request actually needed under pressure does not. The measured
+    spread between the two is the cost of measuring a peak on a roomy card.
+    """
+    # pgw#1586's measured resident weights, so both sides of the comparison are banked
+    # numbers and nothing is fitted to make the assertion land.
+    comps = [ComponentDecl("unet", SDXL_WEIGHTS, phase=1)]
+    spend = Spendable(driver_free_bytes=CARD_USABLE)
+
+    roomy = plan_grant(
+        comps, spendable=spend,
+        request=RequestArena(bytes=SDXL_PEAK_AT_6GIB_CAP, basis="measured"),
+        stream_selector=cheapest_streamed,
+    )
+    pressured = plan_grant(
+        comps, spendable=spend,
+        request=RequestArena(bytes=SDXL_PEAK_AT_2GIB_CAP, basis="measured"),
+        stream_selector=cheapest_streamed,
+    )
+    assert roomy.over_card, "a roomy-card peak overstates the requirement past the card"
+    assert not pressured.over_card, pressured.line()

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -598,27 +598,32 @@ def test_the_declaration_totals_what_the_sizer_totals():
 # --- the group-offload threshold, and what the grant path does to it ------------------------
 
 
-def test_the_group_offload_threshold_is_never_READ_on_the_grant_path(monkeypatch):
+def test_the_threshold_walk_never_decides_a_RESIDENCY(monkeypatch):
     """`_DEFAULT_GROUP_OFFLOAD_THRESHOLD_GB = 6.0` is a hard boundary that drops TWO rungs at
     once, and the ComfyUI floor ladder measured the cost: at a 6144 MiB budget our run peaks
     at 3494 MiB, leaves 5.8 GiB unspent, and takes 37.4-41.4 s against ComfyUI's 24.2 s
-    (1.55-1.71x) — ComfyUI spends 5553 MiB and never leaves its normal path.
+    (1.55-1.71x) while ComfyUI spends 5553 MiB and never leaves its normal path.
 
-    All three uses of the two threshold constants are inside `select_auto_mode`. This asserts
-    the consequence across the whole budget range the ladder covered: with a readable card, a
-    grant is produced and `select_auto_mode` is never CALLED, so the cliff cannot occur.
+    Both threshold constants are used only inside `select_auto_mode`. The claim under test is
+    the exact one the design makes: **whenever the grant places anything on the card, the walk
+    is not consulted**, so the cliff cannot touch a placement the grant made.
 
-    The assertion is deliberately "the walk did not run" rather than "the mode was not
-    group_offload". On a cardless test box every offload rung ends as the `cpu` rung
-    downstream (`cuda_ok` is False), so a mode assertion here would pass for the wrong reason
-    — vacuously green, which is the failure class this file exists to avoid. Each iteration
-    also asserts a grant was actually produced, so the guard cannot pass by never reaching
-    the seam either.
+    It is deliberately NOT "the walk never runs at all". Below the grant's reach — nothing
+    resident, no streamed set — the remaining question is WHICH COARSE RUNG, and the grant's
+    `resident | streamed` vocabulary does not answer it. That case is handed back to the walk
+    on purpose (see the sibling test), because hardcoding a coarse rung there would delete
+    `group_offload` on no measurement at all.
+
+    The assertion is "the walk did not run", NOT "the mode was not group_offload". On a
+    cardless box every offload rung ends as the `cpu` rung downstream (`cuda_ok` is False), so
+    a mode assertion would pass for the wrong reason -- my first version did exactly that.
+    Each iteration also asserts a grant was really produced, so the guard cannot pass by never
+    reaching the seam either.
     """
     import gen_worker.models.memory as m
 
     # Captured ONCE. Re-reading the attribute inside the loop picks up the previous
-    # iteration's spy — monkeypatch does not undo between iterations — and recurses.
+    # iteration's spy -- monkeypatch does not undo between iterations -- and recurses.
     real = m._grant_for_pipeline
     seen: dict = {}
 
@@ -627,6 +632,8 @@ def test_the_group_offload_threshold_is_never_READ_on_the_grant_path(monkeypatch
         seen["grant"] = g
         return g, p
 
+    # Budgets across the ladder's range at which the fixture pipeline (tiny) is placeable, so
+    # every iteration is a grant that PLACED something -- the case the claim is about.
     for free_gb in (7.0, 6.5, 6.0, 5.9, 4.0, 2.5, 1.2, 0.75):
         seen.clear()
         _with_card(monkeypatch, free_gb=free_gb, total_gb=8.0)
@@ -636,22 +643,39 @@ def test_the_group_offload_threshold_is_never_READ_on_the_grant_path(monkeypatch
             lambda **k: pytest.fail(f"the threshold walk ran at {free_gb} GiB free"),
         )
         m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
-        assert seen.get("grant") is not None, f"no grant at {free_gb} GiB — guard is vacuous"
+        g = seen.get("grant")
+        assert g is not None, f"no grant at {free_gb} GiB -- guard is vacuous"
+        assert not g.over_card, f"{free_gb} GiB placed nothing; wrong case for this guard"
 
 
-def test_group_offload_becoming_unreachable_is_an_UNMEASURED_change():
-    """The honest other half, pinned so the test above is not read as a win.
+def test_below_the_grants_reach_the_coarse_rung_is_still_the_walks_call(monkeypatch):
+    """The safety property that lets this land before the floor leg runs.
 
-    `group_offload` is the aggressive per-block rung and the grant path can no longer select
-    it: the streamed-set search fall-through lands on `model_offload`. pgw#1604 measured the
-    6.0 cliff costing 2.1x, so removing it SHOULD help mid-band — but the bottom of the curve
-    now serves on a rung it did not use before, and **nothing here has run on a card**.
+    An earlier version of this seam hardcoded `model_offload` when the grant placed nothing,
+    which made `group_offload` UNREACHABLE on the grant path -- a behaviour change at the
+    bottom of the curve supported by no measurement, inside a change whose whole argument is
+    that unmeasured constants should not decide placements. Deleting a cliff and silently
+    deleting a rung are not the same act.
 
-    There is no assertion to make about speed from a cardless box. What IS assertable is that
-    the grant vocabulary contains no rung at all, which is why the rung question moved out of
-    the decider and into the projection — and why it is the floor-preservation leg, not this
-    file, that decides whether the bottom held.
+    So below the grant's reach the walk still answers, and today's behaviour is preserved.
+    `group_offload` stays reachable; pgw#1636 derives it from the grant's paging DEPTH later.
     """
+    import gen_worker.models.memory as m
+
+    _with_card(monkeypatch, free_gb=0.000_5, total_gb=8.0)
+    asked = []
+
+    def _walk(**k: Any) -> str:
+        asked.append(1)
+        return "group_offload"
+
+    monkeypatch.setattr(m, "select_auto_mode", _walk)
+    m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
+    assert asked, "the coarse rung was decided without consulting the walk"
+
+
+def test_the_grant_vocabulary_contains_no_rung():
+    """Why the coarse-rung question is not the grant's to answer: it has no word for it."""
     from gen_worker.models import grant as G
 
     assert set(G.__all__) & {"RESIDENT", "STREAMED"}

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -593,3 +593,67 @@ def test_the_declaration_totals_what_the_sizer_totals():
     declared = sum(d.weight_bytes for d in m._component_declaration(pipe))
     estimated = int(m.estimate_pipeline_size_gb(pipe) * (1 << 30))
     assert declared == estimated, f"declaration {declared} vs sizer {estimated}"
+
+
+# --- the group-offload threshold, and what the grant path does to it ------------------------
+
+
+def test_the_group_offload_threshold_is_never_READ_on_the_grant_path(monkeypatch):
+    """`_DEFAULT_GROUP_OFFLOAD_THRESHOLD_GB = 6.0` is a hard boundary that drops TWO rungs at
+    once, and the ComfyUI floor ladder measured the cost: at a 6144 MiB budget our run peaks
+    at 3494 MiB, leaves 5.8 GiB unspent, and takes 37.4-41.4 s against ComfyUI's 24.2 s
+    (1.55-1.71x) — ComfyUI spends 5553 MiB and never leaves its normal path.
+
+    All three uses of the two threshold constants are inside `select_auto_mode`. This asserts
+    the consequence across the whole budget range the ladder covered: with a readable card, a
+    grant is produced and `select_auto_mode` is never CALLED, so the cliff cannot occur.
+
+    The assertion is deliberately "the walk did not run" rather than "the mode was not
+    group_offload". On a cardless test box every offload rung ends as the `cpu` rung
+    downstream (`cuda_ok` is False), so a mode assertion here would pass for the wrong reason
+    — vacuously green, which is the failure class this file exists to avoid. Each iteration
+    also asserts a grant was actually produced, so the guard cannot pass by never reaching
+    the seam either.
+    """
+    import gen_worker.models.memory as m
+
+    # Captured ONCE. Re-reading the attribute inside the loop picks up the previous
+    # iteration's spy — monkeypatch does not undo between iterations — and recurses.
+    real = m._grant_for_pipeline
+    seen: dict = {}
+
+    def spy(*a: Any, **k: Any) -> Any:
+        g, p = real(*a, **k)
+        seen["grant"] = g
+        return g, p
+
+    for free_gb in (7.0, 6.5, 6.0, 5.9, 4.0, 2.5, 1.2, 0.75):
+        seen.clear()
+        _with_card(monkeypatch, free_gb=free_gb, total_gb=8.0)
+        monkeypatch.setattr(m, "_grant_for_pipeline", spy)
+        monkeypatch.setattr(
+            m, "select_auto_mode",
+            lambda **k: pytest.fail(f"the threshold walk ran at {free_gb} GiB free"),
+        )
+        m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
+        assert seen.get("grant") is not None, f"no grant at {free_gb} GiB — guard is vacuous"
+
+
+def test_group_offload_becoming_unreachable_is_an_UNMEASURED_change():
+    """The honest other half, pinned so the test above is not read as a win.
+
+    `group_offload` is the aggressive per-block rung and the grant path can no longer select
+    it: the streamed-set search fall-through lands on `model_offload`. pgw#1604 measured the
+    6.0 cliff costing 2.1x, so removing it SHOULD help mid-band — but the bottom of the curve
+    now serves on a rung it did not use before, and **nothing here has run on a card**.
+
+    There is no assertion to make about speed from a cardless box. What IS assertable is that
+    the grant vocabulary contains no rung at all, which is why the rung question moved out of
+    the decider and into the projection — and why it is the floor-preservation leg, not this
+    file, that decides whether the bottom held.
+    """
+    from gen_worker.models import grant as G
+
+    assert set(G.__all__) & {"RESIDENT", "STREAMED"}
+    assert not any("offload" in n.lower() for n in G.__all__), G.__all__
+    assert not any("rung" in n.lower() for n in G.__all__), G.__all__

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -328,9 +328,8 @@ import logging  # noqa: E402
 from typing import Any, cast  # noqa: E402
 
 import torch  # noqa: E402
-from diffusers import DiffusionPipeline  # noqa: E402
+from diffusers import DiffusionPipeline, ModelMixin  # noqa: E402
 from diffusers.configuration_utils import ConfigMixin, register_to_config  # noqa: E402
-from diffusers.models.modeling_utils import ModelMixin  # noqa: E402
 
 
 class _Block(ModelMixin, ConfigMixin):
@@ -358,7 +357,7 @@ def _pipe():
     return _ThreeStagePipeline(_Block(8), _Block(16), _Block(4))
 
 
-def _with_card(monkeypatch, free_gb: float, total_gb: float = 24.0):
+def _with_card(monkeypatch: Any, free_gb: float, total_gb: float = 24.0) -> Any:
     """Present a readable card to `memory`. Without this every test in this file that goes
     through the production entry point silently exercises the fallback instead."""
     import gen_worker.models.memory as m
@@ -375,7 +374,7 @@ def test_the_production_entry_point_actually_reaches_the_grant(monkeypatch):
     seen = {}
     real = m._grant_for_pipeline
 
-    def spy(*a, **k):
+    def spy(*a: Any, **k: Any) -> Any:
         g, p = real(*a, **k)
         seen["grant"] = g
         return g, p
@@ -396,10 +395,13 @@ def test_the_wiring_guard_can_go_red(monkeypatch):
     the fallback. If this passes while the test above also passes, both are measuring
     something real; if the seam were unreachable, this would be the only reachable path."""
     m = _with_card(monkeypatch, free_gb=0.0)
-    walked = []
-    monkeypatch.setattr(
-        m, "select_auto_mode", lambda **k: walked.append(1) or "group_offload"
-    )
+    walked: list = []
+
+    def _walk(**k: Any) -> str:
+        walked.append(1)
+        return "group_offload"
+
+    monkeypatch.setattr(m, "select_auto_mode", _walk)
     m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
     assert walked, "an unreadable card must fall through to the free-VRAM walk"
 

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -577,3 +577,19 @@ def test_an_over_card_grant_is_never_placed_resident(monkeypatch):
     assert applied["mode"] not in ("off", "vae_only"), (
         f"an over-card grant was placed resident as {applied['mode']!r} — {g.line()}"
     )
+
+
+def test_the_declaration_totals_what_the_sizer_totals():
+    """The grant is sized from the declaration; every confession beside it quotes
+    `estimate_pipeline_size_gb`. If those two walks ever disagree, the grant admits against one
+    number and reports another, and nothing in either output would say so.
+
+    They agree today because both bottom out in `module_storage_bytes` over the pipeline's
+    component vocabulary. Pinned so a change to either walk has to notice the other.
+    """
+    import gen_worker.models.memory as m
+
+    pipe = _pipe()
+    declared = sum(d.weight_bytes for d in m._component_declaration(pipe))
+    estimated = int(m.estimate_pipeline_size_gb(pipe) * (1 << 30))
+    assert declared == estimated, f"declaration {declared} vs sizer {estimated}"

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -44,9 +44,17 @@ CARD_FREE = ANIMA_FULLY_RESIDENT_PEAK
 SDXL_WEIGHTS = 5693 * MIB
 SDXL_ACTIVATIONS = 1847 * MIB
 
-# pgw#1627: AOTI's first-call pool, allocated OUTSIDE torch's caching allocator. sdxl sm_89,
-# 4/4 runs, batch-invariant.
-AOTI_FIRST_CALL = 1154 * MIB
+# ⚠️ NOT A MEASUREMENT. pgw#1627's second re-open FALSIFIED the "+1154 MiB, 4/4 runs,
+# batch-invariant" figure on-card 2026-08-21: it was the RED run's consumption, and a death
+# only ever reports the free memory it consumed. Given 1326 MiB more, the same first call
+# consumed ~2474 of 2506 and died identically. sdxl sm_89's compiled demand is UNKNOWN,
+# lower-bounded >2501 MiB; 8 GiB is a MEASURED NO for compiled SDXL UNet-only.
+#
+# The tests below need SOME stamp value to exercise the regime split, so this is a declared
+# HYPOTHETICAL and is named as one. Nothing here asserts it is the real demand — the point
+# under test is that a stamp's PRESENCE gates the compiled admit and its ABSENCE forces
+# eager, which is the rule the falsification above exists to justify.
+_HYPOTHETICAL_STAMP = 1154 * MIB
 
 
 def anima_components(weights: int) -> list[ComponentDecl]:
@@ -137,14 +145,15 @@ def test_compiled_requires_full_residency_and_driver_free_alone():
     """COMPILED IFF FULLY RESIDENT — and the AOTI pool must fit in driver_free, never cache.
 
     Cache is eager-spendable money. The same demand admits compiled when driver_free covers
-    it and does NOT when only the cache makes up the difference; that difference is what
-    killed every 8 GiB compiled-SDXL leg.
+    it and does NOT when only the cache makes up the difference. The stamp value here is a
+    declared HYPOTHETICAL (see `_HYPOTHETICAL_STAMP`) — what is under test is the SPLIT, not
+    the number.
     """
     comps = [ComponentDecl("unet", SDXL_WEIGHTS, phase=1)]
     req = RequestArena(
-        bytes=SDXL_ACTIVATIONS, basis="measured", compiled_extra_bytes=AOTI_FIRST_CALL
+        bytes=SDXL_ACTIVATIONS, basis="measured", compiled_extra_bytes=_HYPOTHETICAL_STAMP
     )
-    need = SDXL_WEIGHTS + SDXL_ACTIVATIONS + AOTI_FIRST_CALL
+    need = SDXL_WEIGHTS + SDXL_ACTIVATIONS + _HYPOTHETICAL_STAMP
 
     ok = plan_grant(
         comps,
@@ -161,8 +170,8 @@ def test_compiled_requires_full_residency_and_driver_free_alone():
     split = plan_grant(
         comps,
         spendable=Spendable(
-            driver_free_bytes=need - AOTI_FIRST_CALL,
-            allocator_cache_bytes=AOTI_FIRST_CALL,
+            driver_free_bytes=need - _HYPOTHETICAL_STAMP,
+            allocator_cache_bytes=_HYPOTHETICAL_STAMP,
         ),
         request=req,
         compile_intent=True,
@@ -212,7 +221,7 @@ def test_compiled_is_refused_when_anything_would_be_streamed():
     g = plan_grant(
         comps,
         spendable=Spendable(driver_free_bytes=5 * GIB),
-        request=RequestArena(bytes=512 * MIB, basis="measured", compiled_extra_bytes=AOTI_FIRST_CALL),
+        request=RequestArena(bytes=512 * MIB, basis="measured", compiled_extra_bytes=_HYPOTHETICAL_STAMP),
         compile_intent=True,
         stream_selector=cheapest_streamed,
     )
@@ -284,7 +293,7 @@ def test_the_headroom_basis_can_go_red():
     added to expose (pgw#1627). Both values must be reachable from the production entry
     point, or the field is decoration."""
     comps = [ComponentDecl("unet", 1 * GIB, phase=1)]
-    stamped = RequestArena(bytes=1 * GIB, basis="measured", compiled_extra_bytes=AOTI_FIRST_CALL)
+    stamped = RequestArena(bytes=1 * GIB, basis="measured", compiled_extra_bytes=_HYPOTHETICAL_STAMP)
     compiled = plan_grant(
         comps,
         spendable=Spendable(driver_free_bytes=64 * GIB),
@@ -310,9 +319,9 @@ def test_the_line_names_every_input_not_the_verdict():
         assert token in line, line
 
 
-@pytest.mark.parametrize("regime,extra", [(EAGER, 0), (COMPILED, AOTI_FIRST_CALL)])
+@pytest.mark.parametrize("regime,extra", [(EAGER, 0), (COMPILED, _HYPOTHETICAL_STAMP)])
 def test_the_request_arena_demand_is_regime_split(regime, extra):
-    req = RequestArena(bytes=512 * MIB, basis="measured", compiled_extra_bytes=AOTI_FIRST_CALL)
+    req = RequestArena(bytes=512 * MIB, basis="measured", compiled_extra_bytes=_HYPOTHETICAL_STAMP)
     assert req.demand(regime) == 512 * MIB + extra
 
 
@@ -509,3 +518,28 @@ def test_a_reserve_read_off_a_roomy_card_overstates_the_requirement():
     )
     assert roomy.over_card, "a roomy-card peak overstates the requirement past the card"
     assert not pressured.over_card, pressured.line()
+
+
+def test_no_stamp_is_the_only_honest_answer_when_the_demand_is_unknown():
+    """pgw#1627's stamp-source rule, as an admission consequence.
+
+    sdxl sm_89's compiled first-call demand is UNKNOWN — the only figure anyone had was a
+    death trace's consumption, and giving the same call 1326 MiB more room made it consume
+    that too. "8 GiB is a MEASURED NO for compiled SDXL UNet-only."
+
+    The grant must reach that verdict from the ABSENCE of a stamp, on a card of any size. A
+    design that only refused compiled when the arithmetic came out short would have admitted
+    it here on a big card, on a demand nobody has ever measured.
+    """
+    comps = [ComponentDecl("unet", SDXL_WEIGHTS, phase=1)]
+    unknown = RequestArena(bytes=SDXL_ACTIVATIONS, basis="measured")  # no compiled stamp
+    for card in (8 * GIB, 24 * GIB, 80 * GIB):
+        g = plan_grant(
+            comps,
+            spendable=Spendable(driver_free_bytes=card),
+            request=unknown,
+            compile_intent=True,
+            stream_selector=cheapest_streamed,
+        )
+        assert g.regime == EAGER, f"{card / GIB:.0f} GiB card: {g.line()}"
+        assert any("mint demand stamp" in n for n in g.notes), g.notes

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -38,11 +38,20 @@ ANIMA_BUDGET_FED_PEAK = 6102 * MIB
 # much to give. Nothing is inferred and no baseline is assumed.
 CARD_FREE = ANIMA_FULLY_RESIDENT_PEAK
 
+# ComfyUI's peak spread across its four anima legs was 6778-7226 MiB. The 448 MiB range is the
+# activation variance; the arm that peaked highest is the one that bounds the request arena.
+# Taken as the activation share so weights + arena reconstructs the demonstrated peak exactly.
+ANIMA_MEASURED_ACTIVATIONS = 448 * MIB
+
 # pgw#1586's GREEN arm: SDXL, weights pinned for the process's life, 7540 MiB peak over
 # 5693 MiB of resident weights => 1847 MiB of activations under the fully-resident allocator
 # regime (fragmentation the offloaded rung never pays).
 SDXL_WEIGHTS = 5693 * MIB
 SDXL_ACTIVATIONS = 1847 * MIB
+
+# pgw#1604, the 7.3 GiB tier: 7350 MiB peak alloc over 5292 MiB of resident weights
+# (placement `text_encoder_2@cpu`) => 2058 MiB of non-weight peak for SDXL at this shape.
+SDXL_MEASURED_ACTIVATIONS = 2058 * MIB
 
 # ⚠️ NOT A MEASUREMENT. pgw#1627's second re-open FALSIFIED the "+1154 MiB, 4/4 runs,
 # batch-invariant" figure on-card 2026-08-21: it was the RED run's consumption, and a death
@@ -91,51 +100,52 @@ def cheapest_streamed(components, *, budget_bytes):
 # --- the case the whole redesign exists for ------------------------------------------------
 
 
-def test_full_residency_is_granted_where_comfyui_demonstrated_it_fits():
-    """THE anima self-harm case, in one assertion.
+def test_full_residency_is_granted_on_the_measurement_comfyui_demonstrated():
+    """THE anima case, stated the way it is actually true.
 
-    ComfyUI ran this exact request fully resident at a 7226 MiB peak on this card, four
-    times, without an OOM, 20-37% faster than we did. Our decider refused full
-    residency and pinned at 6102 MiB. A grant that does not come back RESIDENT here has
-    reproduced the defect.
+    ComfyUI ran this exact request fully resident at a 7226 MiB peak on this card, four times,
+    without an OOM, 20-37% faster than we did. Our decider refused full residency and pinned
+    at 6102 MiB.
+
+    The grant admits it — **given the measurement**. That conditional is the whole correction
+    (see `RequestArena.funds_resident`): a demonstrated peak is exactly what anima has and
+    what SDXL does not, and it is the only thing that tells the two cases apart. A design that
+    admitted full residency without one would also have admitted SDXL, which does not fit.
     """
-    # Weights are sized so that weights + the cold request arena is EXACTLY the peak ComfyUI
-    # demonstrated. No number is invented: the demand under test is the measured peak.
-    weights = ANIMA_FULLY_RESIDENT_PEAK - RequestArena.cold().bytes
+    weights = ANIMA_FULLY_RESIDENT_PEAK - ANIMA_MEASURED_ACTIVATIONS
+    measured = RequestArena(bytes=ANIMA_MEASURED_ACTIVATIONS, basis="measured")
+    g = plan_grant(
+        anima_components(weights),
+        spendable=Spendable(driver_free_bytes=CARD_FREE),
+        request=measured,
+        stream_selector=cheapest_streamed,
+    )
+    assert g.fully_resident and not g.over_card, g.line()
+    assert g.regime == EAGER
+    assert set(g.residency.values()) == {RESIDENT}
+    # The granted occupancy IS the demonstrated peak — 1124 MiB more of the card than our own
+    # budget-fed arm used, and that arm was the slower one.
+    assert g.resident_bytes + g.request_bytes == ANIMA_FULLY_RESIDENT_PEAK
+    assert g.resident_bytes + g.request_bytes > ANIMA_BUDGET_FED_PEAK
+
+
+def test_without_the_measurement_the_same_anima_case_is_NOT_admitted():
+    """The falsifier, and it is the correction stated as a test.
+
+    Same card, same weights, same everything — but a COLD arena. Full residency is refused,
+    because nothing probes a resident placement and a default may not stand in for the
+    measurement that would have justified it. This is the test that would have caught the
+    regression the first version of this module shipped with.
+    """
+    weights = ANIMA_FULLY_RESIDENT_PEAK - ANIMA_MEASURED_ACTIVATIONS
     g = plan_grant(
         anima_components(weights),
         spendable=Spendable(driver_free_bytes=CARD_FREE),
         request=RequestArena.cold(),
         stream_selector=cheapest_streamed,
     )
-    assert g.fully_resident, g.line()
-    assert g.regime == EAGER
-    assert set(g.residency.values()) == {RESIDENT}
-    assert g.streamed_bytes == 0
-    # And the grant spends the card it was given, rather than a number below it: the granted
-    # occupancy is the demonstrated peak, which is 1124 MiB more of the card than our own
-    # budget-fed arm used — and that arm was the slower one.
-    assert g.resident_bytes + g.request_bytes == ANIMA_FULLY_RESIDENT_PEAK
-    assert g.resident_bytes + g.request_bytes > ANIMA_BUDGET_FED_PEAK
-
-
-def test_the_old_two_gib_reserve_is_what_refused_it():
-    """The falsifier for the claim above: reintroduce the deleted guess and the same card,
-    the same weights and the same measurement stop granting full residency.
-
-    This is not testing a code path — it is pinning WHY the constant had to go, so a later
-    reader cannot restore it as a safety improvement without seeing what it costs.
-    """
-    weights = ANIMA_FULLY_RESIDENT_PEAK - RequestArena.cold().bytes
-    two_gib_guess = RequestArena(bytes=2 * GIB, basis="declared")
-    g = plan_grant(
-        anima_components(weights),
-        spendable=Spendable(driver_free_bytes=CARD_FREE),
-        request=two_gib_guess,
-        stream_selector=cheapest_streamed,
-    )
-    assert not g.fully_resident
-    assert g.streamed, "the 2 GiB guess pages components the card had room for"
+    assert any("full residency not admitted" in n for n in g.notes), g.notes
+    assert g.request_basis == "prior"
 
 
 # --- the admission rule ---------------------------------------------------------------------
@@ -393,10 +403,11 @@ def test_the_production_entry_point_actually_reaches_the_grant(monkeypatch):
         m, "select_auto_mode",
         lambda **k: pytest.fail("the free-VRAM walk ran; the grant seam was not reached"),
     )
-    applied = m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
+    m.apply_low_vram_config(_pipe(), mode="auto", logger=logging.getLogger("t"))
+    # The claim is REACH, not verdict: a readable card must produce a grant and must not run
+    # the free-VRAM walk. What the grant then DECIDES is the subject of the other tests, and
+    # asserting a verdict here is what made an earlier version of this guard drift.
     assert seen.get("grant") is not None
-    assert seen["grant"].fully_resident
-    assert applied["mode"] in ("off", "vae_only")
 
 
 def test_the_wiring_guard_can_go_red(monkeypatch):
@@ -463,35 +474,32 @@ SDXL_PEAK_AT_6GIB_CAP = 2603 * MIB
 SDXL_PEAK_AT_2GIB_CAP = 1962 * MIB
 
 
-def test_sdxl_gets_a_resident_row_the_old_ladder_could_not_produce():
-    """pgw#1604's finding 1, inverted into the fix.
+def test_sdxl_fully_resident_does_NOT_fit_this_card_and_the_grant_says_so():
+    """pgw#1604 finding 1, read twice — and the second reading is the one that matters.
 
-    The card cannot hold 6.5 GiB of weights AND a 2.0 GiB guess — that is the arithmetic that
-    produced "no `off` row at any budget". It CAN hold 6.5 GiB of weights and the probe floor,
-    and whether that actually serves is then a question for the card rather than for a
-    constant.
+    Finding 1 reads as an indictment of the decider: *"SDXL is NEVER fully resident on this
+    card, and cannot be... residency wants 8.5 GiB free on a 7.62 GiB card."* But SDXL bf16 is
+    6617 MiB of weights and pgw#1604 measured its non-weight peak at ~2058 MiB (7350 MiB peak
+    alloc at the 7.3 GiB tier over 5292 MiB of resident weights). Fully resident that is
+    **8675 MiB against 7803 MiB of usable card. It genuinely does not fit.**
+
+    So for SDXL the 2 GiB reserve was approximately RIGHT and the old decider was right to
+    refuse. It was a guess that happened to be correct here and wrong on anima — and a guess
+    that is sometimes right is still a guess. The grant must reach the SAME verdict, from the
+    measurement rather than from the coincidence.
     """
-    # SDXL's denoiser is never a paging candidate, so this declaration has nothing to stream
-    # — which is exactly the position the old ladder was in. The predicate that matters here
-    # is therefore `over_card`: did the demand FIT, not was anything paged.
     comps = [ComponentDecl("unet", SDXL_NEEDED, phase=1)]
+    measured = RequestArena(bytes=SDXL_MEASURED_ACTIVATIONS, basis="measured")
     g = plan_grant(
         comps,
         spendable=Spendable(driver_free_bytes=CARD_USABLE),
-        request=RequestArena.cold(),
+        request=measured,
         stream_selector=cheapest_streamed,
     )
-    assert g.fully_resident and not g.over_card, g.line()
-
-    old = plan_grant(
-        comps,
-        spendable=Spendable(driver_free_bytes=CARD_USABLE),
-        request=RequestArena(bytes=2 * GIB, basis="declared"),
-        stream_selector=cheapest_streamed,
-    )
-    assert old.over_card, "the 2 GiB guess is what removed SDXL's resident row"
-    # 6.5 + 2.0 = 8.5 GiB wanted against 7.62 GiB of card. pgw#1604's arithmetic, exactly.
-    assert old.resident_bytes + old.request_bytes > CARD_USABLE
+    assert g.over_card, g.line()
+    assert g.resident_bytes + g.request_bytes > CARD_USABLE
+    # And the arithmetic is the banked one, to the MiB.
+    assert g.resident_bytes + g.request_bytes == SDXL_NEEDED + SDXL_MEASURED_ACTIVATIONS
 
 
 def test_a_reserve_read_off_a_roomy_card_overstates_the_requirement():
@@ -634,7 +642,10 @@ def test_the_threshold_walk_never_decides_a_RESIDENCY(monkeypatch):
 
     # Budgets across the ladder's range at which the fixture pipeline (tiny) is placeable, so
     # every iteration is a grant that PLACED something -- the case the claim is about.
-    for free_gb in (7.0, 6.5, 6.0, 5.9, 4.0, 2.5, 1.2, 0.75):
+    # Budgets at which the fixture pipeline is placeable under a COLD arena (which reserves
+    # COLD_REQUEST_BYTES), so every iteration is a grant that PLACED something -- the case the
+    # claim is about. Below that the walk legitimately regains its coarse-rung authority.
+    for free_gb in (7.0, 6.5, 6.0, 5.9, 4.0, 2.5):
         seen.clear()
         _with_card(monkeypatch, free_gb=free_gb, total_gb=8.0)
         monkeypatch.setattr(m, "_grant_for_pipeline", spy)
@@ -681,3 +692,123 @@ def test_the_grant_vocabulary_contains_no_rung():
     assert set(G.__all__) & {"RESIDENT", "STREAMED"}
     assert not any("offload" in n.lower() for n in G.__all__), G.__all__
     assert not any("rung" in n.lower() for n in G.__all__), G.__all__
+
+
+# --- the landing argument: the SDXL ladder is preserved tier for tier -----------------------
+
+# Real component sizes off ~/.cache/cozy/pgw1587-accept/sdxl-bf16-tree, the exact tree
+# pgw#1604's ladder ran on. Total 6617 MiB = the "needed_gb 6.5" that ladder confessed.
+SDXL_TREE = {
+    "text_encoder": int(234.74 * MIB),
+    "text_encoder_2": int(1325.01 * MIB),
+    "unet": int(4897.45 * MIB),
+    "vae": int(159.58 * MIB),
+}
+SDXL_ORDER = ["text_encoder", "text_encoder_2", "unet", "vae"]
+# SDXL's VAE is force_upcast => dtype-fragile => forced resident, and diffusers drives it by
+# .decode() rather than forward (pgw#1619), so it is `pinned` in the grant's vocabulary too.
+SDXL_PINNED = ["vae"]
+LADDER_TIERS = [7.45, 7.3, 7.0, 6.5, 6.0, 5.0, 4.0, 3.0, 2.5, 2.0, 1.5, 1.2, 1.0, 0.8, 0.6, 0.55]
+
+
+def _grant_ladder_row(tier_gib: float) -> tuple:
+    """The grant's placement at one enforced allocator budget, using the real search."""
+    from gen_worker.models.partial_resident import plan_component_residency
+
+    budget = int(tier_gib * GIB)
+    captured = {}
+
+    def selector(components: Any, *, budget_bytes: int) -> tuple:
+        plan = plan_component_residency(
+            sizes=SDXL_TREE, order=SDXL_ORDER, denoiser="unet",
+            forced_resident=SDXL_PINNED,
+            budget_bytes=int(budget_bytes), free_bytes=budget,
+        )
+        captured["plan"] = plan
+        return tuple(plan.offloaded) if plan.fits else ()
+
+    decls = [
+        ComponentDecl(name=n, weight_bytes=SDXL_TREE[n], phase=i, pinned=(n in SDXL_PINNED))
+        for i, n in enumerate(SDXL_ORDER)
+    ]
+    g = plan_grant(
+        decls,
+        spendable=Spendable(driver_free_bytes=budget, allocator_cache_bytes=0),
+        request=RequestArena.cold(),
+        stream_selector=selector,
+    )
+    plan = captured.get("plan")
+    if g.fully_resident and not g.over_card:
+        return "RESIDENT", ()
+    if plan is not None and plan.fits and plan.offloaded:
+        return "partial_resident", tuple(plan.offloaded)
+    return "COARSE(walk)", ()
+
+
+def _old_ladder_row(tier_gib: float) -> tuple:
+    """What the pre-grant walk answers at the same budget, from its own two constants."""
+    import gen_worker.models.memory as m
+    from gen_worker.models.partial_resident import (
+        PARTIAL_RESIDENT_RESERVE_GB,
+        plan_component_residency,
+    )
+
+    total = sum(SDXL_TREE.values())
+    usable = max(0.0, tier_gib - m._DEFAULT_SAFETY_MARGIN_GB)
+    if total / GIB <= usable:
+        return "RESIDENT", ()
+    if tier_gib <= m._DEFAULT_GROUP_OFFLOAD_THRESHOLD_GB:
+        return "COARSE(walk)", ()
+    # model_offload -> `_plan_partial_resident` retries the search under its own reserve.
+    plan = plan_component_residency(
+        sizes=SDXL_TREE, order=SDXL_ORDER, denoiser="unet",
+        forced_resident=SDXL_PINNED,
+        budget_bytes=int(max(0.0, tier_gib - PARTIAL_RESIDENT_RESERVE_GB) * GIB),
+        free_bytes=int(tier_gib * GIB),
+    )
+    if plan.fits and plan.offloaded:
+        return "partial_resident", tuple(plan.offloaded)
+    return "COARSE(walk)", ()
+
+
+def test_the_sdxl_ladder_is_preserved_tier_for_tier():
+    """THE landing argument, and it is what makes this diff safe to ship before its floor run.
+
+    pgw#1604 measured a 19-tier SDXL curve on this card. If the grant seam changed any
+    placement on that curve, every one of those rows would need re-measuring before anyone
+    could trust the change — and a placement change at the bottom is an OOM risk on a master
+    that auto-deploys.
+
+    It changes none of them. Same tree, same sizes, same search, same enforced budgets: the
+    grant reaches the pre-grant walk's placement at every tier. What pgw#1602 actually changes
+    is the STRUCTURE — one decider instead of three, one reserve with a named basis instead of
+    three anonymous ones, an honest `over_card`, and the compiled-admission discipline. The
+    behaviour it changes is anima's, and only once a measured peak arrives to fund it.
+
+    A failure here is not a test to update. It means a tier moved, and the ladder needs
+    re-measuring on a card before the diff can land.
+    """
+    diffs = []
+    for tier in LADDER_TIERS:
+        new = _grant_ladder_row(tier)
+        old = _old_ladder_row(tier)
+        if new != old:
+            diffs.append(f"{tier} GiB: grant={new} old={old}")
+    assert not diffs, "the grant moved a tier off pgw#1604's measured ladder:\n" + "\n".join(diffs)
+
+
+def test_the_ladder_guard_can_go_red():
+    """Falsification in the file: shrink the cold arena and tiers DO move.
+
+    This is what the first version of this module did — it used the 256 MiB probe floor as the
+    request arena — and it is why the guard above is not vacuous.
+    """
+    from gen_worker.models import grant as G
+
+    real = G.COLD_REQUEST_BYTES
+    try:
+        G.COLD_REQUEST_BYTES = G.PROBE_FLOOR_BYTES
+        moved = [t for t in LADDER_TIERS if _grant_ladder_row(t) != _old_ladder_row(t)]
+    finally:
+        G.COLD_REQUEST_BYTES = real
+    assert moved, "shrinking the cold arena moved no tier — the ladder guard proves nothing"


### PR DESCRIPTION
The pgw half of [va#10](https://github.com/cozy-creator/varena)'s grant seam. varena's half is varena PR #15 (the va#4 blocking defect, which va#10 named as the blocker on pgw#1598 stage 5).

> **This PR changes STRUCTURE, not placement.** The SDXL ladder is preserved tier for tier — pinned by a test across all 16 of pgw#1604's measured tiers. An earlier revision of this branch did change placement, and would have OOMed at the top of the ladder; see "What staging the floor leg found" below.

## The defect this removes

Three functions asked the same question — *does this fit resident* — with three different reserves:

| where | reserve |
|---|---|
| `select_auto_mode` | `weights <= free - _DEFAULT_SAFETY_MARGIN_GB` (2.0 GiB) |
| `_plan_partial_resident` | `weights <= free - PARTIAL_RESIDENT_RESERVE_GB` (2.0 GiB) |
| `plan_component_residency` | `peak <= free - _TRANSIENT_RESERVE_BYTES` (512 MiB) |

…plus a rule, in the source, forbidding any of them from correcting another: *"Nothing to evict means the pipeline fits resident, which is a fit decision `select_auto_mode` already made against a different margin. **Do not overrule it from here.**"*

**Measured cost (varena#3, RTX 4070 Laptop 7.62 GiB).** Our anima serve pinned peak at **6102 MiB in every leg** — at load 5, 14 and 91, deterministically, because it is budget-fed. ComfyUI ran the identical 1024²/20-step/CFG request **fully resident at 6778–7226 MiB**, four legs, no OOM, **20–37% faster**.

## The governing rule

**A placement that cannot be CAUGHT IN FLIGHT must be funded by a MEASUREMENT, never by a default.** pgw#1601 ruled this for compiled; it is not a fact about compiled graphs.

| placement | why it cannot be caught | funded by |
|---|---|---|
| **compiled** | a mid-graph OOM in an AOTI artifact is **process death** (pgw#1255 leg 2) | a mint stamp from a **successful** run |
| **fully resident** | **nothing probes it** — `probe_plan` is reached only under `partial_resident` | a banked per-endpoint request peak |

The **streamed** path is the one that *is* probed, which is why a cold arena may fund it and nothing else. In code: `RequestArena.funds_resident`, with `funds_compiled` defined as *that plus a stamp*, so the two cannot drift.

## What replaces the three reserves — `models/grant.py`

One decision. Pure arithmetic over declared bytes: no torch, no driver, no pipeline, falsifiable on a cardless box.

- **Two arenas.** WEIGHT = real residency (varena's page table, stable VAs). REQUEST = an **accounting-only** headroom number the weight arena must leave unspent — activations stay in torch's allocator and varena is never told about it.
- **Vocabulary `resident | streamed`**, per component, and the answer IS the regime. No rung, no `low_vram_mode`, no ladder in the author's vocabulary.
- **COMPILED IFF FULLY RESIDENT**, and compiled must additionally fit in `driver_free` **alone** (AOTI's first-call pool is outside torch's allocator).
- **varena always says yes.** `Grant` has no `fits` and no `refusal`. A demand the card cannot hold still yields a grant, with `over_card` set.
- **ONE reserve with a named basis**, instead of three anonymous ones. `COLD_REQUEST_BYTES` is **inherited** from `PARTIAL_RESIDENT_RESERVE_GB` — not invented, and *not deleted here*. It is still a constant standing in for a measurement; what changes is that there is one of it, its basis rides on every grant, and the thing that replaces it (`basis="measured"`) has a defined seam to arrive through. Deleting it is pgw#1586's work.

The streamed-set **search** is untouched — `plan_component_residency` keeps it. This module owns the DECISION; that one owns the SEARCH.

## Wiring

`apply_low_vram_config`'s `auto` branch asks `_grant_for_pipeline` first. `select_auto_mode` keeps what the grant does not model — the zero-cause branching (pgw#940) and the unknown-size walk. **Both lease-driven UPGRADE branches are gated on `grant is None`.**

**When the grant places nothing, the coarse-rung question goes back to the walk.** The grant's vocabulary has no word for "model_offload or group_offload". An earlier revision hardcoded `model_offload` there, which deleted `group_offload` by omission on no measurement — inside a change whose whole argument is that unmeasured constants must not decide placements. Behaviour below the grant's reach is now preserved byte-for-byte.

## What staging the floor leg found — at $0, before any card time

Computing the grant's placement per tier from banked numbers killed two claims:

**1. The mid-band prediction died.** At 6.0 GiB the grant reaches the same `group_offload` as the old walk. The binding constraint is the **transient ceiling**, not the reserve — the search says so itself: *"no subset of ['text_encoder', 'text_encoder_2'] brings 6.46 GiB under the 5.75 GiB budget without breaking the transient ceiling."* SDXL's denoiser alone is 4897 MiB on a 6144 MiB budget. That gap is pgw#1636's (derived rung / paging depth), not this PR's.

**2. A regression, which is the serious half.** This module claimed full residency *"is refused only by a MEASUREMENT — a banked peak, or the on-card probe."* **On the resident path there is no probe.** With the 256 MiB probe floor funding it, tiers 7.45 / 7.3 / 7.0 would have been admitted RESIDENT where the old walk chose `partial_resident` and served in 18.4–18.9 s. SDXL fully resident is 6617 MiB of weights + ~2058 MiB measured non-weight peak = **8675 MiB against 7803 MiB of card**. An OOM traded for a working placement.

So **pgw#1604 finding 1 needs reading twice**: *"SDXL is NEVER fully resident on this card"* is not the decider being broken — for SDXL the 2 GiB reserve was approximately **right**. It was a guess that happened to be correct on SDXL and wrong on anima. **A guess that is sometimes right is still a guess**, and **a smaller wrong number is the more dangerous kind, because it fails toward OOM instead of toward slow.**

## Verification

- **`test_the_sdxl_ladder_is_preserved_tier_for_tier`** — all 16 of pgw#1604's tiers, real tree sizes, real search: the grant reaches the old walk's placement at every one. **Red-armed**: shrinking the cold arena back to the probe floor moves tiers, and the guard names which.
- Wiring guards, each **red-armed by sabotage**: readable card ⇒ a grant and no free-VRAM walk; unreadable card ⇒ the fallback; the walk never decides a **residency**; below the grant's reach the walk keeps its coarse-rung authority; an `over_card` grant is never placed resident.
- Every number in `tests/test_grant.py` is a banked measurement with a tracker citation. The anima case asserts full residency **on the measurement ComfyUI demonstrated**, with a sibling asserting a cold arena does *not* get it.
- 150 passed across grant/ledger/partial_resident/vram_fit/partial_stream/endpoint_memory_contract/fail_closed/import_cycles. `mypy src/gen_worker tests` clean. Ruff clean.

**Gate: the floor leg — both rungs (6.0 and 0.55 GiB), both arms (pre-grant baseline vs this branch), `RUNG PRESERVED`/`MOVED` verdicts. Staged, self-tested, awaiting a card window. This PR lands on that proof, not before.**