### PR TITLE
pgw#1628 follow-up: comment named deleted @implements_contract as alive

### DIFF
--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -349,7 +349,7 @@ def unregistered_decode_path_of(obj: Any) -> tuple[UnregisteredDecodePath, ...]:
 
 # ── §1.33: the DEMAND side of the same vocabulary ─────────────────────────────
 #
-# `@implements_contract` above is the SUPPLY-adjacent census — "which decoders
+# `@implements_quant_rule` above is the SUPPLY-adjacent census — "which decoders
 # does this IMAGE contain". The DEMAND is what `Slot(layouts=...)` declares:
 # "what does this slot's code need in order to run". Two facts, one vocabulary,
 # so the handle grammar and the registration refusal are shared verbatim rather


### PR DESCRIPTION
Dead-mechanism audit over the merged purge (coordinator-ordered): one hit. The kept §1.33 comment in tensor_layout_contract.py said `@implements_contract above` — that decorator died in pgw#1621; the decorator above is `@implements_quant_rule`. One comment line, no code change.

Audit scope and result: tensorhub merged tree 0 hits (ImageOnDiskMultiple/UnknownImageOnDiskGB are live constants; `implements_contract` survives there only in RUNTIME STRINGS owned by the th#2251 hub-side cut — bindingcheck/artifact_contract_th1803.go:75 and the th#1939 derivation vocabulary — flagged to that lane, not comment work). pgw merged tree: this one comment; all other mentions are pgw#1621/#1630's own tombstone tests and deletion-aware docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)