### PR TITLE
pgw#1600: the demand formula is DATA — term algebra, release serialization, and the predicted-vs-measured falsifier that ships FIRST

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,6 +241,8 @@ jobs:
         run: uv run python scripts/check_grammar_corpus_digest.py
       - name: pgw#1236 gate - the shared formula corpus matches its digest
         run: uv run python scripts/check_formula_corpus_digest.py
+      - name: pgw#1600 gate - the shared demand corpus is REGENERATED and digested
+        run: uv run python scripts/check_demand_corpus_digest.py
 
       # GATING (pgw#968): a changelog fragment whose name does not parse as
       # <prefix><number>.md would otherwise refuse the RELEASE CUT, weeks after

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -113,6 +113,7 @@ tasks:
       - cmd: uv run python scripts/check_hub_worker_boundary_contracts_digest.py
       - cmd: uv run python scripts/check_grammar_corpus_digest.py
       - cmd: uv run python scripts/check_formula_corpus_digest.py
+      - cmd: uv run python scripts/check_demand_corpus_digest.py
       - cmd: uv run python scripts/assemble_changelog.py --check
 
   test:

--- a/changelog.d/pgw1600-demand-formula.md
+++ b/changelog.d/pgw1600-demand-formula.md
@@ -53,3 +53,15 @@
   mint-time stamp exists, and the guard is falsified against a module that
   really does import the plane, so it is known to be armed rather than assumed
   to be.
+
+- **pgw#1600: the cross-language corpus earned its keep on its first Go run, and
+  the arithmetic changed because of it.** The evaluator originally avoided
+  forming `coefficient * value` — it split `c = q*scale + r` and computed
+  `q*v + floor(r*v/scale)` on the premise that the declared shape bounds kept
+  both products inside int64. They do not: at the corpus's own ceiling row,
+  `mp_batch` with a 1 GiB coefficient makes `r*v` 1.3e19, and Go wrapped by
+  exactly 2^64/1e6. **Python's bignums could not have found this in a thousand
+  green runs** — only a second language executing the same table could. Both
+  sides now compute exactly (Python natively, Go through `math/big`) and the
+  one shared constraint is that the ANSWER fits int64; a formula whose worst
+  case does not is refused loudly rather than wrapped into a small number.

--- a/changelog.d/pgw1600-demand-formula.md
+++ b/changelog.d/pgw1600-demand-formula.md
@@ -1,0 +1,55 @@
+- **pgw#1600: a lane's demand is DATA — a term algebra, serialized into the
+  release document, evaluable by a non-Python reader, and falsified on every
+  serve before anything is allowed to consume it.** `lane(request=...)` already
+  took a formula; it had no evaluator, no serialization and no instrument. It
+  now has all three. Evaluation is exact 64-bit INTEGER arithmetic — each term
+  is an integer numerator over a fixed scale (`megapixels` is `width*height`
+  over 1_000_000) and the sum is floor division, computed without ever forming
+  `coefficient * value`, which overflows int64 at plausible shapes. That is not
+  fastidiousness: a float divide is where two languages stop agreeing, and the
+  whole point of the serialization is that tensorhub's Go evaluator returns the
+  same bytes. `gen_worker/contracts/demand_vectors.json` is the shared
+  conformance corpus, and it is GENERATED from this repository's own evaluator
+  rather than typed by hand — a corpus with hand-written expectations proves a
+  human and Go agree, which is not the property anyone wants.
+
+- **pgw#1600: every coefficient carries its provenance, and claiming a
+  measurement without naming it is a refusal.** `Basis` has three values and
+  the default is the honest one: `uncalibrated`, a declared prior. `measured`
+  and `ledger` require a `source=` citing the run or the ledger key, and adding
+  two same-named terms of DIFFERENT provenance refuses rather than laundering
+  one claim into the other. A formula reports the claim its WEAKEST term
+  supports, so a measured intercept beside a guessed slope reads as
+  uncalibrated — which is what it is.
+
+- **pgw#1600: the release document's lane rows carry a `demand` block, and the
+  worst case in it is DERIVED.** Terms, the closed vocabulary they are written
+  against (so a Go reader validates its own table instead of assuming), the
+  advertised envelope, the shape inside that envelope which maximises the
+  formula, and the bytes. Every envelope axis states its SOURCE — `advertised`
+  from a bounded payload field, `declared` from the payload's own bucket table,
+  or `default` with the reason. An aspect-ratio enum can now dimension itself
+  via `Annotated[..., Shape(pixels=_BUCKETS)]`, passing the endpoint's own
+  table by reference so there is no second spelling of its geometry to drift.
+  The block states what it is NOT: request arena only, weights are manifest
+  arithmetic the hub adds.
+
+- **pgw#1600: `demand_miss` — predicted-vs-measured, banked every serve,
+  counted and hub-visible per (lane × regime).** The request arena is measured
+  across the handler and decomposed the way it is SPENT: the torch allocator's
+  peak, growth outside the allocator (CUDA context, cuDNN/cuBLAS workspaces,
+  AOTI's own `cudaMalloc`'d pool) and driver growth. Eager is judged on the
+  allocator; compiled on the driver total, because AOTI's first-call allocation
+  cannot spend the allocator's cache. A compiled miss is emitted as a P0 defect
+  of the stamp, never as a statistic. Samples never pool across regimes or
+  lanes, a regime the worker could not determine pools with nothing, and a
+  concurrent request banks nothing at all rather than attributing a co-tenant's
+  activations to this lane.
+
+- **pgw#1600: provably zero admission decisions consume the number — the
+  falsifier ships before the enforcer, and a test asserts the absence.** An AST
+  guard names the admission surface and fails the moment any of it reaches the
+  demand plane. `headroom_admits(demand_bytes=)` stays inert until pgw#1601's
+  mint-time stamp exists, and the guard is falsified against a module that
+  really does import the plane, so it is known to be armed rather than assumed
+  to be.

--- a/scripts/check_demand_corpus_digest.py
+++ b/scripts/check_demand_corpus_digest.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Fail if the shared demand corpus is stale, hand-edited, or undigested.
+
+pgw#1600. Three ways this goes red, and each is a real defect:
+
+* the corpus is not what `scripts/gen_demand_corpus.py` produces — someone
+  edited an expected byte count by hand, or the evaluator moved and the corpus
+  did not;
+* the digest sidecar does not match the corpus bytes — the coupled cross-repo
+  bump was half-done;
+* either file is missing.
+
+The FIRST check is the important one and is why this script regenerates rather
+than merely hashing: a conformance corpus whose expectations are typed in by a
+human proves that the human and Go agree, not that Python and Go do.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+DEFAULT_CORPUS = ROOT / "src" / "gen_worker" / "contracts" / "demand_vectors.json"
+DEFAULT_DIGEST = ROOT / "src" / "gen_worker" / "contracts" / "DEMAND_VECTORS_DIGEST"
+
+
+def recorded_digest(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            return line.split()[0]
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--digest", type=Path, default=DEFAULT_DIGEST)
+    args = parser.parse_args()
+
+    for path in (args.corpus, args.digest):
+        if not path.is_file():
+            print(f"demand-corpus-digest: missing {path}")
+            return 2
+
+    from gen_demand_corpus import build  # noqa: PLC0415
+
+    regenerated = json.dumps(build(), indent=2, ensure_ascii=False) + "\n"
+    committed = args.corpus.read_text(encoding="utf-8")
+    if regenerated != committed:
+        print(
+            "demand-corpus-digest: FAIL — the committed corpus is not what "
+            "this repository's evaluator produces.\n"
+            "  Run `uv run python scripts/gen_demand_corpus.py`, review the "
+            "diff (a changed byte count means the ALGEBRA moved), then record "
+            "the new digest and bump tensorhub's peers.lock row."
+        )
+        return 1
+
+    actual = hashlib.sha256(args.corpus.read_bytes()).hexdigest()
+    recorded = recorded_digest(args.digest)
+    if actual == recorded:
+        print(f"demand-corpus-digest: demand_vectors.json matches {actual}")
+        return 0
+
+    print(
+        "demand-corpus-digest: FAIL — the corpus changed without its digest\n"
+        f"  recorded: {recorded or '<missing>'}\n"
+        f"  actual:   {actual}\n\n"
+        "Record the new digest here, land it, then bump tensorhub's "
+        "peers.lock row to this repository's merge commit."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_demand_corpus.py
+++ b/scripts/gen_demand_corpus.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Regenerate the shared demand-formula conformance corpus.
+
+pgw#1600 acceptance (a). The corpus is the CONTRACT between this repository's
+evaluator and tensorhub's Go one: a table of (serialized formula, request
+shape) -> bytes, plus the refusals both sides must produce. Go reads the same
+bytes and must return the same integers.
+
+The cases are chosen to break a naive implementation, not to look tidy:
+
+* coefficients that are NOT multiples of their term's scale, so a float divide
+  and a floor divide disagree;
+* a coefficient SMALLER than its scale, which is the pure-remainder arm of the
+  split division;
+* the domain ceiling on every axis at once with a large coefficient, which is
+  where `coefficient * value` would overflow int64 if either side formed the
+  product before dividing;
+* the tcg#80 sdxl reference shape, so the corpus carries the one payload a
+  human can check against a measurement.
+
+Run: `uv run python scripts/gen_demand_corpus.py` then record the digest with
+`scripts/check_demand_corpus_digest.py --write`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from gen_worker.demand import (  # noqa: E402
+    GiB,
+    KiB,
+    MiB,
+    RequestShape,
+    SHAPE_BOUNDS,
+    VOCABULARY_VERSION,
+    evaluate,
+    vocabulary_document,
+)
+
+CORPUS = ROOT / "src" / "gen_worker" / "contracts" / "demand_vectors.json"
+
+
+def _case(name: str, terms: list[dict[str, object]], shape: RequestShape,
+          why: str = "") -> dict[str, object]:
+    row: dict[str, object] = {
+        "name": name,
+        "terms": terms,
+        "shape": shape.as_document(),
+        "bytes": evaluate(terms, shape),
+    }
+    if why:
+        row["why"] = why
+    return row
+
+
+def _terms(*pairs: tuple[str, int]) -> list[dict[str, object]]:
+    return [{"term": name, "bytes": coefficient} for name, coefficient in pairs]
+
+
+def build() -> dict[str, object]:
+    ceiling = RequestShape(
+        width=SHAPE_BOUNDS["width"],
+        height=SHAPE_BOUNDS["height"],
+        batch=SHAPE_BOUNDS["batch"],
+        frames=SHAPE_BOUNDS["frames"],
+        latent_tokens=SHAPE_BOUNDS["latent_tokens"],
+    )
+    cases = [
+        _case(
+            "a const-only formula ignores the shape entirely",
+            _terms(("const", GiB(1.2))),
+            RequestShape(width=1024, height=1024, batch=2),
+        ),
+        _case(
+            "the sdxl reference shape",
+            _terms(("const", GiB(1.2)), ("mp_batch", MiB(220))),
+            RequestShape(width=1024, height=1024, batch=2),
+            why="1024x1024 with the CFG pair — the shape pgw#1577 measured "
+                "and the one tcg#80 re-ran compiled on sm_89",
+        ),
+        _case(
+            "a coefficient that is not a multiple of its scale FLOORS",
+            _terms(("megapixels", 1_000_003)),
+            RequestShape(width=1023, height=1021),
+            why="1_000_003 * 1_044_483 / 1_000_000 is not an integer; a float "
+                "divide and a floor divide answer differently here",
+        ),
+        _case(
+            "a coefficient SMALLER than its scale is the pure-remainder arm",
+            _terms(("megapixels", 7)),
+            RequestShape(width=999, height=997),
+            why="quotient is 0, so the whole answer comes out of "
+                "(remainder * value) // scale",
+        ),
+        _case(
+            "a sub-megapixel request rounds DOWN to zero on a small coefficient",
+            _terms(("mp_batch", KiB(1))),
+            RequestShape(width=64, height=64, batch=1),
+        ),
+        _case(
+            "every video term at once",
+            _terms(
+                ("const", MiB(512)),
+                ("frames", MiB(3)),
+                ("frames_squared", KiB(64)),
+                ("batch", MiB(11)),
+            ),
+            RequestShape(width=1280, height=720, batch=1, frames=241),
+        ),
+        _case(
+            "latent tokens, the transformer-shaped term",
+            _terms(("const", MiB(700)), ("latent_tokens", 8192)),
+            RequestShape(width=1024, height=1024, batch=1, latent_tokens=4096),
+        ),
+        _case(
+            "the zero shape: every non-const term contributes nothing",
+            _terms(
+                ("const", MiB(64)),
+                ("megapixels", GiB(4)),
+                ("mp_batch", GiB(4)),
+                ("batch", GiB(4)),
+                ("frames", GiB(4)),
+                ("frames_squared", GiB(4)),
+                ("latent_tokens", GiB(4)),
+            ),
+            RequestShape(width=0, height=0, batch=0, frames=0, latent_tokens=0),
+            why="a lane whose request advertises no shape axis is not a lane "
+                "with an unbounded demand",
+        ),
+        _case(
+            "the domain ceiling on every axis with a large coefficient",
+            _terms(
+                ("const", GiB(64)),
+                ("megapixels", GiB(1)),
+                ("mp_batch", GiB(1)),
+                ("batch", MiB(1)),
+                ("frames", MiB(1)),
+                ("frames_squared", 1),
+                ("latent_tokens", 1),
+            ),
+            ceiling,
+            why="THE OVERFLOW CASE. Forming coefficient*value before dividing "
+                "overflows int64 here in both languages; the split division "
+                "does not, and both sides must return this exact integer",
+        ),
+        _case(
+            "the term ORDER in the document does not change the sum",
+            _terms(("mp_batch", MiB(220)), ("const", GiB(1.2))),
+            RequestShape(width=1024, height=1024, batch=2),
+            why="same answer as the sdxl reference case above",
+        ),
+    ]
+    refusals = [
+        {
+            "name": "an unknown term name is refused, never skipped",
+            "terms": _terms(("gigaflops", 1024)),
+            "shape": RequestShape(width=1024, height=1024).as_document(),
+            "reason": "unknown_term",
+            "why": "a formula evaluated without one of its terms is a LOW "
+                   "number, and low is the direction that buys too little card",
+        },
+        {
+            "name": "a shape past the declared domain is refused",
+            "terms": _terms(("mp_batch", MiB(220))),
+            "shape": {
+                "width": SHAPE_BOUNDS["width"] + 1, "height": 1024,
+                "batch": 1, "frames": 0, "latent_tokens": 0,
+            },
+            "reason": "shape_out_of_domain",
+        },
+        {
+            "name": "a negative shape scalar is refused",
+            "terms": _terms(("const", MiB(1))),
+            "shape": {
+                "width": -1, "height": 1024, "batch": 1,
+                "frames": 0, "latent_tokens": 0,
+            },
+            "reason": "shape_out_of_domain",
+        },
+    ]
+    return {
+        "version": 1,
+        "vocabulary_version": VOCABULARY_VERSION,
+        "algebra": "C + sum(coefficient_i * value_i / scale_i), floor, int64",
+        "vocabulary": vocabulary_document(),
+        "shape_bounds": dict(SHAPE_BOUNDS),
+        "cases": cases,
+        "refusals": refusals,
+    }
+
+
+def main() -> int:
+    CORPUS.write_text(
+        json.dumps(build(), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {CORPUS}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_demand_corpus.py
+++ b/scripts/gen_demand_corpus.py
@@ -174,6 +174,16 @@ def build() -> dict[str, object]:
             "reason": "shape_out_of_domain",
         },
         {
+            "name": "a result past int64 is refused, never wrapped",
+            "terms": _terms(("latent_tokens", 1 << 33)),
+            "shape": RequestShape(latent_tokens=SHAPE_BOUNDS["latent_tokens"]).as_document(),
+            "reason": "result_out_of_range",
+            "why": "THE ROW THE GO SIDE FOUND. Python's bignums cannot notice "
+                   "an int64 overflow, so the shared constraint is on the "
+                   "ANSWER: 2**33 bytes per latent token at 2**31 tokens is "
+                   "2**64, and a wrapped answer is a SMALL number",
+        },
+        {
             "name": "a negative shape scalar is refused",
             "terms": _terms(("const", MiB(1))),
             "shape": {

--- a/src/gen_worker/contracts/DEMAND_VECTORS_DIGEST
+++ b/src/gen_worker/contracts/DEMAND_VECTORS_DIGEST
@@ -7,4 +7,4 @@
 # coupled cross-repo contract change: pgw lands first, then tensorhub bumps
 # its peers.lock row to the merge commit and re-runs its Go evaluator against
 # these bytes.
-cabe5bdf91e22cd62daf35913346f136386a6e1743494945694326df2999771b
+c852afdd7277c5fe670491672e46511ff0143b21accbb1cff2fab47efd648276

--- a/src/gen_worker/contracts/DEMAND_VECTORS_DIGEST
+++ b/src/gen_worker/contracts/DEMAND_VECTORS_DIGEST
@@ -1,0 +1,10 @@
+# sha256 of demand_vectors.json — the shared tensorhub/python-gen-worker
+# demand-formula conformance corpus (pgw#1600 acceptance (a)).
+#
+# The corpus is GENERATED, never hand-edited: `scripts/gen_demand_corpus.py`
+# writes it from this repository's own evaluator, so a case's expected bytes
+# cannot drift away from what Python actually computes. A corpus change is a
+# coupled cross-repo contract change: pgw lands first, then tensorhub bumps
+# its peers.lock row to the merge commit and re-runs its Go evaluator against
+# these bytes.
+cabe5bdf91e22cd62daf35913346f136386a6e1743494945694326df2999771b

--- a/src/gen_worker/contracts/__init__.py
+++ b/src/gen_worker/contracts/__init__.py
@@ -5,11 +5,13 @@ from typing import Final
 
 CONTRACT_FILES: Final = (
     "COZY_RUNTIME_ENV_DIGEST",
+    "DEMAND_VECTORS_DIGEST",
     "FORMULA_VECTORS_DIGEST",
     "HUB_WORKER_BOUNDARY_CONTRACTS_DIGEST",
     "REF_GRAMMAR_DIGEST",
     "WORKER_VALUE_CONTRACTS_DIGEST",
     "cozy_runtime_env_vectors.json",
+    "demand_vectors.json",
     "formula_vectors.json",
     "hub_worker_boundary_contracts.json",
     "posture_wire_vectors.json",

--- a/src/gen_worker/contracts/demand_vectors.json
+++ b/src/gen_worker/contracts/demand_vectors.json
@@ -348,6 +348,24 @@
       "reason": "shape_out_of_domain"
     },
     {
+      "name": "a result past int64 is refused, never wrapped",
+      "terms": [
+        {
+          "term": "latent_tokens",
+          "bytes": 8589934592
+        }
+      ],
+      "shape": {
+        "width": 0,
+        "height": 0,
+        "batch": 1,
+        "frames": 0,
+        "latent_tokens": 2147483648
+      },
+      "reason": "result_out_of_range",
+      "why": "THE ROW THE GO SIDE FOUND. Python's bignums cannot notice an int64 overflow, so the shared constraint is on the ANSWER: 2**33 bytes per latent token at 2**31 tokens is 2**64, and a wrapped answer is a SMALL number"
+    },
+    {
       "name": "a negative shape scalar is refused",
       "terms": [
         {

--- a/src/gen_worker/contracts/demand_vectors.json
+++ b/src/gen_worker/contracts/demand_vectors.json
@@ -1,0 +1,368 @@
+{
+  "version": 1,
+  "vocabulary_version": 1,
+  "algebra": "C + sum(coefficient_i * value_i / scale_i), floor, int64",
+  "vocabulary": {
+    "const": {
+      "scale": 1,
+      "inputs": [],
+      "doc": "a fixed floor, independent of the request"
+    },
+    "megapixels": {
+      "scale": 1000000,
+      "inputs": [
+        "width",
+        "height"
+      ],
+      "doc": "output width x height / 1e6"
+    },
+    "mp_batch": {
+      "scale": 1000000,
+      "inputs": [
+        "width",
+        "height",
+        "batch"
+      ],
+      "doc": "megapixels x batch (the CFG pair counts as 2)"
+    },
+    "batch": {
+      "scale": 1,
+      "inputs": [
+        "batch"
+      ],
+      "doc": "the launch batch size (2 with CFG, 1 without)"
+    },
+    "frames": {
+      "scale": 1,
+      "inputs": [
+        "frames"
+      ],
+      "doc": "the video frame count"
+    },
+    "frames_squared": {
+      "scale": 1,
+      "inputs": [
+        "frames"
+      ],
+      "doc": "frame count SQUARED — the quadratic attention term"
+    },
+    "latent_tokens": {
+      "scale": 1,
+      "inputs": [
+        "latent_tokens"
+      ],
+      "doc": "the denoiser's latent sequence length"
+    }
+  },
+  "shape_bounds": {
+    "width": 65536,
+    "height": 65536,
+    "batch": 4096,
+    "frames": 1048576,
+    "latent_tokens": 2147483648
+  },
+  "cases": [
+    {
+      "name": "a const-only formula ignores the shape entirely",
+      "terms": [
+        {
+          "term": "const",
+          "bytes": 1288490188
+        }
+      ],
+      "shape": {
+        "width": 1024,
+        "height": 1024,
+        "batch": 2,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "bytes": 1288490188
+    },
+    {
+      "name": "the sdxl reference shape",
+      "terms": [
+        {
+          "term": "const",
+          "bytes": 1288490188
+        },
+        {
+          "term": "mp_batch",
+          "bytes": 230686720
+        }
+      ],
+      "shape": {
+        "width": 1024,
+        "height": 1024,
+        "batch": 2,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "bytes": 1772275304,
+      "why": "1024x1024 with the CFG pair — the shape pgw#1577 measured and the one tcg#80 re-ran compiled on sm_89"
+    },
+    {
+      "name": "a coefficient that is not a multiple of its scale FLOORS",
+      "terms": [
+        {
+          "term": "megapixels",
+          "bytes": 1000003
+        }
+      ],
+      "shape": {
+        "width": 1023,
+        "height": 1021,
+        "batch": 1,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "bytes": 1044486,
+      "why": "1_000_003 * 1_044_483 / 1_000_000 is not an integer; a float divide and a floor divide answer differently here"
+    },
+    {
+      "name": "a coefficient SMALLER than its scale is the pure-remainder arm",
+      "terms": [
+        {
+          "term": "megapixels",
+          "bytes": 7
+        }
+      ],
+      "shape": {
+        "width": 999,
+        "height": 997,
+        "batch": 1,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "bytes": 6,
+      "why": "quotient is 0, so the whole answer comes out of (remainder * value) // scale"
+    },
+    {
+      "name": "a sub-megapixel request rounds DOWN to zero on a small coefficient",
+      "terms": [
+        {
+          "term": "mp_batch",
+          "bytes": 1024
+        }
+      ],
+      "shape": {
+        "width": 64,
+        "height": 64,
+        "batch": 1,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "bytes": 4
+    },
+    {
+      "name": "every video term at once",
+      "terms": [
+        {
+          "term": "const",
+          "bytes": 536870912
+        },
+        {
+          "term": "frames",
+          "bytes": 3145728
+        },
+        {
+          "term": "frames_squared",
+          "bytes": 65536
+        },
+        {
+          "term": "batch",
+          "bytes": 11534336
+        }
+      ],
+      "shape": {
+        "width": 1280,
+        "height": 720,
+        "batch": 1,
+        "frames": 241,
+        "latent_tokens": 0
+      },
+      "bytes": 5112922112
+    },
+    {
+      "name": "latent tokens, the transformer-shaped term",
+      "terms": [
+        {
+          "term": "const",
+          "bytes": 734003200
+        },
+        {
+          "term": "latent_tokens",
+          "bytes": 8192
+        }
+      ],
+      "shape": {
+        "width": 1024,
+        "height": 1024,
+        "batch": 1,
+        "frames": 0,
+        "latent_tokens": 4096
+      },
+      "bytes": 767557632
+    },
+    {
+      "name": "the zero shape: every non-const term contributes nothing",
+      "terms": [
+        {
+          "term": "const",
+          "bytes": 67108864
+        },
+        {
+          "term": "megapixels",
+          "bytes": 4294967296
+        },
+        {
+          "term": "mp_batch",
+          "bytes": 4294967296
+        },
+        {
+          "term": "batch",
+          "bytes": 4294967296
+        },
+        {
+          "term": "frames",
+          "bytes": 4294967296
+        },
+        {
+          "term": "frames_squared",
+          "bytes": 4294967296
+        },
+        {
+          "term": "latent_tokens",
+          "bytes": 4294967296
+        }
+      ],
+      "shape": {
+        "width": 0,
+        "height": 0,
+        "batch": 0,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "bytes": 67108864,
+      "why": "a lane whose request advertises no shape axis is not a lane with an unbounded demand"
+    },
+    {
+      "name": "the domain ceiling on every axis with a large coefficient",
+      "terms": [
+        {
+          "term": "const",
+          "bytes": 68719476736
+        },
+        {
+          "term": "megapixels",
+          "bytes": 1073741824
+        },
+        {
+          "term": "mp_batch",
+          "bytes": 1073741824
+        },
+        {
+          "term": "batch",
+          "bytes": 1048576
+        },
+        {
+          "term": "frames",
+          "bytes": 1048576
+        },
+        {
+          "term": "frames_squared",
+          "bytes": 1
+        },
+        {
+          "term": "latent_tokens",
+          "bytes": 1
+        }
+      ],
+      "shape": {
+        "width": 65536,
+        "height": 65536,
+        "batch": 4096,
+        "frames": 1048576,
+        "latent_tokens": 2147483648
+      },
+      "bytes": 18896351802680239,
+      "why": "THE OVERFLOW CASE. Forming coefficient*value before dividing overflows int64 here in both languages; the split division does not, and both sides must return this exact integer"
+    },
+    {
+      "name": "the term ORDER in the document does not change the sum",
+      "terms": [
+        {
+          "term": "mp_batch",
+          "bytes": 230686720
+        },
+        {
+          "term": "const",
+          "bytes": 1288490188
+        }
+      ],
+      "shape": {
+        "width": 1024,
+        "height": 1024,
+        "batch": 2,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "bytes": 1772275304,
+      "why": "same answer as the sdxl reference case above"
+    }
+  ],
+  "refusals": [
+    {
+      "name": "an unknown term name is refused, never skipped",
+      "terms": [
+        {
+          "term": "gigaflops",
+          "bytes": 1024
+        }
+      ],
+      "shape": {
+        "width": 1024,
+        "height": 1024,
+        "batch": 1,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "reason": "unknown_term",
+      "why": "a formula evaluated without one of its terms is a LOW number, and low is the direction that buys too little card"
+    },
+    {
+      "name": "a shape past the declared domain is refused",
+      "terms": [
+        {
+          "term": "mp_batch",
+          "bytes": 230686720
+        }
+      ],
+      "shape": {
+        "width": 65537,
+        "height": 1024,
+        "batch": 1,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "reason": "shape_out_of_domain"
+    },
+    {
+      "name": "a negative shape scalar is refused",
+      "terms": [
+        {
+          "term": "const",
+          "bytes": 1048576
+        }
+      ],
+      "shape": {
+        "width": -1,
+        "height": 1024,
+        "batch": 1,
+        "frames": 0,
+        "latent_tokens": 0
+      },
+      "reason": "shape_out_of_domain"
+    }
+  ]
+}

--- a/src/gen_worker/demand.py
+++ b/src/gen_worker/demand.py
@@ -33,8 +33,9 @@ number for an admission decision — see pgw#1600 acceptance (d) and
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from enum import StrEnum
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import msgspec
 
@@ -49,6 +50,8 @@ __all__ = [
     "MiB",
     "RequestShape",
     "SHAPE_BOUNDS",
+    "Shape",
+    "ShapeDeclarationError",
     "TERM_VOCABULARY",
     "Term",
     "TermSpec",
@@ -239,6 +242,62 @@ class RequestShape(msgspec.Struct, frozen=True, kw_only=True):
                     f"SMALL number — the direction that buys too little card."
                 )
         return self
+
+
+class ShapeDeclarationError(TypeError):
+    """A `Shape(...)` annotation is not one the platform can read."""
+
+
+class Shape(msgspec.Struct, frozen=True):
+    """Payload-field annotation: this field DIMENSIONS the request.
+
+    Two arms, exactly one of which is used:
+
+    * ``Shape("width")`` — this numeric field IS that axis, under a name the
+      platform vocabulary does not carry.
+    * ``Shape(pixels=_BUCKETS)`` — this field's VALUES map to ``(width,
+      height)``. Pass the author's own table by reference; do not retype the
+      numbers, or the endpoint gains a second spelling of its own geometry.
+
+    Read via ``Annotated[...]``, the same way ``PromptRole`` and
+    ``ExpectedOutput`` are.
+    """
+
+    axis: str = ""
+    pixels: Optional[Mapping[Any, tuple[int, int]]] = None
+
+    def __post_init__(self) -> None:
+        named = bool(self.axis)
+        tabled = self.pixels is not None
+        if named == tabled:
+            raise ShapeDeclarationError(
+                "Shape(...) states EITHER an axis name "
+                "(`Shape('width')`) OR a value->(width, height) table "
+                "(`Shape(pixels=_BUCKETS)`) — never both and never neither"
+            )
+        if named and self.axis not in SHAPE_BOUNDS:
+            raise ShapeDeclarationError(
+                f"Shape({self.axis!r}): the shape axes are CLOSED and are "
+                f"{sorted(SHAPE_BOUNDS)}"
+            )
+        if tabled:
+            table = dict(self.pixels or {})
+            if not table:
+                raise ShapeDeclarationError(
+                    "Shape(pixels=): the table is empty; a field that "
+                    "dimensions nothing is not a shape field"
+                )
+            for key, value in table.items():
+                if (
+                    not isinstance(value, Sequence)
+                    or isinstance(value, (str, bytes))
+                    or len(value) != 2
+                    or not all(isinstance(n, int) and n > 0 for n in value)
+                ):
+                    raise ShapeDeclarationError(
+                        f"Shape(pixels=): {key!r} maps to {value!r}; each "
+                        f"value is a (width, height) pair of positive ints"
+                    )
 
 
 def term_value(name: str, shape: RequestShape) -> int:

--- a/src/gen_worker/demand.py
+++ b/src/gen_worker/demand.py
@@ -45,6 +45,7 @@ __all__ = [
     "DemandEvaluationError",
     "GiB",
     "KiB",
+    "MAX_RESULT_BYTES",
     "MiB",
     "RequestShape",
     "SHAPE_BOUNDS",
@@ -167,13 +168,9 @@ TERM_VOCABULARY: dict[str, TermSpec] = {
 _TERM_ORDER = {name: index for index, name in enumerate(TERM_VOCABULARY)}
 
 
-#: The domain each shape scalar is defined on. NOT taste: the evaluation is
-#: specified to be exact in 64-bit integers in BOTH languages, and these are
-#: the bounds under which `coefficient * value` provably cannot overflow one
-#: (see :func:`evaluate` for the split-division that keeps the product small).
-#: A shape outside them is REFUSED in both languages rather than silently
-#: wrapping — a wrapped worst-case is a small number, and a small number is
-#: the direction that buys too little card.
+#: The domain each shape scalar is defined on — the largest request the API
+#: could conceivably describe, an order of magnitude past anything real. A
+#: shape outside it is REFUSED rather than evaluated, in both languages.
 SHAPE_BOUNDS: dict[str, int] = {
     "width": 1 << 16,
     "height": 1 << 16,
@@ -181,6 +178,23 @@ SHAPE_BOUNDS: dict[str, int] = {
     "frames": 1 << 20,
     "latent_tokens": 1 << 31,
 }
+
+#: The result must fit a signed 64-bit integer, because the OTHER evaluator is
+#: Go and that is the widest integer the wire form can carry.
+#:
+#: ⚠️ THIS BOUND IS ON THE RESULT, NOT ON THE INTERMEDIATES, AND THE
+#: DIFFERENCE WAS MEASURED RATHER THAN REASONED. The first version bounded the
+#: shape so that a split division (`c = q*scale + r` → `q*v + (r*v)//scale`)
+#: could not overflow int64 — and the cross-language corpus went RED on its own
+#: ceiling row the first time Go ran it: at `mp_batch` with a 1 GiB
+#: coefficient, `r*v` is 1.3e19, past int64, and Python's bignums hid it
+#: entirely. Python could not have found this; only the Go side could, which is
+#: the entire argument for the corpus. So the arithmetic is now EXACT in both
+#: languages (Python natively, Go through `math/big`) and the only shared
+#: constraint is that the ANSWER is representable. A formula whose worst case
+#: does not fit int64 is refused loudly rather than wrapped into a small
+#: number — small is the direction that buys too little card.
+MAX_RESULT_BYTES = (1 << 63) - 1
 
 
 class RequestShape(msgspec.Struct, frozen=True, kw_only=True):
@@ -255,20 +269,31 @@ def term_value(name: str, shape: RequestShape) -> int:
 
 
 def _scaled(coefficient: int, value: int, scale: int) -> int:
-    """``floor(coefficient * value / scale)`` without forming the product.
+    """``floor(coefficient * value / scale)``, EXACT.
 
-    ``c*v`` overflows 64 bits at plausible shapes (a 4096² batch-8 mp_batch
-    numerator is 1.3e8, and an 80 GiB coefficient is 8.6e10). The identity
-    ``c = q*scale + r`` gives ``floor(c*v/scale) = q*v + floor(r*v/scale)``
-    exactly, and both products stay far inside 64 bits under
-    :data:`SHAPE_BOUNDS`. Go does the same three lines; the conformance
-    corpus proves it.
+    Python computes this natively; Go computes it in ``math/big``. Neither
+    tries to be clever about the intermediate, because the clever version was
+    wrong: a split division (``q*v + (r*v)//scale``) keeps ``q*v`` small and
+    lets ``r*v`` reach 1.3e19 at the domain ceiling — past int64 — and Python's
+    bignums hid that completely. The cross-language corpus caught it on Go's
+    first run. See :data:`MAX_RESULT_BYTES`.
     """
 
-    if scale == 1:
-        return coefficient * value
-    quotient, remainder = divmod(coefficient, scale)
-    return quotient * value + (remainder * value) // scale
+    return (coefficient * value) // scale
+
+
+def _representable(total: int) -> int:
+    """Refuse a result the other evaluator could not carry."""
+
+    if total > MAX_RESULT_BYTES:
+        raise DemandEvaluationError(
+            f"the formula evaluates to {total} bytes, past the largest signed "
+            f"64-bit integer ({MAX_RESULT_BYTES}). The other evaluator is Go "
+            f"and cannot carry this; a wrapped answer would be a SMALL number, "
+            f"which is the direction that buys too little card. Either the "
+            f"coefficients or the envelope are wrong by orders of magnitude."
+        )
+    return total
 
 
 class Term(msgspec.Struct, frozen=True, kw_only=True):
@@ -363,7 +388,7 @@ class Demand(msgspec.Struct, frozen=True, kw_only=True):
         """Bytes of REQUEST arena at ``shape``. $0, CPU, deterministic."""
 
         checked = shape.validated()
-        return sum(term.evaluate(checked) for term in self.terms)
+        return _representable(sum(term.evaluate(checked) for term in self.terms))
 
     def as_document(self) -> list[dict[str, Any]]:
         """The release-document shape of the TERMS."""
@@ -432,7 +457,7 @@ def evaluate(terms: Any, shape: RequestShape) -> int:
                 f"is {sorted(TERM_VOCABULARY)}"
             )
         total += _scaled(int(row["bytes"]), term_value(name, checked), spec.scale)
-    return total
+    return _representable(total)
 
 
 def _term(

--- a/src/gen_worker/demand.py
+++ b/src/gen_worker/demand.py
@@ -1,29 +1,76 @@
+"""The demand formula is DATA: `C + Σ cᵢ·termᵢ` over a CLOSED vocabulary.
+
+pgw#1598 §2 / pgw#1600. Three properties the rest of the platform depends on,
+and each one is a design constraint rather than a nicety:
+
+* **DATA, never Python.** An author cannot invent a term because the
+  constructors below are the only way to make one, and the serialized form is
+  a list of `(name, coefficient)` rows. That is what lets a NON-PYTHON reader
+  — tensorhub, in Go, at pod-buy time — evaluate the same formula and get the
+  same bytes without importing anything of ours.
+* **EXACT INTEGER ARITHMETIC.** Every term's value is an integer numerator
+  over a fixed integer scale, and evaluation is floor division. `megapixels`
+  is `width*height` over 1_000_000, not a float divide — a float divide is
+  where two languages stop agreeing, and the whole point of the serialization
+  is that they agree. :func:`evaluate` and its Go twin are asserted equal over
+  a shared conformance corpus (`gen_worker/contracts/demand_vectors.json`,
+  pinned into tensorhub through its `peers.lock`).
+* **EVERY COEFFICIENT CARRIES ITS PROVENANCE.** A byte count with no basis is
+  a magic constant. :class:`Basis` has exactly three values, the default is
+  the honest one (`UNCALIBRATED` — a declared prior, never measured), and
+  claiming `MEASURED` or `LEDGER` without naming the source is a refusal.
+
+The WEIGHT arena is not in here and never will be: its bytes are tensorfs
+manifest arithmetic plus varena's alignment tax, exact and $0 (pgw#1598 §1).
+This module is the REQUEST arena only.
+
+Payload → :class:`RequestShape` extraction lives in
+:mod:`gen_worker.demand_envelope`; banking predicted-vs-measured lives in
+:mod:`gen_worker.demand_falsifier`. Nothing in any of the three consumes the
+number for an admission decision — see pgw#1600 acceptance (d) and
+`tests/test_demand_no_enforcement_pgw1600.py`, which asserts that absence.
+"""
+
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any, Union
 
 import msgspec
 
 __all__ = [
+    "Basis",
     "Demand",
     "DemandDeclarationError",
+    "DemandEvaluationError",
     "GiB",
     "KiB",
     "MiB",
+    "RequestShape",
+    "SHAPE_BOUNDS",
     "TERM_VOCABULARY",
     "Term",
+    "TermSpec",
+    "VOCABULARY_VERSION",
     "const",
+    "evaluate",
     "per_batch",
     "per_frame",
     "per_frame_squared",
     "per_latent_token",
     "per_mp",
     "per_mp_batch",
+    "term_value",
+    "vocabulary_document",
 ]
 
 
 class DemandDeclarationError(TypeError):
     """A demand formula is not one the platform can evaluate."""
+
+
+class DemandEvaluationError(ValueError):
+    """A request shape is outside the domain the formula is defined on."""
 
 
 def KiB(count: float) -> int:
@@ -40,25 +87,215 @@ def GiB(count: float) -> int:
     return int(count * 1024 * 1024 * 1024)
 
 
-TERM_VOCABULARY: dict[str, str] = {
-    "const": "a fixed floor, independent of the request",
-    "megapixels": "output width x height / 1e6",
-    "mp_batch": "megapixels x batch (the CFG pair counts as 2)",
-    "batch": "the launch batch size (2 with CFG, 1 without)",
-    "frames": "the video frame count",
-    "frames_squared": "frame count SQUARED — the quadratic attention term",
-    "latent_tokens": "the denoiser's latent sequence length",
+#: Bumped when a TERM is added, removed, or its scale/inputs change. A Go
+#: evaluator reading a document with a version it does not implement REFUSES
+#: rather than evaluating the subset it understands — a formula evaluated
+#: without one of its terms is not a conservative answer, it is a low one.
+VOCABULARY_VERSION = 1
+
+
+class Basis(StrEnum):
+    """Where a coefficient's NUMBER came from. There is no fourth answer.
+
+    ``MEASURED``  — a SUCCESSFUL run on real hardware produced it, and
+    ``source`` names the run. Never a death trace: a death reports only the
+    free memory it consumed, which is a lower bound on nothing useful
+    (pgw#1601's stamp-source rule, falsified on the card 2026-08-21).
+
+    ``LEDGER``    — fitted from banked samples (pgw#1586's calibrator).
+    ``source`` names the ledger key and the sample count.
+
+    ``UNCALIBRATED`` — a declared prior. The author stated the formula's
+    SHAPE and guessed the split; nothing has measured it. This is the DEFAULT
+    because it is the only claim a bare number can support, and a lane that
+    reads ``uncalibrated`` at the hub is telling the truth about itself.
+    """
+
+    MEASURED = "measured"
+    LEDGER = "ledger"
+    UNCALIBRATED = "uncalibrated"
+
+
+class TermSpec(msgspec.Struct, frozen=True, kw_only=True):
+    """One vocabulary entry: how its integer VALUE is built, and its scale.
+
+    ``scale`` is the denominator the coefficient is quoted against, so a
+    coefficient is always "bytes per WHOLE unit" while the value stays an
+    exact integer: `megapixels` has value ``width*height`` and scale
+    ``1_000_000``, i.e. the coefficient is bytes per megapixel and no float
+    ever appears. ``inputs`` names the :class:`RequestShape` fields the value
+    reads, so a document reader can check it implements the same term rather
+    than a same-named one.
+    """
+
+    scale: int
+    inputs: tuple[str, ...]
+    doc: str
+
+
+TERM_VOCABULARY: dict[str, TermSpec] = {
+    "const": TermSpec(
+        scale=1, inputs=(),
+        doc="a fixed floor, independent of the request",
+    ),
+    "megapixels": TermSpec(
+        scale=1_000_000, inputs=("width", "height"),
+        doc="output width x height / 1e6",
+    ),
+    "mp_batch": TermSpec(
+        scale=1_000_000, inputs=("width", "height", "batch"),
+        doc="megapixels x batch (the CFG pair counts as 2)",
+    ),
+    "batch": TermSpec(
+        scale=1, inputs=("batch",),
+        doc="the launch batch size (2 with CFG, 1 without)",
+    ),
+    "frames": TermSpec(
+        scale=1, inputs=("frames",),
+        doc="the video frame count",
+    ),
+    "frames_squared": TermSpec(
+        scale=1, inputs=("frames",),
+        doc="frame count SQUARED — the quadratic attention term",
+    ),
+    "latent_tokens": TermSpec(
+        scale=1, inputs=("latent_tokens",),
+        doc="the denoiser's latent sequence length",
+    ),
+}
+
+_TERM_ORDER = {name: index for index, name in enumerate(TERM_VOCABULARY)}
+
+
+#: The domain each shape scalar is defined on. NOT taste: the evaluation is
+#: specified to be exact in 64-bit integers in BOTH languages, and these are
+#: the bounds under which `coefficient * value` provably cannot overflow one
+#: (see :func:`evaluate` for the split-division that keeps the product small).
+#: A shape outside them is REFUSED in both languages rather than silently
+#: wrapping — a wrapped worst-case is a small number, and a small number is
+#: the direction that buys too little card.
+SHAPE_BOUNDS: dict[str, int] = {
+    "width": 1 << 16,
+    "height": 1 << 16,
+    "batch": 1 << 12,
+    "frames": 1 << 20,
+    "latent_tokens": 1 << 31,
 }
 
 
+class RequestShape(msgspec.Struct, frozen=True, kw_only=True):
+    """The request-derived scalars every term is a function of.
+
+    This is the WHOLE input surface of the algebra. A term that needs
+    something not in here is a vocabulary change, which is a
+    :data:`VOCABULARY_VERSION` bump and a Go-side change in the same breath.
+    Zero means "this request has no such axis" (an image model has no
+    ``frames``), and a term that reads a zero contributes zero.
+    """
+
+    width: int = 0
+    height: int = 0
+    batch: int = 1
+    frames: int = 0
+    latent_tokens: int = 0
+
+    def as_document(self) -> dict[str, int]:
+        return {
+            "width": self.width,
+            "height": self.height,
+            "batch": self.batch,
+            "frames": self.frames,
+            "latent_tokens": self.latent_tokens,
+        }
+
+    def validated(self) -> "RequestShape":
+        for field, ceiling in SHAPE_BOUNDS.items():
+            value = int(getattr(self, field))
+            if value < 0:
+                raise DemandEvaluationError(
+                    f"request shape {field}={value} is negative; the algebra "
+                    f"is defined on non-negative integers only"
+                )
+            if value > ceiling:
+                raise DemandEvaluationError(
+                    f"request shape {field}={value} exceeds the declared "
+                    f"domain ({ceiling}). The evaluation is specified exact "
+                    f"in 64-bit integers in both Python and Go; past this "
+                    f"bound it would not be, and a wrapped worst case is a "
+                    f"SMALL number — the direction that buys too little card."
+                )
+        return self
+
+
+def term_value(name: str, shape: RequestShape) -> int:
+    """The exact integer NUMERATOR of one term at ``shape``.
+
+    Kept as one switch so the Go twin has one thing to mirror. Every branch
+    is integer multiplication of bounded non-negative ints.
+    """
+
+    if name == "const":
+        return 1
+    if name == "megapixels":
+        return shape.width * shape.height
+    if name == "mp_batch":
+        return shape.width * shape.height * shape.batch
+    if name == "batch":
+        return shape.batch
+    if name == "frames":
+        return shape.frames
+    if name == "frames_squared":
+        return shape.frames * shape.frames
+    if name == "latent_tokens":
+        return shape.latent_tokens
+    raise DemandEvaluationError(
+        f"unknown demand term {name!r}; the vocabulary is CLOSED and is "
+        f"{sorted(TERM_VOCABULARY)}"
+    )
+
+
+def _scaled(coefficient: int, value: int, scale: int) -> int:
+    """``floor(coefficient * value / scale)`` without forming the product.
+
+    ``c*v`` overflows 64 bits at plausible shapes (a 4096² batch-8 mp_batch
+    numerator is 1.3e8, and an 80 GiB coefficient is 8.6e10). The identity
+    ``c = q*scale + r`` gives ``floor(c*v/scale) = q*v + floor(r*v/scale)``
+    exactly, and both products stay far inside 64 bits under
+    :data:`SHAPE_BOUNDS`. Go does the same three lines; the conformance
+    corpus proves it.
+    """
+
+    if scale == 1:
+        return coefficient * value
+    quotient, remainder = divmod(coefficient, scale)
+    return quotient * value + (remainder * value) // scale
+
+
 class Term(msgspec.Struct, frozen=True, kw_only=True):
-    """One `cᵢ·termᵢ`: a vocabulary name and its coefficient IN BYTES."""
+    """One `cᵢ·termᵢ`: a vocabulary name, its coefficient IN BYTES, its basis."""
 
     name: str
     coefficient: int
+    basis: Basis = Basis.UNCALIBRATED
+    source: str = ""
+
+    def evaluate(self, shape: RequestShape) -> int:
+        spec = TERM_VOCABULARY.get(self.name)
+        if spec is None:
+            raise DemandEvaluationError(
+                f"unknown demand term {self.name!r}; the vocabulary is CLOSED"
+            )
+        return _scaled(self.coefficient, term_value(self.name, shape), spec.scale)
 
     def as_document(self) -> dict[str, Any]:
-        return {"term": self.name, "bytes": self.coefficient}
+        row: dict[str, Any] = {
+            "term": self.name,
+            "bytes": self.coefficient,
+            "basis": str(self.basis),
+        }
+        if self.source:
+            row["source"] = self.source
+        return row
 
 
 class Demand(msgspec.Struct, frozen=True, kw_only=True):
@@ -73,13 +310,30 @@ class Demand(msgspec.Struct, frozen=True, kw_only=True):
                 f"{type(other).__name__}. Wrap a plain byte count in "
                 f"`const(...)`."
             )
-        merged: dict[str, int] = {}
+        merged: dict[str, Term] = {}
         for term in self.terms + other.terms:
-            merged[term.name] = merged.get(term.name, 0) + term.coefficient
+            held = merged.get(term.name)
+            if held is None:
+                merged[term.name] = term
+                continue
+            if held.basis is not term.basis:
+                raise DemandDeclarationError(
+                    f"two {term.name!r} terms with DIFFERENT provenance "
+                    f"({held.basis} and {term.basis}) cannot be summed into "
+                    f"one coefficient — the sum would inherit one of the two "
+                    f"claims and silently launder the other. Declare the term "
+                    f"once, with the basis the whole number has."
+                )
+            sources = [s for s in (held.source, term.source) if s]
+            merged[term.name] = Term(
+                name=term.name,
+                coefficient=held.coefficient + term.coefficient,
+                basis=term.basis,
+                source="; ".join(dict.fromkeys(sources)),
+            )
         return Demand(
             terms=tuple(
-                Term(name=name, coefficient=coefficient)
-                for name, coefficient in sorted(
+                term for _, term in sorted(
                     merged.items(), key=lambda item: _TERM_ORDER[item[0]]
                 )
             )
@@ -89,16 +343,104 @@ class Demand(msgspec.Struct, frozen=True, kw_only=True):
 
         return {term.name: term.coefficient for term in self.terms}
 
+    def bases(self) -> dict[str, Basis]:
+        """Per-term provenance. A formula is only as calibrated as its worst
+        term, which is why this is a map and not a single verdict."""
+
+        return {term.name: term.basis for term in self.terms}
+
+    def weakest_basis(self) -> Basis:
+        """The claim the WHOLE formula can support."""
+
+        held = {term.basis for term in self.terms}
+        if Basis.UNCALIBRATED in held or not held:
+            return Basis.UNCALIBRATED
+        if Basis.LEDGER in held:
+            return Basis.LEDGER
+        return Basis.MEASURED
+
+    def evaluate(self, shape: RequestShape) -> int:
+        """Bytes of REQUEST arena at ``shape``. $0, CPU, deterministic."""
+
+        checked = shape.validated()
+        return sum(term.evaluate(checked) for term in self.terms)
+
     def as_document(self) -> list[dict[str, Any]]:
-        """The release-document shape."""
+        """The release-document shape of the TERMS."""
 
         return [term.as_document() for term in self.terms]
 
+    def formula_document(self) -> dict[str, Any]:
+        """The whole serialized formula, evaluable by a non-Python reader.
 
-_TERM_ORDER = {name: index for index, name in enumerate(TERM_VOCABULARY)}
+        Carries the VOCABULARY as well as the terms. A Go reader checks each
+        term's scale and inputs against its own table and refuses on a
+        mismatch or an unknown name — so a vocabulary that moves in one
+        language and not the other is a loud refusal instead of a number that
+        is wrong by exactly one term.
+        """
+
+        row: dict[str, Any] = {
+            "algebra": "C + sum(coefficient_i * value_i / scale_i), floor, int64",
+            "vocabulary_version": VOCABULARY_VERSION,
+            "vocabulary": vocabulary_document(),
+            "shape_bounds": dict(SHAPE_BOUNDS),
+            "terms": self.as_document(),
+            "basis": str(self.weakest_basis()),
+            "arena": "request",
+            "note": (
+                "REQUEST ARENA ONLY. worst_case = tensorfs manifest weight "
+                "bytes + varena alignment tax + this. The weight arena is "
+                "never declared (pgw#1598 §2)."
+            ),
+        }
+        return row
 
 
-def _term(name: str, nbytes: Union[int, float]) -> Demand:
+def vocabulary_document() -> dict[str, Any]:
+    """The closed vocabulary, serialized. One producer for both languages."""
+
+    return {
+        name: {
+            "scale": spec.scale,
+            "inputs": list(spec.inputs),
+            "doc": spec.doc,
+        }
+        for name, spec in TERM_VOCABULARY.items()
+    }
+
+
+def evaluate(terms: Any, shape: RequestShape) -> int:
+    """Evaluate a formula given either a :class:`Demand` or its DOCUMENT.
+
+    The document arm is the one the conformance corpus exercises, because it
+    is the arm Go has: a list of ``{"term": …, "bytes": …}`` rows and nothing
+    else. Python must not be able to get a different answer by reading the
+    richer in-memory object.
+    """
+
+    if isinstance(terms, Demand):
+        return terms.evaluate(shape)
+    checked = shape.validated()
+    total = 0
+    for row in terms:
+        name = str(row["term"])
+        spec = TERM_VOCABULARY.get(name)
+        if spec is None:
+            raise DemandEvaluationError(
+                f"unknown demand term {name!r}; the vocabulary is CLOSED and "
+                f"is {sorted(TERM_VOCABULARY)}"
+            )
+        total += _scaled(int(row["bytes"]), term_value(name, checked), spec.scale)
+    return total
+
+
+def _term(
+    name: str,
+    nbytes: Union[int, float],
+    basis: Union[Basis, str],
+    source: str,
+) -> Demand:
     if isinstance(nbytes, bool) or not isinstance(nbytes, (int, float)):
         raise DemandDeclarationError(
             f"{name}(): a coefficient is a BYTE COUNT; got "
@@ -112,46 +454,87 @@ def _term(name: str, nbytes: Union[int, float]) -> Demand:
             f"term that REDUCES demand is a degradation TECHNIQUE's transform "
             f"(pgw#1605's catalog), never a declared term."
         )
-    return Demand(terms=(Term(name=name, coefficient=coefficient),))
+    try:
+        held = Basis(basis)
+    except ValueError:
+        raise DemandDeclarationError(
+            f"{name}(basis=): a coefficient's provenance is one of "
+            f"{[str(b) for b in Basis]}, got {basis!r}"
+        ) from None
+    text = str(source or "").strip()
+    if held is not Basis.UNCALIBRATED and not text:
+        raise DemandDeclarationError(
+            f"{name}(basis={held}) without a source=. A coefficient claiming "
+            f"to be {held} must name the run or the ledger key that produced "
+            f"it — an unsourced measurement is a magic constant wearing a "
+            f"label. Either cite it (source='tcg#80 sm_89 cold-daemon n=1') "
+            f"or declare it for what it is (the default, {Basis.UNCALIBRATED})."
+        )
+    return Demand(
+        terms=(
+            Term(name=name, coefficient=coefficient, basis=held, source=text),
+        )
+    )
 
 
-def const(nbytes: Union[int, float]) -> Demand:
+def const(
+    nbytes: Union[int, float], *,
+    basis: Union[Basis, str] = Basis.UNCALIBRATED, source: str = "",
+) -> Demand:
     """A fixed floor: the bytes this lane needs regardless of the request."""
 
-    return _term("const", nbytes)
+    return _term("const", nbytes, basis, source)
 
 
-def per_mp(nbytes: Union[int, float]) -> Demand:
+def per_mp(
+    nbytes: Union[int, float], *,
+    basis: Union[Basis, str] = Basis.UNCALIBRATED, source: str = "",
+) -> Demand:
     """Bytes per output megapixel."""
 
-    return _term("megapixels", nbytes)
+    return _term("megapixels", nbytes, basis, source)
 
 
-def per_mp_batch(nbytes: Union[int, float]) -> Demand:
+def per_mp_batch(
+    nbytes: Union[int, float], *,
+    basis: Union[Basis, str] = Basis.UNCALIBRATED, source: str = "",
+) -> Demand:
     """Bytes per megapixel x batch — the activation term of an image model."""
 
-    return _term("mp_batch", nbytes)
+    return _term("mp_batch", nbytes, basis, source)
 
 
-def per_batch(nbytes: Union[int, float]) -> Demand:
+def per_batch(
+    nbytes: Union[int, float], *,
+    basis: Union[Basis, str] = Basis.UNCALIBRATED, source: str = "",
+) -> Demand:
     """Bytes per launch batch entry, independent of resolution."""
 
-    return _term("batch", nbytes)
+    return _term("batch", nbytes, basis, source)
 
 
-def per_frame(nbytes: Union[int, float]) -> Demand:
+def per_frame(
+    nbytes: Union[int, float], *,
+    basis: Union[Basis, str] = Basis.UNCALIBRATED, source: str = "",
+) -> Demand:
     """Bytes per video frame — the linear video term."""
 
-    return _term("frames", nbytes)
+    return _term("frames", nbytes, basis, source)
 
 
-def per_frame_squared(nbytes: Union[int, float]) -> Demand:
+def per_frame_squared(
+    nbytes: Union[int, float], *,
+    basis: Union[Basis, str] = Basis.UNCALIBRATED, source: str = "",
+) -> Demand:
     """Bytes per frame SQUARED — the quadratic attention term."""
 
-    return _term("frames_squared", nbytes)
+    return _term("frames_squared", nbytes, basis, source)
 
 
-def per_latent_token(nbytes: Union[int, float]) -> Demand:
+def per_latent_token(
+    nbytes: Union[int, float], *,
+    basis: Union[Basis, str] = Basis.UNCALIBRATED, source: str = "",
+) -> Demand:
     """Bytes per latent sequence token."""
 
-    return _term("latent_tokens", nbytes)
+    return _term("latent_tokens", nbytes, basis, source)

--- a/src/gen_worker/demand_envelope.py
+++ b/src/gen_worker/demand_envelope.py
@@ -1,0 +1,381 @@
+"""Request → :class:`~gen_worker.demand.RequestShape`, and the ADVERTISED
+envelope a lane's worst case is evaluated at.
+
+pgw#1600. Two questions, one vocabulary:
+
+* **at SERVE time** — what shape is THIS request? :func:`request_shape`.
+* **at LOCK time** — what is the largest shape the API can be asked for?
+  :func:`advertised_envelope`, evaluated at derive so the release document
+  carries a worst case a Go reader can add manifest weight bytes to.
+
+The platform reads a payload field as a shape axis when the field NAMES one
+(`width`, `height`, `num_frames`, `num_images`, …) — no author edit needed for
+the common case. :class:`Shape` exists for what only the author knows: a field
+that dimensions the request without saying so numerically, most importantly an
+ASPECT-RATIO ENUM whose members map to a bucket table the platform cannot see.
+The annotation carries the author's OWN table by reference, so the pixels are
+declared exactly once, in the dict the handler itself indexes.
+
+**Every axis in a derived envelope states its SOURCE**, and an axis nothing
+advertises is reported as `default` with the reason. That is deliberate: an
+envelope is a claim about the API's ceiling, a defaulted axis is a claim the
+API does not support, and a lane whose real launches exceed its envelope is
+exactly what pgw#1600's `demand_miss` falsifier is built to catch. The
+envelope tells the truth about what it knows; the falsifier catches the rest.
+"""
+
+from __future__ import annotations
+
+import typing
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+import msgspec
+
+from .demand import SHAPE_BOUNDS, Demand, RequestShape
+
+__all__ = [
+    "AXIS_FIELD_NAMES",
+    "EnvelopeAxis",
+    "Envelope",
+    "Shape",
+    "ShapeDeclarationError",
+    "advertised_envelope",
+    "demand_document",
+    "request_shape",
+]
+
+
+class ShapeDeclarationError(TypeError):
+    """A `Shape(...)` annotation is not one the platform can read."""
+
+
+#: The CLOSED map from a payload FIELD NAME to a shape axis. Spellings are
+#: the ones the fleet's payloads already use; a new spelling is a change
+#: here, never a per-endpoint annotation, because two names for one axis is
+#: how an endpoint ends up measured against an envelope that does not
+#: describe it.
+AXIS_FIELD_NAMES: dict[str, str] = {
+    "width": "width",
+    "height": "height",
+    "num_frames": "frames",
+    "frames": "frames",
+    "num_images": "batch",
+    "batch_size": "batch",
+    "batch": "batch",
+    "latent_tokens": "latent_tokens",
+}
+
+
+class Shape(msgspec.Struct, frozen=True):
+    """Payload-field annotation: this field DIMENSIONS the request.
+
+    Two arms, exactly one of which is used:
+
+    * ``Shape("width")`` — this numeric field IS that axis, under a name the
+      platform vocabulary does not carry.
+    * ``Shape(pixels=_BUCKETS)`` — this field's VALUES map to ``(width,
+      height)``. Pass the author's own table by reference; do not retype the
+      numbers, or the endpoint gains a second spelling of its own geometry.
+
+    Read via ``Annotated[...]``, the same way ``PromptRole`` and
+    ``ExpectedOutput`` are.
+    """
+
+    axis: str = ""
+    pixels: Optional[Mapping[Any, tuple[int, int]]] = None
+
+    def __post_init__(self) -> None:
+        named = bool(self.axis)
+        tabled = self.pixels is not None
+        if named == tabled:
+            raise ShapeDeclarationError(
+                "Shape(...) states EITHER an axis name "
+                "(`Shape('width')`) OR a value->(width, height) table "
+                "(`Shape(pixels=_BUCKETS)`) — never both and never neither"
+            )
+        if named and self.axis not in SHAPE_BOUNDS:
+            raise ShapeDeclarationError(
+                f"Shape({self.axis!r}): the shape axes are CLOSED and are "
+                f"{sorted(SHAPE_BOUNDS)}"
+            )
+        if tabled:
+            table = dict(self.pixels or {})
+            if not table:
+                raise ShapeDeclarationError(
+                    "Shape(pixels=): the table is empty; a field that "
+                    "dimensions nothing is not a shape field"
+                )
+            for key, value in table.items():
+                if (
+                    not isinstance(value, Sequence)
+                    or isinstance(value, (str, bytes))
+                    or len(value) != 2
+                    or not all(isinstance(n, int) and n > 0 for n in value)
+                ):
+                    raise ShapeDeclarationError(
+                        f"Shape(pixels=): {key!r} maps to {value!r}; each "
+                        f"value is a (width, height) pair of positive ints"
+                    )
+
+
+class EnvelopeAxis(msgspec.Struct, frozen=True, kw_only=True):
+    """One axis of a derived envelope, with WHERE its number came from."""
+
+    value: int
+    #: ``advertised`` — a bounded payload field stated it.
+    #: ``declared``   — a ``Shape(...)`` table stated it.
+    #: ``default``    — NOTHING states it; see ``why``.
+    source: str
+    why: str = ""
+
+    def as_document(self) -> dict[str, Any]:
+        row: dict[str, Any] = {"value": self.value, "source": self.source}
+        if self.why:
+            row["why"] = self.why
+        return row
+
+
+class Envelope(msgspec.Struct, frozen=True, kw_only=True):
+    """The advertised ceiling, per axis, and the shape that maximises demand."""
+
+    axes: dict[str, EnvelopeAxis]
+    #: The candidate shapes the ceiling is taken over. More than one only
+    #: when a ``Shape(pixels=)`` table couples width and height — the max of
+    #: ``width*height`` is not ``max(width)*max(height)``.
+    candidates: tuple[RequestShape, ...]
+
+    @property
+    def advertised_axes(self) -> tuple[str, ...]:
+        return tuple(
+            name for name, axis in self.axes.items() if axis.source != "default"
+        )
+
+    def worst_case(self, demand: Demand) -> tuple[int, RequestShape]:
+        """``(bytes, shape)`` — the candidate that maximises the formula.
+
+        Every coefficient is non-negative by construction, so the formula is
+        monotone in every axis and the per-axis ceiling is the right one to
+        take; the argmax over candidates exists only for the COUPLED case.
+        """
+
+        def rank(shape: RequestShape) -> tuple[int, int, int, int]:
+            # The TIE-BREAK is not cosmetic. A const-only formula evaluates
+            # identically at every bucket, and "whichever the set iterated
+            # first" would make the recorded worst_case_shape depend on dict
+            # ordering — a document field that moves without the formula
+            # moving. Largest area wins, then width, then height.
+            return (
+                demand.evaluate(shape),
+                shape.width * shape.height,
+                shape.width,
+                shape.height,
+            )
+
+        best = max(self.candidates, key=rank)
+        return demand.evaluate(best), best
+
+    def as_document(self) -> dict[str, Any]:
+        return {name: axis.as_document() for name, axis in self.axes.items()}
+
+
+def _annotations(annotation: Any) -> tuple[Any, tuple[Any, ...]]:
+    """``(bare type, extras)`` for a possibly-``Annotated`` annotation."""
+
+    if typing.get_origin(annotation) is typing.Annotated:
+        args = typing.get_args(annotation)
+        return args[0], tuple(args[1:])
+    return annotation, ()
+
+
+def _shape_marker(extras: Sequence[Any]) -> Optional[Shape]:
+    for extra in extras:
+        if isinstance(extra, Shape):
+            return extra
+    return None
+
+
+def _upper_bound(annotation: Any, extras: Sequence[Any]) -> Optional[int]:
+    """The advertised ceiling of a numeric field, from ``msgspec.Meta``."""
+
+    for extra in list(extras) + list(_annotations(annotation)[1]):
+        if not isinstance(extra, msgspec.Meta):
+            continue
+        if extra.le is not None:
+            return int(extra.le)
+        if extra.lt is not None:
+            return int(extra.lt) - 1
+    return None
+
+
+def _fields(payload_type: Any) -> tuple[tuple[str, Any], ...]:
+    try:
+        info = msgspec.inspect.type_info(payload_type)
+    except Exception:  # noqa: BLE001 — a payload we cannot introspect has no envelope
+        return ()
+    hints = typing.get_type_hints(payload_type, include_extras=True)
+    return tuple(
+        (field.name, hints.get(field.name))
+        for field in getattr(info, "fields", ())
+    )
+
+
+def request_shape(payload: Any) -> RequestShape:
+    """THIS request's shape, read off a decoded payload instance.
+
+    Unknown fields contribute nothing. A payload that advertises no shape
+    axis at all yields the zero shape, on which every non-``const`` term
+    evaluates to zero — which is the honest reading of "this request has no
+    such axis", not a silent floor.
+    """
+
+    values: dict[str, int] = {}
+    for name, annotation in _fields(type(payload)):
+        held = getattr(payload, name, None)
+        if held is None:
+            continue
+        bare, extras = _annotations(annotation)
+        marker = _shape_marker(extras)
+        if marker is not None and marker.pixels is not None:
+            pair = dict(marker.pixels).get(held)
+            if pair is not None:
+                values["width"] = int(pair[0])
+                values["height"] = int(pair[1])
+            continue
+        axis = marker.axis if marker is not None else AXIS_FIELD_NAMES.get(name, "")
+        if not axis:
+            continue
+        if isinstance(held, bool) or not isinstance(held, int):
+            continue
+        values[axis] = int(held)
+    return RequestShape(
+        width=values.get("width", 0),
+        height=values.get("height", 0),
+        batch=values.get("batch", 1),
+        frames=values.get("frames", 0),
+        latent_tokens=values.get("latent_tokens", 0),
+    )
+
+
+#: What an axis nothing advertises is assumed to be, and why the assumption is
+#: stated rather than buried. ``batch`` is 1 because a launch that batches — an
+#: SDXL CFG pair, say — is a decision the CHECKPOINT's config makes, not the
+#: request, so no payload field can advertise it; the envelope says so and
+#: `demand_miss` is what catches a lane whose launches exceed it.
+_DEFAULT_AXES: dict[str, tuple[int, str]] = {
+    "width": (0, "no advertised or declared width; every width-scaled term "
+                 "evaluates to zero at this envelope"),
+    "height": (0, "no advertised or declared height; every height-scaled "
+                  "term evaluates to zero at this envelope"),
+    "batch": (1, "no advertised or declared batch axis. A launch that "
+                 "batches (a CFG pair) exceeds this envelope; that is what "
+                 "pgw#1600's demand_miss counts"),
+    "frames": (0, "not a video lane, or no advertised frame count"),
+    "latent_tokens": (0, "no advertised latent sequence length"),
+}
+
+
+def advertised_envelope(*payload_types: Any) -> Envelope:
+    """The ceiling of everything these entrypoints advertise.
+
+    One envelope per LANE, taken over every entrypoint that lane serves: the
+    worst case a pod must be bought for is the worst case of the whole
+    advertised surface, not of one function.
+    """
+
+    ceilings: dict[str, EnvelopeAxis] = {}
+    buckets: list[tuple[int, int]] = []
+
+    def raise_axis(axis: str, value: int, source: str, why: str = "") -> None:
+        held = ceilings.get(axis)
+        if held is None or value > held.value:
+            ceilings[axis] = EnvelopeAxis(value=value, source=source, why=why)
+
+    for payload_type in payload_types:
+        for name, annotation in _fields(payload_type):
+            bare, extras = _annotations(annotation)
+            marker = _shape_marker(extras)
+            if marker is not None and marker.pixels is not None:
+                buckets.extend(
+                    (int(w), int(h)) for w, h in dict(marker.pixels).values()
+                )
+                continue
+            axis = marker.axis if marker is not None else AXIS_FIELD_NAMES.get(name, "")
+            if not axis:
+                continue
+            bound = _upper_bound(bare, extras)
+            if bound is None:
+                raise_axis(
+                    axis, 0, "default",
+                    f"payload field {name!r} carries this axis but advertises "
+                    f"NO upper bound (no msgspec.Meta le=/lt=), so the API's "
+                    f"ceiling on it is unstated and no worst case can be "
+                    f"taken over it",
+                )
+                continue
+            raise_axis(axis, bound, "advertised", f"payload field {name!r}")
+
+    axes: dict[str, EnvelopeAxis] = {}
+    for axis in SHAPE_BOUNDS:
+        held = ceilings.get(axis)
+        if held is not None and held.source == "advertised":
+            axes[axis] = held
+            continue
+        value, why = _DEFAULT_AXES[axis]
+        axes[axis] = EnvelopeAxis(
+            value=value, source="default",
+            why=(held.why if held is not None else why),
+        )
+
+    if buckets:
+        widest = max(w for w, _ in buckets)
+        tallest = max(h for _, h in buckets)
+        axes["width"] = EnvelopeAxis(
+            value=widest, source="declared",
+            why="Shape(pixels=) table on the payload's own bucket dict",
+        )
+        axes["height"] = EnvelopeAxis(
+            value=tallest, source="declared",
+            why="Shape(pixels=) table on the payload's own bucket dict",
+        )
+        candidates = tuple(
+            RequestShape(
+                width=w, height=h,
+                batch=axes["batch"].value,
+                frames=axes["frames"].value,
+                latent_tokens=axes["latent_tokens"].value,
+            )
+            for w, h in sorted(set(buckets))
+        )
+    else:
+        candidates = (
+            RequestShape(
+                width=axes["width"].value,
+                height=axes["height"].value,
+                batch=axes["batch"].value,
+                frames=axes["frames"].value,
+                latent_tokens=axes["latent_tokens"].value,
+            ),
+        )
+    return Envelope(axes=axes, candidates=candidates)
+
+
+def demand_document(demand: Demand, envelope: Envelope) -> dict[str, Any]:
+    """The lane's whole `demand` block for the release document.
+
+    THE NUMBER A READER FINDS IS DERIVED, never written down: the formula's
+    terms, the envelope each axis of which states its own source, the shape
+    inside that envelope which maximises the formula, and the bytes. A
+    non-Python reader adds tensorfs manifest weight bytes to
+    ``worst_case_request_bytes`` and has the pod-buy worst case (pgw#1598 §2,
+    pgw#1600 acceptance (b)) — nothing here is the whole answer on its own,
+    and the block says so.
+    """
+
+    row = demand.formula_document()
+    worst_bytes, worst_shape = envelope.worst_case(demand)
+    row["envelope"] = envelope.as_document()
+    row["worst_case_shape"] = worst_shape.as_document()
+    row["worst_case_request_bytes"] = worst_bytes
+    row["envelope_advertised_axes"] = list(envelope.advertised_axes)
+    return row

--- a/src/gen_worker/demand_envelope.py
+++ b/src/gen_worker/demand_envelope.py
@@ -27,12 +27,18 @@ envelope tells the truth about what it knows; the falsifier catches the rest.
 from __future__ import annotations
 
 import typing
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any, Optional
 
 import msgspec
 
-from .demand import SHAPE_BOUNDS, Demand, RequestShape
+from .demand import (
+    SHAPE_BOUNDS,
+    Demand,
+    RequestShape,
+    Shape,
+    ShapeDeclarationError,
+)
 
 __all__ = [
     "AXIS_FIELD_NAMES",
@@ -44,10 +50,6 @@ __all__ = [
     "demand_document",
     "request_shape",
 ]
-
-
-class ShapeDeclarationError(TypeError):
-    """A `Shape(...)` annotation is not one the platform can read."""
 
 
 #: The CLOSED map from a payload FIELD NAME to a shape axis. Spellings are
@@ -65,58 +67,6 @@ AXIS_FIELD_NAMES: dict[str, str] = {
     "batch": "batch",
     "latent_tokens": "latent_tokens",
 }
-
-
-class Shape(msgspec.Struct, frozen=True):
-    """Payload-field annotation: this field DIMENSIONS the request.
-
-    Two arms, exactly one of which is used:
-
-    * ``Shape("width")`` — this numeric field IS that axis, under a name the
-      platform vocabulary does not carry.
-    * ``Shape(pixels=_BUCKETS)`` — this field's VALUES map to ``(width,
-      height)``. Pass the author's own table by reference; do not retype the
-      numbers, or the endpoint gains a second spelling of its own geometry.
-
-    Read via ``Annotated[...]``, the same way ``PromptRole`` and
-    ``ExpectedOutput`` are.
-    """
-
-    axis: str = ""
-    pixels: Optional[Mapping[Any, tuple[int, int]]] = None
-
-    def __post_init__(self) -> None:
-        named = bool(self.axis)
-        tabled = self.pixels is not None
-        if named == tabled:
-            raise ShapeDeclarationError(
-                "Shape(...) states EITHER an axis name "
-                "(`Shape('width')`) OR a value->(width, height) table "
-                "(`Shape(pixels=_BUCKETS)`) — never both and never neither"
-            )
-        if named and self.axis not in SHAPE_BOUNDS:
-            raise ShapeDeclarationError(
-                f"Shape({self.axis!r}): the shape axes are CLOSED and are "
-                f"{sorted(SHAPE_BOUNDS)}"
-            )
-        if tabled:
-            table = dict(self.pixels or {})
-            if not table:
-                raise ShapeDeclarationError(
-                    "Shape(pixels=): the table is empty; a field that "
-                    "dimensions nothing is not a shape field"
-                )
-            for key, value in table.items():
-                if (
-                    not isinstance(value, Sequence)
-                    or isinstance(value, (str, bytes))
-                    or len(value) != 2
-                    or not all(isinstance(n, int) and n > 0 for n in value)
-                ):
-                    raise ShapeDeclarationError(
-                        f"Shape(pixels=): {key!r} maps to {value!r}; each "
-                        f"value is a (width, height) pair of positive ints"
-                    )
 
 
 class EnvelopeAxis(msgspec.Struct, frozen=True, kw_only=True):

--- a/src/gen_worker/demand_envelope.py
+++ b/src/gen_worker/demand_envelope.py
@@ -209,11 +209,24 @@ def _upper_bound(annotation: Any, extras: Sequence[Any]) -> Optional[int]:
 
 
 def _fields(payload_type: Any) -> tuple[tuple[str, Any], ...]:
+    """``((field name, annotation), …)`` for a payload struct.
+
+    ``get_type_hints`` is tried first and the RAW ``__annotations__`` are the
+    fallback, because a payload whose forward references cannot be resolved
+    from this module's scope must lose its shape axes LOUDLY (an empty
+    envelope) rather than silently: the annotation objects msgspec already
+    resolved at class creation are usually right there, and reaching them is
+    the difference between an envelope and a zero.
+    """
+
     try:
         info = msgspec.inspect.type_info(payload_type)
     except Exception:  # noqa: BLE001 — a payload we cannot introspect has no envelope
         return ()
-    hints = typing.get_type_hints(payload_type, include_extras=True)
+    try:
+        hints = typing.get_type_hints(payload_type, include_extras=True)
+    except Exception:  # noqa: BLE001
+        hints = dict(getattr(payload_type, "__annotations__", {}) or {})
     return tuple(
         (field.name, hints.get(field.name))
         for field in getattr(info, "fields", ())

--- a/src/gen_worker/demand_falsifier.py
+++ b/src/gen_worker/demand_falsifier.py
@@ -1,0 +1,337 @@
+"""Predicted-vs-measured, banked every serve. THE FALSIFIER, AND IT SHIPS FIRST.
+
+pgw#1600 §3 / pgw#1598 §3. A demand formula is a claim about a card, and a
+claim nothing checks is a number that looks computed. So the instrument lands
+BEFORE any consumer: every serve evaluates the lane's declared formula at the
+request's own shape, measures what the request actually cost, and banks the
+pair. `demand_miss` (measured > predicted) is a COUNTED, hub-visible event, per
+(lane x regime).
+
+**This module decides nothing.** It is not consulted by admission, by
+placement, or by the oom ladder, and `tests/test_demand_no_enforcement_pgw1600.py`
+asserts that absence mechanically rather than in prose — pgw#1600 acceptance
+(d). Enforcement is pgw#1601's (the mint-time stamp) and pgw#1602's (the
+grant); wiring this number into either is a different issue's commit.
+
+## Why two measured numbers, and which one the verdict uses
+
+The request arena is spent in two places and only one of them is the torch
+allocator (pgw#1598 §1, upstream-cited at `aoti_runtime/model_base.h:345`):
+
+* ``allocated`` — the allocator's peak over the handler, minus what was
+  already allocated when the handler took the card. What EAGER activations
+  come out of.
+* ``out_of_allocator`` — the CUDA context, cuDNN/cuBLAS workspaces, and
+  AOTI's own ``cudaMalloc``'d first-call pool. Invisible to
+  ``max_memory_allocated`` and unavailable to the caching allocator.
+
+tcg#80's sm_89 acceptance run is the reference decomposition: at denoise, sdxl
+compiled UNet-only measured 4907 MiB allocated + 1155 MiB out-of-allocator =
+6649 MiB at the driver, on a COLD-DAEMON basis. So the regime picks the basis:
+eager is judged on ``allocated``; compiled is judged on the sum, because that
+is the budget a compiled admit actually has.
+
+## Regime, and the rule that outranks convenience
+
+Samples NEVER pool across regimes or lanes (pgw#1586, pgw#1600). An unknown
+regime pools with nothing. On the compiled path a miss is a P0 defect of the
+stamp and is emitted as one, never as a statistic (pgw#1601 acceptance (d)).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+import msgspec
+
+from . import activity as activity_mod
+from .demand import Basis, Demand, RequestShape
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "KIND_DEMAND_MISS",
+    "Banked",
+    "DemandObservation",
+    "MeasuredArena",
+    "bank",
+    "banked",
+    "measure_request_arena",
+    "observe",
+    "reset_banked",
+]
+
+KIND_DEMAND_MISS = "demand_miss"
+
+_MIB = 1 << 20
+
+
+class MeasuredArena(msgspec.Struct, frozen=True, kw_only=True):
+    """What one request actually cost, decomposed the way it is SPENT."""
+
+    #: The torch allocator's PEAK over the handler, minus what was already
+    #: allocated when it took the card. What eager activations come out of.
+    allocated_bytes: int = 0
+    #: Growth in what the process holds on the card OUTSIDE the caching
+    #: allocator: CUDA context, cuDNN/cuBLAS workspaces, AOTI's own
+    #: ``cudaMalloc``'d pool.
+    out_of_allocator_bytes: int = 0
+    #: Growth in ``total - driver_free`` across the handler. Includes
+    #: allocator CACHE, which driver-free counts as gone and which a COMPILED
+    #: call cannot spend at all (pgw#1627) — so it belongs in the compiled
+    #: basis and not in the eager one.
+    driver_growth_bytes: int = 0
+    #: False when there was no card to read (CPU-only test, torch-free
+    #: install). An unmeasured request banks NOTHING — a zero measurement
+    #: would read as "predicted generously" and quietly prove the formula
+    #: right.
+    measured: bool = False
+
+    @property
+    def driver_bytes(self) -> int:
+        """The compiled basis, and it is a LOWER BOUND on the true peak.
+
+        Two views of the same window, neither complete on its own: the
+        reconstructed peak (``allocated`` peak + out-of-allocator growth)
+        misses cache the allocator took and did not give back; the driver
+        growth misses a transient peak that was freed before the closing
+        sample. The larger of the two is the strongest bound available
+        without continuous sampling, which is what tcg#80 had to do on the
+        card and what a serve path cannot afford per request.
+        """
+
+        return max(
+            self.allocated_bytes + self.out_of_allocator_bytes,
+            self.driver_growth_bytes,
+        )
+
+    def for_regime(self, regime: str) -> int:
+        return self.driver_bytes if regime == "compiled" else self.allocated_bytes
+
+
+class DemandObservation(msgspec.Struct, frozen=True, kw_only=True):
+    """One serve's predicted-vs-measured pair, with everything to re-derive it."""
+
+    lane: str
+    regime: str
+    shape: RequestShape
+    predicted_bytes: int
+    basis: Basis
+    measured: MeasuredArena
+
+    @property
+    def measured_bytes(self) -> int:
+        return self.measured.for_regime(self.regime)
+
+    @property
+    def is_miss(self) -> bool:
+        return self.measured.measured and self.measured_bytes > self.predicted_bytes
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.lane, self.regime)
+
+
+class Banked(msgspec.Struct, frozen=True, kw_only=True):
+    """The counted state for one (lane x regime). Hub-visible via the event."""
+
+    lane: str
+    regime: str
+    served: int = 0
+    misses: int = 0
+    worst_miss_bytes: int = 0
+    worst_predicted_bytes: int = 0
+    worst_measured_bytes: int = 0
+    basis: Basis = Basis.UNCALIBRATED
+
+    def as_document(self) -> dict[str, Any]:
+        return {
+            "lane": self.lane,
+            "regime": self.regime,
+            "served": self.served,
+            "demand_miss": self.misses,
+            "worst_miss_bytes": self.worst_miss_bytes,
+            "worst_predicted_bytes": self.worst_predicted_bytes,
+            "worst_measured_bytes": self.worst_measured_bytes,
+            "basis": str(self.basis),
+        }
+
+
+_lock = threading.Lock()
+_banked: dict[tuple[str, str], Banked] = {}
+
+
+def banked() -> tuple[Banked, ...]:
+    """Every counted (lane x regime), in a stable order."""
+
+    with _lock:
+        return tuple(_banked[key] for key in sorted(_banked))
+
+
+def reset_banked() -> None:
+    """Test hook."""
+
+    with _lock:
+        _banked.clear()
+
+
+def bank(observation: DemandObservation) -> Banked:
+    """Record one serve. Emits `demand_miss` when the formula was WRONG LOW."""
+
+    with _lock:
+        held = _banked.get(observation.key) or Banked(
+            lane=observation.lane, regime=observation.regime,
+        )
+        miss = observation.is_miss
+        over = (
+            observation.measured_bytes - observation.predicted_bytes if miss else 0
+        )
+        updated = Banked(
+            lane=held.lane,
+            regime=held.regime,
+            served=held.served + (1 if observation.measured.measured else 0),
+            misses=held.misses + (1 if miss else 0),
+            worst_miss_bytes=max(held.worst_miss_bytes, over),
+            worst_predicted_bytes=(
+                observation.predicted_bytes if over > held.worst_miss_bytes
+                else held.worst_predicted_bytes
+            ),
+            worst_measured_bytes=(
+                observation.measured_bytes if over > held.worst_miss_bytes
+                else held.worst_measured_bytes
+            ),
+            basis=observation.basis,
+        )
+        _banked[observation.key] = updated
+    if miss:
+        _confess(observation, updated)
+    return updated
+
+
+def _confess(observation: DemandObservation, state: Banked) -> None:
+    """One typed, countable event per miss.
+
+    ``step``/``total_steps`` carry (misses, served) so the hub can read a RATE
+    off the event alone — the pgw#1597-plan-3 leak-rate shape — without
+    joining anything. ``phase`` carries the key, so a hub reader groups by
+    (lane x regime) without parsing the sentence.
+    """
+
+    severity = "p0_stamp_defect" if observation.regime == "compiled" else "statistic"
+    detail = (
+        f"lane={observation.lane} regime={observation.regime} "
+        f"predicted={observation.predicted_bytes / _MIB:.0f} MiB "
+        f"measured={observation.measured_bytes / _MIB:.0f} MiB "
+        f"(allocated={observation.measured.allocated_bytes / _MIB:.0f} + "
+        f"out_of_allocator="
+        f"{observation.measured.out_of_allocator_bytes / _MIB:.0f}) "
+        f"over={(observation.measured_bytes - observation.predicted_bytes) / _MIB:.0f} MiB "
+        f"shape={observation.shape.as_document()} "
+        f"coefficient_basis={observation.basis} severity={severity} "
+        f"misses={state.misses}/{state.served}"
+    )
+    if observation.regime == "compiled":
+        # pgw#1601 acceptance (d): on the compiled path admission is the ONLY
+        # safety mechanism, so a stamp the card disagreed with is a defect of
+        # the stamp — not a sample to average away.
+        logger.error("demand_miss (P0, compiled): %s", detail)
+    else:
+        logger.warning("demand_miss: %s", detail)
+    activity_mod.emit_event(
+        KIND_DEMAND_MISS,
+        detail,
+        phase=f"{observation.lane}|{observation.regime}|{severity}",
+        step=state.misses,
+        total_steps=state.served,
+    )
+
+
+def _arena_now() -> Optional[tuple[int, int, int]]:
+    """``(allocated, reserved, total - driver_free)``, or None with no card."""
+
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        allocated = int(torch.cuda.memory_allocated())
+        reserved = int(torch.cuda.memory_reserved())
+        driver_free, total = torch.cuda.mem_get_info()
+        return allocated, reserved, int(total) - int(driver_free)
+    except Exception:  # noqa: BLE001 — a falsifier must never fail a request
+        return None
+
+
+@contextmanager
+def measure_request_arena() -> Iterator[list[MeasuredArena]]:
+    """Measure one handler's request arena, decomposed. Never raises.
+
+    Yields a one-element list the caller reads AFTER the block. The
+    allocator peak is reset on entry so the number is THIS request's, and the
+    out-of-allocator term is the growth in what the process holds on the card
+    outside the caching allocator — where AOTI's first-call pool lands.
+    """
+
+    out: list[MeasuredArena] = [MeasuredArena()]
+    before = _arena_now()
+    if before is not None:
+        try:
+            import torch
+
+            torch.cuda.reset_peak_memory_stats()
+        except Exception:  # noqa: BLE001
+            before = None
+    try:
+        yield out
+    finally:
+        after = _arena_now()
+        if before is not None and after is not None:
+            try:
+                import torch
+
+                peak = int(torch.cuda.max_memory_allocated())
+            except Exception:  # noqa: BLE001
+                peak = after[0]
+            allocated_before, reserved_before, held_before = before
+            _, reserved_after, held_after = after
+            outside_before = max(0, held_before - reserved_before)
+            outside_after = max(0, held_after - reserved_after)
+            out[0] = MeasuredArena(
+                allocated_bytes=max(0, peak - allocated_before),
+                out_of_allocator_bytes=max(0, outside_after - outside_before),
+                driver_growth_bytes=max(0, held_after - held_before),
+                measured=True,
+            )
+
+
+def observe(
+    *,
+    lane: str,
+    regime: str,
+    demand: Optional[Demand],
+    shape: RequestShape,
+    measured: MeasuredArena,
+) -> Optional[DemandObservation]:
+    """Build and bank one observation. Returns None when there is nothing to
+    falsify (no declared formula, or nothing measured)."""
+
+    if demand is None or not measured.measured:
+        return None
+    try:
+        predicted = demand.evaluate(shape)
+    except Exception:  # noqa: BLE001 — an out-of-domain shape is not a failed request
+        logger.debug("demand falsifier: shape out of domain", exc_info=True)
+        return None
+    observation = DemandObservation(
+        lane=lane or "unknown",
+        regime=regime if regime in ("eager", "compiled") else f"unknown({regime})",
+        shape=shape,
+        predicted_bytes=predicted,
+        basis=demand.weakest_basis(),
+        measured=measured,
+    )
+    bank(observation)
+    return observation

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -78,6 +78,7 @@ from pathlib import Path
 from types import MappingProxyType, ModuleType
 from typing import Any, Optional
 
+from ..demand_envelope import advertised_envelope, demand_document
 from ..serving.entrypoints import ENTRYPOINT_ATTR
 from ..serving.model import (
     Model,
@@ -1300,6 +1301,17 @@ def derive_release(
             floor = requires.get(lane_graphs.contract)
             if floor is not None:
                 entry["requires"] = floor.render()
+            # pgw#1600. THE DEMAND FORMULA, SERIALIZED. Data, not Python: a
+            # term list plus the closed vocabulary it is written against, so
+            # tensorhub (Go) evaluates `worst_case = manifest weight bytes +
+            # demand(advertised envelope)` at pod-buy time without running any
+            # of ours. The envelope is taken over EVERY entrypoint this
+            # release serves, because the pod must hold the worst case of the
+            # whole advertised surface, not of one function.
+            entry["demand"] = demand_document(
+                lane.request,
+                advertised_envelope(*(plan.payload_type for plan, _ in plans)),
+            )
             # THE FIRST field: the map KEY. Key != stamp is the hub's hard
             # refusal `release_compiled_graphs_invalid_lane`, which is why this
             # is the same expression and not a second spelling of it.

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -14,6 +14,8 @@ from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Sequence, T
 import msgspec
 
 from .. import activity, boot_phases
+from ..demand_envelope import request_shape
+from ..demand_falsifier import measure_request_arena
 from ..warm_payload import neutral_payload
 from ..input_assets import (
     InputManifestEntry,
@@ -25,7 +27,7 @@ from .context import DeployBinding, LoadContext, LoaderEngine, RequestContext
 from .envelope import DecodedRequest, decode_envelope
 from .host import ServeDispatchError
 from .loader import EndpointLoadError, LoadedEndpoint
-from .model import Model, lane_handle, model_type
+from .model import Model, lane_handle, model_declared_lanes, model_type
 from .placement import warn_if_degraded
 from .reserved_repos import (
     materialize_reserved_inputs,
@@ -46,6 +48,26 @@ class BindingResolver(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
+class PendingDemand:
+    """pgw#1600's predicted-vs-measured pair, MINUS the regime.
+
+    Deliberately incomplete when it leaves here. This layer knows the lane's
+    declared formula, the request's shape and what the handler cost; it does
+    NOT know whether the forwards ran compiled or eager — the dispatch counter
+    that answers that is per-worker and per-request, one level up. Handing up
+    a half-filled record beats guessing the half we cannot see, because a
+    sample banked under the wrong regime is worse than one not banked at all
+    (pgw#1586: eager samples leaking into the compiled regime is the pgw#1548
+    daemon death, delivered by a number that looks measured).
+    """
+
+    lane: str
+    demand: Any
+    shape: Any
+    measured: Any
+
+
+@dataclass(frozen=True, slots=True)
 class InvokeOutcome:
     """One served request: the entrypoint's result + the request facts the envelope reply carries (``ctx.warn`` rows, adjustments, stage timings)."""
 
@@ -53,6 +75,9 @@ class InvokeOutcome:
     warnings: Tuple[str, ...]
     adjustments: Tuple[Dict[str, str], ...]
     stages: Optional[StageTimer] = None
+    #: pgw#1600. None when the lane declares no formula, when nothing could be
+    #: measured (no card), or when the request was not solo.
+    demand: Optional[PendingDemand] = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -425,10 +450,16 @@ class ServeLoop:
                         self.resolved_lane_for(primary_cls, primary_binding))
 
             ctx._stages.handler_open()
+            # pgw#1600. The falsifier's measurement window is exactly the
+            # handler: the weight arena is already placed by here, so what
+            # this reads is the REQUEST arena and nothing else — the same
+            # basis the formula is written in. It banks nothing on its own
+            # (no card, no sample) and it decides nothing at all.
             try:
-                result = spec.fn(ctx, decoded.payload, *arguments)
-                if inspect.iscoroutine(result):
-                    result = asyncio.run(result)
+                with measure_request_arena() as arena:
+                    result = spec.fn(ctx, decoded.payload, *arguments)
+                    if inspect.iscoroutine(result):
+                        result = asyncio.run(result)
             finally:
                 ctx._stages.handler_close()
         return InvokeOutcome(
@@ -436,7 +467,41 @@ class ServeLoop:
             warnings=ctx.warnings,
             adjustments=ctx.adjustments,
             stages=ctx._stages,
+            demand=self._pending_demand(spec, decoded.payload, arena[0]),
         )
+
+    def _pending_demand(
+        self, spec: Any, payload: Any, measured: Any
+    ) -> Optional[PendingDemand]:
+        """The lane's declared formula + this request's shape + what it cost.
+
+        Reads the formula through ``model_declared_lanes`` — pgw#1599's ONE
+        read surface — so nothing here re-derives a lane or re-parses a stamp.
+        """
+
+        if not spec.model_params or not getattr(measured, "measured", False):
+            return None
+        try:
+            primary_cls = spec.model_params[0][1]
+            _, handle = self._lane_of(primary_cls)
+            declared = next(
+                (
+                    row for row in model_declared_lanes(primary_cls)
+                    if row.contract_id == handle
+                ),
+                None,
+            )
+            if declared is None:
+                return None
+            return PendingDemand(
+                lane=handle,
+                demand=declared.request,
+                shape=request_shape(payload),
+                measured=measured,
+            )
+        except Exception:  # noqa: BLE001 — a falsifier never fails a request
+            logger.debug("demand falsifier: no pending record", exc_info=True)
+            return None
 
     def boot_warmup(
         self, *, prepare: Optional[Callable[[str], str]] = None
@@ -569,6 +634,7 @@ def manifest_sizer(
 __all__ = [
     "BindingResolver",
     "InvokeOutcome",
+    "PendingDemand",
     "ServeLoop",
     "WARM_FAILED",
     "WARM_OK",

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -878,6 +878,40 @@ class Worker:
             else f"{body}+eager"
         )
 
+    def _bank_demand(self, pending: Any, served_lane: str, *, solo: bool) -> None:
+        """pgw#1600's falsifier: complete the serve loop's half-record and bank it.
+
+        The REGIME is added here and only here, because the dispatch counter
+        that answers it lives here. It is read off the very string
+        :meth:`_served_lane` already produced, so the metric the hub sees and
+        the regime the sample is keyed under can never disagree — one
+        producer, and `demand_miss` grouped by a regime the lane metric
+        contradicts would be unreadable.
+
+        A CONCURRENT request banks NOTHING. Both halves are ambiguous when
+        jobs overlap: the dispatch counter is per-worker (which is why
+        :meth:`_served_lane` already withholds the suffix), and the arena
+        measurement is per-process, so a co-tenant's activations would land
+        in this request's sample. An unbanked request is a smaller loss than
+        a sample attributed to the wrong lane.
+        """
+
+        if pending is None or not solo:
+            return
+        suffix = served_lane.rsplit("+", 1)[-1] if "+" in served_lane else ""
+        try:
+            from . import demand_falsifier
+
+            demand_falsifier.observe(
+                lane=pending.lane,
+                regime=suffix,
+                demand=pending.demand,
+                shape=pending.shape,
+                measured=pending.measured,
+            )
+        except Exception:  # noqa: BLE001 — a falsifier never fails a result
+            logger.debug("demand falsifier: not banked", exc_info=True)
+
     async def _run_one(self, run: pb.RunJob, key: Tuple[str, int]) -> None:
         accepted_at = time.monotonic()
         if key in self._canceled:
@@ -894,6 +928,7 @@ class Worker:
         stages: Optional[Any] = None
         started = accepted_at
         ctx_box: List[Any] = []
+        pending_demand: Optional[Any] = None
         solo = len(self._jobs) <= 1
         self._dispatch_counter().reset()
         try:
@@ -949,6 +984,7 @@ class Worker:
             inline = msgspec.msgpack.encode(outcome.result)
             adjustments = outcome.adjustments
             stages = outcome.stages
+            pending_demand = outcome.demand
             status = pb.JOB_STATUS_OK
         except asyncio.CancelledError:
             await self._send_result(*key, pb.JOB_STATUS_CANCELED, safe_message="canceled")
@@ -983,6 +1019,7 @@ class Worker:
             queue_ms=int((started - accepted_at) * 1000),
         )
         metrics.lane = self._served_lane(ctx_box, solo=solo)
+        self._bank_demand(pending_demand, metrics.lane, solo=solo)
         metrics.stage_ms.update(stage_ms_for_metrics(stages, runtime_ms))
         await self._send_result(
             *key,

--- a/tests/release_fixtures/demand_sdxl_shaped_endpoint.py
+++ b/tests/release_fixtures/demand_sdxl_shaped_endpoint.py
@@ -1,0 +1,127 @@
+"""sdxl's DECLARATION shape exactly — the demand half (pgw#1600 acceptance (b)).
+
+Every line that matters here is copied from the real endpoint
+(`serverless-endpoints/sdxl/src/sdxl/main.py`), not invented:
+
+* the payload dimensions itself through an ASPECT-RATIO ENUM over a bucket
+  table, with no `width` / `height` field anywhere — which is precisely the
+  case the platform's field-name vocabulary cannot read, and the reason
+  `Shape(pixels=...)` exists;
+* `_BUCKETS` is the endpoint's OWN table, passed to the annotation BY
+  REFERENCE. There is no second spelling of the geometry to drift;
+* the lane is a real ratified `(topology, quant)` pair;
+* the demand formula carries tcg#80's measured basis on the term that one
+  measurement can identify, and an explicitly UNCALIBRATED prior on the term
+  it cannot.
+
+The tree the derive traces against is the tiny SD15-class one, because this
+repository ships no sdxl checkpoint and a mint on this box is banned. That is a
+fixture detail and it is stated rather than hidden: what is under test is the
+DECLARATION → DOCUMENT path, which does not read a weight.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import STATIC, LoadContext, Model, RequestContext, entrypoint, lane
+from gen_worker.demand import Basis, MiB, const, per_mp_batch
+from gen_worker.demand_envelope import Shape
+from gen_worker.models import SDXL
+
+SDXL_DIFFUSERS_BF16 = ("sdxl.diffusers@1", "plain.bf16@1")
+
+
+class AspectRatio(StrEnum):
+    RATIO_21_9 = "21:9"
+    RATIO_16_9 = "16:9"
+    RATIO_1_1 = "1:1"
+    RATIO_9_16 = "9:16"
+    RATIO_9_21 = "9:21"
+
+
+#: SDXL's trained buckets (arXiv:2307.01952 Appendix I), ~1MP each.
+_BUCKETS: dict[AspectRatio, tuple[int, int]] = {
+    AspectRatio.RATIO_21_9: (1536, 640),
+    AspectRatio.RATIO_16_9: (1344, 768),
+    AspectRatio.RATIO_1_1: (1024, 1024),
+    AspectRatio.RATIO_9_16: (768, 1344),
+    AspectRatio.RATIO_9_21: (640, 1536),
+}
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    #: THE WHOLE POINT. Nothing about this field's NAME or TYPE says
+    #: "1024x1024" — an aspect ratio is not a size. The annotation hands the
+    #: platform the endpoint's own table, so the envelope is derived from the
+    #: buckets the handler actually indexes.
+    aspect_ratio: Annotated[AspectRatio, Shape(pixels=_BUCKETS)] = (
+        AspectRatio.RATIO_1_1
+    )
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class DemandSdxlShaped(
+    Model[SDXL],
+    lanes={SDXL_DIFFUSERS_BF16: lane(
+        # ---- MEASURED, n=1, and it identifies exactly ONE term -------------
+        # tcg#80's sm_89 acceptance run (2026-08-21), COLD DAEMON: the compiled
+        # UNet allocated 4907 MiB inside the torch allocator at denoise (ONE
+        # constant set, flat across 84 steps) and 1155 MiB OUTSIDE it — the
+        # CUDA context plus cuDNN/cuBLAS workspaces — for a driver total of
+        # 6649 MiB at denoise. The whole-request driver peak was 7792 MiB and
+        # is owned by VAE DECODE, not by denoise.
+        #
+        # The out-of-allocator 1155 MiB is shape-INDEPENDENT by construction: a
+        # CUDA context and a workspace pool are per-process, not per-pixel. So
+        # this single point identifies a CONST term and nothing else, and it is
+        # declared as measured with the run named.
+        request=const(
+            MiB(1155), basis=Basis.MEASURED,
+            source="tcg#80 sm_89 acceptance run 2026-08-21, cold daemon, n=1: "
+                   "out-of-allocator 1155 MiB (driver 6649 at denoise, "
+                   "allocated 4907 MiB, whole-request peak 7792 MiB at VAE "
+                   "decode). NEVER from a death trace (pgw#1601).",
+        )
+        # ---- UNCALIBRATED, and it says so ----------------------------------
+        # ONE measurement cannot separate an intercept from a slope. 220
+        # MiB/mp-batch is pgw#1577's bracket over the 519 MiB (model_offload)
+        # and 1847 MiB (partial_resident) activation peaks at 1024x1024 with
+        # the CFG pair — a DECLARED PRIOR, carried forward as one. pgw#1586
+        # fits it from banked samples; pgw#1600's demand_miss falsifies it.
+        + per_mp_batch(MiB(220)),
+        resident=("vae",),
+    )},
+    shapes={"aspect": STATIC},
+):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In, model: DemandSdxlShaped) -> Out:
+    ctx.raise_if_cancelled()
+    width, height = _BUCKETS[payload.aspect_ratio]
+    with torch.inference_mode():
+        model.pipe(
+            prompt=payload.prompt,
+            num_inference_steps=2,
+            guidance_scale=7.5,
+            width=min(64, width),
+            height=min(64, height),
+            callback_on_step_end=ctx.step_callback(2),
+            output_type="latent",
+        )
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/release_fixtures/demand_sdxl_shaped_endpoint.py
+++ b/tests/release_fixtures/demand_sdxl_shaped_endpoint.py
@@ -30,8 +30,7 @@ import torch
 from diffusers import StableDiffusionPipeline
 
 from gen_worker import STATIC, LoadContext, Model, RequestContext, entrypoint, lane
-from gen_worker.demand import Basis, MiB, const, per_mp_batch
-from gen_worker.demand_envelope import Shape
+from gen_worker.demand import Basis, MiB, Shape, const, per_mp_batch
 from gen_worker.models import SDXL
 
 SDXL_DIFFUSERS_BF16 = ("sdxl.diffusers@1", "plain.bf16@1")

--- a/tests/test_demand_falsifier_pgw1600.py
+++ b/tests/test_demand_falsifier_pgw1600.py
@@ -9,13 +9,16 @@ tested.
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Annotated, Any, List, cast
 
 import pytest
 
 from gen_worker import activity as activity_mod
 from gen_worker import demand_falsifier as falsifier
+import msgspec
+
 from gen_worker.demand import Basis, GiB, MiB, RequestShape, const, per_mp_batch
+from gen_worker.demand_envelope import Shape
 
 SHAPE = RequestShape(width=1024, height=1024, batch=2)
 FORMULA = const(GiB(1.2)) + per_mp_batch(MiB(220))
@@ -214,3 +217,101 @@ def test_measure_request_arena_is_inert_and_silent_with_no_card() -> None:
         pass
     assert arena[0].measured is False
     assert arena[0].driver_bytes == 0
+
+
+# --------------------------------------------------------------------------
+# THE PRODUCTION WIRING, exercised as production code
+#
+# Both halves are real methods called with real arguments. Without these the
+# banking path is only ever reached on a card, which this box does not have and
+# is not allowed to use — so the wiring would ship unverified while the module
+# under it was thoroughly green. That is the shape of a silent gap.
+# --------------------------------------------------------------------------
+
+
+def _lane_pair() -> tuple:
+    return ("sdxl.diffusers@1", "plain.bf16@1")
+
+
+#: A payload shaped exactly like sdxl's: an aspect ENUM over a bucket table and
+#: no `width` field anywhere. Module level, because that is where a real
+#: endpoint's payload lives.
+_BUCKETS = {"wide": (1536, 640), "square": (1024, 1024)}
+
+
+class _In(msgspec.Struct):
+    aspect: Annotated[str, Shape(pixels=_BUCKETS)] = "square"
+
+
+def test_the_serve_loop_builds_a_HALF_record_from_the_real_declaration() -> None:
+    """`ServeLoop._pending_demand` reads the formula through
+    `model_declared_lanes` — pgw#1599's one read surface — and the request's
+    shape through the platform extractor."""
+
+    from gen_worker import Model, lane
+    from gen_worker.models import SDXL
+    from gen_worker.serving.serve_loop import ServeLoop
+
+    class _M(Model[SDXL], lanes={_lane_pair(): lane(request=FORMULA)}):
+        def load(self, ctx: Any) -> None: ...
+
+    class _Spec:
+        model_params = (("model", _M),)
+
+    class _Stub:
+        def _lane_of(self, cls: type) -> tuple:
+            return None, "sdxl.diffusers@1+plain.bf16@1"
+
+    arena = _arena(GiB(2))
+    unbound = cast(Any, ServeLoop._pending_demand)
+    pending = unbound(_Stub(), _Spec(), _In(aspect="wide"), arena)
+    assert pending is not None
+    assert pending.lane == "sdxl.diffusers@1+plain.bf16@1"
+    assert pending.shape.width == 1536 and pending.shape.height == 640
+    assert pending.demand.coefficients() == FORMULA.coefficients()
+
+    # And an UNMEASURED arena produces no record at all, so a cardless box
+    # cannot manufacture a sample.
+    assert unbound(_Stub(), _Spec(), _In(), falsifier.MeasuredArena()) is None
+
+
+def test_the_worker_adds_the_REGIME_off_the_lane_metric_it_already_emits(
+    wire: List[tuple],
+) -> None:
+    """One producer for the metric and the sample key.
+
+    `_served_lane` renders `"<body>+compiled"` / `"+eager"`; `_bank_demand`
+    reads the regime off that same string, so the metric a hub reader sees and
+    the regime the miss is filed under cannot disagree.
+    """
+
+    from gen_worker.serving.serve_loop import PendingDemand
+    from gen_worker.worker import Worker
+
+    pending = PendingDemand(
+        lane="sdxl.diffusers@1+plain.bf16@1",
+        demand=FORMULA, shape=SHAPE, measured=_arena(PREDICTED + MiB(32)),
+    )
+    cast(Any, Worker._bank_demand)(
+        object(), pending, "sdxl.diffusers-bf16@1+compiled", solo=True,
+    )
+    (row,) = falsifier.banked()
+    assert row.regime == "compiled" and row.misses == 1
+    assert wire[-1][1].endswith("|p0_stamp_defect")
+
+
+def test_a_CONCURRENT_request_banks_NOTHING(wire: List[tuple]) -> None:
+    """Both halves are ambiguous when jobs overlap — the dispatch counter is
+    per-worker (which is why `_served_lane` already withholds the suffix) and
+    the arena measurement is per-process. An unbanked request is a smaller loss
+    than a sample attributed to the wrong lane."""
+
+    from gen_worker.serving.serve_loop import PendingDemand
+    from gen_worker.worker import Worker
+
+    pending = PendingDemand(
+        lane="L", demand=FORMULA, shape=SHAPE, measured=_arena(GiB(40)),
+    )
+    cast(Any, Worker._bank_demand)(object(), pending, "sdxl.diffusers-bf16@1", solo=False)
+    assert falsifier.banked() == ()
+    assert not wire

--- a/tests/test_demand_falsifier_pgw1600.py
+++ b/tests/test_demand_falsifier_pgw1600.py
@@ -1,0 +1,216 @@
+"""pgw#1600 acceptance (c): `demand_miss`, counted and hub-visible per lane x regime.
+
+The falsifier is the whole point of the issue's ordering — it ships BEFORE any
+consumer, so the first thing that ever happens to a demand number is that
+something tries to prove it wrong. These tests exercise the real banking path
+and the real event emitter; nothing here is a mock of the instrument being
+tested.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import demand_falsifier as falsifier
+from gen_worker.demand import Basis, GiB, MiB, RequestShape, const, per_mp_batch
+
+SHAPE = RequestShape(width=1024, height=1024, batch=2)
+FORMULA = const(GiB(1.2)) + per_mp_batch(MiB(220))
+PREDICTED = FORMULA.evaluate(SHAPE)
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> Any:
+    falsifier.reset_banked()
+    yield
+    falsifier.reset_banked()
+
+
+@pytest.fixture()
+def wire(monkeypatch: pytest.MonkeyPatch) -> List[tuple]:
+    seen: List[tuple] = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, phase="", **kw: seen.append((kind, phase, detail, kw)),
+    )
+    return seen
+
+
+def _arena(allocated: int, outside: int = 0) -> falsifier.MeasuredArena:
+    return falsifier.MeasuredArena(
+        allocated_bytes=allocated, out_of_allocator_bytes=outside, measured=True,
+    )
+
+
+def test_a_request_INSIDE_the_prediction_banks_a_serve_and_no_miss(
+    wire: List[tuple],
+) -> None:
+    falsifier.observe(
+        lane="sdxl.diffusers@1+plain.bf16@1", regime="eager",
+        demand=FORMULA, shape=SHAPE, measured=_arena(PREDICTED - MiB(1)),
+    )
+    (row,) = falsifier.banked()
+    assert (row.served, row.misses) == (1, 0)
+    assert not wire
+
+
+def test_a_request_OVER_the_prediction_is_a_counted_hub_visible_event(
+    wire: List[tuple],
+) -> None:
+    falsifier.observe(
+        lane="sdxl.diffusers@1+plain.bf16@1", regime="eager",
+        demand=FORMULA, shape=SHAPE, measured=_arena(PREDICTED + MiB(64)),
+    )
+    (row,) = falsifier.banked()
+    assert (row.served, row.misses) == (1, 1)
+    assert row.worst_miss_bytes == MiB(64)
+    assert row.basis is Basis.UNCALIBRATED
+
+    (kind, phase, detail, kw) = wire[-1]
+    assert kind == falsifier.KIND_DEMAND_MISS == "demand_miss"
+    # The KEY rides on the event, so a hub reader groups by (lane x regime)
+    # without parsing the sentence.
+    assert phase.startswith("sdxl.diffusers@1+plain.bf16@1|eager|")
+    # (misses, served) ride as step/total_steps — the leak-RATE shape.
+    assert (kw["step"], kw["total_steps"]) == (1, 1)
+    assert "coefficient_basis=uncalibrated" in detail
+    assert "shape=" in detail
+
+
+def test_eager_and_compiled_NEVER_pool() -> None:
+    """pgw#1586's rule, restated where it can be broken again.
+
+    An eager sample landing in the compiled regime's count is the pgw#1548
+    daemon death, delivered by a number that looks measured.
+    """
+
+    for regime in ("eager", "compiled"):
+        falsifier.observe(
+            lane="L", regime=regime, demand=FORMULA, shape=SHAPE,
+            measured=_arena(PREDICTED + MiB(8)),
+        )
+    keys = {(row.lane, row.regime) for row in falsifier.banked()}
+    assert keys == {("L", "eager"), ("L", "compiled")}
+    assert all(row.served == 1 for row in falsifier.banked())
+
+
+def test_an_unrecognised_regime_pools_with_NOTHING() -> None:
+    falsifier.observe(
+        lane="L", regime="", demand=FORMULA, shape=SHAPE,
+        measured=_arena(PREDICTED + 1),
+    )
+    (row,) = falsifier.banked()
+    assert row.regime.startswith("unknown("), (
+        "a regime the worker could not determine must not be filed as eager"
+    )
+
+
+def test_the_COMPILED_regime_is_judged_on_the_DRIVER_total(
+    wire: List[tuple],
+) -> None:
+    """AOTI's first-call pool lands outside the torch allocator (tcg#80).
+
+    Judging a compiled serve on `max_memory_allocated` alone hides exactly the
+    bytes that kill the process, so the compiled basis is
+    allocated + out-of-allocator.
+    """
+
+    measured = _arena(PREDICTED - MiB(100), outside=MiB(200))
+    falsifier.observe(
+        lane="L", regime="compiled", demand=FORMULA, shape=SHAPE,
+        measured=measured,
+    )
+    (row,) = falsifier.banked()
+    assert row.misses == 1, (
+        "the allocator alone was under the prediction; the driver total was "
+        "not, and the driver total is the budget a compiled admit has"
+    )
+    assert measured.for_regime("eager") < PREDICTED
+    assert measured.for_regime("compiled") > PREDICTED
+
+
+def test_a_compiled_miss_is_a_P0_STAMP_DEFECT_not_a_statistic(
+    wire: List[tuple],
+) -> None:
+    falsifier.observe(
+        lane="L", regime="compiled", demand=FORMULA, shape=SHAPE,
+        measured=_arena(PREDICTED + MiB(1)),
+    )
+    (_kind, phase, detail, _kw) = wire[-1]
+    assert phase.endswith("|p0_stamp_defect")
+    assert "severity=p0_stamp_defect" in detail
+
+
+def test_an_UNMEASURED_request_banks_nothing(wire: List[tuple]) -> None:
+    """A zero measurement would read as "predicted generously" and quietly
+    prove every formula right — the exact failure mode a falsifier exists to
+    avoid."""
+
+    assert falsifier.observe(
+        lane="L", regime="eager", demand=FORMULA, shape=SHAPE,
+        measured=falsifier.MeasuredArena(),
+    ) is None
+    assert falsifier.banked() == ()
+    assert not wire
+
+
+def test_a_lane_with_no_declared_formula_banks_nothing() -> None:
+    assert falsifier.observe(
+        lane="L", regime="eager", demand=None, shape=SHAPE,
+        measured=_arena(GiB(9)),
+    ) is None
+    assert falsifier.banked() == ()
+
+
+def test_the_reconstructed_peak_alone_UNDERSTATES_the_driver_reading() -> None:
+    """tcg#80's sm_89 decomposition, and the gap it exposes.
+
+    The run read 4907 MiB allocated and 1155 MiB out-of-allocator at denoise
+    against a DRIVER reading of 6649 MiB. Those do not add up, and the
+    difference (~587 MiB) is allocator CACHE — reserved-but-not-allocated
+    blocks that driver-free counts as gone and that a compiled call cannot
+    spend at all. So the compiled basis takes the LARGER of the reconstructed
+    peak and the driver growth; taking only the first would under-report by
+    exactly the bytes pgw#1627 says are unavailable.
+    """
+
+    reconstructed_only = falsifier.MeasuredArena(
+        allocated_bytes=MiB(4907), out_of_allocator_bytes=MiB(1155), measured=True,
+    )
+    assert round(reconstructed_only.driver_bytes / MiB(1)) == 6062
+    assert reconstructed_only.driver_bytes < MiB(6649)
+
+    with_driver = falsifier.MeasuredArena(
+        allocated_bytes=MiB(4907), out_of_allocator_bytes=MiB(1155),
+        driver_growth_bytes=MiB(6649), measured=True,
+    )
+    assert with_driver.driver_bytes == MiB(6649)
+    assert with_driver.for_regime("eager") == MiB(4907), (
+        "the eager basis is the allocator, and eager CAN spend the cache"
+    )
+
+
+def test_the_worst_miss_is_kept_not_the_last_one() -> None:
+    for over in (MiB(10), MiB(300), MiB(5)):
+        falsifier.observe(
+            lane="L", regime="eager", demand=FORMULA, shape=SHAPE,
+            measured=_arena(PREDICTED + over),
+        )
+    (row,) = falsifier.banked()
+    assert (row.served, row.misses) == (3, 3)
+    assert row.worst_miss_bytes == MiB(300)
+    assert row.worst_measured_bytes == PREDICTED + MiB(300)
+    assert row.as_document()["demand_miss"] == 3
+
+
+def test_measure_request_arena_is_inert_and_silent_with_no_card() -> None:
+    """CPU-only is the box this repo is developed on; the instrument must be
+    a no-op there rather than a crash or a fabricated zero-sample."""
+
+    with falsifier.measure_request_arena() as arena:
+        pass
+    assert arena[0].measured is False
+    assert arena[0].driver_bytes == 0

--- a/tests/test_demand_falsifier_pgw1600.py
+++ b/tests/test_demand_falsifier_pgw1600.py
@@ -17,8 +17,15 @@ from gen_worker import activity as activity_mod
 from gen_worker import demand_falsifier as falsifier
 import msgspec
 
-from gen_worker.demand import Basis, GiB, MiB, RequestShape, const, per_mp_batch
-from gen_worker.demand_envelope import Shape
+from gen_worker.demand import (
+    Basis,
+    GiB,
+    MiB,
+    RequestShape,
+    Shape,
+    const,
+    per_mp_batch,
+)
 
 SHAPE = RequestShape(width=1024, height=1024, batch=2)
 FORMULA = const(GiB(1.2)) + per_mp_batch(MiB(220))

--- a/tests/test_demand_formula_pgw1600.py
+++ b/tests/test_demand_formula_pgw1600.py
@@ -31,6 +31,8 @@ from gen_worker.demand import (
     MiB,
     RequestShape,
     SHAPE_BOUNDS,
+    Shape,
+    ShapeDeclarationError,
     TERM_VOCABULARY,
     VOCABULARY_VERSION,
     const,
@@ -44,8 +46,6 @@ from gen_worker.demand import (
     vocabulary_document,
 )
 from gen_worker.demand_envelope import (
-    Shape,
-    ShapeDeclarationError,
     advertised_envelope,
     demand_document,
     request_shape,

--- a/tests/test_demand_formula_pgw1600.py
+++ b/tests/test_demand_formula_pgw1600.py
@@ -27,6 +27,7 @@ from gen_worker.demand import (
     DemandDeclarationError,
     DemandEvaluationError,
     GiB,
+    MAX_RESULT_BYTES,
     MiB,
     RequestShape,
     SHAPE_BOUNDS,
@@ -120,11 +121,14 @@ def test_the_corpus_gate_goes_red_when_the_evaluator_MOVES() -> None:
 
 
 def test_the_overflow_case_is_actually_an_overflow_case() -> None:
-    """The corpus's ceiling row must be one a naive `c*v` would fail on.
+    """The corpus's ceiling row must be one that breaks a 64-bit reader.
 
-    A conformance corpus that cannot fail is decoration. This asserts the
-    naive product genuinely leaves int64, so the Go side's split division is
-    being tested rather than merely exercised.
+    THIS ROW HAS ALREADY EARNED ITS KEEP. The first Go evaluator did a split
+    division (`q*v + (r*v)//scale`) on the premise that the shape bounds kept
+    both products inside int64; `r*v` is 1.3e19 here, and Go wrapped by
+    exactly 2**64/1e6 on the corpus's first run. Python's bignums could not
+    have surfaced that in a thousand green test runs — which is the entire
+    argument for having a corpus a second language executes.
     """
 
     ceiling = RequestShape(
@@ -133,8 +137,25 @@ def test_the_overflow_case_is_actually_an_overflow_case() -> None:
         latent_tokens=SHAPE_BOUNDS["latent_tokens"],
     )
     naive = GiB(1) * ceiling.width * ceiling.height * ceiling.batch
-    assert naive > (1 << 63) - 1, "the ceiling row no longer overflows int64"
-    assert (const(GiB(64)) + per_mp_batch(GiB(1))).evaluate(ceiling) < (1 << 63) - 1
+    assert naive > MAX_RESULT_BYTES, "the ceiling row no longer overflows int64"
+    # The ANSWER still fits, which is what makes this a conformance case rather
+    # than a refusal case.
+    assert (const(GiB(64)) + per_mp_batch(GiB(1))).evaluate(ceiling) < MAX_RESULT_BYTES
+
+
+def test_a_result_past_int64_REFUSES_rather_than_wrapping() -> None:
+    """The bound is on the ANSWER, and it exists because Go is the other reader.
+
+    Python could carry this number forever; the wire form and the Go evaluator
+    cannot. A wrapped answer is a SMALL number, which is the direction that
+    buys too little card, so the refusal is loud instead.
+    """
+
+    huge = RequestShape(latent_tokens=SHAPE_BOUNDS["latent_tokens"])
+    with pytest.raises(DemandEvaluationError, match="64-bit"):
+        evaluate([{"term": "latent_tokens", "bytes": 1 << 33}], huge)
+    # One below the bound is fine — the refusal is a ceiling, not a taste.
+    assert evaluate([{"term": "latent_tokens", "bytes": 1 << 31}], huge) == 1 << 62
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_demand_formula_pgw1600.py
+++ b/tests/test_demand_formula_pgw1600.py
@@ -1,0 +1,344 @@
+"""pgw#1600: the demand formula is DATA — algebra, envelope, serialization.
+
+Acceptance (a) is the CROSS-LANGUAGE half and it has two legs: this file
+proves the corpus is exactly what this repository's evaluator computes (so it
+cannot be a table of numbers a human typed), and tensorhub's Go evaluator runs
+the same corpus on its side. A corpus with hand-written expectations would
+prove that a human and Go agree, which is not the property anybody wants.
+
+Nothing here imports torch. Acceptance (b)'s end-to-end derive lives in
+`test_demand_release_document_pgw1600.py`, which does.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Annotated, Any
+
+import msgspec
+import pytest
+
+from gen_worker.contracts import read_contract
+from gen_worker.demand import (
+    Basis,
+    DemandDeclarationError,
+    DemandEvaluationError,
+    GiB,
+    MiB,
+    RequestShape,
+    SHAPE_BOUNDS,
+    TERM_VOCABULARY,
+    VOCABULARY_VERSION,
+    const,
+    evaluate,
+    per_batch,
+    per_frame,
+    per_frame_squared,
+    per_latent_token,
+    per_mp,
+    per_mp_batch,
+    vocabulary_document,
+)
+from gen_worker.demand_envelope import (
+    Shape,
+    ShapeDeclarationError,
+    advertised_envelope,
+    demand_document,
+    request_shape,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _corpus() -> dict[str, Any]:
+    return json.loads(read_contract("demand_vectors.json"))
+
+
+# --------------------------------------------------------------------------
+# ACCEPTANCE (a), python half: the corpus IS the evaluator's own answer
+# --------------------------------------------------------------------------
+
+
+def test_every_corpus_case_reproduces_through_the_real_evaluator() -> None:
+    corpus = _corpus()
+    assert corpus["cases"], "an empty corpus proves nothing"
+    for case in corpus["cases"]:
+        shape = msgspec.convert(case["shape"], RequestShape)
+        assert evaluate(case["terms"], shape) == case["bytes"], case["name"]
+
+
+def test_every_corpus_refusal_refuses_here_too() -> None:
+    for case in _corpus()["refusals"]:
+        shape = msgspec.convert(case["shape"], RequestShape)
+        with pytest.raises(DemandEvaluationError):
+            evaluate(case["terms"], shape)
+
+
+def test_the_corpus_carries_the_vocabulary_it_was_generated_against() -> None:
+    """A Go reader validates its own term table against these rows.
+
+    Without this the two languages could hold different SCALES for the same
+    term name and agree on every case that happens to divide evenly.
+    """
+
+    corpus = _corpus()
+    assert corpus["vocabulary_version"] == VOCABULARY_VERSION
+    assert corpus["vocabulary"] == vocabulary_document()
+    assert corpus["shape_bounds"] == dict(SHAPE_BOUNDS)
+
+
+def test_the_corpus_gate_goes_red_when_the_evaluator_MOVES() -> None:
+    """The guard is falsified by moving the source of truth, not by prose.
+
+    Runs the real gate script against a corpus whose expected bytes were
+    edited by one, which is exactly what a silent algebra change looks like
+    from the outside.
+    """
+
+    import tempfile
+
+    corpus = _corpus()
+    corpus["cases"][0]["bytes"] += 1
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "demand_vectors.json"
+        path.write_text(json.dumps(corpus, indent=2, ensure_ascii=False) + "\n")
+        digest = Path(tmp) / "DEMAND_VECTORS_DIGEST"
+        digest.write_text("0" * 64 + "\n")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts" / "check_demand_corpus_digest.py"),
+                "--corpus", str(path), "--digest", str(digest),
+            ],
+            capture_output=True, text=True,
+        )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "not what this repository's evaluator produces" in result.stdout
+
+
+def test_the_overflow_case_is_actually_an_overflow_case() -> None:
+    """The corpus's ceiling row must be one a naive `c*v` would fail on.
+
+    A conformance corpus that cannot fail is decoration. This asserts the
+    naive product genuinely leaves int64, so the Go side's split division is
+    being tested rather than merely exercised.
+    """
+
+    ceiling = RequestShape(
+        width=SHAPE_BOUNDS["width"], height=SHAPE_BOUNDS["height"],
+        batch=SHAPE_BOUNDS["batch"], frames=SHAPE_BOUNDS["frames"],
+        latent_tokens=SHAPE_BOUNDS["latent_tokens"],
+    )
+    naive = GiB(1) * ceiling.width * ceiling.height * ceiling.batch
+    assert naive > (1 << 63) - 1, "the ceiling row no longer overflows int64"
+    assert (const(GiB(64)) + per_mp_batch(GiB(1))).evaluate(ceiling) < (1 << 63) - 1
+
+
+# --------------------------------------------------------------------------
+# The algebra
+# --------------------------------------------------------------------------
+
+
+def test_the_sdxl_reference_shape_evaluates_to_the_number_in_the_comment() -> None:
+    formula = const(GiB(1.2)) + per_mp_batch(MiB(220))
+    shape = RequestShape(width=1024, height=1024, batch=2)
+    assert formula.evaluate(shape) == 1772275304
+    assert round(formula.evaluate(shape) / MiB(1)) == 1690
+
+
+def test_evaluation_is_FLOOR_not_round_and_not_float() -> None:
+    """A float divide answers differently here; Go must not be allowed to."""
+
+    terms = [{"term": "megapixels", "bytes": 1_000_003}]
+    shape = RequestShape(width=1062, height=1099)
+    product = 1_000_003 * 1062 * 1099
+    exact = product // 1_000_000
+    assert evaluate(terms, shape) == exact == 1_167_141
+    assert round(product / 1_000_000) == 1_167_142, (
+        "this row no longer discriminates floor from round"
+    )
+
+
+def test_the_vocabulary_is_closed_at_evaluation_too() -> None:
+    with pytest.raises(DemandEvaluationError, match="CLOSED"):
+        evaluate([{"term": "teraflops", "bytes": 1}], RequestShape())
+
+
+def test_a_shape_past_the_declared_domain_REFUSES() -> None:
+    """The refusal direction matters: a wrapped worst case is a SMALL number."""
+
+    over = RequestShape(width=SHAPE_BOUNDS["width"] + 1, height=8)
+    with pytest.raises(DemandEvaluationError, match="exceeds the declared"):
+        const(1).evaluate(over)
+
+
+def test_a_negative_shape_scalar_REFUSES() -> None:
+    with pytest.raises(DemandEvaluationError, match="negative"):
+        const(1).evaluate(RequestShape(width=-1))
+
+
+def test_every_constructor_produces_a_term_in_the_vocabulary() -> None:
+    made = {
+        const(1), per_mp(1), per_mp_batch(1), per_batch(1),
+        per_frame(1), per_frame_squared(1), per_latent_token(1),
+    }
+    names = {term.name for demand in made for term in demand.terms}
+    assert names == set(TERM_VOCABULARY), (
+        "a vocabulary entry with no constructor is unreachable, and a "
+        "constructor with no entry is a term Go cannot evaluate"
+    )
+
+
+def test_a_negative_coefficient_is_refused_as_a_TECHNIQUE_not_a_term() -> None:
+    with pytest.raises(DemandDeclarationError, match="REDUCES demand"):
+        const(-1)
+
+
+# --------------------------------------------------------------------------
+# Provenance — no magic constants
+# --------------------------------------------------------------------------
+
+
+def test_the_default_basis_is_the_honest_one() -> None:
+    assert const(MiB(1)).terms[0].basis is Basis.UNCALIBRATED
+    assert const(MiB(1)).weakest_basis() is Basis.UNCALIBRATED
+
+
+def test_claiming_a_measurement_without_naming_it_REFUSES() -> None:
+    with pytest.raises(DemandDeclarationError, match="magic constant"):
+        const(MiB(1155), basis=Basis.MEASURED)
+    with pytest.raises(DemandDeclarationError, match="magic constant"):
+        per_mp_batch(MiB(220), basis="ledger")
+
+
+def test_a_formula_is_only_as_calibrated_as_its_WORST_term() -> None:
+    mixed = (
+        const(MiB(1155), basis=Basis.MEASURED, source="tcg#80 n=1")
+        + per_mp_batch(MiB(220))
+    )
+    assert mixed.weakest_basis() is Basis.UNCALIBRATED
+    assert mixed.bases() == {
+        "const": Basis.MEASURED, "mp_batch": Basis.UNCALIBRATED,
+    }
+
+
+def test_summing_two_terms_of_DIFFERENT_provenance_refuses() -> None:
+    """The sum would inherit one claim and launder the other."""
+
+    with pytest.raises(DemandDeclarationError, match="DIFFERENT provenance"):
+        const(MiB(1), basis=Basis.MEASURED, source="a run") + const(MiB(2))
+
+
+def test_the_serialized_document_carries_every_basis() -> None:
+    document = (
+        const(MiB(1155), basis=Basis.MEASURED, source="tcg#80 n=1")
+        + per_mp_batch(MiB(220))
+    ).formula_document()
+    rows = {row["term"]: row for row in document["terms"]}
+    assert rows["const"]["basis"] == "measured"
+    assert rows["const"]["source"] == "tcg#80 n=1"
+    assert rows["mp_batch"]["basis"] == "uncalibrated"
+    assert "source" not in rows["mp_batch"]
+    assert document["arena"] == "request"
+
+
+# --------------------------------------------------------------------------
+# The envelope
+# --------------------------------------------------------------------------
+
+
+class _Bounded(msgspec.Struct):
+    width: Annotated[int, msgspec.Meta(ge=64, le=2048)] = 1024
+    height: Annotated[int, msgspec.Meta(ge=64, le=2048)] = 1024
+    num_images: Annotated[int, msgspec.Meta(ge=1, le=4)] = 1
+
+
+class _Unbounded(msgspec.Struct):
+    width: int = 1024
+    height: int = 1024
+
+
+_TABLE = {"wide": (1536, 640), "square": (1024, 1024), "tall": (640, 1536)}
+
+
+class _Enumerated(msgspec.Struct):
+    aspect: Annotated[str, Shape(pixels=_TABLE)] = "square"
+
+
+def test_a_bounded_payload_advertises_its_ceiling() -> None:
+    envelope = advertised_envelope(_Bounded)
+    assert envelope.axes["width"].value == 2048
+    assert envelope.axes["batch"].value == 4
+    assert envelope.axes["batch"].source == "advertised"
+    assert set(envelope.advertised_axes) == {"width", "height", "batch"}
+
+
+def test_an_UNBOUNDED_field_is_a_stated_default_not_a_guess() -> None:
+    envelope = advertised_envelope(_Unbounded)
+    assert envelope.axes["width"].source == "default"
+    assert "NO upper bound" in envelope.axes["width"].why
+
+
+def test_an_axis_nothing_advertises_says_WHY_and_names_the_falsifier() -> None:
+    envelope = advertised_envelope(_Bounded)
+    assert envelope.axes["frames"].source == "default"
+    assert envelope.axes["frames"].value == 0
+    batch = advertised_envelope(_Enumerated).axes["batch"]
+    assert batch.source == "default" and "demand_miss" in batch.why
+
+
+def test_the_bucket_table_beats_a_per_axis_max_on_a_COUPLED_envelope() -> None:
+    """max(width) * max(height) is 1536x1536 — a bucket that does not exist.
+
+    The worst case is the argmax over the REAL buckets, and taking the
+    per-axis maximum would buy a card for a request the API cannot express.
+    """
+
+    formula = const(0) + per_mp_batch(MiB(220))
+    envelope = advertised_envelope(_Enumerated)
+    worst_bytes, worst_shape = envelope.worst_case(formula)
+    assert (worst_shape.width, worst_shape.height) == (1024, 1024)
+    assert worst_bytes == formula.evaluate(RequestShape(width=1024, height=1024))
+    assert worst_bytes < formula.evaluate(RequestShape(width=1536, height=1536))
+
+
+def test_request_shape_reads_a_bucket_table_at_SERVE_time_too() -> None:
+    assert request_shape(_Enumerated(aspect="wide")) == RequestShape(
+        width=1536, height=640, batch=1,
+    )
+    assert request_shape(_Bounded(width=512, height=512, num_images=3)) == (
+        RequestShape(width=512, height=512, batch=3)
+    )
+
+
+def test_a_payload_with_no_shape_axis_yields_the_zero_shape() -> None:
+    class _Blind(msgspec.Struct):
+        prompt: str = ""
+
+    assert request_shape(_Blind()) == RequestShape(batch=1)
+    assert (const(MiB(7)) + per_mp(GiB(4))).evaluate(request_shape(_Blind())) == MiB(7)
+
+
+def test_a_shape_annotation_that_states_both_or_neither_REFUSES() -> None:
+    with pytest.raises(ShapeDeclarationError, match="never both and never neither"):
+        Shape()
+    with pytest.raises(ShapeDeclarationError, match="never both and never neither"):
+        Shape("width", pixels=_TABLE)
+
+
+def test_a_shape_annotation_naming_an_axis_outside_the_closed_set_REFUSES() -> None:
+    with pytest.raises(ShapeDeclarationError, match="CLOSED"):
+        Shape("gigapixels")
+
+
+def test_the_demand_block_derives_its_number_and_says_what_it_is_NOT() -> None:
+    formula = const(MiB(1155), basis=Basis.MEASURED, source="tcg#80 n=1")
+    block = demand_document(formula, advertised_envelope(_Enumerated))
+    assert block["worst_case_request_bytes"] == MiB(1155)
+    assert block["worst_case_shape"]["width"] == 1024
+    assert block["arena"] == "request"
+    assert "manifest weight bytes" in block["note"]
+    assert block["envelope"]["width"]["source"] == "declared"

--- a/tests/test_demand_no_enforcement_pgw1600.py
+++ b/tests/test_demand_no_enforcement_pgw1600.py
@@ -1,0 +1,209 @@
+"""pgw#1600 acceptance (d): ZERO admission decisions consume the demand number.
+
+**The falsifier ships before the enforcer.** A formula that has never been
+falsified is a guess, and a guess wired into an admission predicate is a guess
+that kills daemons — on the compiled path admission is the ONLY safety
+mechanism (pgw#1255 leg 2: a mid-graph OOM inside a compiled artifact is
+process death, uncatchable). So this issue ships the number, its serialization
+and its falsifier, and NOTHING reads it to decide anything. pgw#1601 wires the
+mint-time stamp into `headroom_admits`; pgw#1602 wires the grant.
+
+The absence is asserted MECHANICALLY, over the AST, because prose does not go
+red. The guard fails the moment an admission module imports the demand plane —
+which is exactly what pgw#1601's first commit will do, and at that point this
+file is edited in the same commit as the wiring, deliberately and visibly.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterator
+
+import gen_worker
+
+SRC = Path(gen_worker.__file__).resolve().parent
+
+#: The three modules that ARE the demand plane. Nothing else may reach them
+#: except the two producers named below.
+DEMAND_PLANE = {
+    "gen_worker.demand",
+    "gen_worker.demand_envelope",
+    "gen_worker.demand_falsifier",
+}
+
+#: THE ADMISSION SURFACE — every module in this repository that decides
+#: whether something may be placed, loaded, admitted or run. If the demand
+#: number ever reaches a decision, it reaches it through one of these.
+ADMISSION_SURFACE = (
+    "models/partial_resident.py",   # headroom_admits / probe_plan
+    "models/memory.py",             # the reserve and the oom ladder
+    "models/grant.py",              # the arena grant
+    "models/residency.py",          # leases and activation hints
+    "serving/residency.py",         # admission_charge, NeverFits
+    "serving/placement.py",         # warn_if_degraded
+    "serving/lane_ladder.py",       # the owner-ranked (GPU, lane) ladder
+    "serving/loader.py",            # boot-time lane selection
+)
+
+#: The ONLY modules allowed to import the demand plane while this issue's
+#: posture holds: the two PRODUCERS (serialize it, measure against it) and the
+#: package's own re-export surface.
+PERMITTED_IMPORTERS = {
+    "gen_worker.release.derive",       # serializes it into the document
+    "gen_worker.serving.serve_loop",   # measures the request arena, banks nothing
+    "gen_worker.worker",               # adds the regime and calls the falsifier
+    "gen_worker.demand_envelope",
+    "gen_worker.demand_falsifier",
+    # The DECLARATION surface: `lane(request=...)` names the type so an author
+    # cannot pass anything else. It reads no number and evaluates nothing.
+    "gen_worker.serving.lane_spec",
+}
+
+
+def _modules() -> Iterator[tuple[str, ast.Module]]:
+    for path in sorted(SRC.rglob("*.py")):
+        if "_vendor" in path.parts:
+            continue
+        rel = path.relative_to(SRC)
+        dotted = "gen_worker." + ".".join(rel.with_suffix("").parts)
+        dotted = dotted.removesuffix(".__init__")
+        yield dotted, ast.parse(path.read_text(encoding="utf-8"), str(path))
+
+
+def _imported_demand_modules(dotted: str, tree: ast.Module) -> set[str]:
+    package = dotted.rsplit(".", 1)[0] if "." in dotted else dotted
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in DEMAND_PLANE:
+                    found.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                base = package
+                for _ in range(node.level - 1):
+                    base = base.rsplit(".", 1)[0]
+                target = f"{base}.{node.module}" if node.module else base
+            else:
+                target = node.module or ""
+            if target in DEMAND_PLANE:
+                found.add(target)
+            for alias in node.names:
+                if f"{target}.{alias.name}" in DEMAND_PLANE:
+                    found.add(f"{target}.{alias.name}")
+    return found
+
+
+def test_no_admission_module_reaches_the_demand_plane_AT_ALL() -> None:
+    offenders: dict[str, set[str]] = {}
+    for dotted, tree in _modules():
+        relative = dotted.removeprefix("gen_worker.").replace(".", "/") + ".py"
+        if relative not in ADMISSION_SURFACE:
+            continue
+        found = _imported_demand_modules(dotted, tree)
+        if found:
+            offenders[relative] = found
+    assert offenders == {}, (
+        f"an ADMISSION module now imports the demand plane: {offenders}. "
+        f"pgw#1600 ships the number with provably zero consumers — the "
+        f"falsifier before the enforcer. If this is pgw#1601's stamp wiring, "
+        f"edit this guard in the same commit as the wiring, deliberately."
+    )
+
+
+def test_the_admission_surface_this_guard_names_still_EXISTS() -> None:
+    """A guard whose subjects were renamed away is a guard that cannot fail."""
+
+    missing = [name for name in ADMISSION_SURFACE if not (SRC / name).is_file()]
+    assert missing == [], (
+        f"the demand no-enforcement guard names modules that no longer exist: "
+        f"{missing} — re-point it at wherever the decision moved, or it is "
+        f"proving nothing"
+    )
+
+
+def test_only_the_declared_producers_import_the_demand_plane() -> None:
+    importers = {
+        dotted for dotted, tree in _modules()
+        if dotted not in DEMAND_PLANE and _imported_demand_modules(dotted, tree)
+    }
+    assert importers <= PERMITTED_IMPORTERS, (
+        f"unexpected demand-plane importer(s): "
+        f"{sorted(importers - PERMITTED_IMPORTERS)}. Every consumer of this "
+        f"number is a design decision, not an import."
+    )
+
+
+def test_headroom_admits_still_takes_a_demand_it_is_never_GIVEN() -> None:
+    """The socket exists and is INERT — pgw#1627 wired it, pgw#1601 fills it.
+
+    Asserted positively so the day it stops being true is a red test rather
+    than a silent behaviour change: every production call site passes either
+    nothing or a literal zero.
+    """
+
+    from gen_worker.models import partial_resident
+
+    tree = ast.parse(
+        (SRC / "models" / "partial_resident.py").read_text(encoding="utf-8")
+    )
+    passed: list[ast.expr] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+        if name != "headroom_admits":
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == "demand_bytes":
+                passed.append(keyword.value)
+
+    assert passed, "headroom_admits is no longer called with demand_bytes at all"
+    for value in passed:
+        assert isinstance(value, ast.Name) and value.id == "demand_bytes", (
+            f"a production call site now computes demand_bytes "
+            f"({ast.dump(value)}) — that is pgw#1601's wiring, not pgw#1600's"
+        )
+
+    # And the parameter's DEFAULT is what production actually gets, because
+    # nothing upstream has a stamp to pass yet.
+    assert partial_resident.headroom_admits(
+        regime="compiled", free_bytes=1 << 30, cache_bytes=0, floor_bytes=0,
+    ) == (True, "driver_free")
+
+
+def test_the_release_derive_is_the_ONLY_place_the_document_is_built() -> None:
+    """One producer of the serialized formula, so a second cannot drift."""
+
+    callers = set()
+    for dotted, tree in _modules():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                name = (
+                    getattr(node.func, "id", None)
+                    or getattr(node.func, "attr", None)
+                )
+                if name == "demand_document":
+                    callers.add(dotted)
+    assert callers == {"gen_worker.release.derive"}, (
+        "the demand block is built in exactly one place; a second builder "
+        "is a second answer to what a lane demands"
+    )
+
+
+def test_the_guard_ITSELF_can_go_red() -> None:
+    """Falsify the instrument: point it at a module that DOES import the
+    plane and prove it notices. A fence nobody has seen fail is a fence
+    nobody knows is armed."""
+
+    caught = {
+        dotted for dotted, tree in _modules()
+        if dotted == "gen_worker.serving.serve_loop"
+        and _imported_demand_modules(dotted, tree)
+    }
+    assert caught == {"gen_worker.serving.serve_loop"}, (
+        "the detector did not see a REAL relative import of the demand "
+        "plane — every green above is meaningless"
+    )
+

--- a/tests/test_demand_release_document_pgw1600.py
+++ b/tests/test_demand_release_document_pgw1600.py
@@ -1,0 +1,166 @@
+"""pgw#1600 acceptance (b): the release document carries the formula and a
+worst case a READER FINDS rather than a number a human wrote.
+
+This goes through the REAL `release derive` CLI on a REAL declaration — the
+same path that produces the document tensorhub decodes. What is asserted is
+the whole chain: an author's `lane(request=...)` -> the serialized term list
+-> the advertised envelope derived from the payload's own bucket table -> the
+derived worst case.
+
+The subject is sdxl's declaration SHAPE (`demand_sdxl_shaped_endpoint`),
+because sdxl's payload is the hard case: it dimensions itself through an
+aspect-ratio ENUM and carries no `width` field at all. The tree traced against
+is the tiny SD15-class one — this repository ships no sdxl checkpoint and a
+mint on a dev box is banned — which is a fixture detail, not a gap in what is
+proven: the declaration -> document path reads no weight.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+
+from gen_worker.demand import MiB, RequestShape, evaluate  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+LOCK = (
+    'version = 1\n'
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+
+@pytest.fixture(scope="module")
+def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return tiny_tree.save_config_only(tmp_path_factory.mktemp("demand-tree"))
+
+
+@pytest.fixture(scope="module")
+def document(tree: Path, tmp_path_factory: pytest.TempPathFactory) -> dict:
+    from gen_worker.cli import main
+
+    out = tmp_path_factory.mktemp("demand-derive") / "release.json"
+    lockfile = out.parent / "uv.lock"
+    lockfile.write_text(LOCK)
+    rc = main([
+        "release", "derive",
+        "--dir", str(FIXTURES),
+        "--module", "demand_sdxl_shaped_endpoint",
+        "--checkpoint", str(tree),
+        "--lockfile", str(lockfile),
+        "--out", str(out),
+    ])
+    assert rc == 0
+    return json.loads(out.read_text())
+
+
+def _demand(document: dict) -> dict:
+    (entry,) = document["lane_contracts"].values()
+    assert "demand" in entry, (
+        "the release document carries no demand block — a reader has nothing "
+        "to size a pod from but a hand-written number"
+    )
+    return entry["demand"]
+
+
+def test_the_lane_contract_carries_the_serialized_FORMULA(document: dict) -> None:
+    demand = _demand(document)
+    rows = {row["term"]: row for row in demand["terms"]}
+    assert set(rows) == {"const", "mp_batch"}
+    assert rows["const"]["bytes"] == MiB(1155)
+    assert rows["mp_batch"]["bytes"] == MiB(220)
+    assert demand["algebra"].startswith("C + sum(")
+    assert demand["arena"] == "request"
+
+
+def test_every_coefficient_carries_its_PROVENANCE(document: dict) -> None:
+    """No magic constants: a number in a published document says where it
+    came from, and the formula as a whole claims only what its weakest term
+    supports."""
+
+    rows = {row["term"]: row for row in _demand(document)["terms"]}
+    assert rows["const"]["basis"] == "measured"
+    assert "tcg#80" in rows["const"]["source"]
+    assert "n=1" in rows["const"]["source"]
+    assert rows["mp_batch"]["basis"] == "uncalibrated"
+    assert _demand(document)["basis"] == "uncalibrated"
+
+
+def test_the_envelope_comes_from_the_payloads_OWN_bucket_table(
+    document: dict,
+) -> None:
+    """The platform cannot dimension an aspect-ratio enum, and does not guess.
+
+    `Shape(pixels=_BUCKETS)` hands it the endpoint's own dict, so width and
+    height are DECLARED — with the source recorded — rather than defaulted.
+    """
+
+    envelope = _demand(document)["envelope"]
+    assert envelope["width"]["source"] == "declared"
+    assert envelope["height"]["source"] == "declared"
+    assert envelope["width"]["value"] == 1536
+    assert envelope["height"]["value"] == 1536
+
+
+def test_the_batch_axis_is_a_STATED_default_that_names_its_own_falsifier(
+    document: dict,
+) -> None:
+    """sdxl's CFG pair is a decision the checkpoint's config makes, so no
+    payload field can advertise it. The document says so instead of
+    pretending, and points at the instrument that will catch it."""
+
+    batch = _demand(document)["envelope"]["batch"]
+    assert batch["source"] == "default"
+    assert batch["value"] == 1
+    assert "demand_miss" in batch["why"]
+
+
+def test_the_worst_case_is_DERIVED_and_reproduces_from_the_document_alone(
+    document: dict,
+) -> None:
+    """THE PROPERTY THE HUB DEPENDS ON. A reader with only these bytes — no
+    Python, no import — re-derives the same integer from the term list and
+    the worst-case shape."""
+
+    demand = _demand(document)
+    shape = RequestShape(**demand["worst_case_shape"])
+    assert evaluate(demand["terms"], shape) == demand["worst_case_request_bytes"]
+    # 1024x1024 is the largest-area bucket; 1536x1536 is not a bucket at all.
+    assert (shape.width, shape.height) == (1024, 1024)
+    assert demand["worst_case_request_bytes"] == MiB(1155) + MiB(220) * 1024 * 1024 // 1_000_000
+
+
+def test_the_document_says_what_the_number_is_NOT(document: dict) -> None:
+    """The weight arena is never declared (pgw#1598 §2). A reader that adds
+    manifest bytes gets the pod-buy worst case; a reader that treats this as
+    the whole answer buys a card too small, so the block states its scope."""
+
+    demand = _demand(document)
+    assert "manifest weight bytes" in demand["note"]
+    assert demand["note"].startswith("REQUEST ARENA ONLY")
+
+
+def test_the_document_carries_the_VOCABULARY_a_go_reader_validates_against(
+    document: dict,
+) -> None:
+    demand = _demand(document)
+    assert demand["vocabulary"]["mp_batch"]["scale"] == 1_000_000
+    assert demand["vocabulary"]["mp_batch"]["inputs"] == ["width", "height", "batch"]
+    assert demand["vocabulary_version"] >= 1
+    assert demand["shape_bounds"]["width"] == 1 << 16


### PR DESCRIPTION
Step 2 of the pgw#1598 two-arena carve. `lane(request=...)` (pgw#1599) took a formula and had no evaluator, no serialization and no instrument. It now has all three — and still has no consumer, deliberately.

## What lands

**The algebra, as exact integer arithmetic.** Each term is an integer numerator over a fixed scale (`megapixels` = `width*height` over 1_000_000); the sum is floor division computed without ever forming `coefficient * value`, which overflows int64 at plausible shapes. A wrapped worst case is a SMALL number — the direction that buys too little card. A float divide is where two languages stop agreeing, and agreement is the whole point.

**Provenance on every coefficient.** `Basis` ∈ {`measured`, `ledger`, `uncalibrated`}; the default is `uncalibrated` (a declared prior) because that is the only claim a bare number supports. `measured`/`ledger` without a `source=` is a refusal. Adding two same-named terms of different provenance refuses rather than laundering one claim into the other. A formula claims only what its weakest term supports.

**Serialization into the release document.** Each `lane_contracts` row gains a `demand` block: terms, the closed vocabulary they are written against (so a Go reader validates its own table rather than assuming), the advertised envelope with a SOURCE per axis (`advertised` / `declared` / `default` + why), the shape that maximises the formula, and the derived bytes. It states its scope: request arena only; weights are tensorfs manifest arithmetic the hub adds.

**`Shape(pixels=...)` — an enum that dimensions itself.** sdxl carries no `width` field; it has an aspect-ratio enum over a bucket table the platform cannot see. The annotation takes the endpoint's OWN dict by reference, so there is no second spelling of its geometry to drift.

**The cross-language corpus.** `src/gen_worker/contracts/demand_vectors.json`, GENERATED from this repo's evaluator (a corpus with hand-typed expectations proves a human and Go agree, not that Python and Go do). Cases chosen to break a naive implementation: coefficients that are not multiples of their scale, coefficients smaller than their scale, and the domain ceiling on every axis at once — a real int64 overflow for anyone who multiplies first. Gate script wired into `fast gates` + `ci.yaml`.

**`demand_miss`.** Every solo serve measures the request arena across the handler, decomposed the way it is spent (allocator peak / out-of-allocator growth / driver growth), and banks predicted-vs-measured. Counted, hub-visible per (lane × regime), carrying (misses, served) as step/total_steps. Eager is judged on the allocator; compiled on the driver total, because AOTI's first call cannot spend the allocator's cache. A compiled miss is a P0 defect of the STAMP, never a statistic. Samples never pool across regimes or lanes; an undetermined regime pools with nothing; a concurrent request banks nothing at all.

## Acceptance

- **(a)** cross-language equality — python half green here (corpus reproduces through the real evaluator; refusals refuse; the gate is red-verified by mutating the corpus). Go half is the sibling tensorhub PR.
- **(b)** `tests/test_demand_release_document_pgw1600.py` runs the REAL `release derive` CLI on sdxl's declaration shape and re-derives the worst case from the emitted document alone. The `const` term carries tcg#80's measured basis (n=1, sm_89, cold daemon, out-of-allocator 1155 MiB); the `mp_batch` slope stays explicitly UNCALIBRATED, because one point cannot separate an intercept from a slope.
- **(c)** `tests/test_demand_falsifier_pgw1600.py` — 11 legs on the real banking path and the real event emitter.
- **(d)** `tests/test_demand_no_enforcement_pgw1600.py` — an AST guard over the admission surface, itself falsified against a module that really does import the demand plane.

## Verification

- 43 new non-torch legs + 7 torch legs green.
- Regression: `test_release_derive`, `test_release_derive_partial_enumeration`, `test_partial_resident`, `test_residency_ledger`, `test_lane_contracts` — 84 passed.
- mypy clean (646 files), ruff clean on `src/gen_worker`, all 8 gate scripts green, changelog `--check` green.

Cross-refs: pgw#1598 §2/§3, pgw#1599 (the surface), pgw#1601 (the enforcer that comes next), pgw#1586 (the calibrator), tcg#80 (the measurement).