### PR TITLE
pgw#1627: seam gate unwraps the adapter guard; 1154-as-demand struck

### DIFF
--- a/src/gen_worker/models/partial_resident.py
+++ b/src/gen_worker/models/partial_resident.py
@@ -659,18 +659,25 @@ def headroom_admits(
       counting it is right (pgw#1586: the bug that term fixed was a SPURIOUS
       REFUSAL, and past the probe the failure mode is retries-and-serve).
     * ``compiled`` — the budget is ``driver_free`` ONLY, against
-      ``demand + floor``. AOTI's first-call pool (+1154 MiB measured on sdxl
-      sm_89, 4/4 runs, batch-invariant) allocates OUTSIDE the torch allocator
-      and cannot spend the cache. Counting cache here is the arithmetic that
-      killed every 8 GiB compiled-SDXL leg: admitted on ``free+cache`` =
-      2.2 GiB against a real budget of ``driver_free`` = 1.18 GiB, process
-      death at step 0, no traceback — and a mid-graph OOM on the compiled
-      path is uncatchable (pgw#1255 leg 2), so admission is the ONLY safety.
+      ``demand + floor``. AOTI's first-call allocation lands OUTSIDE the
+      torch allocator and cannot spend the cache. Counting cache here is the
+      arithmetic that killed every 8 GiB compiled-SDXL leg: admitted on
+      ``free+cache`` = 2.2 GiB against a real budget of ``driver_free`` =
+      1.18 GiB, process death at step 0, no traceback — and a mid-graph OOM
+      on the compiled path is uncatchable (pgw#1255 leg 2), so admission is
+      the ONLY safety.
 
     ``demand_bytes`` is the compiled artifact's out-of-allocator first-call
     demand — pgw#1601's mint-time stamp once it lands; 0 until a caller has
-    one. The basis string goes on the confession line so a reader of the
-    admit can see WHICH budget the split used without the code in hand.
+    one. ⚠️ THE STAMP MUST COME FROM A *SUCCESSFUL* RUN, NEVER A DEATH
+    TRACE: the on-card discriminator falsified the first "+1154 MiB" figure
+    — with 1326 MiB more freed, the first call consumed ~2474 of 2506
+    available and died identically, i.e. a death only ever reports the free
+    memory it consumed (greedy or weight-scaled allocation), so no death
+    yields a demand. sdxl sm_89's demand is UNKNOWN, lower-bounded
+    > 2501 MiB, and 8 GiB is a MEASURED NO for compiled SDXL UNet-only.
+    The basis string goes on the confession line so a reader of the admit
+    can see WHICH budget the split used without the code in hand.
     """
     if regime == "compiled":
         ok = int(free_bytes) >= int(demand_bytes) + int(floor_bytes)
@@ -751,20 +758,32 @@ def probe_plan(
 def compiled_dispatch_armed(module: Any) -> bool:
     """Is ``module``'s next forward a COMPILED call? (pgw#1627)
 
-    torchcg's adopt path installs its dispatcher as an INSTANCE attribute —
-    ``module.forward = dispatcher`` (adopt.py) — which is why the read goes
-    through ``__dict__`` rather than ``getattr``: a bare class ``forward``
-    means no dispatcher was ever installed. Duck-typed on the dispatcher's
-    ``armed_graphs()`` (its own arming signal) instead of an isinstance
-    against the vendored class, so a torchcg the release env pins itself
-    still answers. An armed dispatcher can still fall through to eager on a
-    shape miss, so this can over-release — one spare ``empty_cache`` — but
-    never under-protect the compiled call.
+    Answered by ``serving.adapter_guard.armed_graphs`` — the ONE accessor
+    that sees the dispatcher THROUGH whatever currently fronts
+    ``module.forward`` — and deliberately not by reading ``forward``
+    ourselves. The first version of this gate duck-typed
+    ``__dict__["forward"].armed_graphs`` directly, and the on-card run
+    proved it inert on every production compiled endpoint:
+    ``adapter_guard.install()`` runs AFTER adopt on the same module and
+    rebinds ``module.forward`` to its ``guarded`` closure, so the read
+    found the guard, not the dispatcher, and answered False with 2 graphs
+    armed (receipt: red_stub_calls=0, fwd_module=…adapter_guard,
+    submodules_with_dispatcher=0). Third instance of the same defect class
+    — a gate keyed on a WRAPPED signal instead of the signal's own accessor
+    (pgw#1587's rung token, the install-time gate the first #1627 test
+    caught, now the guard wrapper) — and ``dispatcher_of``'s docstring had
+    already named the rule: anything asking "is this module routing through
+    its dispatcher" must ask THERE, so a new wrapper is one change, not one
+    per reader.
+
+    An armed dispatcher can still fall through to eager on a shape miss (or
+    the guard can route eager for a live adapter), so this can over-release
+    — one spare ``empty_cache`` — but never under-protect the compiled call.
     """
     try:
-        fwd = getattr(module, "__dict__", {}).get("forward")
-        armed = getattr(fwd, "armed_graphs", None)
-        return bool(callable(armed) and armed())
+        from ..serving.adapter_guard import armed_graphs
+
+        return bool(armed_graphs(module))
     except Exception:  # noqa: BLE001 — a gate that raises would cost the request
         return False
 

--- a/tests/test_partial_resident.py
+++ b/tests/test_partial_resident.py
@@ -615,12 +615,18 @@ def test_the_probe_counts_the_reusable_allocator_pool_as_available():
 # pgw#1627 — the headroom split: allocator cache is EAGER-ONLY money
 # --------------------------------------------------------------------------
 
-# The 8 GiB death, as measured (arm-static-c51ba51f/up.log): driver_free at the
-# compiled first call, the dead cache parking stranded in the allocator, and
-# AOTI's out-of-allocator first-call demand (sdxl sm_89, 4/4, batch-invariant).
+# The 8 GiB death, as measured (arm-static-c51ba51f/up.log): driver_free at
+# the compiled first call and the dead cache parking stranded in the allocator.
 _DEATH_FREE = int(1.18 * _GIB)
 _DEATH_CACHE = int(1.02 * _GIB)
-_AOTI_DEMAND = int(1.15 * _GIB)
+# A HYPOTHETICAL stamp value exercising the predicate's arithmetic — NOT a
+# measured demand. The on-card discriminator FALSIFIED the original
+# "+1154 MiB demand" reading of the death log: with 1326 MiB more freed the
+# first call consumed ~2474 of 2506 available and died identically, so a death
+# only ever reports the free memory it consumed (greedy or weight-scaled). The
+# real sdxl sm_89 demand is UNKNOWN (> 2501 MiB) and a stamp may only come
+# from a SUCCESSFUL run (pgw#1601).
+_HYPOTHETICAL_STAMP = int(1.15 * _GIB)
 
 
 def test_the_death_shape_numbers_refuse_compiled_and_admit_eager():
@@ -633,7 +639,7 @@ def test_the_death_shape_numbers_refuse_compiled_and_admit_eager():
 
     ok, basis = headroom_admits(
         regime="compiled", free_bytes=_DEATH_FREE, cache_bytes=_DEATH_CACHE,
-        demand_bytes=_AOTI_DEMAND,
+        demand_bytes=_HYPOTHETICAL_STAMP,
     )
     assert not ok, (
         "the compiled predicate admitted the death shape — 1.18 GiB of "
@@ -653,23 +659,30 @@ def test_the_death_shape_numbers_refuse_compiled_and_admit_eager():
     assert basis == "free+cache"
 
 
-def test_post_release_driver_free_admits_compiled():
-    """The other half of the fix: `release_cached_vram()` hands the parked
-    cache back to the driver, and THEN the same card admits the compiled
-    call. 4782 weights + 371 ctx + 1154 AOTI pool + 450 activations = 6757 of
-    7808 MiB — fits with ~1 GiB spare, which is what the on-card TEST 1
-    validates against this predicate."""
+def test_post_release_driver_free_admits_compiled_when_a_stamp_fits():
+    """Predicate arithmetic only: once `release_cached_vram()` returns the
+    parked cache to the driver, driver_free covering stamp+floor ADMITS.
+    (The on-card run showed the REAL sm_89 first call takes more than even
+    post-release free on this card — >2501 MiB — so with a real stamp the
+    same card correctly REFUSES: 8 GiB is a measured NO for compiled SDXL
+    UNet-only. A split that refused a fitting stamp would be a cliff.)"""
     from gen_worker.models.partial_resident import headroom_admits
 
     ok, basis = headroom_admits(
         regime="compiled", free_bytes=_DEATH_FREE + _DEATH_CACHE,
-        cache_bytes=0, demand_bytes=_AOTI_DEMAND,
+        cache_bytes=0, demand_bytes=_HYPOTHETICAL_STAMP,
     )
     assert ok, (
-        "post-release driver_free (2.20 GiB) covers demand+floor (1.40 GiB) "
+        "post-release driver_free (2.20 GiB) covers stamp+floor (1.40 GiB) "
         "and must admit — a split that refuses this is a cliff, not a guard"
     )
     assert basis == "driver_free"
+    # And a stamp at the on-card LOWER BOUND refuses this card outright.
+    ok, _ = headroom_admits(
+        regime="compiled", free_bytes=_DEATH_FREE + _DEATH_CACHE,
+        cache_bytes=0, demand_bytes=int(2.45 * _GIB),
+    )
+    assert not ok, "a >2.4 GiB stamp must refuse 2.20 GiB of driver_free"
 
 
 def test_probe_plan_itself_refuses_a_compiled_leg_the_cache_would_admit():
@@ -690,7 +703,7 @@ def test_probe_plan_itself_refuses_a_compiled_leg_the_cache_would_admit():
     try:
         ok, reported, basis = pr.probe_plan(
             parked, free_bytes_now=lambda: _DEATH_FREE,
-            regime="compiled", demand_bytes=_AOTI_DEMAND,
+            regime="compiled", demand_bytes=_HYPOTHETICAL_STAMP,
         )
         eager_ok, _, _ = pr.probe_plan(
             parked, free_bytes_now=lambda: _DEATH_FREE,
@@ -753,12 +766,12 @@ def test_a_compiled_load_refuses_the_death_shape_THROUGH_the_production_path():
     demands the driver_free basis AND the refusal."""
     armed, facts = _admit_through_production_path(
         regime="compiled", free_bytes=_DEATH_FREE, cache_bytes=_DEATH_CACHE,
-        demand_bytes=_AOTI_DEMAND)
+        demand_bytes=_HYPOTHETICAL_STAMP)
     assert facts.get("headroom_basis") == "driver_free", (
         "a compiled load's probe still confesses the eager basis — the "
         "regime never reached the predicate (the dead-plumbing finding)"
     )
-    assert facts.get("headroom_demand_bytes") == _AOTI_DEMAND, (
+    assert facts.get("headroom_demand_bytes") == _HYPOTHETICAL_STAMP, (
         "the demand the admit was checked against must be in the confession, "
         "or demand=0 inertness is indistinguishable from a real guard"
     )
@@ -828,16 +841,24 @@ class _FakeDispatcher:
         return self.eager_forward(*args, **kwargs)
 
 
-def _seam_events(adopt: bool) -> List[str]:
+def _seam_events(adopt: bool, guard: bool = False) -> List[str]:
     """Arm the rung, THEN (optionally) adopt, then serve one request —
     recording park / release / compiled-call order.
 
     The adopt-AFTER-hook-install ordering is the death log's own
     (residency confession before `adopt: … armed`), and it is load-bearing:
     a gate evaluated at hook-install time reads "not compiled" forever and
-    this test's `released` event never appears."""
+    this test's `released` event never appears.
+
+    ``guard=True`` is THE PRODUCTION SHAPE: `host.py` runs
+    `adapter_guard.install()` after adopt on the same module, which rebinds
+    `module.forward` to its `guarded` closure. The first gate duck-typed
+    `forward.armed_graphs` directly and was proven INERT on-card against
+    exactly this shape (red_stub_calls=0 with 2 graphs armed) — a seam test
+    that arms a dispatcher without the guard stays green forever."""
     import gen_worker.models.memory as m
     import gen_worker.models.partial_resident as pr
+    import gen_worker.serving.adapter_guard as ag
 
     events: List[str] = []
     pipe = _pipeline()
@@ -846,6 +867,12 @@ def _seam_events(adopt: bool) -> List[str]:
 
     if adopt:
         pipe.unet.forward = _FakeDispatcher(pipe.unet, events)
+        if guard:
+            assert ag.install(pipe.unet), (
+                "the adapter guard refused the fake dispatcher — the fixture "
+                "no longer matches dispatcher_of's duck-type and this test "
+                "is not exercising the production forward shape"
+            )
 
     real_park = pr.ParkedComponent.park
     real_release = m.release_cached_vram
@@ -869,19 +896,39 @@ def _seam_events(adopt: bool) -> List[str]:
     return events
 
 
-def test_the_seam_releases_the_cache_between_park_and_the_compiled_call():
-    """Acceptance (b): parked → released → first compiled call, in that
-    order. The dispatcher is installed AFTER the hooks (adopt runs after the
-    rung arms, per the death log), so a release gated at install time — the
-    pgw#1587 wrong-moment shape — fails here by never firing."""
-    events = _seam_events(adopt=True)
+def test_the_seam_releases_the_cache_THROUGH_the_adapter_guard():
+    """THE PRODUCTION SHAPE, and the red test the first two PRs lacked:
+    dispatcher adopted, then `adapter_guard.install()` rebinds forward to its
+    guard closure — the gate must see the dispatcher THROUGH the wrapper
+    (via adapter_guard's own accessor) or it is inert on every compiled
+    endpoint, which is exactly what the on-card run measured against
+    790d0290. Order: parked → released → first compiled call."""
+    events = _seam_events(adopt=True, guard=True)
     assert "parked" in events, "the seam never parked — the instrument is blind"
     assert "released" in events, (
-        "the park→compiled seam never released the allocator cache; either "
-        "the gate was read at install time (before adopt) or it does not "
-        "recognise an armed dispatcher"
+        "the park→compiled seam never released the allocator cache WITH THE "
+        "ADAPTER GUARD INSTALLED — the gate is reading module.forward "
+        "directly instead of asking adapter_guard.dispatcher_of/armed_graphs "
+        "(the third gate-keyed-on-a-wrapped-signal instance)"
     )
     assert "compiled_call" in events
+    assert events.index("parked") < events.index("released") < events.index(
+        "compiled_call"
+    ), f"wrong order at the seam: {events}"
+
+
+def test_the_seam_releases_for_a_bare_dispatcher_too():
+    """The pre-guard shape (local runs, any host that skips the guard): a
+    dispatcher fronting forward directly must also release. The dispatcher
+    is installed AFTER the hooks (adopt runs after the rung arms, per the
+    death log), so a release gated at install time — the pgw#1587
+    wrong-moment shape — fails here by never firing."""
+    events = _seam_events(adopt=True, guard=False)
+    assert "parked" in events
+    assert "released" in events, (
+        "the seam released only through the guard wrapper — a bare armed "
+        "dispatcher must gate the release too"
+    )
     assert events.index("parked") < events.index("released") < events.index(
         "compiled_call"
     ), f"wrong order at the seam: {events}"
@@ -950,6 +997,9 @@ def test_the_seam_gate_reads_the_DENOISER_not_whichever_module_holds_the_hook():
     assert armed
 
     pipe.unet.forward = _FakeDispatcher(pipe.unet, events)
+    import gen_worker.serving.adapter_guard as ag
+
+    assert ag.install(pipe.unet)  # production shape: guard over the dispatcher
     real_release = m.release_cached_vram
     m.release_cached_vram = lambda: events.append("released")
     try:


### PR DESCRIPTION
Second re-open, both findings the forensics lane's, verified on-card against 790d0290.

**Finding 1 — seam release inert in production.** `adapter_guard.install()` rebinds `module.forward` to its guard closure after adopt, so the gate's duck-type on `__dict__["forward"].armed_graphs` answered False with 2 graphs armed (on-card: `red_stub_calls=0`, `fwd_module=…adapter_guard`, `submodules_with_dispatcher=0`). Fix: the gate asks `adapter_guard.armed_graphs` — the accessor whose docstring already owns this question — which sees the dispatcher through any wrapper. Third instance of the gate-keyed-on-a-wrapped-signal class (pgw#1587's rung token → the install-time gate → the guard wrapper), named in the gate's docstring and the tracker.

**Tests:** the seam tests now install the adapter guard (the production forward shape) — the old gate goes red against them (proven by sabotage); a bare-dispatcher case keeps the unguarded shape covered; the mid-stage denoiser test is guard-shaped too.

**Finding 2 — "+1154 MiB" was never a demand.** With the release forced, the first call consumed ~2474 of 2506 available and died identically — a death only reports the free memory it consumed. Code/tests no longer present it as measured demand (`_HYPOTHETICAL_STAMP`), `headroom_admits` states the pgw#1601 stamp must come from a SUCCESSFUL run, sm_89 demand is UNKNOWN (>2501 MiB), and 8 GiB is a measured NO for compiled SDXL UNet-only. (The merge messages of #1169/#1170 carry the falsified figure; the tracker correction is the record.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)