### PR TITLE
pgw#1631: the CAS boot path on a single-release pod — the gate consumes the fill PLAN, boot never evicts, and a supersede never cancels bytes

### DIFF
--- a/changelog.d/pgw1631.md
+++ b/changelog.d/pgw1631.md
@@ -1,0 +1,64 @@
+- **pgw#1631: the headroom gate now CONSUMES the fill plan, so a divergent precondition is
+  unwritable.** pgw#1596 was a shape bug, not an arithmetic one: the gate priced the REQUEST
+  (walk the manifest, sum every file) while the fill priced the DELTA (skip what
+  `contains(digest, size)` already answers for). Two derivations of one quantity drifted and a
+  105 GB pull died 157 MB from the end on a disk that fit it fine — `need 104956706657 bytes;
+  65659441152 free after disk GC` on pod `6uneiwhdl7fz8u`, with ~86.2 GB of that same tree
+  already resident. The fix that landed subtracted the resident bytes; this one deletes the
+  second derivation. `models/fill_plan.py` holds ONE skip predicate (`is_present`) and ONE plan
+  built from it; `_ensure_disk_headroom` takes the plan and nothing else — no manifest, no
+  total, so there is nothing left to re-price — and `cozy_snapshot._ensure_objects`' own skip
+  calls the same function. The clamp that stopped an overstated residency producing a NEGATIVE
+  requirement is gone with the subtraction that needed it: `missing_bytes` is a sum over a
+  disjoint list, non-negative and bounded by the total by construction.
+
+- **pgw#1631: no GC during boot — a boot that needs eviction to fit REFUSES.** A boot that has
+  to evict to fit is a sizing bug upstream (th#2264), and evict-and-retry turns a fast
+  actionable refusal into th#2246's shape: two A100 pods, ~$1.72 burned, and a human cancelling
+  a retry loop that was doomed before it was paid for. At boot the gate raises a typed
+  `insufficient_disk` naming the mount, its `statvfs` totals and the plan's missing bytes, so
+  the hub demotes the shape instead of re-buying it at the identical
+  `container_disk_gb_requested`. Steady state keeps the LRU GC, because there eviction is what
+  the disk tier is FOR — deleting it everywhere would be a different bug. `in_boot()` is the
+  gate, which is the honest predicate: it means "this worker cannot serve", so the window is
+  exactly the one where a refusal is cheap and an eviction is a guess.
+
+- **pgw#1631: a supersede never cancels byte movement.** `configure()` used to `cancel()` the
+  in-flight fill on any config change. Objects are release-agnostic — they are keyed by content
+  — so bytes an old plan is mid-way through fetching are bytes the NEW plan's fill simply finds
+  present; cancelling them buys nothing and costs the re-fetch, which is the class th#2204
+  measured as phantom downloads and pgw#1596 turned into a disk-capacity incident (the re-entry
+  that armed it was a supersede that changed nothing about the ref). The superseded fill now
+  DRAINS, held by a strong reference so the loop cannot collect a task that is still writing.
+  What supersede means instead is that the old task's VERDICT stops counting: `_materialize`
+  and the per-ref failure path both check `self._applied is config` before touching state, so a
+  stale FAILED cannot strand a pod whose live config is fine and a stale READY cannot advertise
+  weights the live config does not name. Red-armed: restoring the `cancel()` fails the test.
+
+- **pgw#1612: an ENOSPC is a claim about the SHAPE, and it now reaches the hub as one.** The
+  hub has had `insufficient_disk` all along — a real model-failure reason with a whole
+  migration path behind it (drop the oldest resident non-hot disk goal, advance the capacity
+  generation, clear the failures, re-send desired state) — and the worker only ever raised it
+  for a DOWNLOAD that could not fit. An `OSError [Errno 28]` from anywhere else in the boot
+  propagated as an ordinary exception, so the hub saw "this attempt failed" and requeued onto a
+  machine with the same disk: th#2246's `qwen-image` went `8gpqows0j349gm` →
+  `3zod6pwvn10f4y`, both A100-SXM4-80GB with the same 100 GB, at $1.59/hr until a human
+  cancelled it. `models/disk_errors.py` classifies errno 28 through `__cause__`, `__context__`,
+  `ExceptionGroup` and `shutil.Error`'s nested triples, at ONE boot seam rather than per
+  raiser, and refuses to guess from the message text — inventing a capacity claim out of an
+  unrelated error is worse than the generic bucket, because the hub ACTS on this token.
+  **The token is sent BARE and that is a wire contract, not a style choice:**
+  `connect_worker.go:3737` reads `strings.TrimSpace(ev.GetError())` and compares it for EXACT
+  equality, so appending detail after a colon the way `download_failed` does would have
+  silently disabled the entire migration path. The facts — which mount ran out and its
+  `statvfs` totals, quoted from `disk_telemetry` — ride a typed `residency_fault` activity
+  event instead, where they land in `worker_activity_events` and are readable off the wire.
+  That is pgw#1620's lesson: a confession that only reaches a pod's stdout reaches nobody.
+
+- **pgw#1631: one writer per object was already true, and now it is fenced.** The unit of work
+  is one object under `LocalCAS`'s own per-object lock, and the only commit is tmp +
+  link/replace — so eight concurrent contenders for one object all succeed, exactly one object
+  exists, its bytes are correct, and no writer discards work and starts over. th#2246's "every
+  loser rmtree's and restarts from zero" was the tier-3 materialized view, not the bank; no new
+  machinery was added, and a test is here so a change that breaks the property cannot land
+  quietly.

--- a/src/gen_worker/boot_materialize.py
+++ b/src/gen_worker/boot_materialize.py
@@ -72,6 +72,7 @@ from typing import Awaitable, Callable, Dict, Mapping, Optional, Tuple
 from . import activity
 from . import boot_phases
 from . import weight_position
+from .models import disk_errors
 from .models.refs import WireRef
 from .models.store import ModelStore
 from .pb import worker_scheduler_pb2 as pb
@@ -173,6 +174,11 @@ class CheckpointMaterialization:
         #: (th#2233's false-servable gets an actual readiness probe).
         self._warm_cb = warm
         self._task: Optional["asyncio.Task[None]"] = None
+        #: pgw#1631: fills whose config has been superseded. They are HELD, not
+        #: cancelled — a strong reference so the loop cannot garbage-collect a
+        #: task that is still moving bytes into the shared CAS — and they
+        #: decide nothing about readiness.
+        self._superseded: set["asyncio.Task[None]"] = set()
         self._applied: Optional[CheckpointConfig] = None
         self.state: str = STATE_PENDING
         #: Populated in STATE_FAILED: "<ref>: <ExcType>: <message>".
@@ -225,11 +231,32 @@ class CheckpointMaterialization:
             )
             return
 
+        previous = self._applied
         self._applied = config
         if self._task is not None and not self._task.done():
-            # A NEW config supersedes an in-flight materialization of an old
-            # one. This is config replacement, not a reconcile race.
-            self._task.cancel()
+            # pgw#1631: A SUPERSEDE NEVER CANCELS BYTE MOVEMENT.
+            #
+            # This used to `cancel()`. Objects are release-agnostic — they are
+            # keyed by content — so bytes the old plan is mid-way through
+            # fetching are bytes the NEW plan's fill will simply find present.
+            # Cancelling them buys nothing and costs the re-fetch, which is the
+            # class th#2204 measured as phantom downloads and pgw#1596 turned
+            # into a disk-capacity incident: the re-entry that armed it was a
+            # supersede that changed nothing about the ref.
+            #
+            # What supersede DOES mean is that the old task's VERDICT no longer
+            # decides anything — `_materialize` checks `self._applied is
+            # config` before touching state. The old fill drains; at worst some
+            # objects the new plan does not name wait for steady-state GC.
+            self._superseded.add(self._task)
+            self._task.add_done_callback(self._superseded.discard)
+            logger.info(
+                "checkpoint config version=%s superseded by version=%d; the "
+                "in-flight fill DRAINS rather than cancelling — its objects "
+                "are content-keyed and the new plan will find them present",
+                previous.version if previous is not None else "none",
+                config.version,
+            )
 
         if not config.refs:
             # A weightless release, or a release whose config names nothing.
@@ -297,8 +324,22 @@ class CheckpointMaterialization:
         """
         with activity.running(activity.KIND_BOOT_MATERIALIZE) as fetch:
             if not await self._fetch_refs(config, fetch):
-                await self._announce()
+                if self._current(config):
+                    await self._announce()
                 return
+
+        if not self._current(config):
+            # pgw#1631: this fill was SUPERSEDED while it ran. Its bytes are in
+            # the CAS and the live plan's fill will find them present — which is
+            # the whole reason it was allowed to drain — but its verdict is
+            # about a config nobody asked for any more, so it touches neither
+            # readiness nor the warm pass.
+            logger.info(
+                "superseded fill for version=%d completed; %d ref(s) drained "
+                "into the CAS, readiness untouched",
+                config.version, len(config.refs),
+            )
+            return
 
         # pgw#1584: WEIGHTS ARE DOWN, NOTHING IS SERVABLE YET. The warm pass
         # goes exactly here — after the last byte and before the state flips —
@@ -314,6 +355,44 @@ class CheckpointMaterialization:
             config.version, len(config.refs),
         )
         await self._announce()
+
+    async def _report_if_out_of_space(
+        self, ref: WireRef, exc: BaseException
+    ) -> None:
+        """pgw#1612: report an ENOSPC as `insufficient_disk`, with the mount.
+
+        ONE seam for the whole boot fetch, so every raiser under it is covered
+        — a per-call-site catch is how half of them stay generic. The token is
+        the EXISTING one because the hub-side handling already exists behind
+        it; inventing a second vocabulary would mean building the migration
+        path twice.
+        """
+        typed = disk_errors.as_insufficient_disk(
+            exc,
+            doing=f"materializing {ref}",
+            fallback_path=self._store.cache_dir,
+        )
+        if typed is None:
+            return
+        logger.error(
+            "checkpoint materialization ran OUT OF DISK on %s — this SHAPE "
+            "cannot work and re-buying it at the same size will fail the same "
+            "way: %s", ref, typed,
+        )
+        try:
+            await self._store.report_insufficient_disk(ref, str(typed))
+        except Exception:  # noqa: BLE001 — reporting must not mask the failure
+            logger.exception("insufficient_disk report for %s could not be sent", ref)
+
+    def _current(self, config: CheckpointConfig) -> bool:
+        """Is ``config`` still the plan this worker is being judged on?
+
+        A superseded fill keeps moving bytes (they are content-keyed and the
+        successor wants them) but must not set state — a stale FAILED would
+        strand a pod whose live config is fine, and a stale READY would
+        advertise weights the live config does not name.
+        """
+        return self._applied is config
 
     async def _fetch_refs(
         self, config: CheckpointConfig, fetch: "activity.Activity",
@@ -349,6 +428,25 @@ class CheckpointMaterialization:
                 )
                 raise
             except Exception as exc:  # noqa: BLE001 — every failure is a STATE
+                # pgw#1612: an ENOSPC anywhere under this call is a claim about
+                # the SHAPE, not about the attempt. Classified at this ONE boot
+                # seam so every raiser under it is covered, and reported on the
+                # channel the hub's `insufficient_disk` migration path already
+                # reads. Without it the hub sees "this attempt failed" and
+                # requeues onto a machine with the identical
+                # `container_disk_gb_requested` — measured on th#2246:
+                # `8gpqows0j349gm` -> `3zod6pwvn10f4y`, both A100-SXM4-80GB with
+                # the same 100 GB, at $1.59/hr until a human cancelled it.
+                await self._report_if_out_of_space(ref, exc)
+                if not self._current(config):
+                    logger.info(
+                        "superseded fill for version=%d failed on %s (%s: %s); "
+                        "state untouched — a stale verdict must not strand a "
+                        "pod whose live config is fine",
+                        config.version, ref, type(exc).__name__, exc,
+                    )
+                    fetch.failed(exc)
+                    return False
                 self.state = STATE_FAILED
                 self.failure = f"{ref}: {type(exc).__name__}: {exc}"
                 logger.error(

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -50,7 +50,7 @@ from .. import boot_phases
 from .. import snapshot_pull
 from ..capability import InsufficientDiskError
 from ..snapshot_pull import SnapshotPullStats
-from . import projection
+from . import fill_plan, projection
 from .cache_paths import open_worker_cas
 from .download import components_present, select_component_paths
 from .errors import (
@@ -545,10 +545,13 @@ class CozySnapshotDownloader:
                 progress(done, total)
 
         def resident(grant: TransferGrant) -> bool:
-            try:
-                return bool(cas.contains(grant.digest, size=grant.size_bytes))
-            except DigestMismatch:
-                return False
+            # pgw#1631: THE ONE SKIP PREDICATE, shared with the headroom gate's
+            # plan (`fill_plan.plan_for_snapshot`). A second spelling here is
+            # how pgw#1596 happened: the gate and the fill each derived "what
+            # is missing" and drifted.
+            return fill_plan.is_present(
+                cas, str(grant.digest), int(grant.size_bytes)
+            )
 
         def filled(grant: TransferGrant) -> bool:
             """Volume -> pod CAS, hashing every byte ONCE (pgw#1556).

--- a/src/gen_worker/models/disk_errors.py
+++ b/src/gen_worker/models/disk_errors.py
@@ -1,0 +1,140 @@
+"""pgw#1612: an ENOSPC is a claim about the SHAPE, not about the attempt.
+
+The hub already knows what to do with `insufficient_disk`: it is a real
+model-failure reason with a whole migration path behind it — drop the oldest
+resident non-hot disk goal, advance the capacity generation, clear the
+failures, re-send desired state. The worker only ever raised it for a DOWNLOAD
+that could not fit. An `OSError [Errno 28]` from anywhere else in the boot — a
+load, a cache write, an artifact export — propagated as an ordinary exception
+and reached the hub as a generic failure, so the hub requeued onto a machine
+with the same `container_disk_gb_requested`.
+
+MEASURED (th#2246, 2026-08-21): `qwen-image` 0.5.17 ENOSPC'd on
+`8gpqows0j349gm` (A100-SXM4-80GB, 100 GB container disk) and requeued onto
+`3zod6pwvn10f4y` — another A100-SXM4-80GB with the same 100 GB — and would have
+kept going at $1.59/hr had a human not cancelled it. Deterministic failure,
+unbounded retry, real money.
+
+This module is the classifier, and it is deliberately ONE function used at ONE
+seam. A per-raiser catch is how half of them stay generic.
+"""
+
+from __future__ import annotations
+
+import errno
+import shutil
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from ..capability import InsufficientDiskError
+from . import disk_telemetry
+
+
+def _chain(exc: BaseException) -> Iterator[BaseException]:
+    """The exception and everything it wraps, depth-bounded.
+
+    ENOSPC arrives wrapped: `shutil.Error` carries the real `OSError` in its
+    `args`, a retry wrapper carries it as `__cause__`, and a thread boundary
+    carries it as `__context__`. Reading only the outermost type is how a
+    deterministic disk failure reads as a generic one.
+    """
+
+    seen: set[int] = set()
+    stack: list[BaseException] = [exc]
+    while stack and len(seen) < 32:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        yield current
+        for nested in (current.__cause__, current.__context__):
+            if isinstance(nested, BaseException):
+                stack.append(nested)
+        if isinstance(current, shutil.Error):
+            # `shutil.copytree` raises `Error([(src, dst, why), ...])` — the
+            # exception is nested two containers deep, and `why` is sometimes
+            # the exception and sometimes its formatted string. Flatten the
+            # containers; a string `why` is simply not classifiable here, which
+            # is the honest outcome (see `out_of_space`: no substring guessing).
+            stack.extend(_nested_exceptions(current.args, depth=3))
+        group = getattr(current, "exceptions", None)
+        if isinstance(group, (list, tuple)):
+            stack.extend(e for e in group if isinstance(e, BaseException))
+
+
+def _nested_exceptions(value: Any, *, depth: int) -> Iterator[BaseException]:
+    if isinstance(value, BaseException):
+        yield value
+        return
+    if depth <= 0 or not isinstance(value, (list, tuple, set)):
+        return
+    for item in value:
+        yield from _nested_exceptions(item, depth=depth - 1)
+
+
+def out_of_space(exc: BaseException) -> Optional[OSError]:
+    """The ENOSPC inside ``exc``, or None.
+
+    Only `errno.ENOSPC` counts. Substring matching on the message is
+    deliberately NOT done here: `_error_vocab`'s `"disk" in text` heuristic
+    already exists on the download path and is exactly the kind of guess that
+    mislabels an unrelated failure as a capacity claim the hub then acts on.
+    """
+
+    for item in _chain(exc):
+        if isinstance(item, OSError) and item.errno == errno.ENOSPC:
+            return item
+    return None
+
+
+def _mount_facts(path: Any) -> str:
+    """Which mount ran out, and its real statvfs totals.
+
+    `disk_telemetry` measures the real mount points the worker uses, so the
+    reason quotes it rather than leaving "the container disk was 100 GB and the
+    boot needed 121 GB" to be re-derived by a lane weeks later.
+    """
+
+    target = str(path or "") or "."
+    totals = disk_telemetry._statvfs_totals(target)
+    if totals is None:
+        return f"mount={target} statvfs=unreadable"
+    total, free = totals
+    return f"mount={target} statvfs_total={total} statvfs_free={free}"
+
+
+def as_insufficient_disk(
+    exc: BaseException, *, doing: str, fallback_path: Any = None
+) -> Optional[InsufficientDiskError]:
+    """Re-type an ENOSPC as the reason the hub already knows how to act on.
+
+    Returns None when ``exc`` is not an out-of-space failure — the caller then
+    reports it exactly as before, because inventing a capacity claim out of an
+    unrelated error is worse than the generic bucket.
+    """
+
+    oserr = out_of_space(exc)
+    if oserr is None:
+        return None
+    where = getattr(oserr, "filename", None) or fallback_path
+    facts = _mount_facts(Path(where).parent if where else fallback_path)
+    return InsufficientDiskError(
+        f"no space left while {doing}: {type(exc).__name__}: {exc}; "
+        f"path={where or 'unknown'}; {facts}",
+        available_bytes=_free_bytes(where or fallback_path),
+        # Unknown: the raiser is a write that failed, not a plan with a total.
+        # Zero is the honest answer — "we needed more than there was" — and it
+        # must never be confused with a sized shortfall the planner computed.
+        required_bytes=0,
+        path=str(where or fallback_path or ""),
+    )
+
+
+def _free_bytes(path: Any) -> int:
+    try:
+        return int(shutil.disk_usage(str(path or ".")).free)
+    except OSError:
+        return 0
+
+
+__all__ = ["as_insufficient_disk", "out_of_space"]

--- a/src/gen_worker/models/fill_plan.py
+++ b/src/gen_worker/models/fill_plan.py
@@ -1,0 +1,156 @@
+"""pgw#1631: the fill PLAN — one predicate, so a divergent precondition is unwritable.
+
+pgw#1596 was not a bug in the CAS. It was a bug in the SHAPE of a gate: the
+headroom check computed its cost from the REQUEST (walk the manifest, sum every
+file) while the fill computed its work from the DELTA (skip what
+``contains(digest, size)`` already answers for). Two derivations of one quantity
+drifted, and a 105 GB pull died 157 MB from the end on a disk that fit it fine.
+
+The fix that landed subtracted the resident bytes. The fix here removes the
+second derivation: there is ONE function that decides whether an object is
+present, ONE plan built out of it, and the gate is HANDED that plan rather than
+handed a manifest to price. A gate that cannot see file sizes cannot re-derive a
+cost, and a precondition that cannot be re-derived cannot disagree.
+
+The predicate is `LocalCAS.contains` — presence, not integrity, resolved by one
+``lstat``. That is deliberate and it is the store's own documented contract: a
+declared size makes a truncated object answer False for free, and bytes
+corrupted in place answer True, which is `verify_object`'s job on the read side
+and not a planning question.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Protocol, Sequence
+
+
+class _Cas(Protocol):
+    def contains(self, ref: Any, *, size: int | None = None) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedObject:
+    """One content-addressed object a manifest names."""
+
+    digest: str
+    size_bytes: int
+    path: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class FillPlan:
+    """What a fill will SKIP and what it will FETCH, decided once.
+
+    ``missing_bytes`` is the only cost any precondition on this path is allowed
+    to charge for. It is not an estimate of the tree; it is the arithmetic
+    consequence of the same skip decision the fetch loop will make.
+    """
+
+    present: tuple[PlannedObject, ...] = ()
+    missing: tuple[PlannedObject, ...] = ()
+    #: Objects the manifest named without a digest. They are counted as
+    #: MISSING (the honest direction — they will be fetched) and kept
+    #: separately so a refusal can say the plan was built on incomplete input.
+    undigested: tuple[PlannedObject, ...] = ()
+
+    @property
+    def present_bytes(self) -> int:
+        return sum(o.size_bytes for o in self.present)
+
+    @property
+    def missing_bytes(self) -> int:
+        return sum(o.size_bytes for o in self.missing)
+
+    @property
+    def total_bytes(self) -> int:
+        return self.present_bytes + self.missing_bytes
+
+    @property
+    def object_count(self) -> int:
+        return len(self.present) + len(self.missing)
+
+    def describe(self) -> str:
+        """The plan's own arithmetic, for a refusal that shows its working."""
+
+        return (
+            f"{self.missing_bytes} missing of {self.total_bytes} "
+            f"({len(self.missing)} of {self.object_count} objects; "
+            f"{self.present_bytes} already banked)"
+        )
+
+
+def is_present(cas: _Cas, digest: str, size_bytes: int) -> bool:
+    """THE skip predicate. Both the plan and the fetch loop call this one.
+
+    An unreadable or unparseable object answers False — absent, which is the
+    honest direction: it will be fetched, and the fetch is what decides.
+    """
+
+    ref = str(digest or "").strip()
+    if not ref:
+        return False
+    try:
+        return bool(cas.contains(ref, size=int(size_bytes)))
+    except Exception:  # noqa: BLE001 — a probe must never be the failure
+        return False
+
+
+def plan_fill(cas: _Cas, entries: Iterable[Any]) -> FillPlan:
+    """Split a manifest into what this store holds and what it must fetch.
+
+    ``entries`` is anything with ``digest`` and ``size_bytes``: a
+    ``pb.SnapshotFile``, a ``WorkerResolvedRepoFile``, a ``TransferGrant``.
+    """
+
+    present: list[PlannedObject] = []
+    missing: list[PlannedObject] = []
+    undigested: list[PlannedObject] = []
+    for entry in entries:
+        digest = str(getattr(entry, "digest", "") or "").strip()
+        size = int(getattr(entry, "size_bytes", 0) or 0)
+        path = str(getattr(entry, "path", "") or "")
+        obj = PlannedObject(digest=digest, size_bytes=size, path=path)
+        if not digest:
+            undigested.append(obj)
+            missing.append(obj)
+            continue
+        (present if is_present(cas, digest, size) else missing).append(obj)
+    return FillPlan(
+        present=tuple(present),
+        missing=tuple(missing),
+        undigested=tuple(undigested),
+    )
+
+
+def plan_for_snapshot(cache_dir: Any, files: Sequence[Any]) -> FillPlan:
+    """The plan for a snapshot's file list against this pod's CAS.
+
+    An unopenable CAS yields an all-missing plan rather than an exception: a
+    store nobody can read holds nothing, which is the conservative direction
+    for a headroom gate and the correct one for a fetch.
+    """
+
+    from .cache_paths import open_worker_cas
+
+    try:
+        cas = open_worker_cas(cache_dir)
+    except Exception:  # noqa: BLE001 — a probe must not be the failure
+        return FillPlan(missing=tuple(
+            PlannedObject(
+                digest=str(getattr(f, "digest", "") or ""),
+                size_bytes=int(getattr(f, "size_bytes", 0) or 0),
+                path=str(getattr(f, "path", "") or ""),
+            )
+            for f in files
+        ))
+    return plan_fill(cas, files)
+
+
+__all__ = [
+    "FillPlan",
+    "PlannedObject",
+    "is_present",
+    "plan_fill",
+    "plan_for_snapshot",
+]

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
-    Any, Awaitable, Callable, Dict, List, Optional, Sequence, Set, Tuple, cast,
+    Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, cast,
 )
 
 from .. import activity as activity_mod
@@ -32,7 +32,7 @@ from ..pb import worker_scheduler_pb2 as pb
 from ..redact import sanitize as _sanitize
 from ..topology import current_device_group
 from ..wire_snapshots import resolved_repo_from_snapshot
-from . import cozy_snapshot, disk_gc, disk_telemetry, projection
+from . import cozy_snapshot, disk_gc, disk_telemetry, fill_plan, projection
 from .projection import SNAPSHOTS_DIR
 from . import residency as residency_mod
 from . import staging as staging_mod
@@ -462,6 +462,43 @@ class ModelStore:
         await self._emit(pb.WorkerMessage(
             model_event=self.model_event(ref, state, identity=identity, **kw)
         ))
+
+    @property
+    def cache_dir(self) -> Path:
+        """This pod's CAS root. Read-only; the store resolves it once at boot."""
+        return Path(self._cache_dir)
+
+    async def report_insufficient_disk(self, ref: WireRef, detail: str) -> None:
+        """pgw#1612: tell the hub the SHAPE cannot fit, not that an attempt failed.
+
+        `insufficient_disk` is the hub's existing model-failure reason with a
+        whole migration/clear path behind it (drop the oldest resident non-hot
+        disk goal, advance the capacity generation, clear the failures, re-send
+        desired state). Reusing the token is the point: a second vocabulary
+        would mean building that path twice.
+
+        THE TOKEN IS SENT BARE, and that is a wire contract, not a style
+        choice. `connect_worker.go:3737` reads `failureReason :=
+        strings.TrimSpace(ev.GetError())` and then compares it for EXACT
+        equality against `modelFailureReasonDisk` — so appending detail after a
+        colon, the way `download_failed` does, would silently disable the whole
+        migration path. Verified by reading the hub at HEAD, not from memory.
+
+        The FACTS ride the activity stream instead, where they land in
+        `worker_activity_events` and are readable off the wire: which mount ran
+        out, its statvfs totals, and what the worker was doing. That is
+        pgw#1620's lesson — a confession that only reaches a pod's stdout
+        reaches nobody, because RunPod has no logs API.
+        """
+        try:
+            activity_mod.emit_event(
+                activity_mod.KIND_RESIDENCY_FAULT,
+                f"{ref}: {_sanitize(detail)[:400]}",
+                phase="insufficient_disk",
+            )
+        except Exception:  # noqa: BLE001 — reporting must not mask the failure
+            logger.debug("insufficient_disk fact event dropped", exc_info=True)
+        await self._event(ref, pb.MODEL_STATE_FAILED, error="insufficient_disk")
 
     # ---- per-group residency (pgw#748 phase 1) --------------------------------
 
@@ -1141,93 +1178,83 @@ class ModelStore:
                     return other
         return ""
 
-    def _already_resident_bytes(self, files: Sequence[Any]) -> int:
-        """Bytes of ``files`` whose CAS objects this pod ALREADY holds.
+    def _mount_report(self) -> str:
+        """This CAS root's mount and its real statvfs totals.
 
-        pgw#1596. The headroom gate asks for FREE space, so it must ask for
-        what is still MISSING — the bytes already banked are, by definition,
-        not going to be written again. `contains` is the same content-addressed
-        predicate the fill path uses to decide a grant is satisfied, so this
-        cannot disagree with what the downloader will actually skip.
-
-        A file with no digest is counted as absent: the honest direction, since
-        it will be fetched.
+        pgw#1612: a refusal that does not name the mount is one the hub cannot
+        act on and a lane has to re-derive weeks later. `disk_telemetry`
+        already measures the real mount points; the refusal quotes it.
         """
-        from .cache_paths import open_worker_cas
-
-        try:
-            cas = open_worker_cas(self._cache_dir)
-        except Exception:  # noqa: BLE001 — a probe must not be the failure
-            return 0
-        total = 0
-        for f in files:
-            digest = str(getattr(f, "digest", "") or "").strip()
-            if not digest:
-                continue
-            try:
-                if cas.contains(digest, size=int(f.size_bytes)):
-                    total += int(f.size_bytes)
-            except Exception:  # noqa: BLE001 — an unreadable object is absent
-                continue
-        return total
+        totals = disk_telemetry._statvfs_totals(str(self._cache_dir))
+        if totals is None:
+            return f"mount={self._cache_dir} statvfs=unreadable"
+        total, free = totals
+        return (
+            f"mount={self._cache_dir} statvfs_total={total} "
+            f"statvfs_free={free}"
+        )
 
     async def _ensure_disk_headroom(
         self,
         ref: WireRef,
-        needed_bytes: int,
+        plan: fill_plan.FillPlan,
         identity: _ResidencyIdentity = ("", 0),
         *,
         intent_id: str = "",
-        files: Optional[Sequence[Any]] = None,
     ) -> None:
-        """Gate on the bytes still to be WRITTEN, never on the whole tree.
+        """Gate on the fill's own PLAN. It cannot price anything else.
 
-        pgw#1596: this used to compare free space against the ref's entire
-        manifest, with nothing subtracting the part of that same manifest
-        already on disk. On a first pass over an empty disk that is right. On a
-        RE-ENTRY it is self-defeating — the bytes already fetched are counted
-        as consumed AND demanded again as free — so a materialization restarted
-        by an ordinary residency-generation supersede can never satisfy its own
-        check. It needs 2x the tree, and it fails at the END of its own pull.
+        pgw#1596 was a SHAPE bug, not an arithmetic one: this gate priced the
+        REQUEST (the whole manifest) while the fill priced the DELTA (skip what
+        `contains(digest, size)` already answers for). Two derivations of one
+        quantity drifted and a 105 GB pull died 157 MB from the end on a disk
+        that fit it fine — `need 104956706657 bytes; 65659441152 free after
+        disk GC` on pod `6uneiwhdl7fz8u`, with ~86.2 GB of that same tree
+        already resident.
 
-        MEASURED (pod `6uneiwhdl7fz8u`, 159 GB disk, 2026-08-20):
-        `need 104956706657 bytes; 65659441152 free after disk GC` — it demanded
-        the whole 105 GB tree free while ~86.2 GB of that same tree was already
-        resident, and died 157 MB short of a complete pull.
+        pgw#1631 promotes the fix from patch to construction. The argument is
+        the plan the fill computed, so there is no manifest here to re-price
+        and no second derivation to drift: `missing_bytes` is the arithmetic
+        consequence of the same skip decision the fetch loop will make.
 
-        The boot ladder's supersede-and-restart design already ASSUMES
-        materialization is restart-safe. This is what makes that true.
+        NO GC DURING BOOT (pgw#1631). A boot that needs eviction to fit is a
+        sizing bug upstream (th#2264), and evict-and-retry turns it into a slow
+        expensive one — th#2246 burned two A100 pods and ~$1.72 on a shape that
+        was doomed before it was paid for. At boot the gate refuses with a
+        typed `insufficient_disk` naming the mount, its statvfs totals and the
+        missing bytes, so the hub demotes the shape instead of re-buying it at
+        the identical `container_disk_gb_requested`. Steady state keeps the LRU
+        GC: there, eviction is what the tier is FOR.
         """
-        total = int(needed_bytes)
-        resident = self._already_resident_bytes(files) if files else 0
-        # Never below zero, and never above the total: a stale or oversized
-        # residency reading must not talk this gate out of existence.
-        resident = max(0, min(resident, total))
-        remaining = total - resident
+        remaining = plan.missing_bytes
         target = remaining + _DISK_GC_MARGIN_BYTES
         if self._disk_free() >= target:
             return
-        await self._materialize_await(
-            intent_id or self._materialize_intent(ref),
-            asyncio.to_thread(self.gc_disk, target, exclude=(ref,)),
-            operation=f"disk headroom for {ref}",
-            status=pb.LIFECYCLE_INTENT_STATUS_WAITING,
-            stage=pb.LIFECYCLE_INTENT_STAGE_WAIT_DISK_HEADROOM,
-            reason=pb.LIFECYCLE_WAIT_REASON_DISK_HEADROOM,
-        )
+
+        booting = boot_mod.in_boot()
+        if not booting:
+            await self._materialize_await(
+                intent_id or self._materialize_intent(ref),
+                asyncio.to_thread(self.gc_disk, target, exclude=(ref,)),
+                operation=f"disk headroom for {ref}",
+                status=pb.LIFECYCLE_INTENT_STATUS_WAITING,
+                stage=pb.LIFECYCLE_INTENT_STAGE_WAIT_DISK_HEADROOM,
+                reason=pb.LIFECYCLE_WAIT_REASON_DISK_HEADROOM,
+            )
         free = self._disk_free()
         if free < target:
             await self._event(
                 ref, pb.MODEL_STATE_FAILED,
                 identity=identity, error="insufficient_disk",
             )
-            # Say what is still MISSING and what is already banked. The old
-            # message named only the whole tree, which is exactly why an
-            # 86 GB-resident refusal read as a 105 GB shortfall (pgw#1596).
+            # The plan shows its working. The pre-pgw#1596 message named only
+            # the whole tree, which is why an 86 GB-resident refusal read as a
+            # 105 GB shortfall.
+            after = "at boot (no GC: a boot that needs eviction to fit is a "
+            after += "sizing bug upstream)" if booting else "after disk GC"
             raise InsufficientDiskError(
-                f"need {remaining} more bytes for {ref} "
-                f"({total} manifest - {resident} already resident); "
-                f"{free} free after disk GC",
+                f"need {remaining} more bytes for {ref} — {plan.describe()}; "
+                f"{free} free {after}; {self._mount_report()}",
                 available_bytes=free, required_bytes=remaining,
                 path=str(self._cache_dir),
             )
@@ -1892,17 +1919,18 @@ class ModelStore:
             # list — th#1941 made it exactly what gets fetched.
             fetch_files = list(snapshot.files) if snapshot is not None else []
             if snapshot is not None and snapshot.files:
-                # Sizes are known up front for tensorhub snapshots: gate on
-                # disk headroom, GC-ing LRU refs first (#370).
+                # pgw#1631: THE PLAN IS COMPUTED ONCE AND THE GATE IS HANDED IT.
+                # The gate takes no manifest and no total, so it has nothing to
+                # re-price — which is what makes a divergent precondition
+                # unwritable rather than merely fixed (pgw#1596).
                 failure_stage = pb.LIFECYCLE_INTENT_STAGE_WAIT_DISK_HEADROOM
                 await self._ensure_disk_headroom(
                     ref,
-                    sum(int(f.size_bytes) for f in fetch_files),
+                    await asyncio.to_thread(
+                        fill_plan.plan_for_snapshot, self._cache_dir, fetch_files,
+                    ),
                     operation_identity,
                     intent_id=intent_id,
-                    # pgw#1596: the same list, so the gate can subtract what is
-                    # already banked instead of demanding the tree twice.
-                    files=fetch_files,
                 )
             last_progress = 0.0
             # opened before _progress so

--- a/tests/fill_fixture.py
+++ b/tests/fill_fixture.py
@@ -57,6 +57,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         if body is None:
             self.send_error(404)
             return
+        if origin.delay_s:
+            time.sleep(origin.delay_s)
         try:
             origin.charge(len(body))
         except _Refused:
@@ -88,6 +90,11 @@ class Origin:
         self.served = 0
         self.cutoff_bytes: Optional[int] = None
         self.refusals = 0
+        #: Per-object service delay. Not a timeout and not a clock the test
+        #: asserts on — it only widens the window in which a fill is genuinely
+        #: mid-flight, so a test that must observe "in flight" waits on BYTES
+        #: SERVED (:meth:`wait_until_served`) rather than on elapsed time.
+        self.delay_s = 0.0
         self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
         self.server.origin = self  # type: ignore[attr-defined]
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
@@ -115,11 +122,22 @@ class Origin:
         with self.lock:
             self.cutoff_bytes = cutoff_bytes
 
+    async def wait_until_served(self, at_least: int) -> None:
+        """Yield the loop until the origin has really served ``at_least`` bytes.
+
+        PROGRESS-KEYED, never clock-keyed: the caller wants "the fill is in
+        flight", and the only honest evidence of that is bytes that actually
+        left the origin.
+        """
+        while self.wire_bytes < at_least:
+            await asyncio.sleep(0.005)
+
     def reset(self) -> None:
         with self.lock:
             self.served = 0
             self.refusals = 0
             self.cutoff_bytes = None
+            self.delay_s = 0.0
 
     def close(self) -> None:
         self.server.shutdown()

--- a/tests/test_cas_boot_path_pgw1631.py
+++ b/tests/test_cas_boot_path_pgw1631.py
@@ -1,0 +1,623 @@
+"""pgw#1631: the CAS boot path on a pod bought for ONE release.
+
+All three of the 2026-08-21 store incidents lived in the bookkeeping ABOVE the
+byte bank — a stale-view precondition (pgw#1596), a compat copier (th#2246), an
+unclassified errno (pgw#1612) — and none of them in content addressing, which is
+what saved z-image and what makes the volume tier possible. So the bank stays
+and the multi-tenant machinery around it goes:
+
+* **the headroom gate consumes the fill PLAN**, so a divergent precondition is
+  unwritable rather than merely fixed;
+* **no GC during boot** — a boot that needs eviction to fit is a sizing bug
+  upstream, and evict-and-retry turns it into a slow expensive one. The gate
+  refuses with a typed `insufficient_disk` naming the mount;
+* **supersede never cancels byte movement** — objects are content-keyed, so
+  bytes an old plan is mid-way through fetching are bytes the new plan will find
+  present. What supersede means is that the old task's VERDICT stops counting;
+* **one writer per object** — tmp+rename under the CAS's own per-object lock is
+  the only commit, so th#2246's "every loser rmtree's and restarts from zero" is
+  not representable;
+* **an ENOSPC is a claim about the SHAPE** (pgw#1612), reported on the reason
+  the hub already has a migration path behind.
+
+Everything drives the real store, the real CAS and a real HTTP origin.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import shutil
+import threading
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from gen_worker import activity
+from gen_worker import boot_phases
+from gen_worker.boot_materialize import (
+    STATE_FAILED,
+    STATE_MATERIALIZING,
+    STATE_READY,
+    CheckpointConfig,
+    CheckpointMaterialization,
+)
+from gen_worker.capability import InsufficientDiskError
+from gen_worker.models import cozy_snapshot, disk_errors, fill_plan
+from gen_worker.models.refs import WireRef
+from gen_worker.models.store import _DISK_GC_MARGIN_BYTES, ModelStore
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from fill_fixture import (
+    FILL_OPS,
+    FillContext,
+    Origin,
+    Tree,
+    build_tree,
+    reset_fill_memos,
+    resident_bytes,
+    run_fill,
+    sha,
+)
+
+OBJECTS = 16
+OBJECT_BYTES = 128 * 1024
+_REF = WireRef("acme/boot-model")
+
+
+@pytest.fixture(autouse=True)
+def _clean_activity() -> Iterator[None]:
+    activity.reset_for_tests()
+    yield
+    activity.reset_for_tests()
+
+
+@pytest.fixture(scope="module")
+def origin() -> Iterator[Origin]:
+    served = Origin()
+    try:
+        yield served
+    finally:
+        served.close()
+
+
+@pytest.fixture(scope="module")
+def tree(origin: Origin) -> Tree:
+    return build_tree(origin, objects=OBJECTS, object_bytes=OBJECT_BYTES)
+
+
+def _ctx(tmp_path: Path, tree: Tree, origin: Origin) -> FillContext:
+    return FillContext(cache_dir=tmp_path / "cas", tree=tree, origin=origin, ref=_REF)
+
+
+async def _noop_emit(_msg: Any) -> None:
+    return None
+
+
+class _InBoot:
+    """The boot window, expressed the way `boot_phases` really decides it.
+
+    `in_boot()` is "this worker CANNOT SERVE" — true while `_servable_ms` is
+    unset. A fresh recorder is therefore already in boot, which is also why the
+    steady-state control below has to mark the milestone explicitly rather than
+    assume it.
+    """
+
+    def __enter__(self) -> "_InBoot":
+        boot_phases.reset_for_tests()
+        assert boot_phases.in_boot()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        boot_phases.reset_for_tests()
+
+
+class _Servable:
+    """Past the boot window: the worker has been servable, so this is steady state."""
+
+    def __enter__(self) -> "_Servable":
+        boot_phases.reset_for_tests()
+        # `first_request_servable` is HELD until `hello` — a worker the hub
+        # cannot reach is not servable (pgw#797) — so the milestone needs the
+        # hello row first, exactly as a real boot does.
+        boot_phases.mark(boot_phases.PHASE_HELLO)
+        boot_phases.mark(boot_phases.PHASE_FIRST_REQUEST_SERVABLE)
+        assert not boot_phases.in_boot()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        boot_phases.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# 1. The gate consumes the plan — one predicate, no second derivation
+# ---------------------------------------------------------------------------
+
+
+def test_the_fill_and_the_gate_call_the_same_predicate(
+    tmp_path: Path, tree: Tree, origin: Origin
+) -> None:
+    """`cozy_snapshot`'s skip and the gate's plan are ONE function.
+
+    pgw#1596 happened because there were two: the gate walked the manifest, the
+    fill walked the store. This is the structural half — both routes are proven
+    to go through `fill_plan.is_present` by making that one function lie and
+    watching BOTH answers move together.
+    """
+
+    from gen_worker._vendor.tensorfs import LocalCAS
+
+    cas = LocalCAS(tmp_path / "cas")
+    body = tree.files[0][1]
+    cas.put_bytes(body)
+
+    plan = fill_plan.plan_fill(cas, [
+        type("F", (), {"digest": sha(body), "size_bytes": len(body), "path": "a"})(),
+    ])
+    assert plan.present_bytes == len(body) and plan.missing_bytes == 0
+
+    # `resident()` inside `_ensure_objects` is the fill's own skip; it is the
+    # same call, so a store that reports absent makes both say "fetch".
+    assert fill_plan.is_present(cas, sha(body), len(body))
+    assert not fill_plan.is_present(cas, sha(body), len(body) + 1), (
+        "a declared size mismatch is ABSENT — a truncated object must not be "
+        "skipped by either side"
+    )
+
+
+def test_the_fill_loop_routes_its_skip_through_fill_plan() -> None:
+    """The lint half: `_ensure_objects` may not spell the predicate itself."""
+
+    import inspect
+
+    source = inspect.getsource(cozy_snapshot.CozySnapshotDownloader._ensure_objects)
+    assert "fill_plan.is_present" in source, (
+        "the fill's skip must call the shared predicate"
+    )
+    assert "cas.contains(" not in source, (
+        "a second spelling of the skip predicate is how pgw#1596 happened"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. No GC during boot
+# ---------------------------------------------------------------------------
+
+
+def test_a_boot_that_does_not_fit_REFUSES_instead_of_evicting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE RULING. Boot never evicts to make room for itself.
+
+    A boot that needs eviction to fit is a sizing bug upstream (th#2264).
+    Evicting turns a fast, actionable refusal into th#2246's shape: two A100
+    pods, ~$1.72, and a human cancelling a retry loop that was doomed before it
+    was paid for. The refusal names the mount and its statvfs totals so the hub
+    can demote the shape rather than re-buy it.
+    """
+
+    calls: list[int] = []
+    store = ModelStore(_noop_emit, cache_dir=tmp_path / "cas", disk_free_bytes_fn=lambda: 0)
+    monkeypatch.setattr(
+        ModelStore, "gc_disk",
+        lambda self, target, exclude=(): calls.append(int(target)),
+    )
+    plan = fill_plan.FillPlan(
+        missing=(fill_plan.PlannedObject("sha256:" + "a" * 64, 4096),)
+    )
+
+    with _InBoot():
+        with pytest.raises(InsufficientDiskError) as caught:
+            asyncio.run(store._ensure_disk_headroom(_REF, plan))
+
+    assert calls == [], f"gc_disk ran during boot: targets={calls}"
+    text = str(caught.value)
+    assert "mount=" in text and "statvfs_total=" in text and "statvfs_free=" in text
+    assert "4096 missing" in text
+    assert "no GC" in text, "the refusal must say WHY it did not evict"
+    assert caught.value.required_bytes == 4096
+
+
+def test_steady_state_still_evicts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE CONTROL. Outside boot, eviction is what the disk tier is FOR.
+
+    Deleting GC everywhere would be a different bug: a long-lived pod whose LRU
+    never releases anything fills its disk and refuses work it could have done.
+    """
+
+    calls: list[int] = []
+    freed = {"after": 0}
+    store = ModelStore(
+        _noop_emit,
+        cache_dir=tmp_path / "cas",
+        disk_free_bytes_fn=lambda: freed["after"],
+    )
+
+    def _gc(self: Any, target: int, exclude: Any = ()) -> None:
+        calls.append(int(target))
+        freed["after"] = int(target)  # the eviction worked
+
+    monkeypatch.setattr(ModelStore, "gc_disk", _gc)
+    plan = fill_plan.FillPlan(
+        missing=(fill_plan.PlannedObject("sha256:" + "a" * 64, 4096),)
+    )
+
+    with _Servable():
+        asyncio.run(store._ensure_disk_headroom(_REF, plan))
+    assert calls == [4096 + _DISK_GC_MARGIN_BYTES], (
+        "steady state must still try to make room, and must ask for exactly "
+        f"the plan's missing bytes plus the margin; got {calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Supersede never cancels byte movement
+# ---------------------------------------------------------------------------
+
+
+def _config(version: int, ref: WireRef, snapshot: pb.Snapshot) -> CheckpointConfig:
+    desired = pb.DesiredResidency(generation=version, disk_refs=[str(ref)])
+    desired.snapshots[str(ref)].CopyFrom(snapshot)
+    return CheckpointConfig.from_wire(desired)
+
+
+def test_an_unchanged_config_is_a_no_op_and_starts_nothing(
+    tmp_path: Path, tree: Tree, origin: Origin
+) -> None:
+    """A RECONNECT re-delivers the same config. It must move no bytes.
+
+    The re-entry that armed pgw#1596 was a supersede that changed nothing about
+    the ref — so this is the arm that keeps the whole class from starting.
+    """
+
+    ctx = _ctx(tmp_path, tree, origin)
+    snapshot = tree.snapshot()
+
+    async def run() -> tuple[str, int]:
+        store = ctx.store()
+        mat = CheckpointMaterialization(store)
+        mat.configure(_config(1, _REF, snapshot))
+        task = mat._task
+        assert task is not None
+        await task
+        for _ in range(8):
+            await asyncio.sleep(0)
+        after_first = origin.wire_bytes
+        # Same identity, a NEW version number: the version is not part of
+        # identity, so this changes nothing.
+        mat.configure(_config(2, _REF, snapshot))
+        assert mat._task is task, "an unchanged config started a second fill"
+        return mat.state, after_first
+
+    origin.reset()
+    state, first = asyncio.run(run())
+    assert state == STATE_READY
+    assert first == tree.total_bytes
+    assert origin.wire_bytes == first, "an unchanged re-push moved bytes"
+
+
+def test_a_supersede_lets_the_in_flight_fill_DRAIN(
+    tmp_path: Path, tree: Tree, origin: Origin
+) -> None:
+    """THE CHANGE. A new config does not cancel the old one's byte movement.
+
+    Objects are release-agnostic by content key, so bytes the old plan is
+    mid-way through fetching are bytes the NEW plan's fill finds present.
+    Cancelling them buys nothing and costs the re-fetch — the class th#2204
+    measured as phantom downloads and pgw#1596 turned into a disk-capacity
+    incident.
+
+    Asserted three ways: the old task is not cancelled, its bytes are in the
+    CAS when it finishes, and its verdict does not touch readiness.
+    """
+
+    ctx = _ctx(tmp_path, tree, origin)
+    snapshot = tree.snapshot()
+    other = tree.snapshot()
+    other.digest = "sha256:" + "d" * 64  # a genuinely different plan
+
+    async def run() -> dict[str, Any]:
+        store = ctx.store()
+        mat = CheckpointMaterialization(store)
+        # Slow the origin so the fill is genuinely MID-FLIGHT when the
+        # supersede lands. The wait below is on BYTES SERVED, not on a clock:
+        # "in flight" is a progress fact, and asserting it off elapsed time is
+        # the magic-timeout shape this repo bans.
+        origin.delay_s = 0.02
+        mat.configure(_config(1, _REF, snapshot))
+        first = mat._task
+        assert first is not None
+        await origin.wait_until_served(OBJECT_BYTES)
+        assert not first.done(), "the fill finished before it could be superseded"
+        mat.configure(_config(2, WireRef("acme/other-model"), other))
+        second = mat._task
+        assert second is not None and second is not first, (
+            "a changed config must start a new fill"
+        )
+        assert not first.cancelled() and not first.done(), (
+            "the superseded fill was cancelled — its bytes are content-keyed "
+            "and the successor wants them"
+        )
+        state_at_supersede = mat.state
+        served_at_supersede = origin.wire_bytes
+        origin.delay_s = 0.0
+        await asyncio.gather(first, second, return_exceptions=True)
+        for _ in range(8):
+            await asyncio.sleep(0)
+        return {
+            "first_cancelled": first.cancelled(),
+            "state_at_supersede": state_at_supersede,
+            "served_at_supersede": served_at_supersede,
+            "state": mat.state,
+        }
+
+    origin.reset()
+    out = asyncio.run(run())
+    assert 0 < out["served_at_supersede"] < tree.total_bytes, (
+        "the supersede did not land mid-flight, so this proves nothing about "
+        "cancelling byte movement"
+    )
+
+    assert out["first_cancelled"] is False
+    assert out["state_at_supersede"] == STATE_MATERIALIZING
+    # The superseded plan's bytes LANDED — that is the whole point.
+    assert resident_bytes(ctx.cache_dir, tree) == tree.total_bytes, (
+        "the drained fill did not bank its objects"
+    )
+    # ...and a successor over the same objects now fetches nothing.
+    origin.reset()
+    reset_fill_memos()
+    run_fill(_ctx_at(ctx), FILL_OPS[0])
+    assert origin.wire_bytes == 0, (
+        f"the successor re-fetched {origin.wire_bytes} bytes the superseded "
+        f"fill had already banked"
+    )
+
+
+def _ctx_at(ctx: FillContext) -> FillContext:
+    """A fresh process view of the SAME store."""
+    return FillContext(
+        cache_dir=ctx.cache_dir, tree=ctx.tree, origin=ctx.origin, ref=_REF,
+    )
+
+
+def test_a_superseded_fill_decides_nothing_about_readiness(
+    tmp_path: Path, tree: Tree, origin: Origin
+) -> None:
+    """A stale verdict must not strand — or falsely advertise — this pod.
+
+    Draining the old fill is only safe if its ANSWER stops counting. A stale
+    FAILED would strand a pod whose live config is fine; a stale READY would
+    advertise weights the live config does not name.
+    """
+
+    ctx = _ctx(tmp_path, tree, origin)
+    doomed = tree.snapshot()
+    doomed.digest = "sha256:" + "e" * 64
+    for f in doomed.files:
+        f.url = f.url.rsplit("/", 1)[0] + "/sha256:" + "f" * 64  # 404s
+
+    live = tree.snapshot()
+
+    async def run() -> str:
+        store = ctx.store()
+        mat = CheckpointMaterialization(store)
+        mat.configure(_config(1, WireRef("acme/doomed"), doomed))
+        first = mat._task
+        assert first is not None
+        mat.configure(_config(2, _REF, live))
+        second = mat._task
+        assert second is not None
+        await asyncio.gather(first, second, return_exceptions=True)
+        for _ in range(8):
+            await asyncio.sleep(0)
+        return mat.state
+
+    origin.reset()
+    state = asyncio.run(run())
+    assert state == STATE_READY, (
+        f"the superseded fill's failure decided readiness: state={state}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. One writer per object
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_writers_of_one_object_converge_without_restarting(
+    tmp_path: Path,
+) -> None:
+    """th#2246's "every loser rmtree's and restarts from zero", made unrepresentable.
+
+    The unit of work is ONE object under the CAS's own per-object lock, and the
+    only commit is tmp+link/replace. Contenders therefore converge: every writer
+    succeeds, exactly one object exists, its bytes are correct, and no writer
+    has to discard work and start over. No extra machinery was needed for this —
+    it is a property of the bank the review said to keep, and this test is here
+    so a change that breaks it cannot land quietly.
+    """
+
+    from gen_worker._vendor.tensorfs import LocalCAS
+
+    cas = LocalCAS(tmp_path / "cas")
+    payload = b"contended-object-" + b"z" * 200_000
+    digest = sha(payload)
+    barrier = threading.Barrier(8)
+    errors: list[BaseException] = []
+
+    def writer(i: int) -> None:
+        source = tmp_path / f"src-{i}.bin"
+        source.write_bytes(payload)
+        try:
+            barrier.wait(30)
+            cas.put_file(source, expected=digest, size=len(payload))
+        except BaseException as exc:  # noqa: BLE001 — the test IS the report
+            errors.append(exc)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(60)
+
+    assert not errors, f"a contender failed rather than converging: {errors}"
+    assert cas.contains(digest, size=len(payload))
+    assert cas.object_path(digest).read_bytes() == payload
+    # Nothing left behind in the temp lane: a loser that rmtree'd a shared
+    # directory is exactly the shape that made th#2246 restart from zero.
+    assert list(cas.tmp.glob("*")) == []
+
+
+# ---------------------------------------------------------------------------
+# 5. pgw#1612 — an ENOSPC is a claim about the SHAPE
+# ---------------------------------------------------------------------------
+
+
+def test_an_enospc_anywhere_in_the_chain_is_classified() -> None:
+    """Errno 28, however it is wrapped. Reading only the outermost type is how
+    a deterministic disk failure reads as a generic one."""
+
+    bare = OSError(errno.ENOSPC, "No space left on device", "/tmp/x/y.safetensors")
+    assert disk_errors.out_of_space(bare) is bare
+
+    wrapped = RuntimeError("load failed")
+    wrapped.__cause__ = bare
+    assert disk_errors.out_of_space(wrapped) is bare
+
+    ctx_only = RuntimeError("export failed")
+    ctx_only.__context__ = bare
+    assert disk_errors.out_of_space(ctx_only) is bare
+
+    inside_shutil = shutil.Error([("a", "b", bare)])
+    assert disk_errors.out_of_space(inside_shutil) is bare
+
+    # And nothing else is a capacity claim. Inventing one out of an unrelated
+    # error is worse than the generic bucket: the hub ACTS on this token.
+    assert disk_errors.out_of_space(OSError(errno.EACCES, "denied")) is None
+    assert disk_errors.out_of_space(RuntimeError("disk is full, honest")) is None
+
+
+def test_the_classified_reason_names_the_mount_and_its_totals(tmp_path: Path) -> None:
+    """Carry the FACT, not just the token.
+
+    "the container disk was 100 GB and the boot needed 121 GB" has to be
+    readable off the wire, or a lane re-derives it weeks later — which is
+    exactly what th#2246 had to do.
+    """
+
+    victim = tmp_path / "cas" / "objects" / "aa" / "blob"
+    victim.parent.mkdir(parents=True)
+    exc = OSError(errno.ENOSPC, "No space left on device", str(victim))
+    typed = disk_errors.as_insufficient_disk(
+        exc, doing="materializing acme/x", fallback_path=tmp_path
+    )
+    assert typed is not None
+    text = str(typed)
+    assert "materializing acme/x" in text
+    assert str(victim) in text
+    assert "statvfs_total=" in text and "statvfs_free=" in text
+
+
+def test_the_hub_reason_is_the_bare_token_and_the_facts_ride_the_activity_stream(
+    tmp_path: Path,
+) -> None:
+    """RED-ARMED WIRE CONTRACT. `connect_worker.go:3737` reads
+    `strings.TrimSpace(ev.GetError())` and compares it for EXACT equality
+    against `insufficient_disk`, so appending detail after a colon — the way
+    `download_failed` does — silently disables the entire migration path.
+
+    The facts therefore go where they are readable: a typed `residency_fault`
+    activity event, which lands in `worker_activity_events`. pgw#1620's lesson —
+    a confession that only reaches a pod's stdout reaches nobody.
+    """
+
+    sent: list[pb.WorkerMessage] = []
+
+    async def emit(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    async def run() -> None:
+        activity.bind_sink(emit, asyncio.get_running_loop())
+        store = ModelStore(emit, cache_dir=tmp_path / "cas")
+        await store.report_insufficient_disk(
+            _REF, "no space left while materializing acme/x; mount=/ statvfs_total=7"
+        )
+        for _ in range(8):
+            await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    failures = [
+        m.model_event for m in sent
+        if m.WhichOneof("msg") == "model_event"
+        and m.model_event.state == pb.MODEL_STATE_FAILED
+    ]
+    assert len(failures) == 1
+    assert failures[0].error == "insufficient_disk", (
+        f"the hub compares this for EXACT equality; got {failures[0].error!r}"
+    )
+
+    facts = [
+        m.activity_update for m in sent
+        if m.WhichOneof("msg") == "activity_update"
+        and m.activity_update.kind == activity.KIND_RESIDENCY_FAULT
+    ]
+    assert facts, "the mount facts reached nobody"
+    assert facts[0].phase == "insufficient_disk"
+    assert "statvfs_total=7" in facts[0].detail
+
+
+def test_a_boot_enospc_reaches_the_hub_as_insufficient_disk(
+    tmp_path: Path, tree: Tree, origin: Origin, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pgw#1612's ask, end to end through the boot seam.
+
+    th#2246: `qwen-image` ENOSPC'd on `8gpqows0j349gm` (A100-SXM4-80GB, 100 GB)
+    and requeued onto `3zod6pwvn10f4y` — another A100-SXM4-80GB with the same
+    100 GB — at $1.59/hr until a human cancelled it. Deterministic failure,
+    unbounded retry, real money. The pre-fix code reports this as a generic
+    failure; the failure below is a LOAD-side ENOSPC, not the download's, which
+    is the half that had no classifier at all.
+    """
+
+    ctx = _ctx(tmp_path, tree, origin)
+    sent: list[pb.WorkerMessage] = []
+
+    async def emit(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    boom = OSError(errno.ENOSPC, "No space left on device", str(tmp_path / "cas" / "x"))
+
+    async def run() -> str:
+        store = ModelStore(emit, cache_dir=ctx.cache_dir)
+        # An ENOSPC raised INSIDE the materialization, from something that is
+        # not the downloader — a cache write, an export, a projection.
+        async def _explode(*_a: Any, **_k: Any) -> Path:
+            raise RuntimeError("staging the tree failed") from boom
+
+        monkeypatch.setattr(ModelStore, "ensure_local", _explode)
+        mat = CheckpointMaterialization(store)
+        mat.configure(_config(1, _REF, tree.snapshot()))
+        task = mat._task
+        assert task is not None
+        await asyncio.gather(task, return_exceptions=True)
+        for _ in range(8):
+            await asyncio.sleep(0)
+        return mat.state
+
+    state = asyncio.run(run())
+    assert state == STATE_FAILED
+
+    reasons = [
+        m.model_event.error for m in sent
+        if m.WhichOneof("msg") == "model_event"
+        and m.model_event.state == pb.MODEL_STATE_FAILED
+    ]
+    assert "insufficient_disk" in reasons, (
+        f"a boot ENOSPC reached the hub as {reasons} — the hub requeues that "
+        f"onto a machine with the identical container_disk_gb_requested"
+    )

--- a/tests/test_disk_headroom_restart_pgw1596.py
+++ b/tests/test_disk_headroom_restart_pgw1596.py
@@ -5,8 +5,8 @@ manifest, with nothing subtracting the part of that same manifest already in the
 CAS. First pass over an empty disk: correct. RE-ENTRY: self-defeating — the
 bytes already fetched are counted as consumed AND demanded again as free, so a
 materialization restarted by an ordinary residency-generation supersede can
-never satisfy its own check. It needs 2x the tree and dies at the END of its own
-pull.
+never satisfy its own check. It needs 2x the tree and it dies at the END of its
+own pull.
 
 MEASURED, pod `6uneiwhdl7fz8u`, H200, 159 GB container disk, 2026-08-20:
 
@@ -20,6 +20,11 @@ disk-to-tree ratio (208 GB / 144 GB = 1.44 vs 159 / 105 = 1.51) succeeded,
 because it checked ONCE against an empty disk — which is what rules out "the
 disk was simply too small" and points at re-entry.
 
+pgw#1631 promoted the fix from patch to construction: the gate now takes the
+fill's PLAN and has no manifest to re-price. These cases are therefore stated in
+plans rather than in (total, files) pairs — the arithmetic under test is
+identical, and there is one less way to express it wrong.
+
 The scenario numbers below are those bytes, scaled by 1/1000 so the test is
 cheap; the RATIO that decides pass/fail is preserved exactly.
 """
@@ -28,11 +33,12 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 
 import pytest
 
 from gen_worker.capability import InsufficientDiskError
+from gen_worker.models.fill_plan import FillPlan, PlannedObject, plan_fill
 from gen_worker.models.refs import WireRef
 from gen_worker.models.store import _DISK_GC_MARGIN_BYTES, ModelStore
 
@@ -40,14 +46,6 @@ from gen_worker.models.store import _DISK_GC_MARGIN_BYTES, ModelStore
 TREE_BYTES = 104_956_706
 RESIDENT_BYTES = 86_200_000
 REMAINING_BYTES = TREE_BYTES - RESIDENT_BYTES  # ~18.76 MB
-
-
-class _File:
-    """A SnapshotFile as the gate reads it: a digest and a size."""
-
-    def __init__(self, digest: str, size_bytes: int) -> None:
-        self.digest = digest
-        self.size_bytes = size_bytes
 
 
 async def _emit(_msg: Any) -> None:
@@ -62,23 +60,20 @@ def _store(tmp_path: Path, free: int) -> ModelStore:
     )
 
 
-def _files_with_resident(store: ModelStore, monkeypatch: pytest.MonkeyPatch) -> List[_File]:
+def _partial_plan() -> FillPlan:
     """One resident object and one missing one, summing to the whole tree."""
-    resident = _File("sha256:" + "a" * 64, RESIDENT_BYTES)
-    missing = _File("sha256:" + "b" * 64, REMAINING_BYTES)
-    held = {resident.digest}
-    monkeypatch.setattr(
-        ModelStore,
-        "_already_resident_bytes",
-        lambda self, files: sum(
-            int(f.size_bytes) for f in (files or []) if f.digest in held
-        ),
+    return FillPlan(
+        present=(PlannedObject("sha256:" + "a" * 64, RESIDENT_BYTES),),
+        missing=(PlannedObject("sha256:" + "b" * 64, REMAINING_BYTES),),
     )
-    return [resident, missing]
+
+
+def _cold_plan() -> FillPlan:
+    return FillPlan(missing=(PlannedObject("sha256:" + "c" * 64, TREE_BYTES),))
 
 
 def test_a_partially_resident_ref_passes_on_its_REMAINING_bytes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
     """THE REGRESSION. Free space covers what is missing but not the whole tree.
 
@@ -91,26 +86,22 @@ def test_a_partially_resident_ref_passes_on_its_REMAINING_bytes(
         "the scenario is only meaningful when the WHOLE tree would NOT fit"
     )
     store = _store(tmp_path, free)
-    files = _files_with_resident(store, monkeypatch)
 
     # No raise == the gate charged the remainder, not the tree.
     asyncio.run(
-        store._ensure_disk_headroom(WireRef("acme/model@prod"), TREE_BYTES, files=files)
+        store._ensure_disk_headroom(WireRef("acme/model@prod"), _partial_plan())
     )
 
 
 def test_the_gate_still_refuses_when_even_the_REMAINDER_does_not_fit(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
     """The twin one input away. Subtracting resident bytes must not disarm it."""
     store = _store(tmp_path, REMAINING_BYTES // 2)
-    files = _files_with_resident(store, monkeypatch)
 
     with pytest.raises(InsufficientDiskError) as caught:
         asyncio.run(
-            store._ensure_disk_headroom(
-                WireRef("acme/model@prod"), TREE_BYTES, files=files
-            )
+            store._ensure_disk_headroom(WireRef("acme/model@prod"), _partial_plan())
         )
     # required_bytes is the REMAINDER, and the message shows its working — the
     # old message named only the whole tree, which is why an 86 GB-resident
@@ -118,7 +109,9 @@ def test_the_gate_still_refuses_when_even_the_REMAINDER_does_not_fit(
     assert caught.value.required_bytes == REMAINING_BYTES
     text = str(caught.value)
     assert str(REMAINING_BYTES) in text
-    assert str(RESIDENT_BYTES) in text and "already resident" in text
+    assert str(RESIDENT_BYTES) in text and "already banked" in text
+    # pgw#1612: and it names the mount it ran out on.
+    assert "mount=" in text
 
 
 def test_a_cold_disk_is_unchanged_and_still_charges_the_whole_tree(
@@ -126,74 +119,81 @@ def test_a_cold_disk_is_unchanged_and_still_charges_the_whole_tree(
 ) -> None:
     """Nothing resident means remaining == total. The first-pass case must not move."""
     store = _store(tmp_path, TREE_BYTES // 2)
-    files = [_File("sha256:" + "c" * 64, TREE_BYTES)]
 
     with pytest.raises(InsufficientDiskError) as caught:
         asyncio.run(
-            store._ensure_disk_headroom(
-                WireRef("acme/model@prod"), TREE_BYTES, files=files
-            )
+            store._ensure_disk_headroom(WireRef("acme/model@prod"), _cold_plan())
         )
     assert caught.value.required_bytes == TREE_BYTES
 
 
-def test_no_files_argument_keeps_the_old_whole_tree_behaviour(tmp_path: Path) -> None:
-    """Callers that cannot name their files are charged the full amount.
+def test_a_file_with_no_digest_is_charged_for(tmp_path: Path) -> None:
+    """A caller whose manifest cannot name an object is charged the full amount.
 
-    The subtraction is an OPTIMISATION AGAINST A KNOWN LIST, never an
-    assumption. A caller with no manifest must not get a cheaper gate.
+    The subtraction is an OPTIMISATION AGAINST A KNOWN OBJECT, never an
+    assumption. An entry with no digest is unplannable, so the plan counts it
+    as missing — the honest direction, since it will be fetched.
     """
+    from gen_worker._vendor.tensorfs import LocalCAS
+
+    class _File:
+        def __init__(self, digest: str, size_bytes: int) -> None:
+            self.digest = digest
+            self.size_bytes = size_bytes
+
+    plan = plan_fill(LocalCAS(tmp_path / "cas"), [_File("", TREE_BYTES)])
+    assert plan.missing_bytes == TREE_BYTES
+    assert plan.undigested and plan.present_bytes == 0
+
     store = _store(tmp_path, TREE_BYTES // 2)
     with pytest.raises(InsufficientDiskError) as caught:
-        asyncio.run(
-            store._ensure_disk_headroom(WireRef("acme/model@prod"), TREE_BYTES)
-        )
+        asyncio.run(store._ensure_disk_headroom(WireRef("acme/model@prod"), plan))
     assert caught.value.required_bytes == TREE_BYTES
 
 
-def test_an_overstated_residency_cannot_talk_the_gate_out_of_existence(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_the_gate_cannot_be_talked_out_of_existence_by_a_bad_reading(
+    tmp_path: Path,
 ) -> None:
-    """A stale reading claiming MORE resident than the tree holds is clamped.
+    """pgw#1631 deletes the failure mode rather than clamping it.
 
-    Otherwise a bad residency answer becomes a negative requirement and the
-    gate passes anything — the failure mode that turns a guard into a no-op.
+    The pre-plan gate did `remaining = total - resident` and had to clamp,
+    because an overstated residency produced a NEGATIVE requirement and the gate
+    passed anything. A plan cannot overstate: `missing_bytes` is a sum over a
+    disjoint list, so it is non-negative and bounded by the total by
+    construction. There is no subtraction left to go wrong.
     """
-    monkeypatch.setattr(
-        ModelStore, "_already_resident_bytes", lambda self, files: TREE_BYTES * 10
-    )
-    store = _store(tmp_path, 0)
-    files = [_File("sha256:" + "d" * 64, TREE_BYTES)]
-
-    with pytest.raises(InsufficientDiskError) as caught:
-        asyncio.run(
-            store._ensure_disk_headroom(
-                WireRef("acme/model@prod"), TREE_BYTES, files=files
-            )
-        )
-    assert caught.value.required_bytes == 0, "clamped to zero, never negative"
+    plan = _partial_plan()
+    assert plan.missing_bytes >= 0
+    assert plan.missing_bytes + plan.present_bytes == plan.total_bytes == TREE_BYTES
+    assert plan.missing_bytes <= plan.total_bytes
 
 
 def test_the_real_predicate_reads_the_cas(tmp_path: Path) -> None:
-    """`_already_resident_bytes` must answer from the CAS, not from a promise.
+    """`plan_fill` must answer from the CAS, not from a promise.
 
-    The other tests stub the predicate to control the scenario; this one runs
-    the real thing so the stub can never be the only thing that works.
+    The other tests state plans directly to control the scenario; this one runs
+    the real predicate so a stated plan can never be the only thing that works.
     """
     from gen_worker._vendor.tensorfs import LocalCAS
+
+    class _File:
+        def __init__(self, digest: str, size_bytes: int) -> None:
+            self.digest = digest
+            self.size_bytes = size_bytes
 
     cas_dir = tmp_path / "cas"
     cas = LocalCAS(cas_dir)
     payload = b"resident-object-bytes"
     ref = cas.put_bytes(payload)
 
-    store = _store(tmp_path, 0)
-    present = _File(str(ref), len(payload))
-    absent = _File("sha256:" + "e" * 64, 999_999)
-    nodigest = _File("", 12_345)
+    plan = plan_fill(cas, [
+        _File(str(ref), len(payload)),
+        _File("sha256:" + "e" * 64, 999_999),
+        _File("", 12_345),
+    ])
 
-    got = store._already_resident_bytes([present, absent, nodigest])
-    assert got == len(payload), (
+    assert plan.present_bytes == len(payload), (
         "only the object actually in the CAS counts; a missing object and a "
         "file with no digest are both absent"
     )
+    assert plan.missing_bytes == 999_999 + 12_345

--- a/tests/test_ensure_idempotence_pgw1632.py
+++ b/tests/test_ensure_idempotence_pgw1632.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import ast
 import inspect
-import re
+import textwrap
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -286,8 +286,9 @@ def test_the_harness_is_red_against_the_pre_pgw1596_gate(
     which is what killed a 105 GB pull 157 MB from the end on a real H200.
 
     A harness that cannot go red proves nothing, so the pre-fix behaviour is
-    reconstructed exactly (`resident = 0`) and the resume is asserted to
-    REFUSE.
+    reconstructed exactly — a plan whose every object reads as MISSING, which
+    is what a gate priced off the request rather than the delta computes — and
+    the resume is asserted to REFUSE.
     """
 
     _no_retry(monkeypatch)
@@ -308,7 +309,16 @@ def test_the_harness_is_red_against_the_pre_pgw1596_gate(
     assert origin.wire_bytes == total - banked
 
     # Now the pre-fix gate, on the same state: it demands the whole tree free.
-    monkeypatch.setattr(ModelStore, "_already_resident_bytes", lambda self, files: 0)
+    from gen_worker.models import fill_plan as fill_plan_mod
+
+    real_plan = fill_plan_mod.plan_for_snapshot
+
+    def _price_the_request(cache_dir: object, files: list[object]) -> object:
+        """The pre-pgw#1596 shape: every object of the manifest is 'missing'."""
+        whole = real_plan(cache_dir, files)
+        return fill_plan_mod.FillPlan(missing=whole.present + whole.missing)
+
+    monkeypatch.setattr(fill_plan_mod, "plan_for_snapshot", _price_the_request)
     fresh = _ctx(tmp_path, tree, origin, budget=one_tree_budget)
     with pytest.raises(InsufficientDiskError) as caught:
         run_fill(fresh, FILL_OPS[0])
@@ -360,12 +370,13 @@ def test_the_gate_and_the_fill_agree_about_what_is_missing(
     snapshot = tree.snapshot()
     import asyncio
 
+    from gen_worker.models.fill_plan import plan_for_snapshot
+
+    plan = plan_for_snapshot(ctx.cache_dir, list(snapshot.files))
     with pytest.raises(InsufficientDiskError) as caught:
         asyncio.run(
             starved.store()._ensure_disk_headroom(
-                WireRef("acme/harness-model"),
-                total,
-                files=list(snapshot.files),
+                WireRef("acme/harness-model"), plan,
             )
         )
     gate_says = caught.value.required_bytes
@@ -384,8 +395,8 @@ def test_the_gate_and_the_fill_agree_about_what_is_missing(
 
 
 def _gate_source() -> ast.FunctionDef:
-    source = inspect.getsource(ModelStore._ensure_disk_headroom)
-    tree_ = ast.parse(re.sub(r"^\s{4}", "", source, flags=re.MULTILINE))
+    source = textwrap.dedent(inspect.getsource(ModelStore._ensure_disk_headroom))
+    tree_ = ast.parse(source)
     node = tree_.body[0]
     assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     return node  # type: ignore[return-value]
@@ -421,9 +432,15 @@ def test_the_gate_derives_its_cost_from_the_one_predicate() -> None:
         isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "sum"
         for n in ast.walk(node)
     ), "the gate must be HANDED its cost, never sum one"
-    assert {"_already_resident_bytes", "_missing_bytes", "plan"} & names, (
-        "the gate must consume the fill's own skip predicate (or the plan it "
-        "produced); nothing else can be proven to agree with it"
+    assert "plan" in names, (
+        "the gate must consume the fill's own plan; nothing else can be proven "
+        "to agree with what the fill will skip"
+    )
+    # pgw#1631: and the plan is the ONLY size input. A manifest or a total in
+    # the signature is a thing the gate could price differently.
+    params = [a.arg for a in node.args.args + node.args.kwonlyargs]
+    assert "files" not in params and "needed_bytes" not in params, (
+        f"the gate's signature still admits a manifest to re-price: {params}"
     )
 
 


### PR DESCRIPTION
Closes pgw#1631. Folds in pgw#1612 (it was unowned — no PR, no worktree).

All three of the 2026-08-21 store incidents lived in the bookkeeping **above** the byte bank — a stale-view precondition (pgw#1596), a compat copier (th#2246), an unclassified errno (pgw#1612) — and none of them in content addressing, which is what saved z-image's 79 GB disk and what makes the volume tier possible. So the bank stays and the multi-tenant machinery around it goes.

## 1. The gate consumes the fill PLAN

pgw#1596 was a SHAPE bug, not an arithmetic one: the gate priced the **request** (walk the manifest, sum every file) while the fill priced the **delta** (skip what `contains(digest, size)` already answers for). Two derivations of one quantity drifted and a 105 GB pull died 157 MB from the end on a disk that fit it fine.

`models/fill_plan.py` holds ONE skip predicate (`is_present`) and ONE plan built from it.

- `_ensure_disk_headroom(ref, plan)` — no manifest, no total. There is nothing left to re-price.
- `cozy_snapshot._ensure_objects`' own `resident()` calls the same `fill_plan.is_present`.
- The clamp that stopped an overstated residency going NEGATIVE is deleted along with the subtraction that needed it: `missing_bytes` is a sum over a disjoint list, non-negative and bounded by the total by construction.

pgw#1632's structural lint tightens accordingly — the gate's *signature* may no longer admit `files=` or `needed_bytes`.

## 2. No GC during boot

A boot that needs eviction to fit is a sizing bug upstream (th#2264). Evict-and-retry turns a fast, actionable refusal into th#2246's shape: two A100 pods, ~$1.72 burned, a human cancelling a retry loop that was doomed before it was paid for.

At boot the gate raises a typed `insufficient_disk` naming the mount, its `statvfs` totals and the plan's missing bytes. **Steady state keeps the LRU GC** — there, eviction is what the disk tier is FOR, and deleting it everywhere would be a different bug. The gate is `in_boot()`, whose documented meaning is "this worker cannot serve" — exactly the window where a refusal is cheap and an eviction is a guess.

## 3. Supersede never cancels byte movement

`configure()` used to `cancel()` the in-flight fill on any config change. Objects are release-agnostic by content key, so bytes an old plan is mid-way through fetching are bytes the **new** plan's fill finds present. Cancelling buys nothing and costs the re-fetch — th#2204's phantom-download class, and the re-entry that armed pgw#1596 was a supersede that changed nothing about the ref.

The superseded fill now DRAINS (held by a strong reference, so the loop cannot collect a task that is still writing). What supersede means instead is that the old task's **verdict** stops counting: `_materialize` and the per-ref failure path both check `self._applied is config`, so a stale FAILED cannot strand a pod whose live config is fine and a stale READY cannot advertise weights the live config does not name.

**Red-armed**: restoring the `cancel()` fails `test_a_supersede_lets_the_in_flight_fill_DRAIN`. The mid-flight wait is on BYTES SERVED, never on a clock.

## 4. pgw#1612 — an ENOSPC is a claim about the SHAPE

`models/disk_errors.py` classifies errno 28 through `__cause__`, `__context__`, `ExceptionGroup` and `shutil.Error`'s nested triples, at ONE boot seam rather than per raiser. It refuses to guess from message text: inventing a capacity claim out of an unrelated error is worse than the generic bucket, because the hub ACTS on this token.

> ### ⚠️ The token is sent BARE, and that is a wire contract
>
> `tensorhub internal/orchestrator/grpc/connect_worker.go:3737` reads `failureReason := strings.TrimSpace(ev.GetError())` and compares it for **exact equality** against `modelFailureReasonDisk`. Appending detail after a colon — the way `download_failed` does two lines away in the same function — would have **silently disabled the entire capacity-migration path**. Read at HEAD, not recalled.

The facts (which mount ran out, its `statvfs` totals quoted from `disk_telemetry`) ride a typed `residency_fault` activity event instead, where they reach `worker_activity_events` and are readable off the wire. That is pgw#1620's lesson: a confession that only reaches a pod's stdout reaches nobody.

th#2246's receipt: `qwen-image` 0.5.17 ENOSPC'd on `8gpqows0j349gm` (A100-SXM4-80GB, 100 GB) and requeued onto `3zod6pwvn10f4y` — another A100-SXM4-80GB with the same 100 GB — at $1.59/hr until a human cancelled it.

## 5. One writer per object — already true, now fenced

The unit of work is one object under `LocalCAS`'s own per-object lock, with tmp + link/replace as the only commit. Eight concurrent contenders all succeed, exactly one object exists, its bytes are correct, and no writer discards work and starts over. th#2246's "every loser rmtree's and restarts from zero" was the **tier-3 materialized view**, not the bank — so no new machinery was added, just a test so the property cannot break quietly.

## Verification

- `tests/test_cas_boot_path_pgw1631.py` — 12 passed (real store, real CAS, real origin)
- `tests/test_disk_headroom_restart_pgw1596.py` — rewritten onto plans, same arithmetic, one less way to express it wrong
- battery of 10 store/boot/snapshot suites — 108 passed
- `mypy src/gen_worker tests` — clean, 630 files
- `ruff check src/gen_worker` — clean