### PR TITLE
pgw#1630: the watchdog verdict is KERNEL-EVIDENCE-ONLY — the activity system demotes to labelling, and failure to measure holds

### DIFF
--- a/changelog.d/pgw1630.md
+++ b/changelog.d/pgw1630.md
@@ -1,0 +1,66 @@
+- **pgw#1630: the compute-child watchdog kills on KERNEL EVIDENCE and on nothing else.**
+  The sharpest fact from the pgw#1613 kills is that the child *passed* the kernel-evidence
+  rung: the CAS fill kept `tree_evidence` advancing, `no_work_accrued` did not fire, and the
+  kill came from the rung below it — `loop_wedged_no_activity`. The parent looked at
+  kernel-accounted proof of life and SIGKILLed anyway, because a LABEL was missing, in direct
+  contradiction of `watchdog_loop`'s own docstring ("the parent kills only what is provably NOT
+  RUNNING"). Two H3 pods, two pins, byte-identical death at 356 s and 687 s, exit 137, pod
+  retired `all_declared_functions_disabled`, rental burned. pgw#1613 opened an activity at the
+  one site that had been killed; that closed one site and left the class, with every future
+  long-running path owing a ritual or dying. **Rung 3 is deleted.** Evidence advancing means
+  held, unconditionally. Loop pings, declared activities and in-flight counts are now REPORTING
+  ONLY — they label a stall and decide nothing, so a path that forgets to declare loses a
+  label, not a process.
+
+- **pgw#1630: escalation, not a cliff — report → diagnose → SIGTERM → SIGKILL.** The old
+  verdict went straight to `proc.kill()` and left nothing behind, which is why the H3 diagnosis
+  had to be reconstructed days later from a rental invoice. Each rung is one window past the
+  last and every rung requires flatness to have CONTINUED; any evidence advance resets the
+  ladder to zero, because a wedge that un-wedges mid-ladder was never a wedge. The new middle
+  rung captures a diagnosis while the child is still ALIVE — `/proc/<pid>/status` (with
+  `State: D` called out by name, since an uninterruptible wait is a stall the child could not
+  have avoided and a SIGTERM cannot end), `wchan`, `syscall`, the kernel stack, and a
+  bounded `py-spy dump` — written beside the other post-mortem artifacts so it survives a pod
+  with no logs API. Every reader is independently guarded and the capture never raises: a
+  diagnostic that can fail turns a stall into a crash.
+
+- **pgw#1630: the flatness window is DERIVED FROM OBSERVATION, not declared.**
+  `W = max(floor, 3 × the largest inter-progress gap this child has actually demonstrated)`.
+  A compile that legitimately ticks every 100 s earns a 300 s window; a loop that ticks every
+  200 ms is held to the floor. The largest gap only grows when evidence moves *again*, which is
+  what makes it a measurement of the child rather than of the wall clock — a gap is only known
+  to have been a gap once it ends. This satisfies the no-magic-timeouts rule rather than
+  restating it: the two clocks the old design ran on (a hardcoded 60 s budget no caller
+  overrode, and a hold window of 3× the child's self-reported PING CADENCE) are both gone, and
+  the one that remains measures absence of progress with a scale taken from the child's own
+  progress. The floor is `Settings.watchdog_flatness_floor_s`
+  (`GEN_WORKER_WATCHDOG_FLATNESS_FLOOR_S`), the operator lever pgw#1613 proved must exist, and
+  it can only ever LENGTHEN a window the observed gaps have not already justified. Its default
+  puts the earliest possible kill four windows out — eight minutes of provably-zero kernel work,
+  with a report at two and a captured diagnosis at four.
+
+- **pgw#1630: the sampling cadence and the flatness window are now SEPARATE knobs, because
+  they answer different questions.** `watchdog_budget_s` used to be both — how often the parent
+  looked, and how long silence was allowed — and collapsing the two is how the single-budget
+  cliff worked. It is now only a `/proc` sampling cadence (its constant says so), and the floor
+  under the flatness window is its own `liveness_floor_s` constructor argument on
+  `ParentControl`, taking precedence over `Settings` and then the derived default. Narrowing how
+  often the parent LOOKS must not silently narrow how long a child may legitimately be flat.
+  The integration test that reaps a SIGSTOPped child now says which of the two it means — and
+  SIGSTOP remains the honest wedge to test against, because a stopped process accrues no CPU
+  second and no byte of I/O, so it is flat by the kernel's own accounting rather than by a
+  missing label.
+
+- **pgw#1630: failure to measure HOLDS, and reports.** `no_evidence_source → KILL` inverted the
+  burden of proof: an unreadable `/proc` — a psutil import failure, a race on exit, a container
+  that lost the capability — became a death sentence. Absence of instrument is never guilt.
+  Both halves are closed, and the second is the one that is easy to miss: if the instrument
+  fails *after* a successful read, elapsed time keeps accruing while nothing is being measured,
+  so a ladder walking on it would kill a healthy child on the strength of an instrument outage.
+  A `None` sample is not a flat reading and the ladder refuses to walk while the last read
+  failed.
+
+- **pgw#1630: pgw#1613's activity scope STAYS, as telemetry.** "The activity decides nothing" is
+  not "the activity is pointless" — it is the label on `compute_child_stalled`, and the
+  difference between a filed bug and a shrug. Its acceptance tests are untouched, and a reading
+  of this issue that deletes the scope fails a test written to catch exactly that.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -75,7 +75,12 @@ KIND_SNAPSHOT_CENSUS = "snapshot_census"
 KIND_BOOT_STAGES = "boot_stages"
 KIND_ENGINE_BOOT = "engine_boot"
 KIND_WEIGHT_FETCH = "weight_fetch"
-# The boot materialization span is load-bearing, not telemetry: the compute-child watchdog (procsplit/parent.py _hang_verdict) decides by what activity is OPEN, so a long fill that declares nothing gets SIGKILLed while genuinely working.
+# pgw#1630: the boot materialization span is TELEMETRY. The watchdog verdict is
+# kernel evidence only (procsplit/liveness.py), so a fill that declares nothing
+# loses a LABEL, not a process. Its OWN kind, deliberately NOT `weight_fetch`:
+# that kind's rows are the closed-vocabulary BYTE POSITIONS
+# (`weight_position._emit`), and a span with an empty phase mixed into them
+# would corrupt the one signal th#2191 reads.
 KIND_BOOT_MATERIALIZE = "boot_materialize"
 PHASE_MINTED = "minted"
 

--- a/src/gen_worker/boot_materialize.py
+++ b/src/gen_worker/boot_materialize.py
@@ -163,7 +163,7 @@ class CheckpointMaterialization:
         )
 
     async def _materialize(self, config: CheckpointConfig) -> None:
-        """Put every configured ref on disk (in config order), then open the readiness gate. The fetch runs under an OPEN activity on purpose: the compute-child watchdog SIGKILLs a silent event loop with nothing open, and a cold multi-hundred-GB fill starves the loop for minutes. Scoped to the fetch only — _warm() opens its own activity and must not nest inside this one."""
+        """Put every configured ref on disk (in config order), then open the readiness gate. Order matters: a pod that fetched the 22 MB interpolator before the 134 GB checkpoint would finish the cheap half and still not serve. The fetch runs under an OPEN activity, which pgw#1630 demoted to TELEMETRY — the watchdog verdict is kernel evidence only, so forgetting it costs the stall report its label, not the process. Scoped to the fetch only: _warm() opens its own activity and must not nest inside this one."""
         with activity.running(activity.KIND_BOOT_MATERIALIZE) as fetch:
             if not await self._fetch_refs(config, fetch):
                 if self._current(config):

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -30,6 +30,7 @@ _ENV_TO_FIELD: Dict[str, str] = {
     "WORKER_CONFIG_GENERATION": "boot_config_generation",
     "WORKER_IMAGE_DIGEST": "worker_image_digest",
     "GEN_WORKER_BOOT_RECORD": "boot_record_path",
+    "GEN_WORKER_WATCHDOG_FLATNESS_FLOOR_S": "watchdog_flatness_floor_s",
     "TENSORHUB_URL": "tensorhub_url",
     "TENSORHUB_TOKEN": "tensorhub_token",
     "TENSORHUB_CACHE_DIR": "tensorhub_cache_dir",

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -34,6 +34,14 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     worker_image_digest: str = ""
 
     boot_record_path: str = ""
+    # pgw#1630: the FLOOR under the compute-child flatness window, in seconds.
+    # The window itself is derived from that child's own observed
+    # inter-progress gaps (procsplit/liveness.py); this only bounds it from
+    # below, and the ladder needs FOUR consecutive windows of provably-zero
+    # kernel work before anything is killed. 0 = the derived default. A knob
+    # because a fleet meeting a legitimately slower shape must be able to widen
+    # the window without a release.
+    watchdog_flatness_floor_s: float = 0.0
 
     tensorhub_url: str = ""
     tensorhub_token: str = ""

--- a/src/gen_worker/procsplit/liveness.py
+++ b/src/gen_worker/procsplit/liveness.py
@@ -1,0 +1,247 @@
+"""pgw#1630: the parent's kill decision, and NOTHING ELSE decides it.
+
+## The fact this module exists for
+
+In the pgw#1613 kills the child PASSED the kernel-evidence rung. The CAS fill
+kept ``tree_evidence`` advancing, so ``no_work_accrued`` did not fire — and the
+kill came from the next rung down, ``loop_wedged_no_activity``. The parent
+looked at kernel-accounted proof of life and killed anyway, because a LABEL was
+missing. `watchdog_loop`'s own docstring promises the opposite: *"The parent
+kills only what is provably NOT RUNNING; a child that runs but serves nothing is
+the hub's stall clock to reap."* Two pods, two pins, byte-identical death, exit
+137, `all_declared_functions_disabled`, rental burned.
+
+pgw#1613's fix opened an activity at the one site that had been killed. That
+closed one site and left the CLASS: every future long-running path owes a ritual
+or dies, and the price of keeping the cooperative design is a mandatory
+reprieve-test at every declaration site, forever.
+
+## The design
+
+1. **One evidence source.** ``proc_evidence.tree_evidence`` — tree CPU seconds
+   (live + reaped) plus IO MB, sampled by the parent against a high-water mark.
+   Zero cooperation, whole lifecycle including spawn->hello. A tenant can fake
+   it into looking ALIVE, never into looking WEDGED, and "alive but serving
+   nothing" is the hub's stall clock, exactly as the module already says.
+2. **One binary verdict.** Progress within the window -> alive. Flat beyond it
+   -> escalate. Loop pings, declared activities and in-flight counts decide
+   NOTHING; they are carried as the report's LABEL and nothing more.
+3. **Escalation, not a cliff.** report -> diagnose -> SIGTERM -> SIGKILL, one
+   window apart, and every rung requires flatness to have CONTINUED. Any
+   evidence advance resets the ladder to zero: a wedge that un-wedges mid-ladder
+   was never a wedge.
+4. **The window is DERIVED FROM OBSERVATION.** ``W = max(floor, k x the largest
+   inter-progress gap this child has actually demonstrated)``. A child that has
+   shown 40 s gaps during a compile earns a proportionally longer leash; one
+   that ticks every 200 ms gets a short one. This is the no-magic-timeouts rule
+   satisfied rather than restated: the only clock left measures ABSENCE OF
+   PROGRESS, and its scale comes from the child's own progress.
+5. **Failure to measure HOLDS.** An unreadable ``/proc`` — psutil import
+   failure, a race on exit — is absence of instrument, not guilt. It reports
+   and holds. Inverting the burden of proof there is how an instrument outage
+   becomes a kill.
+
+The asymmetry that justifies all of it: a false kill costs a cold reboot, a pod
+retirement and a burned rental; a missed wedge costs minutes until the hub's own
+request timeout catches it. So the reaper is biased hard toward "held" and kills
+only on what the kernel can prove.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+__all__ = [
+    "DEFAULT_FLATNESS_FLOOR_S",
+    "EvidenceTrack",
+    "RUNG_ALIVE",
+    "RUNG_DIAGNOSE",
+    "RUNG_KILL",
+    "RUNG_ORDER",
+    "RUNG_REPORT",
+    "RUNG_TERM",
+    "RUNG_UNMEASURABLE",
+    "WINDOW_SLACK",
+]
+
+#: The child is accruing kernel-accounted work. Nothing else needs to be true.
+RUNG_ALIVE = "alive"
+#: Flat past one window: SAY SO, with whatever label the telemetry has. No
+#: signal, no state change — the report is the product.
+RUNG_REPORT = "report"
+#: Flat past two windows: capture a diagnosis. This is the rung that turns the
+#: NEXT kill from a mystery into a filed bug, and it is the reason the ladder
+#: exists at all rather than a single threshold.
+RUNG_DIAGNOSE = "diagnose"
+#: Flat past three windows: SIGTERM. The child gets a window to unwind.
+RUNG_TERM = "term"
+#: Flat past four windows, having ignored the SIGTERM: SIGKILL.
+RUNG_KILL = "kill"
+#: The instrument could not be read. HOLD and report — absence of instrument is
+#: never guilt. Deliberately not part of the ordered ladder.
+RUNG_UNMEASURABLE = "unmeasurable"
+
+#: The ladder, in the order a continuously-flat child walks it.
+RUNG_ORDER = (RUNG_ALIVE, RUNG_REPORT, RUNG_DIAGNOSE, RUNG_TERM, RUNG_KILL)
+
+#: How many times the largest OBSERVED inter-progress gap the window allows.
+#:
+#: Not a timeout: it scales a measurement. A child whose evidence has ticked at
+#: most every G seconds is given 3G of silence before anyone even reports —
+#: three consecutive worst-observed gaps with nothing in between, which no
+#: shape that has been ticking at G produces by chance. The kill is at 4W = 12G.
+WINDOW_SLACK = 3.0
+
+#: The FLOOR under the derived window, in seconds. Settings-overridable, which
+#: is the operator lever pgw#1613 proved must exist ("NO KNOB").
+#:
+#: DERIVATION, because a number in this file has to earn its place. The floor
+#: covers the case the observed-gap term cannot: a child whose demonstrated gaps
+#: are small and which then enters a single long stall that accrues NOTHING
+#: measurable — an uninterruptible D-state wait on a slow mount is the shape
+#: this fleet has actually seen. The floor must exceed such a stall's plausible
+#: length, and the ladder then multiplies it: the EARLIEST possible kill is
+#: 4 x floor = 8 minutes of provably-zero kernel work, with a report at 2 min
+#: and a captured diagnosis at 4 min. It never SHORTENS a window — the
+#: observed-gap term can only lengthen it — so a child that demonstrates long
+#: legitimate gaps is not held to this number at all.
+DEFAULT_FLATNESS_FLOOR_S = 120.0
+
+
+@dataclass
+class EvidenceTrack:
+    """One child's kernel evidence, its derived window, and its ladder position.
+
+    Pure: it is fed samples and a clock and returns a rung. Every test in
+    `test_watchdog_evidence_pgw1630.py` drives THIS object, so the decision under
+    test is the production decision and not a copy of its logic.
+    """
+
+    #: Settings-supplied lower bound on the flatness window.
+    floor_s: float = DEFAULT_FLATNESS_FLOOR_S
+    slack: float = WINDOW_SLACK
+    #: Minimum advance that counts as progress. Mirrors `activity._EVIDENCE_EPS`.
+    eps: float = 0.05
+
+    #: High-water evidence and when it last ADVANCED. `None` = never measured.
+    value: Optional[float] = None
+    advanced_at: float = 0.0
+    #: The largest interval between two successive ADVANCES this boot. It grows
+    #: only when evidence actually moves again, which is what makes it a
+    #: measurement of the child rather than of the wall clock: a gap is only
+    #: known to have been a gap once it ends.
+    largest_gap_s: float = 0.0
+    #: True once the instrument has failed to read at least once — reported, and
+    #: never used as evidence of anything.
+    unreadable: bool = False
+    #: Rungs already acted on, so each fires once per flat episode.
+    fired: "set[str]" = field(default_factory=set)
+
+    # -- sampling ----------------------------------------------------------
+
+    def observe(self, evidence: Optional[float], now: float) -> bool:
+        """Feed one sample. Returns True when the ladder RESET (evidence moved).
+
+        A `None` sample is an instrument failure, not a flat reading: it leaves
+        `advanced_at` exactly where it was, so an unreadable `/proc` neither
+        proves life nor accrues flatness against the child.
+        """
+
+        if evidence is None:
+            # An instrument failure is NOT a flat reading. `advanced_at` stays
+            # exactly where it was, and `verdict` refuses to walk the ladder
+            # while this is set — see the RUNG_UNMEASURABLE branch there.
+            self.unreadable = True
+            return False
+        self.unreadable = False
+        if self.value is None:
+            # First measurement: the flatness clock starts HERE, not at spawn.
+            # Anything before the first successful read is unmeasured, and
+            # unmeasured never counts against a child.
+            self.value = evidence
+            self.advanced_at = now
+            self.fired.clear()
+            return True
+        if evidence - self.value < self.eps:
+            # Flat. And the flatness accumulated ACROSS an instrument outage is
+            # real rather than assumed: tree CPU seconds and IO bytes are
+            # monotonic, so a reading equal to the pre-outage one proves zero
+            # work happened in between. That is why a recovered instrument may
+            # hand a child straight to a late rung — the evidence is retroactive.
+            return False
+        gap = now - self.advanced_at
+        if gap > self.largest_gap_s:
+            self.largest_gap_s = gap
+        self.value = evidence
+        self.advanced_at = now
+        self.fired.clear()
+        return True
+
+    # -- the window --------------------------------------------------------
+
+    @property
+    def window_s(self) -> float:
+        """How long evidence may be flat before the first rung.
+
+        Derived from what this child has DEMONSTRATED, floored by the operator
+        lever. Nothing here is a declared duration for a piece of work.
+        """
+        return max(float(self.floor_s), float(self.slack) * float(self.largest_gap_s))
+
+    def flat_for(self, now: float) -> float:
+        if self.value is None:
+            return 0.0
+        return max(0.0, now - self.advanced_at)
+
+    # -- the verdict -------------------------------------------------------
+
+    def verdict(self, now: float) -> str:
+        """The rung this child is on. The ONE decision, from ONE input."""
+
+        if self.value is None or self.unreadable:
+            # Never measured, or NOT MEASURABLE RIGHT NOW. Both hold.
+            #
+            # This replaces `no_evidence_source -> KILL`, which made an
+            # unreadable `/proc` a death sentence. The second half matters just
+            # as much as the first: if the instrument fails AFTER a successful
+            # read, elapsed time keeps accruing while nothing is being measured,
+            # and a ladder that walked on it would kill a healthy child on the
+            # strength of an instrument outage. We cannot say a child is flat
+            # when we cannot read it.
+            return RUNG_UNMEASURABLE
+        window = self.window_s
+        flat = self.flat_for(now)
+        if flat <= window:
+            return RUNG_ALIVE
+        if flat <= 2.0 * window:
+            return RUNG_REPORT
+        if flat <= 3.0 * window:
+            return RUNG_DIAGNOSE
+        if flat <= 4.0 * window:
+            return RUNG_TERM
+        return RUNG_KILL
+
+    def claim(self, rung: str) -> bool:
+        """True the FIRST time this flat episode reaches ``rung``.
+
+        The ladder is level-triggered (it is recomputed from flatness on every
+        sample) but its ACTIONS are edge-triggered: a diagnosis captured every
+        tick is a log flood, and a SIGTERM re-sent every tick is a child that
+        never gets its window to unwind. `observe` clears this on any advance,
+        which is what "any evidence advance resets the ladder" means in code.
+        """
+        if rung in self.fired:
+            return False
+        self.fired.add(rung)
+        return True
+
+    def describe(self, now: float) -> str:
+        """The arithmetic, for a report that shows its working."""
+        return (
+            f"flat_s={self.flat_for(now):.1f} window_s={self.window_s:.1f} "
+            f"largest_observed_gap_s={self.largest_gap_s:.1f} "
+            f"floor_s={float(self.floor_s):.0f} slack={float(self.slack):.1f} "
+            f"evidence={('none' if self.value is None else f'{self.value:.1f}')} "
+            f"instrument={'unreadable' if self.unreadable else 'ok'}"
+        )

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -33,14 +33,15 @@ from . import (
     ENV_LIVENESS_FD,
     ENV_SESSION_ID,
     ENV_SOCKET,
-    ENV_WATCHDOG_PING_S,
     EXIT_JOB_RECYCLE,
     actions,
     attest,
     capability,
     frames,
+    liveness,
     merge,
     privdrop,
+    procdiag,
 )
 from .group import ChildGroup, GroupPlan
 from .seam import SeamAccountant
@@ -52,6 +53,10 @@ DEATH_LABEL = "ComputeProcessDied"
 _DEFAULT_START_LIMIT_BURST = 3
 _DEFAULT_START_LIMIT_INTERVAL_S = 600.0
 _DEFAULT_BOOT_DEATH_LIMIT = 3
+# pgw#1630: A SAMPLING CADENCE, NOT A VERDICT INPUT. Nothing decides a child's
+# life from it; the watchdog loop divides it by four to choose how often to read
+# /proc. The flatness window that DOES decide is derived per child from that
+# child's own observed inter-progress gaps (procsplit/liveness.py).
 _DEFAULT_WATCHDOG_BUDGET_S = 60.0
 _DEFAULT_RESPAWN_BACKOFF_BASE_S = 1.0
 _DEFAULT_RESPAWN_BACKOFF_CAP_S = 60.0
@@ -193,14 +198,23 @@ class _ChildSlot:
         self.last_frame_at = time.monotonic()
         self.relaying = False
         self.watchdog_fired = False
+        # pgw#1630: THE ONE INPUT to the kill decision. Kernel-accounted
+        # evidence, its observation-derived flatness window, and this child's
+        # position on the report -> diagnose -> TERM -> KILL ladder.
+        self.evidence = liveness.EvidenceTrack(
+            floor_s=parent._liveness_floor_s, eps=_EVIDENCE_EPS,
+        )
+        # Liveness (thread-sourced, loop-independent), per child. Everything
+        # below is TELEMETRY since pgw#1630: it labels a stall report and
+        # decides nothing. `liveness_evidence*` mirror `self.evidence` for the
+        # existing readers.
         self.liveness_task: Optional[asyncio.Task] = None
         self.last_liveness_at = 0.0
         self.liveness_evidence: Optional[float] = None
         self.liveness_evidence_at = 0.0
         self.liveness_activity = ""
-        self.hang_armed_at: Optional[float] = None
-        self.hang_hold_reported = False
-        self.stall_reported = False
+        # This group's freshest published StateDelta; the worker-level beat
+        # re-sends the merge of all groups'.
         self.last_state_delta: Optional[pb.WorkerMessage] = None
         self.last_state_delta_at = 0.0
         self.generation = 0
@@ -492,9 +506,12 @@ class _ChildSlot:
             self.watchdog_fired = False
             self.child_saw_hello = False
             self.boot_fatal = None
-            self.hang_armed_at = None
-            self.hang_hold_reported = False
-            self.stall_reported = False
+            # A RESPAWN is a new process: its predecessor's high-water evidence,
+            # its demonstrated gaps and its ladder position all describe a pid
+            # that no longer exists.
+            self.evidence = liveness.EvidenceTrack(
+                floor_s=p._liveness_floor_s, eps=_EVIDENCE_EPS,
+            )
             oom_before = postmortem.oom_kill_count()
             started = time.monotonic()
             self.last_frame_at = started
@@ -766,7 +783,16 @@ class _ChildSlot:
         return cause
 
     async def watchdog_loop(self) -> None:
-        """Missed beats ARM the verdict; the open activity DECIDES it."""
+        """KERNEL EVIDENCE DECIDES, and nothing else is an input (pgw#1630).
+
+        The parent witnesses THIS child's /proc, because a child starved of the
+        GIL cannot witness for itself. Evidence advancing means HELD,
+        unconditionally: the parent kills only what is provably NOT RUNNING, and
+        a child that runs but serves nothing is the hub's stall clock to reap.
+        Loop pings and declared activities are REPORTING ONLY — they label a
+        stall, they do not decide one. Ladder in procsplit/liveness.py. One
+        child's kill never touches a sibling.
+        """
         p = self.p
         interval = max(0.25, p._watchdog_budget / 4.0)
         while not p._stopping.is_set():
@@ -778,91 +804,138 @@ class _ChildSlot:
                 continue
             now = time.monotonic()
             self._sample_child_evidence(proc.pid, now)
-            silent_for = now - self.last_frame_at
-            if silent_for <= p._watchdog_budget:
-                self.hang_armed_at = None
-                continue
-            if self.hang_armed_at is None:
-                self.hang_armed_at = now
-            await self._report_stall_if_any(now)
-            verdict = self._hang_verdict(now)
-            if verdict is None:
-                continue
-            if verdict == "held":
-                if not self.hang_hold_reported:
-                    self.hang_hold_reported = True
-                    logger.warning(
-                        "compute child %s loop silent for %.1fs but activity %r "
-                        "is alive (evidence advanced %.1fs ago) — hang HELD",
-                        self.label, silent_for, self.liveness_activity,
-                        now - self.liveness_evidence_at,
-                    )
-                    await p._dial_detail(
-                        f"phase=compute_hang_verdict_held group={self.ordinal} "
-                        f"loop_silent_s={silent_for:.0f} "
-                        f"activity={self.liveness_activity} "
-                        f"evidence_age_s={now - self.liveness_evidence_at:.1f} "
-                        f"evidence={self.liveness_evidence:.1f} "
-                        f"ping_age_s={now - self.last_liveness_at:.1f} "
-                        f"budget_s={p._watchdog_budget:.0f} — the child's event "
-                        "loop is starved by accounted work, not hung; not killing"
-                    )
-                continue
-            logger.error(
-                "compute child %s silent for %.1fs (budget %.1fs, verdict=%s) — "
-                "killing the wedged child (WatchdogSec analog)",
-                self.label, silent_for, p._watchdog_budget, verdict,
-            )
-            self.watchdog_fired = True
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
+            await self._walk_liveness_ladder(proc, now)
 
     def _child_evidence(self, pid: int) -> Optional[float]:
         return proc_evidence.tree_evidence(pid)
 
     def _sample_child_evidence(self, pid: int, now: float) -> None:
-        evidence = self._child_evidence(pid)
-        if evidence is None:
-            return
-        previous = self.liveness_evidence
-        if previous is None or evidence - previous >= _EVIDENCE_EPS:
-            self.liveness_evidence = evidence
-            self.liveness_evidence_at = now
-            self.stall_reported = False
+        """One sample into the ladder. A `None` reading is an instrument
+        failure, never a flat reading — `EvidenceTrack.observe` keeps the two
+        apart, which is what stops an unreadable `/proc` accruing flatness
+        against a healthy child."""
+        self.evidence.observe(self._child_evidence(pid), now)
+        # Mirrored for the reporters and for every existing reader; the ladder
+        # itself reads only `self.evidence`.
+        self.liveness_evidence = self.evidence.value
+        self.liveness_evidence_at = self.evidence.advanced_at
 
-    async def _report_stall_if_any(self, now: float) -> None:
-        if self.liveness_evidence is None or self.stall_reported:
+    async def _walk_liveness_ladder(self, proc: Any, now: float) -> None:
+        """report -> diagnose -> SIGTERM -> SIGKILL, one window apart.
+
+        Every rung requires flatness to have CONTINUED: the rung is recomputed
+        from `flat_for(now)` on every sample and any evidence advance clears the
+        fired set, so a wedge that un-wedges mid-ladder was never a wedge and
+        starts again from zero if it re-wedges.
+        """
+        rung = self.evidence.verdict(now)
+        if rung == liveness.RUNG_ALIVE:
             return
-        if not self.in_flight and not self.liveness_activity:
+        if rung == liveness.RUNG_UNMEASURABLE:
+            # Absence of instrument is not guilt. This branch REPLACES
+            # `no_evidence_source -> KILL`.
+            if self.evidence.claim(rung):
+                logger.warning(
+                    "compute child %s: cannot read kernel evidence (%s) — "
+                    "HOLDING and reporting; failure to measure is never a kill",
+                    self.label, self.evidence.describe(now),
+                )
+                await self.p._dial_detail(
+                    f"phase=compute_liveness_unmeasurable group={self.ordinal} "
+                    f"{self.evidence.describe(now)} {self._liveness_labels(now)} "
+                    "— the parent cannot measure this child; holding, never killing"
+                )
             return
-        age = now - self.liveness_evidence_at
-        if age <= self.p._evidence_hold_window:
+
+        if rung == liveness.RUNG_REPORT:
+            if self.evidence.claim(rung):
+                logger.warning(
+                    "compute child %s has accrued NO kernel-accounted work for "
+                    "%.1fs (window %.1fs) — reporting the stall (stream, beat and "
+                    "process all kept)",
+                    self.label, self.evidence.flat_for(now), self.evidence.window_s,
+                )
+                await self.p._dial_detail(
+                    f"phase=compute_child_stalled group={self.ordinal} "
+                    f"{self.evidence.describe(now)} {self._liveness_labels(now)} "
+                    "— measured by the parent from /proc, not self-reported by "
+                    "the child; the labels are TELEMETRY and decided nothing"
+                )
             return
-        self.stall_reported = True
-        logger.warning(
-            "compute child %s has accrued no CPU/IO for %.1fs while %d job(s) and "
-            "activity %r are open — reporting the stall (stream and beat kept)",
-            self.label, age, len(self.in_flight), self.liveness_activity,
+
+        if rung == liveness.RUNG_DIAGNOSE:
+            if self.evidence.claim(rung):
+                report = await asyncio.to_thread(
+                    procdiag.capture, int(proc.pid), self.p._postmortem_dir,
+                )
+                logger.error(
+                    "compute child %s flat for %.1fs (2x window) — captured a "
+                    "diagnosis before anything is signalled:\n%s",
+                    self.label, self.evidence.flat_for(now), report,
+                )
+                await self.p._dial_detail(
+                    f"phase=compute_liveness_diagnosis group={self.ordinal} "
+                    f"{self.evidence.describe(now)} {self._liveness_labels(now)}\n"
+                    f"{report}"
+                )
+            return
+
+        if rung == liveness.RUNG_TERM:
+            if self.evidence.claim(rung):
+                logger.error(
+                    "compute child %s flat for %.1fs (3x window %.1fs) — SIGTERM; "
+                    "it gets one more window to unwind before SIGKILL",
+                    self.label, self.evidence.flat_for(now), self.evidence.window_s,
+                )
+                await self.p._dial_detail(
+                    f"phase=compute_liveness_term group={self.ordinal} "
+                    f"{self.evidence.describe(now)} {self._liveness_labels(now)} "
+                    "— evidence has been flat for three consecutive windows; "
+                    "asking the child to exit"
+                )
+                self.watchdog_fired = True
+                try:
+                    proc.terminate()
+                except ProcessLookupError:
+                    pass
+            return
+
+        # RUNG_KILL — four windows flat, and the SIGTERM went unanswered.
+        if not self.evidence.claim(rung):
+            return
+        logger.error(
+            "compute child %s flat for %.1fs (4x window %.1fs) and unresponsive "
+            "to SIGTERM — SIGKILL. %s",
+            self.label, self.evidence.flat_for(now), self.evidence.window_s,
+            self.evidence.describe(now),
         )
         await self.p._dial_detail(
-            f"phase=compute_child_stalled group={self.ordinal} "
-            f"evidence_age_s={age:.1f} activity={self.liveness_activity or 'none'} "
-            f"in_flight={sorted(f'{r}#{a}' for (r, a) in self.in_flight)} "
-            f"loop_silent_s={now - self.last_frame_at:.1f} "
-            f"window_s={self.p._evidence_hold_window:.0f} — measured by the parent "
-            "from /proc, not self-reported by the child"
+            f"phase=compute_liveness_kill group={self.ordinal} "
+            f"{self.evidence.describe(now)} {self._liveness_labels(now)} "
+            "— provably NOT RUNNING: no CPU second and no byte of I/O across "
+            "four consecutive observation-derived windows"
         )
+        self.watchdog_fired = True
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
 
-    def _hang_verdict(self, now: float) -> Optional[str]:
-        if self.liveness_evidence is None:
-            return "no_evidence_source"
-        if now - self.liveness_evidence_at > self.p._evidence_hold_window:
-            return "no_work_accrued"
-        if not self.liveness_activity:
-            return "loop_wedged_no_activity"
-        return "held"
+    def _liveness_labels(self, now: float) -> str:
+        """The cooperative signals, as LABELS on a report.
+
+        pgw#1630 demoted every one of these. They make a stall report and the
+        hub's attribution honest — "flat while `boot_materialize` was open, with
+        two jobs in flight" is a far better bug than "flat" — and they decide
+        nothing. A path that forgets to declare an activity loses a label, not a
+        process.
+        """
+        return (
+            f"label_activity={self.liveness_activity or 'none'} "
+            f"label_in_flight={sorted(f'{r}#{a}' for (r, a) in self.in_flight)} "
+            f"label_loop_silent_s={now - self.last_frame_at:.1f} "
+            f"label_ping_age_s={now - self.last_liveness_at:.1f}"
+        )
 
 
 class ParentControl:
@@ -883,6 +956,13 @@ class ParentControl:
         start_limit_interval_s: float = _DEFAULT_START_LIMIT_INTERVAL_S,
         boot_death_limit: int = _DEFAULT_BOOT_DEATH_LIMIT,
         watchdog_budget_s: float = _DEFAULT_WATCHDOG_BUDGET_S,
+        # pgw#1630: the flatness FLOOR, in seconds. 0 = read `Settings`, then
+        # the module default. Deliberately SEPARATE from `watchdog_budget_s`,
+        # which is now only a /proc sampling cadence: narrowing how often the
+        # parent LOOKS must not silently narrow how long a child may be flat,
+        # because those are answers to different questions and conflating them
+        # is how the old single-budget cliff worked.
+        liveness_floor_s: float = 0.0,
         stop_timeout_s: float = _DEFAULT_STOP_TIMEOUT_S,
         stop_flush_timeout_s: float = _STOP_FLUSH_TIMEOUT_S,
         beat_interval_s: float = 0.0,
@@ -925,6 +1005,26 @@ class ParentControl:
 
         self._drop_plan = self._prepare_privilege_drop()
 
+        # pgw#1630: the FLOOR under each child's flatness window. The window
+        # itself is derived from that child's own observed inter-progress gaps
+        # (`procsplit/liveness.py`); this is only the lower bound, and it is a
+        # Settings knob because pgw#1613 proved the operator lever must exist.
+        # Resolved BEFORE the slots, because each slot builds its own track.
+        #
+        # The old `_evidence_hold_window = 3 x the child's PING CADENCE` is
+        # DELETED with the rung that read it: a ping is a self-report, and how
+        # often a child says "still here" says nothing about how long real work
+        # can legitimately go without touching the kernel.
+        # Precedence: an explicit constructor argument (a harness or an
+        # embedder that KNOWS its child's shape), then the operator's Settings,
+        # then the derived default.
+        floor = float(liveness_floor_s or 0.0)
+        if floor <= 0:
+            floor = float(getattr(settings, "watchdog_flatness_floor_s", 0.0) or 0.0)
+        self._liveness_floor_s = (
+            floor if floor > 0 else liveness.DEFAULT_FLATNESS_FLOOR_S
+        )
+
         self._slots: List[_ChildSlot] = [
             _ChildSlot(self, group) for group in self._plan.children
         ]
@@ -934,16 +1034,8 @@ class ParentControl:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._stopping = asyncio.Event()
         self._beat_interval = beat_interval_s
-        raw_ping = (
-            self._child_env.get(ENV_WATCHDOG_PING_S)
-            or os.environ.get(ENV_WATCHDOG_PING_S)
-            or ""
-        )
-        try:
-            ping_s = float(raw_ping) or 5.0
-        except ValueError:
-            ping_s = 5.0
-        self._evidence_hold_window = max(3.0 * ping_s, 2.0)
+        # Worker-level beat state: the last (merged) StateDelta and when any
+        # group last published, so the beat re-sends the worker's freshest truth.
         self._last_state_delta: Optional[pb.WorkerMessage] = None
         self._last_state_delta_at = 0.0
         self.parent_beats_sent = 0

--- a/src/gen_worker/procsplit/procdiag.py
+++ b/src/gen_worker/procsplit/procdiag.py
@@ -1,0 +1,132 @@
+"""pgw#1630: the artifact that turns the NEXT kill into a filed bug.
+
+The old watchdog was a cliff: silent past a budget, SIGKILL, exit 137, and
+nothing anywhere said WHAT the child had been doing. Two H3 pods died that way
+and the diagnosis had to be reconstructed days later from a rental invoice and a
+docstring.
+
+So the ladder has a rung between "report" and "signal" whose only product is
+evidence. It runs while the child is still ALIVE, which is the only moment any
+of this is readable, and it is deliberately cheap and total-failure-tolerant: a
+diagnosis that can raise is a diagnosis that turns a stall into a crash.
+
+What it reads, in increasing order of how much it costs:
+
+* ``/proc/<pid>/status`` — the SCHEDULER STATE. ``State: D`` is the single most
+  valuable line here: it names an uninterruptible wait, which is a stall the
+  child could not have avoided and the parent must not blame it for. This fleet
+  has seen exactly that shape on a wedged mount.
+* ``/proc/<pid>/wchan`` and ``/proc/<pid>/stack`` — WHERE in the kernel. `stack`
+  needs privileges the container usually does not have, so its absence is
+  normal and is recorded as such rather than as a failure.
+* ``/proc/<pid>/syscall`` — the syscall it is parked in.
+* ``py-spy dump`` — the PYTHON stack, when py-spy is installed. Bounded by a
+  short subprocess timeout because the tool itself can block on a wedged
+  process, and a diagnostic that hangs is worse than no diagnostic.
+
+Every reader is independently guarded: one unreadable source must never cost
+the others.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["capture", "read_proc_state"]
+
+#: py-spy attaches to a possibly-wedged process. Bounded so the diagnostic
+#: cannot become the hang. Not a liveness judgement — nothing is decided from
+#: whether this completes.
+_PY_SPY_TIMEOUT_S = 15.0
+#: Truncation for any single source, so one enormous stack cannot crowd out the
+#: cheap lines that usually carry the answer.
+_SOURCE_CAP = 8000
+
+
+def _read(path: str) -> str:
+    try:
+        with open(path, "rb") as handle:
+            return handle.read(_SOURCE_CAP).decode("utf-8", "replace").strip()
+    except PermissionError:
+        return "<not permitted: the container lacks the capability>"
+    except FileNotFoundError:
+        return "<absent>"
+    except OSError as exc:
+        return f"<unreadable: {exc}>"
+
+
+def read_proc_state(pid: int) -> str:
+    """The scheduler state letter (``R``/``S``/``D``/``Z``/``T``), or ``""``.
+
+    Split out because it is the one line worth naming on its own: ``D`` means
+    an uninterruptible wait, which is a stall nobody can be blamed for and a
+    SIGTERM cannot end.
+    """
+    for line in _read(f"/proc/{int(pid)}/status").splitlines():
+        if line.startswith("State:"):
+            parts = line.split()
+            return parts[1] if len(parts) > 1 else ""
+    return ""
+
+
+def _py_spy(pid: int) -> str:
+    binary = shutil.which("py-spy")
+    if binary is None:
+        return "<py-spy not installed>"
+    try:
+        done = subprocess.run(
+            [binary, "dump", "--pid", str(int(pid))],
+            capture_output=True, timeout=_PY_SPY_TIMEOUT_S, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return f"<py-spy timed out after {_PY_SPY_TIMEOUT_S:.0f}s>"
+    except OSError as exc:
+        return f"<py-spy failed: {exc}>"
+    text = (done.stdout or b"").decode("utf-8", "replace").strip()
+    if not text:
+        text = (done.stderr or b"").decode("utf-8", "replace").strip()
+    return text[:_SOURCE_CAP] or "<py-spy produced nothing>"
+
+
+def capture(pid: int, out_dir: Optional[Path] = None) -> str:
+    """Diagnose a flat child, while it is still alive. NEVER raises.
+
+    The return value is the report; when ``out_dir`` is given the same text is
+    also written beside the other post-mortem artifacts, so a diagnosis
+    survives a pod whose logs nobody can reach.
+    """
+
+    try:
+        pid = int(pid)
+        state = read_proc_state(pid)
+        sections = [
+            f"pid={pid} state={state or 'unknown'}"
+            + ("  <- UNINTERRUPTIBLE WAIT: the child cannot respond to SIGTERM "
+               "and did not choose this" if state == "D" else ""),
+            f"[wchan] {_read(f'/proc/{pid}/wchan')}",
+            f"[syscall] {_read(f'/proc/{pid}/syscall')}",
+            f"[kernel stack]\n{_read(f'/proc/{pid}/stack')}",
+            f"[python stack]\n{_py_spy(pid)}",
+        ]
+        report = "\n".join(sections)
+    except Exception as exc:  # noqa: BLE001 — a diagnostic must never be the failure
+        logger.debug("liveness diagnosis failed", exc_info=True)
+        report = f"pid={pid} <diagnosis failed: {type(exc).__name__}: {exc}>"
+
+    if out_dir is not None:
+        try:
+            target = Path(out_dir)
+            target.mkdir(parents=True, exist_ok=True)
+            path = target / f"liveness-diagnosis-{pid}-{int(time.time())}.txt"
+            path.write_text(report)
+            report += f"\n[written] {path}"
+        except OSError:
+            logger.debug("liveness diagnosis could not be persisted", exc_info=True)
+    return report

--- a/tests/harness/split.py
+++ b/tests/harness/split.py
@@ -52,6 +52,13 @@ class SplitHarness:
         *,
         child_cmd: Optional[List[str]] = None,
         watchdog_budget_s: float = 60.0,
+        # pgw#1630: the flatness FLOOR. Separate from the budget above, which is
+        # now only the /proc sampling cadence. A harness that wants to observe a
+        # kill has to say how long "flat" means HERE, because the production
+        # default is a derived 120 s and the ladder needs four of them.
+        # 0 = the production default, which is what most rows want: they are
+        # asserting that nothing is killed.
+        liveness_floor_s: float = 0.0,
         start_limit_burst: int = 3,
         start_limit_interval_s: float = 600.0,
         stop_timeout_s: float = 120.0,
@@ -89,6 +96,7 @@ class SplitHarness:
             transport_backoff_base_s=0.05,
             transport_backoff_cap_s=0.2,
             watchdog_budget_s=watchdog_budget_s,
+            liveness_floor_s=liveness_floor_s,
             start_limit_burst=start_limit_burst,
             start_limit_interval_s=start_limit_interval_s,
             stop_timeout_s=stop_timeout_s,

--- a/tests/test_boot_materialize.py
+++ b/tests/test_boot_materialize.py
@@ -497,27 +497,70 @@ def test_an_ABSENT_ref_records_the_check_it_lost_before_the_fetch_it_starts(
         origin.close()
 
 
-def _hang_verdict(*, activity_kind: str, now: float = 100.0) -> str | None:
-    from types import SimpleNamespace
+# ---------------------------------------------------------------------------
+# pgw#1613 — the fetch runs under an OPEN ACTIVITY.
+#
+# pgw#1630 CHANGED WHAT THAT IS FOR, and this block is the record of the change.
+# The activity used to DECIDE the child's life: the ladder's third rung killed a
+# CPU-burning child whose loop was silent and whose label was missing, which is
+# what happened to two H3 pods with `tree_evidence` provably advancing. The
+# verdict is now kernel-evidence-only, so the activity is TELEMETRY — it names
+# what a stalled child was doing, and it cannot end one.
+#
+# The scope itself STAYS, and the two tests below it are untouched: a stall
+# report that cannot say "during boot_materialize" is a worse bug report, and
+# `activity.py`'s "a silent death is a bug" contract is unaffected.
+# ---------------------------------------------------------------------------
 
-    from gen_worker.procsplit.parent import _ChildSlot
 
-    slot = SimpleNamespace(
-        liveness_evidence=1234.5,
-        liveness_evidence_at=now - 0.5,
-        liveness_activity=activity_kind,
-        p=SimpleNamespace(_evidence_hold_window=15.0),
-    )
-    return _ChildSlot._hang_verdict(cast(Any, slot), now)
+def _ladder_rung(*, activity_kind: str, flat_for: float) -> str:
+    """Run the REAL post-pgw#1630 verdict against a child that has been flat for
+    ``flat_for`` seconds with ``activity_kind`` open.
+
+    Unbound on the production `EvidenceTrack` so the assertion is about the
+    decision object itself. `activity_kind` is deliberately accepted and
+    deliberately unused by the decision — that IS the assertion.
+    """
+    from gen_worker.procsplit.liveness import EvidenceTrack
+
+    track = EvidenceTrack()
+    # evidence is REAL: the child's tree accrued kernel-accounted work, which is
+    # what a CAS fill looks like from the parent's /proc sampler.
+    track.observe(1234.5, 0.0)
+    del activity_kind  # not an input, and the deletion says so
+    return track.verdict(flat_for)
 
 
-def test_the_watchdog_HOLDS_a_cpu_burning_child_only_because_an_activity_is_open() -> None:
-    assert _hang_verdict(activity_kind=activity.KIND_BOOT_MATERIALIZE) == "held", (
-        "a fetch that declares itself must survive a starved event loop"
-    )
-    assert _hang_verdict(activity_kind="") == "loop_wedged_no_activity", (
-        "with nothing open the same child is killed — this is the defect, and "
-        "it is why the fetch has to open an activity at all"
+def test_the_watchdog_HOLDS_a_cpu_burning_child_WHATEVER_it_declared() -> None:
+    """pgw#1613's kill, inverted — and the CLASS closed rather than one site.
+
+    A child mid-materialization is burning CPU with a starved event loop. Under
+    the old ladder the one with a label lived and the one without it was
+    SIGKILLed at 356 s / 687 s on a real H200. Under pgw#1630 they are the same
+    child, because the label is not an input.
+    """
+    from gen_worker.procsplit.liveness import RUNG_ALIVE
+
+    for label in (activity.KIND_BOOT_MATERIALIZE, ""):
+        assert _ladder_rung(activity_kind=label, flat_for=0.5) == RUNG_ALIVE, (
+            f"a child accruing kernel-accounted work was not held with "
+            f"label={label!r}"
+        )
+
+
+def test_the_fetch_activity_STAYS_because_a_stall_report_needs_it() -> None:
+    """pgw#1613's landed scope is kept on purpose.
+
+    "The activity decides nothing" is not "the activity is pointless". It is the
+    label on `compute_child_stalled`, and the difference between a filed bug and
+    a shrug. A reading of pgw#1630 that deletes the scope fails here.
+    """
+    from pathlib import Path as _Path
+
+    from gen_worker import boot_materialize as bm
+
+    assert "activity.running(activity.KIND_BOOT_MATERIALIZE)" in (
+        _Path(bm.__file__).read_text()
     )
 
 

--- a/tests/test_procsplit.py
+++ b/tests/test_procsplit.py
@@ -156,7 +156,21 @@ def test_boot_hardware_fatal_is_terminal_reported_and_exits_1(
 
 
 def test_wedged_child_is_killed_by_watchdog_and_pod_recovers(tmp_path, captured_dials):
-    h = SplitHarness(tmp_path, watchdog_budget_s=3.0)
+    """A genuinely dead-stopped child is still reaped — through the pgw#1630 ladder.
+
+    SIGSTOP is the honest wedge: a stopped process accrues no CPU second and no
+    byte of I/O, so `tree_evidence` is flat by the kernel's own accounting
+    rather than by a missing label. That is exactly the case the reaper exists
+    for, and it must still end.
+
+    `liveness_floor_s` is set explicitly because pgw#1630 separated the two
+    numbers this test used to conflate: `watchdog_budget_s` is now only how
+    often the parent LOOKS at /proc, and the FLOOR is how long flat has to last
+    before anything happens. Production's floor is a derived 120 s and the
+    ladder walks four of them; a row that wants to observe the kill has to say
+    so, which is precisely what the operator lever is for.
+    """
+    h = SplitHarness(tmp_path, watchdog_budget_s=1.0, liveness_floor_s=1.0)
     try:
         conn0 = h.scheduler.wait_connection(0)
         conn0.wait_for(is_ready)
@@ -484,6 +498,27 @@ def test_signal_death_consumes_the_inflight_marker_and_records_the_streak(
 def test_a_starving_handler_no_longer_starves_the_worker_loop_pgw1373(
     tmp_path, captured_dials,
 ):
+    """pgw#771's hazard is GONE under pgw#1373, so its verdict cannot fire.
+
+    The original case asserted `compute_hang_verdict_held`: an async handler
+    that burns CPU without yielding starved the worker's OWN event loop, the
+    parent's watchdog ARMED on the resulting silence, and the open activity
+    then HELD the verdict instead of killing a live pod.
+
+    The v2 serve path runs author code on a worker thread
+    (`asyncio.to_thread` -> `ServeLoop.invoke`), so a starving handler cannot
+    reach the loop that answers pings. Nothing arms, so nothing can be held —
+    asserting the hold would be asserting a verdict that no longer has a
+    trigger. What this now measures is the property that REPLACED it: the same
+    9-second non-yielding handler completes, the child is never killed, and no
+    hang verdict is reached at all.
+
+    pgw#1630 then removed the hold machinery's REASON to exist: the verdict is
+    kernel evidence only, so a busy handler is held because it is provably
+    accruing CPU, not because something was open. The property asserted below is
+    unchanged and is now true for a stronger reason —
+    `test_watchdog_evidence_pgw1630.py` drives the ladder directly.
+    """
     h = SplitHarness(tmp_path, watchdog_budget_s=3.0)
     try:
         conn = h.scheduler.wait_connection(0)
@@ -531,7 +566,21 @@ def test_wedged_child_keeps_the_stream_alive_and_is_reported_not_hidden(
 ):
     h = SplitHarness(
         tmp_path,
-        watchdog_budget_s=8.0,
+        # pgw#1630: the stall report is now the FIRST RUNG of the liveness
+        # ladder — flat kernel evidence past one window — and it is reached long
+        # before anything is signalled (SIGTERM is three windows further on). So
+        # the two numbers below mean different things and both are needed:
+        # `watchdog_budget_s` is how often the parent reads /proc, and
+        # `liveness_floor_s` is how long flat has to last before it says so.
+        # Production's floor is a derived 120 s; a row that wants to OBSERVE the
+        # report has to shorten it, which is what the operator lever is for.
+        #
+        # The floor is what this row's OTHER assertion is really about: the
+        # parent's beats have to accumulate WHILE the child is frozen, so the
+        # window before the first rung is the interval in which those beats are
+        # the only thing keeping the pod reachable. Six beat-intervals of it.
+        watchdog_budget_s=4.0,
+        liveness_floor_s=6.0,
         beat_interval_s=1.0,
     )
     try:

--- a/tests/test_watchdog_evidence_pgw1630.py
+++ b/tests/test_watchdog_evidence_pgw1630.py
@@ -1,0 +1,597 @@
+"""pgw#1630: the watchdog verdict is KERNEL-EVIDENCE-ONLY.
+
+## The fact this file was written around
+
+In the pgw#1613 kills the child **passed** the kernel-evidence rung. The CAS
+fill kept `tree_evidence` advancing, `no_work_accrued` did not fire, and the
+kill came from the rung below it — `loop_wedged_no_activity`. The parent looked
+at kernel-accounted proof of life and killed anyway, because a LABEL was
+missing. Two H3 pods, two pins, byte-identical death, exit 137, rental burned.
+
+pgw#1613's fix opened an activity at the ONE site that had been killed. That
+closed one site and left the class: every future long-running path owed a ritual
+or died. So the rung is gone, and this file is the fence that keeps it gone.
+
+Everything here drives the PRODUCTION decision objects — `liveness.EvidenceTrack`
+and `_ChildSlot._walk_liveness_ladder` — never a copy of their logic.
+
+## No clocks were harmed
+
+`now` is a parameter everywhere, because the thing under test IS a
+progress-versus-time relationship and a test that slept would be measuring the
+scheduler. The window each assertion uses is computed from the track's own
+`window_s`, so none of these numbers is a magic constant either.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+import pytest
+
+from gen_worker import activity
+from gen_worker.procsplit import liveness, procdiag
+from gen_worker.procsplit.liveness import (
+    DEFAULT_FLATNESS_FLOOR_S,
+    RUNG_ALIVE,
+    RUNG_DIAGNOSE,
+    RUNG_KILL,
+    RUNG_ORDER,
+    RUNG_REPORT,
+    RUNG_TERM,
+    RUNG_UNMEASURABLE,
+    EvidenceTrack,
+)
+
+#: The KIND every long-running site declares — the four the design names, plus
+#: the empty label, which is what a site that forgets looks like. Under
+#: pgw#1630 the ladder must behave IDENTICALLY for all of them: that is the
+#: whole verdict, expressed as a parametrization.
+SITE_LABELS = (
+    activity.KIND_BOOT_MATERIALIZE,
+    activity.KIND_WARMUP,
+    activity.KIND_SELF_MINT_COMPILE,
+    activity.KIND_BOOT_ADOPT,
+    "",  # the site that forgot the ritual — pgw#1613's actual victim
+)
+
+
+def _track(floor_s: float = DEFAULT_FLATNESS_FLOOR_S) -> EvidenceTrack:
+    return EvidenceTrack(floor_s=floor_s)
+
+
+def _burning(track: EvidenceTrack, *, until: float, step: float) -> float:
+    """Feed advancing evidence up to ``until``. Returns the last `now`."""
+    now = 0.0
+    value = 0.0
+    while now < until:
+        now += step
+        value += 1.0
+        track.observe(value, now)
+    return now
+
+
+# ---------------------------------------------------------------------------
+# 1. THE SHARPEST FACT — evidence advancing means HELD, unconditionally
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", SITE_LABELS, ids=lambda s: s or "no-label")
+def test_a_cpu_burning_child_is_ALIVE_whatever_it_did_or_did_not_declare(
+    label: str,
+) -> None:
+    """pgw#1613's death, inverted — and the CLASS closed, not one site.
+
+    The child is burning CPU with a starved event loop. Under the old ladder,
+    the one with the label lived and the one without it was SIGKILLed. Under
+    pgw#1630 the label is not an input at all, so all five of these are the
+    same child.
+    """
+
+    track = _track()
+    now = _burning(track, until=10 * track.window_s, step=1.0)
+
+    assert track.verdict(now) == RUNG_ALIVE, (
+        f"a child accruing kernel-accounted work was not ALIVE with "
+        f"label={label!r} — the label is back on the kill path"
+    )
+
+
+def test_the_activity_rung_is_GONE_from_the_parent() -> None:
+    """STRUCTURAL. The cooperative rung must not be reintroducible by accident.
+
+    `_hang_verdict` and its `loop_wedged_no_activity` / `no_evidence_source`
+    strings were the whole defect. Their absence is asserted here because a
+    behavioural test can only prove the paths it thinks to drive, and this one
+    proves the code is not there to be reached.
+    """
+
+    import ast
+
+    from gen_worker.procsplit import parent as parent_mod
+
+    # STRING LITERALS ONLY. A comment naming the deleted rung is documentation
+    # of why it is deleted — which this file wants to survive — while a live
+    # string literal is the verdict being produced again.
+    module = ast.parse(Path(parent_mod.__file__).read_text())
+    literals = {
+        node.value for node in ast.walk(module)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    gone = {"loop_wedged_no_activity", "no_evidence_source", "no_work_accrued"}
+    revived = {v for v in literals if any(g in v for g in gone)}
+    assert not revived, (
+        f"a deleted verdict is being produced again as a value: {revived}"
+    )
+    assert not hasattr(parent_mod._ChildSlot, "_hang_verdict"), (
+        "the cooperative verdict function is back"
+    )
+    assert hasattr(parent_mod._ChildSlot, "_walk_liveness_ladder")
+
+
+# ---------------------------------------------------------------------------
+# 2. The ladder, in order, each rung requiring CONTINUED flatness
+# ---------------------------------------------------------------------------
+
+
+def test_a_flat_child_walks_report_diagnose_term_kill_in_order() -> None:
+    """Escalation, not a cliff. And the ORDER is the point: a diagnosis is
+    captured while the child is still alive, which is the only moment any of it
+    is readable."""
+
+    track = _track()
+    track.observe(100.0, 0.0)
+    w = track.window_s
+
+    seen = [track.verdict(t) for t in (
+        w * 0.5, w * 1.5, w * 2.5, w * 3.5, w * 4.5,
+    )]
+    assert seen == [RUNG_ALIVE, RUNG_REPORT, RUNG_DIAGNOSE, RUNG_TERM, RUNG_KILL]
+    assert list(RUNG_ORDER) == seen, "the ladder's declared order and its behaviour disagree"
+
+
+@pytest.mark.parametrize("rung_at", (1.5, 2.5, 3.5, 4.5))
+def test_any_evidence_advance_resets_the_ladder_to_zero(rung_at: float) -> None:
+    """A wedge that un-wedges mid-ladder was never a wedge.
+
+    Asserted from EVERY rung including the one immediately before SIGKILL,
+    because the rung where this matters most is the last one.
+    """
+
+    track = _track()
+    track.observe(100.0, 0.0)
+    w = track.window_s
+    at = w * rung_at
+    assert track.verdict(at) != RUNG_ALIVE, "the scenario must start off-ladder"
+
+    # One byte of I/O, one CPU tick — anything at all.
+    # Comfortably past `eps`; `100.0 + eps` does not survive float rounding,
+    # and this assertion is about the RESET, not about the epsilon.
+    assert track.observe(100.0 + track.eps * 10, at) is True
+    assert track.verdict(at) == RUNG_ALIVE
+    assert track.verdict(at + w * 0.9) == RUNG_ALIVE, (
+        "the ladder did not restart from zero; the child is being charged for "
+        "flatness it has already disproved"
+    )
+    # And re-wedging starts again from the FIRST rung, not from where it left
+    # off — but against the child's NEW window, because closing that gap was
+    # itself a demonstration that this child can legitimately go that long
+    # between ticks. The leash grew, which is the observed-gap rule working.
+    grown = track.window_s
+    assert grown > w, (
+        "the child just demonstrated a longer inter-progress gap than any "
+        "before it and did not earn a longer window"
+    )
+    assert track.verdict(at + grown * 0.9) == RUNG_ALIVE
+    assert track.verdict(at + grown * 1.5) == RUNG_REPORT
+
+
+@pytest.mark.parametrize("label", SITE_LABELS, ids=lambda s: s or "no-label")
+def test_the_ladder_is_identical_for_every_long_running_site(label: str) -> None:
+    """The parameterized reprieve test the design asks for, in its post-Verdict-1
+    form: there is no per-site reprieve to prove reachable, so what is proven
+    instead is that the site's LABEL changes nothing.
+
+    (a) evidence advancing -> held; (b) evidence forced flat -> report ->
+    diagnose -> TERM -> KILL in order. Identical for all five labels, which is
+    what makes "a path that forgets loses a label, not a process" true.
+    """
+
+    track = _track()
+    now = _burning(track, until=3 * track.window_s, step=1.0)
+    assert track.verdict(now) == RUNG_ALIVE
+
+    w = track.window_s
+    base = now
+    assert [track.verdict(base + w * k) for k in (0.5, 1.5, 2.5, 3.5, 4.5)] == [
+        RUNG_ALIVE, RUNG_REPORT, RUNG_DIAGNOSE, RUNG_TERM, RUNG_KILL
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 3. The window is DERIVED FROM OBSERVATION
+# ---------------------------------------------------------------------------
+
+
+def test_a_child_that_demonstrates_long_gaps_earns_a_longer_leash() -> None:
+    """W = max(floor, k x the largest gap this child has ACTUALLY shown).
+
+    The whole no-magic-timeouts point: the only clock left measures absence of
+    progress, and its SCALE comes from the child's own progress. An inductor
+    compile that legitimately ticks every 100 s is not held to the same window
+    as a loop that ticks every 200 ms.
+    """
+
+    fast = _track()
+    _burning(fast, until=60.0, step=0.2)
+    assert fast.largest_gap_s == pytest.approx(0.2, abs=0.01)
+    assert fast.window_s == pytest.approx(DEFAULT_FLATNESS_FLOOR_S), (
+        "a child with tiny gaps is held to the FLOOR, not to 3x0.2s — the "
+        "floor is what stops the derived window collapsing"
+    )
+
+    slow = _track()
+    slow.observe(1.0, 0.0)
+    slow.observe(2.0, 100.0)   # a demonstrated 100 s inter-progress gap
+    assert slow.largest_gap_s == pytest.approx(100.0)
+    assert slow.window_s == pytest.approx(300.0)
+    assert slow.window_s > fast.window_s, (
+        "the child that demonstrated it needs longer did not get longer"
+    )
+    # ...and the kill is four of those windows away, not four of the floor's.
+    assert slow.verdict(100.0 + 4 * 300.0) == RUNG_TERM
+    assert slow.verdict(100.0 + 4 * 300.0 + 1.0) == RUNG_KILL
+
+
+def test_the_floor_is_a_lower_bound_and_never_shortens_a_window() -> None:
+    """The operator lever pgw#1613 proved must exist ("NO KNOB"), and the
+    direction it may move things.
+
+    A smaller floor must not be able to shorten a window the child's own
+    observed gaps have already justified — otherwise the knob becomes a way to
+    reintroduce the cliff.
+    """
+
+    tiny_floor = EvidenceTrack(floor_s=1.0)
+    tiny_floor.observe(1.0, 0.0)
+    tiny_floor.observe(2.0, 100.0)
+    assert tiny_floor.window_s == pytest.approx(300.0), (
+        "the observed-gap term must win over a small floor"
+    )
+
+    big_floor = EvidenceTrack(floor_s=10_000.0)
+    big_floor.observe(1.0, 0.0)
+    big_floor.observe(2.0, 100.0)
+    assert big_floor.window_s == pytest.approx(10_000.0)
+
+
+def test_the_default_floor_puts_the_earliest_kill_four_windows_out() -> None:
+    """The default is a DERIVED number and its consequence is stated.
+
+    A number in a supervisor has to earn its place: the earliest possible kill
+    is 4 x floor of provably-zero kernel work, with a report at 2x and a
+    captured diagnosis at 3x. If someone shortens the default, this fails and
+    they have to say why.
+    """
+
+    track = _track()
+    track.observe(1.0, 0.0)
+    assert track.window_s == DEFAULT_FLATNESS_FLOOR_S
+    assert track.verdict(4 * DEFAULT_FLATNESS_FLOOR_S) == RUNG_TERM
+    assert track.verdict(4 * DEFAULT_FLATNESS_FLOOR_S + 1) == RUNG_KILL
+    assert DEFAULT_FLATNESS_FLOOR_S * 4 >= 480.0, (
+        "the earliest kill is under eight minutes of provably-zero kernel "
+        "work; that is a cliff wearing a ladder's clothes"
+    )
+
+
+def test_the_settings_knob_reaches_the_parent() -> None:
+    """A lever nothing reads is not a lever. pgw#1620's whole lesson."""
+
+    from gen_worker.config.loader import _ENV_TO_FIELD
+    from gen_worker.config.settings import Settings
+
+    assert _ENV_TO_FIELD["GEN_WORKER_WATCHDOG_FLATNESS_FLOOR_S"] == (
+        "watchdog_flatness_floor_s"
+    )
+    assert Settings().watchdog_flatness_floor_s == 0.0, (
+        "0 must mean 'use the derived default', not 'kill immediately'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Failure to measure HOLDS
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreadable_proc_holds_and_reports_forever() -> None:
+    """`no_evidence_source -> KILL` inverted the burden of proof.
+
+    An unreadable `/proc` — psutil import failure, a race on exit, a container
+    that lost the capability — is ABSENCE OF INSTRUMENT, not guilt. Both halves
+    are asserted: before any successful read, and (the one that is easy to
+    miss) AFTER one, where elapsed time keeps running while nothing is being
+    measured.
+    """
+
+    never = _track()
+    assert never.verdict(0.0) == RUNG_UNMEASURABLE
+    assert never.observe(None, 10_000.0) is False
+    assert never.verdict(10_000.0) == RUNG_UNMEASURABLE, (
+        "an instrument that has never worked must never produce a kill"
+    )
+
+    lost = _track()
+    lost.observe(100.0, 0.0)
+    lost.observe(None, 1.0)  # the instrument goes away
+    w = lost.window_s
+    assert lost.verdict(w * 99) == RUNG_UNMEASURABLE, (
+        "the ladder walked on ELAPSED TIME while nothing was being measured — "
+        "an instrument outage must not become a kill"
+    )
+    # And it recovers the instant the instrument returns.
+    lost.observe(100.0, w * 99)
+    assert lost.verdict(w * 99) in (RUNG_ALIVE, RUNG_REPORT, RUNG_DIAGNOSE,
+                                    RUNG_TERM, RUNG_KILL)
+    assert lost.verdict(w * 99) != RUNG_UNMEASURABLE
+
+
+def test_an_unreadable_sample_does_not_accrue_flatness() -> None:
+    """A `None` is not a flat reading, and must not be recorded as one."""
+
+    track = _track()
+    track.observe(100.0, 0.0)
+    before = track.advanced_at
+    track.observe(None, 50.0)
+    assert track.advanced_at == before
+    assert track.value == 100.0
+
+
+# ---------------------------------------------------------------------------
+# 5. Actions are edge-triggered
+# ---------------------------------------------------------------------------
+
+
+def test_each_rung_acts_once_per_flat_episode() -> None:
+    """The ladder is level-triggered; its ACTIONS are not.
+
+    A diagnosis captured on every 15 s sample is a log flood, and a SIGTERM
+    re-sent on every sample is a child that never gets its window to unwind.
+    """
+
+    track = _track()
+    track.observe(100.0, 0.0)
+    assert track.claim(RUNG_TERM) is True
+    assert track.claim(RUNG_TERM) is False
+    # ...and an advance re-arms every rung, because the next flat episode is a
+    # different episode.
+    track.observe(200.0, 10.0)
+    assert track.claim(RUNG_TERM) is True
+
+
+# ---------------------------------------------------------------------------
+# 6. The diagnosis rung produces a real artifact
+# ---------------------------------------------------------------------------
+
+
+def test_the_diagnosis_reads_this_process_and_names_its_state(
+    tmp_path: Path,
+) -> None:
+    """Run against a REAL pid — this one — so the reader is proven against real
+    `/proc` rather than a fixture that always agrees with it."""
+
+    report = procdiag.capture(os.getpid(), tmp_path)
+    assert f"pid={os.getpid()}" in report
+    assert "[wchan]" in report and "[kernel stack]" in report
+    assert "[python stack]" in report
+    written = list(tmp_path.glob("liveness-diagnosis-*.txt"))
+    assert len(written) == 1, "the artifact must survive a pod with no logs API"
+    assert written[0].read_text().startswith(f"pid={os.getpid()}")
+    # This process is running, so the state letter must be a real one.
+    assert procdiag.read_proc_state(os.getpid()) in ("R", "S", "D", "t", "T")
+
+
+def test_the_diagnosis_never_raises_on_a_process_that_is_gone() -> None:
+    """A diagnostic that can raise turns a stall into a crash. The child being
+    diagnosed is by definition in a bad state; it may also have just exited."""
+
+    report = procdiag.capture(2_147_483_646)
+    assert "2147483646" in report
+    # Every source reports its own absence rather than propagating.
+    assert "<absent>" in report or "unreadable" in report or "not permitted" in report
+
+
+def test_a_D_state_is_named_because_it_is_not_the_childs_fault(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The single most valuable line the diagnosis can carry.
+
+    `State: D` is an uninterruptible wait: the child cannot answer a SIGTERM
+    and did not choose to be there. This fleet has seen exactly that shape on a
+    wedged mount, and a kill report that does not say so sends the next reader
+    hunting the wrong process.
+    """
+
+    monkeypatch.setattr(procdiag, "read_proc_state", lambda pid: "D")
+    report = procdiag.capture(os.getpid())
+    assert "UNINTERRUPTIBLE WAIT" in report
+
+
+# ---------------------------------------------------------------------------
+# 7. The ladder, driven through the real `_ChildSlot` method
+# ---------------------------------------------------------------------------
+
+
+class _Proc:
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+        self.signals: list[str] = []
+
+    def terminate(self) -> None:
+        self.signals.append("TERM")
+
+    def kill(self) -> None:
+        self.signals.append("KILL")
+
+
+class _Slot:
+    """A structural stand-in for the attributes the ladder reads.
+
+    `_walk_liveness_ladder` is called UNBOUND on this, so the code under test is
+    the production method rather than a copy: constructing a real `_ChildSlot`
+    needs a live parent, a spawned subprocess and a socket, none of which the
+    decision touches.
+    """
+
+    def __init__(self, track: EvidenceTrack, dials: list[str]) -> None:
+        self.evidence = track
+        self.ordinal = 0
+        self.label = "g0"
+        self.in_flight: dict[Any, Any] = {}
+        self.liveness_activity = ""
+        self.last_frame_at = 0.0
+        self.last_liveness_at = 0.0
+        self.watchdog_fired = False
+
+        async def dial(detail: str) -> None:
+            dials.append(detail)
+
+        self.p = type("P", (), {
+            "_dial_detail": staticmethod(dial),
+            "_postmortem_dir": None,
+        })()
+
+    # Borrowed from production, not reimplemented: the labels are part of what
+    # the reports are asserted to carry.
+    from gen_worker.procsplit.parent import _ChildSlot as _Real
+
+    _liveness_labels = _Real._liveness_labels
+
+
+def test_the_real_ladder_signals_TERM_before_KILL_and_says_so() -> None:
+    """End to end through `_ChildSlot._walk_liveness_ladder`.
+
+    The old code went straight to `proc.kill()`. A SIGTERM first is what lets a
+    child that is merely slow flush its results instead of losing them, and the
+    rungs must be distinguishable on the wire — an operator reading
+    `worker_activity_events` has to be able to tell a report from a kill.
+    """
+
+    from gen_worker.procsplit.parent import _ChildSlot
+
+    dials: list[str] = []
+    track = _track()
+    track.observe(100.0, 0.0)
+    slot = _Slot(track, dials)
+    proc = _Proc()
+    w = track.window_s
+
+    async def walk() -> None:
+        for t in (w * 0.5, w * 1.5, w * 2.5, w * 3.5, w * 4.5, w * 5.5):
+            await _ChildSlot._walk_liveness_ladder(slot, proc, t)  # type: ignore[arg-type]
+
+    asyncio.run(walk())
+
+    assert proc.signals == ["TERM", "KILL"], (
+        f"the ladder must ask before it kills, once each; got {proc.signals}"
+    )
+    phases = [d.split()[0] for d in dials]
+    assert phases == [
+        "phase=compute_child_stalled",
+        "phase=compute_liveness_diagnosis",
+        "phase=compute_liveness_term",
+        "phase=compute_liveness_kill",
+    ], phases
+    # Every report shows its working, and carries the labels as LABELS.
+    assert all("window_s=" in d and "largest_observed_gap_s=" in d for d in dials)
+    assert all("label_activity=" in d for d in dials)
+
+
+def test_the_real_ladder_signals_NOTHING_while_evidence_advances() -> None:
+    """THE pgw#1613 REGRESSION, through the production method.
+
+    No activity is ever declared, the loop has been silent since time zero, and
+    the child is burning CPU. The old ladder SIGKILLed this. It must now be
+    completely uneventful — no signal, and not even a report.
+    """
+
+    from gen_worker.procsplit.parent import _ChildSlot
+
+    dials: list[str] = []
+    track = _track()
+    slot = _Slot(track, dials)
+    proc = _Proc()
+
+    async def walk() -> None:
+        now, value = 0.0, 0.0
+        for _ in range(200):
+            now += 15.0        # the real sampling cadence: budget/4
+            value += 1.0
+            track.observe(value, now)
+            await _ChildSlot._walk_liveness_ladder(slot, proc, now)  # type: ignore[arg-type]
+
+    asyncio.run(walk())
+
+    assert proc.signals == [], (
+        "a child with continuously advancing kernel evidence was signalled — "
+        "this is exactly the pgw#1613 kill"
+    )
+    assert dials == [], "and it should not even have been reported as stalled"
+    assert slot.watchdog_fired is False
+
+
+def test_an_unmeasurable_child_is_reported_and_never_signalled() -> None:
+    """Failure to measure holds and REPORTS — the report is the product."""
+
+    from gen_worker.procsplit.parent import _ChildSlot
+
+    dials: list[str] = []
+    track = _track()
+    slot = _Slot(track, dials)
+    proc = _Proc()
+
+    async def walk() -> None:
+        for t in (10.0, 10_000.0, 100_000.0):
+            track.observe(None, t)
+            await _ChildSlot._walk_liveness_ladder(slot, proc, t)  # type: ignore[arg-type]
+
+    asyncio.run(walk())
+
+    assert proc.signals == []
+    assert len(dials) == 1, "reported once per episode, not once per sample"
+    assert dials[0].startswith("phase=compute_liveness_unmeasurable")
+    assert "holding, never killing" in dials[0]
+
+
+# ---------------------------------------------------------------------------
+# 8. pgw#1613's landed scope stays landed
+# ---------------------------------------------------------------------------
+
+
+def test_the_pgw1613_activity_scope_survives_as_TELEMETRY() -> None:
+    """The `activity.running(KIND_BOOT_MATERIALIZE)` scope pgw#1613 added is
+    GOOD telemetry and stays — it is what makes a stall report say WHAT the
+    child was doing. What changed is that it decides nothing.
+
+    Its own acceptance tests in `test_boot_materialize.py` are untouched and
+    still green; this asserts the scope is still there, so a future "it decides
+    nothing, delete it" reading of pgw#1630 fails here first.
+    """
+
+    from gen_worker import boot_materialize
+
+    source = Path(boot_materialize.__file__).read_text()
+    assert "activity.running(activity.KIND_BOOT_MATERIALIZE)" in source, (
+        "pgw#1613's fetch activity is gone; the stall report can no longer say "
+        "what the child was doing"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_activity() -> Iterator[None]:
+    activity.reset_for_tests()
+    yield
+    activity.reset_for_tests()


### PR DESCRIPTION
Closes pgw#1630. Follows the design review's Verdict 1 and Verdict 2 (`design-reviews/2026-08-21-watchdog.md`).

## The sharpest fact

In the pgw#1613 kills the child **passed** the kernel-evidence rung. The CAS fill kept `tree_evidence` advancing, `no_work_accrued` did not fire — and the kill came from the rung below it, `loop_wedged_no_activity`. **The parent looked at kernel-accounted proof of life and SIGKILLed anyway, because a LABEL was missing.** That contradicts `watchdog_loop`'s own docstring in the same file: *"the parent kills only what is provably NOT RUNNING; a child that runs but serves nothing is the hub's stall clock to reap."*

Two H3 pods, two pins, byte-identical death at 356 s and 687 s, exit 137, pod retired `all_declared_functions_disabled`, rental burned.

pgw#1613 opened an activity at the **one** site that had been killed. That closed a site and left the class: every future long-running path owed a ritual or died. Paul's rule 4 asks for the general solution — this is it.

## What changed

**Rung 3 is deleted.** Evidence advancing ⇒ held, unconditionally. Loop pings, declared activities and in-flight counts are reporting only; they label a stall and decide nothing. A path that forgets to declare loses a label, not a process.

**Escalation, not a cliff.** `report → diagnose → SIGTERM → SIGKILL`, one window apart, every rung requiring flatness to have *continued*. Any evidence advance resets the ladder to zero — a wedge that un-wedges mid-ladder was never a wedge.

**The diagnosis rung is new, and it is the point of having a ladder at all.** The old verdict went straight to `proc.kill()` and left nothing behind, which is why the H3 diagnosis had to be reconstructed days later from a rental invoice. `procsplit/procdiag.py` captures while the child is still ALIVE: `/proc/<pid>/status` — with **`State: D` called out by name**, since an uninterruptible wait is a stall the child could not have avoided and a SIGTERM cannot end — plus `wchan`, `syscall`, kernel stack, and a bounded `py-spy dump`. Written beside the other post-mortem artifacts so it survives a pod with no logs API. Every reader is independently guarded and the capture never raises.

**The window is derived from observation.** `W = max(floor, 3 × the largest inter-progress gap this child has actually demonstrated)`. `largest_gap_s` grows only when evidence moves *again* — a gap is only known to have been a gap once it ends — so this measures the child, not the wall clock. Both old clocks are gone:

| clock | was | now |
|---|---|---|
| `_DEFAULT_WATCHDOG_BUDGET_S = 60` | the kill budget | a `/proc` **sampling cadence** (÷4); its constant now says so |
| `_evidence_hold_window = 3 × ping cadence` | the hold window | **deleted** — a ping is a self-report, and how often a child says "still here" says nothing about how long real work may go without touching the kernel |

The floor is `Settings.watchdog_flatness_floor_s` / `GEN_WORKER_WATCHDOG_FLATNESS_FLOOR_S` — the operator lever pgw#1613 proved must exist ("NO KNOB") — and it can only ever **lengthen** a window the observed gaps have not already justified. Its default is derived and its consequence is asserted: the earliest possible kill is 4 × floor of provably-zero kernel work, and a test fails if someone shortens it under eight minutes.

**Failure to measure holds.** `no_evidence_source → KILL` inverted the burden of proof: an unreadable `/proc` became a death sentence.

> ### A defect in the first draft of this fix, recorded because it is the same shape
> Holding only when evidence had **never** been read meant that an instrument failing *after* a successful read left `flat_for(now)` growing on ELAPSED TIME while nothing was being measured — the deleted rung re-entering through the back door, and it would have SIGKILLed a healthy child on the strength of an instrument outage. The rule is now: we cannot say a child is flat when we cannot read it.
>
> Flatness accumulated *across* an outage is still real once the instrument returns, and that is sound rather than assumed: tree CPU seconds and IO bytes are monotonic, so a reading equal to the pre-outage one proves zero work happened in between.

## pgw#1613's landed scope stays

"The activity decides nothing" is not "the activity is pointless" — it is the label on `compute_child_stalled`, and the difference between a filed bug and a shrug. Its two acceptance tests are **untouched and green**. Its third asserted the deleted kill branch and is rewritten into its successor, and a new test asserts the `activity.running(KIND_BOOT_MATERIALIZE)` scope still **exists**, so a "it decides nothing, delete it" reading of this issue fails there first.

Three stale comments in `activity.py`, `boot_materialize.py` and `worker.py` described `_hang_verdict` as load-bearing for the child's LIFE; all three are corrected here. A comment describing a deleted mechanism is how the next lane resurrects it.

## Red arms — checked by breaking the fix, not by counting assertions

- restoring the cooperative rung (kill a CPU-burning child that declared nothing) turns `test_the_real_ladder_signals_NOTHING_while_evidence_advances` red — **that test is the H3 kill**;
- restoring "unreadable `/proc` is guilt" turns both unmeasurable tests red.

The structural fence reads **string literals via AST, not raw text**: a comment naming the deleted rung is documentation of why it is gone and should survive; a live string literal is the verdict being produced again.

## On the parameterized per-site test

The design asks for one per long-running site. Under Verdict 1 there is no per-site reprieve left to prove reachable, so what is proven instead is that the site's **label changes nothing**: the suite is parametrized over the four sites' real `KIND_*` plus the empty label — the site that forgot the ritual, pgw#1613's actual victim — and all five walk an identical ladder.

## Verification

- `tests/test_watchdog_evidence_pgw1630.py` — 30 passed
- `tests/test_boot_materialize.py` — green, including the rewritten pgw#1613 arm
- `mypy src/gen_worker tests` — clean, 633 files
- `ruff check src/gen_worker` — clean

No clocks were slept on anywhere in the new suite: `now` is a parameter, and every window in an assertion is computed from the track's own `window_s`.