### PR TITLE
pgw#1621: cut 0.128.0 — the worker cut to tensor-layout contract v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.127.2"
+version = "0.128.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -573,7 +573,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.127.2"
+version = "0.128.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Cut BECAUSE A POD RUN NEEDS ONE (docs/releasing.md rule 1): th#2251's
production battery (items 4a/4b — the fleet serving through v2 stamps, juggle
admission consuming v2) is gated on endpoints repinning to a wheel that carries
this, and the serverless-endpoints re-key wave cannot start without one.
Batched with everything ready at this moment: 29 commits since v0.127.2,
spanning pgw#1621, #1626, #1627, #1631, #1632, #1633 and the tcg#79 re-vendor.

MINOR, not patch, because this DELETES public API: `KNOWN_CONTRACTS` and its
six handle constants, `implements_contract`/`ContractDecoder`/
`DecodeDimensions` and the five decode dimensions, `DTYPE_MIN_SM`,
`FLOOR_LOSING_SPELLINGS`, `capability_floor_for_dtype`, `TensorLayoutContract`,
`MissingContract` and its fifteen `_library` constants, `LaneContract` and
`DTYPELESS_UPSTREAM_LANES`. A lane is now the `(topology, quant)` STAMP PAIR.

Cut from a PINNED commit — `0a50965f`, the pgw#1621 merge — not master's tip.
pgw#1627 landed underneath this lane mid-flight, which is exactly the case the
release doc warns about; it is IN this range and named above rather than picked
up silently. Must-ride, ancestor-verified against this tree rather than taken
from cut notes: `0a50965f` (the v2 merge), `2da69ac5` (torchcg dcadeb2 —
without it every release derive dies), `b04160ed` (tensorfs ac9c9d4 — the
corpus that covers the fleet), `9f7496ae`.

STEP 0 WAS NOT RUN, AND [[#1615]] ALREADY OWNS WHY. `CHANGELOG.md` was
DELIBERATELY DELETED — 19,101 lines — by [[#1582]] `b35da9ad`, sweeping a
deletion Paul had made locally; `assemble_changelog.py`'s CUT path still reads
it unguarded and dies `FileNotFoundError`. #1615 filed that after the 0.127.2
cut and is open ON A PAUL RULING (either the changelog machinery is orphaned
and goes, or the file comes back) — so nothing is invented here and no fragment
is force-consumed. The assembler's own refusal is right: *"that version is
released and its section should exist; do not invent one."* `--check`, which is
what `fast gates` runs, reads only `changelog.d/` and passes, exit 0.

A SECOND STALE STEP, NOT YET TRACKED. Rule 2 tells the cutter to bump
`TENSORHUB_SUPPORTED_GEN_WORKER_VERSIONS` in lockstep with each MINOR. THAT
GATE NO LONGER EXISTS — verified two ways on tensorhub master: the env var
appears nowhere, and `internal/genworkercompat` (its home, per the hub's own
dropped-issue log) is deleted with zero references left. th#1282 /
DESIGN-RULINGS §1.27 retired it deliberately: refusing workers by
`gen_worker_version` gates on a Python developer-contract semver that appears
nowhere in the wire protocol and would not exist for a Go or Rust worker, and a
floor bounds only builds BELOW it. `gen_worker_version` is telemetry. So this
MINOR has no hub prerequisite — which is worth knowing, because the doc makes
it look like one. Filed as a follow-up to #1615's ruling.