### PR TITLE
pgw#1649: one owner per physical quantity — six re-derivations collapse, and the 25% admission charge says what it is

### DIFF
--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -40,11 +40,13 @@ RULE_HF_FP8_BLOCKWISE = "hf.fp8-blockwise@1"
 from .fp8_storage import restructure_fp8_storage
 from .rung import touches_host_ram
 from .memory import (
+    effective_ram_floor_gb,
     flush_memory,
     get_available_vram_gb,
     meta_tensors,
     probe_host_ram,
 )
+from .grant import COLD_REQUEST_BYTES
 from .hf_fp8_blockwise import detect_hf_fp8_blockwise, load_hf_fp8_blockwise
 from .safetensors_header import header_len_ok, read_header
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
@@ -63,6 +65,8 @@ from .w8a8 import (
 )
 
 logger = logging.getLogger(__name__)
+
+_GIB = 1024 ** 3
 
 _DTYPE_MAP = {
     "float16": "float16",
@@ -697,7 +701,11 @@ def pipeline_weight_lane(pipeline: Any) -> str:
     return ""
 
 
-_EMERGENCY_MARGIN_GB = 2.0
+#: The VRAM the fp8 emergency rung leaves for the request when it sizes its
+#: budget. pgw#1649 rung (a): a bare `2.0` with no comment, the FIFTH producer
+#: of `grant.COLD_REQUEST_BYTES` (measured: pgw#1586's 1847 MiB, pgw#1604's
+#: ~2058 MiB). Same value, one owner, changeable only by evidence.
+_EMERGENCY_MARGIN_GB = COLD_REQUEST_BYTES / _GIB
 
 
 def runtime_fp8_storage_supported() -> bool:
@@ -1148,16 +1156,21 @@ def _weightless_model_dir(src: Path) -> bool:
     return next(src.rglob("*.safetensors"), None) is None
 
 
-_GIB = 1024 ** 3
-_STAGING_FLOOR_GB = 8.0
-_STAGING_FLOOR_FRACTION = 0.2
-
 
 def _staging_floor_bytes(total_bytes: int) -> int:
-    if total_bytes <= 0:
-        return int(_STAGING_FLOOR_GB * _GIB)
-    return int(min(_STAGING_FLOOR_GB * _GIB,
-                   max(_GIB, total_bytes * _STAGING_FLOOR_FRACTION)))
+    """Host RAM this staging path must leave alone, in bytes.
+
+    pgw#1649 rung (a). This module declared its own `_STAGING_FLOOR_GB = 8.0` /
+    `_STAGING_FLOOR_FRACTION = 0.2` and re-derived `min(8, max(1, total*0.2))`
+    byte-identically — the FOURTH producer of a quantity pgw#973 gave a sole
+    owner, and the exact broken-promise shape `memory.py`'s own comment above
+    `effective_ram_floor_gb` warns about, one file over. It imports the owner
+    now; the threat model (gw#407 reclaim-thrash stalling the gRPC keepalive)
+    and the adaptive-below-40-GiB reasoning live there, once.
+    """
+    return int(effective_ram_floor_gb(
+        float(total_bytes) / _GIB if total_bytes > 0 else 0.0
+    ) * _GIB)
 
 
 def _admit_component_staging(component: str, nbytes: int) -> None:
@@ -1217,7 +1230,10 @@ def modular_staging_units(base: Path) -> Dict[str, int]:
     return units
 
 
-_STREAMED_HYDRATION_VRAM_MARGIN_GB = 2.0
+#: The VRAM streamed hydration leaves for the request on top of the tree.
+#: pgw#1649 rung (a): the SIXTH producer of `grant.COLD_REQUEST_BYTES`, and the
+#: second one in this file alone. Same value, one owner.
+_STREAMED_HYDRATION_VRAM_MARGIN_GB = COLD_REQUEST_BYTES / _GIB
 
 
 @dataclass(frozen=True)

--- a/src/gen_worker/models/oom_ladder.py
+++ b/src/gen_worker/models/oom_ladder.py
@@ -20,10 +20,55 @@ ATTENTION_SLICED_RETRY_PHASE = "attention_sliced_retry"
 
 _INSTALLED = "_cozy_oom_ladder"
 
+#: The buffer count in the per-latent decode estimate:
+#: `ACTIVATION_BUFFERS x block_out_channels[0] x spatial^2 x temporal x
+#: dtype_bytes`. DERIVED, not picked — pgw#1499 restored here after the
+#: pgw#1628 comment purge left the site bare (pgw#1649).
+#:
+#: ComfyUI hand-measures a coefficient per VAE class; this formula derives one,
+#: and reproduces their sd15/SDXL number (`2178 x 64 x dtype`) to 0.1% and
+#: Wan-2.1's to ~1.5x. It is a FIRST GUESS by construction and that is the
+#: point: every rung below rung 0 is chosen by a REAL OOM, never by the
+#: estimate, which is what makes the formula's error survivable.
 ACTIVATION_BUFFERS = 17
 
+#: The share of free VRAM the tile solver may plan a decode into.
+#:
+#: (d) AUTHOR-DECLARED, **UNMEASURED** (pgw#1649, census §1.3). The 20% held
+#: back is not a measured allocator reserve — it is slack against the same
+#: estimate `ACTIVATION_BUFFERS` admits is a first guess, taken on the ONE
+#: input the solver reads (`get_available_vram_gb`) at the moment an OOM has
+#: already proven the previous plan wrong.
+#:
+#: Deriving it was considered and REFUSED: the honest expression is
+#: `free - transient_reserve`, and `partial_resident._TRANSIENT_RESERVE_BYTES`
+#: (512 MiB, measured twice on-card including a falsified 256 MiB arm) is the
+#: only measured member of that family — but it prices an ONLOAD transient, a
+#: different physical quantity from a tiled decode's activation slack, and
+#: importing it would launder one measurement into a claim about another.
+#: A fraction that is honest about being a fraction beats a subtraction that
+#: is not. The falsifier is the ladder itself: a rung that OOMs anyway is
+#: this number being wrong, and the descent is already driven by that OOM.
 BUDGET_FRACTION = 0.8
 
+#: The tile overlap, as a fraction of the tile edge — ONE producer (pgw#1649).
+#: `TilePlan.overlap` computed `edge // 4` while `apply_tile_plan` set a
+#: literal `tile_overlap_factor=0.25` sixty lines away: the same policy, two
+#: spellings, and only one of them would move if the blend ever changed.
+#:
+#: (d) AUTHOR-DECLARED: 25% is the diffusers default `tile_overlap_factor`
+#: this code SETS on VAEs that expose it, so the solver's own overlap agrees
+#: with the knob it hands the VAE instead of contradicting it.
+TILE_OVERLAP_FRACTION = 0.25
+
+#: Two slice rungs, then a hard RuntimeError on a paid request.
+#:
+#: (d) AUTHOR-DECLARED: these are torch/diffusers' OWN attention-slicing
+#: settings, not a tuned pair — `"auto"` slices by head count and `"max"` is
+#: one head at a time, which is the smallest slice the API can express. There
+#: is no third rung to add; below `"max"` the next lever is a different
+#: mechanism (tiling, offload), which is why the ladder ENDS rather than
+#: continuing with a smaller number.
 ATTENTION_LADDER: Tuple[str, ...] = ("auto", "max")
 
 
@@ -36,7 +81,7 @@ class TilePlan:
 
     @property
     def overlap(self) -> int:
-        return max(1, self.edge // 4)
+        return max(1, int(self.edge * TILE_OVERLAP_FRACTION))
 
     def __str__(self) -> str:
         t = f"x{self.frames}f" if self.frames else ""
@@ -64,7 +109,27 @@ def solve_tile_ladder(
     min_frames: int = 1,
     max_rungs: int = 5,
 ) -> Tuple[TilePlan, ...]:
-    """The tile ladder for one decode, largest tile first."""
+    """The tile ladder for one decode, largest tile first.
+
+    THE GEOMETRY, stated (pgw#1649 rung (d) — these three decided how many OOM
+    retries a paid request gets before it dies, with zero comment):
+
+    * `base_edge=32` latents = a 256 px tile at the sd/SDXL spatial ratio of 8,
+      and 512 px at a video VAE's 16 — diffusers' own `tile_latent_min_size`
+      for AutoencoderKL is 32, so rung 0 is the upstream default rather than a
+      number of ours. Rung 0 is additionally shrunk once whenever it still
+      covers the WHOLE latent, because a tile the size of the frame that just
+      OOMed is not a retry (pgw#1499).
+    * `min_edge=8` latents = a 64 px tile: below this the per-tile constant
+      cost and the seam count dominate, and the next lever is a different
+      mechanism, not a smaller tile.
+    * `max_rungs=5` is the ARITHMETIC of the two above, not an independent
+      budget: halving 32 -> 16 -> 8 is two edge rungs, and the frame axis
+      halves first on a video VAE, so five rungs reaches `min_edge` with slack
+      for the frame halvings and the rung-0 shrink. It is a TERMINATION bound
+      (the walk also breaks when neither axis can halve), which is why it is
+      safe for it to be generous rather than exact.
+    """
     latent_h = max(1, int(latent_h))
     latent_w = max(1, int(latent_w))
     latent_frames = max(0, int(latent_frames))
@@ -109,6 +174,13 @@ def solve_tile_ladder(
 def decode_bytes_per_latent(vae: Any, *, dtype_bytes: int = 2) -> float:
     """Estimated peak decode bytes per LATENT element for this VAE."""
     cfg = getattr(vae, "config", None)
+    # DERIVED whenever the config is readable (`block_out_channels[0]`, and the
+    # spatial ratio from the block count). The two fallbacks below are (d)
+    # AUTHOR-DECLARED for the case where it is not: 128 channels and a spatial
+    # ratio of 8 are the SD-family values, generalized — an over-estimate for
+    # sd15/SDXL's own 128/8 (exact) and for anything narrower, which is the
+    # safe direction for a decode budget. pgw#1649: the generalization used to
+    # be silent.
     channels = 128
     blocks = getattr(cfg, "block_out_channels", None) if cfg is not None else None
     if blocks:
@@ -154,7 +226,7 @@ def apply_tile_plan(vae: Any, plan: TilePlan) -> Dict[str, Any]:
         attrs: Tuple[Tuple[str, Any], ...] = (
             ("tile_sample_min_size", sample_edge),
             ("tile_latent_min_size", plan.edge),
-            ("tile_overlap_factor", 0.25),
+            ("tile_overlap_factor", TILE_OVERLAP_FRACTION),
         )
         for attr, attr_value in attrs:
             if hasattr(vae, attr):

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -24,6 +24,7 @@ from .memory import (
     log_ram_budget_once,
     repair_device_placement,
 )
+from .grant import COLD_REQUEST_BYTES
 from .pinned_swap import swap_object
 from .pinned_swap import cached_swap_bytes
 from .. import hostfacts
@@ -31,7 +32,18 @@ from .. import hostfacts
 logger = logging.getLogger(__name__)
 
 _GiB = 1024 ** 3
-_VRAM_MARGIN_BYTES = 2 * _GiB
+
+#: The VRAM one request needs BEYOND the weights, spent by `fits_in_vram` and
+#: by the eviction target below.
+#:
+#: pgw#1649 rung (a): this was a bare `2 * _GiB` with no comment — the FOURTH
+#: producer of a quantity `grant.py` states it consolidated ("there is now ONE
+#: of it instead of three"). It imports that owner now, which is the only
+#: member of the family carrying a measurement: pgw#1586's green arm banked
+#: 1847 MiB of activations over resident weights, pgw#1604 independently
+#: ~2058 MiB. The value does not move (2048 MiB == 2 GiB); what moves is that
+#: it can only be changed in one place, and by evidence.
+_VRAM_MARGIN_BYTES = COLD_REQUEST_BYTES
 def _effective_ram_floor_gb() -> float:
     return effective_ram_floor_gb(get_total_ram_gb())
 

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -57,6 +57,16 @@ _DOWNLOAD_RETRIES = 3
 _PROGRESS_EVENT_MIN_INTERVAL_S = 5.0
 _MISSING_SNAPSHOT_WAIT_S = 60.0
 
+#: Free DISK the GC drives toward, on top of what the pending pull still needs.
+#:
+#: (d) AUTHOR-DECLARED, **UNMEASURED** (pgw#1649). It is NOT the 2 GiB VRAM
+#: margin — `grant.COLD_REQUEST_BYTES` owns that one and every VRAM producer
+#: now imports it. This is a DIFFERENT PHYSICAL QUANTITY that happens to carry
+#: the same number, and the two must never be collapsed on the strength of
+#: that coincidence: slack against the loader's own scratch (a partial shard,
+#: a `.incomplete` file, a projection's hardlink churn) while a multi-hundred-GB
+#: tree lands, not against an allocator. A disk that fills mid-pull fails the
+#: pull; it does not OOM a card.
 _DISK_GC_MARGIN_BYTES = 2 * _GiB
 _DISK_GC_GRACE_S = 300.0
 

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -237,14 +237,19 @@ def _stated_env(
 
 
 def _serve_envelopes(args: argparse.Namespace, loaded: Any) -> int:
-    from .residency import ResidencyManager
+    from .residency import HEADROOM_DIVISOR, ResidencyManager
     from .serve_loop import ServeLoop, manifest_sizer
 
     tree = _checkpoint_tree(args, loaded)
     weight = args.weight_bytes or sum(
         f.stat().st_size for f in tree.rglob("*") if f.is_file()
     ) or 1
-    headroom = max(weight // 4, 1)
+    # ONE owner for this quantity (pgw#1649): this local envelope path used to
+    # restate `weight // 4` as a bare literal beside `worker.SnapshotSizer`'s
+    # copy of the same fraction — two producers of one policy, the reasoning
+    # written at neither. It IMPORTS the owner now; the justification, the
+    # casualty and the deletion condition are all at its definition.
+    headroom = max(weight // HEADROOM_DIVISOR, 1)
     budget = int(args.vram_budget_gb * (1024**3)) or (weight + headroom)
 
     class _LocalResolver:

--- a/src/gen_worker/serving/gguf_fit.py
+++ b/src/gen_worker/serving/gguf_fit.py
@@ -12,11 +12,15 @@ import msgspec
 
 from ..api.errors import FatalError
 from ..models.materialized_view import third_party_dir
+from ..models.memory import GPU_VRAM_OVERHEAD_GB
 
 logger = logging.getLogger(__name__)
 
 _GiB = 1024**3
-_OVERHEAD_GB = 1.0
+#: pgw#1649 rung (a): the fixed driver/framebuffer/CUDA-context overhead has
+#: ONE owner, and it is the one that carries the reasoning. This file declared
+#: a bare `_OVERHEAD_GB = 1.0` — the same physical quantity, same value, no
+#: statement of what it is. It IMPORTS the owner now (deletes 1).
 _SPLIT_RE = re.compile(r"-\d{5}-of-\d{5}\.gguf$")
 
 __all__ = [
@@ -138,7 +142,7 @@ def plan_fit(
     free_vram_gb: float,
     n_ctx: Optional[int] = None,
     kv_bytes_per_elem: float = 2.0,
-    overhead_gb: float = _OVERHEAD_GB,
+    overhead_gb: float = GPU_VRAM_OVERHEAD_GB,
 ) -> LlamaFitPlan:
     """Size ``-ngl`` / ``-c`` to the VRAM budget."""
     ctx = int(n_ctx or info.n_ctx_train or 4096)

--- a/src/gen_worker/serving/residency.py
+++ b/src/gen_worker/serving/residency.py
@@ -33,6 +33,50 @@ class Charge:
         return self.weight_bytes + self.headroom_bytes
 
 
+#: THE activation headroom every admission charges: stored tree bytes // this.
+#: ONE OWNER (pgw#1649) — `worker.SnapshotSizer` and `serving/__main__.py`'s
+#: local envelope path both used to spell `weight // 4` as a bare literal, two
+#: producers of one policy with the reasoning written at neither.
+#:
+#: ⚠️ AUTHOR-DECLARED, **UNMEASURED**, and with a KNOWN CASUALTY (census §4.2
+#: row 2). 25% of the STORED tree is not a statement about activations at all —
+#: it is a fraction of a number that measures something else, and it scales
+#: with the wrong quantity. minimax-h3's DiT lane was refused as needing
+#: 180,063,706,300 bytes on an 84 GB H100 that had been serving it
+#: (`tests/test_admission_lane_declaration_pgw1590.py` reproduces the refusal
+#: byte for byte): 133 GB of stored bf16 becomes ~66 GB of w8a8 inside `load`,
+#: the charge cannot see a `setup()`-time `quantize_()`, and this divisor then
+#: charges a THIRD of that phantom again — 36 GB of the 180.
+#:
+#: WHY IT IS STILL HERE, which is a posture and not an oversight. The obvious
+#: replacement is the lane's own declared `request=` demand at the advertised
+#: envelope — the identical `weight bytes + demand(envelope)` expression
+#: tensorhub already evaluates to BUY the pod (pgw#1598 §2, pgw#1600), so one
+#: producer would mean the pod could not refuse what the hub bought. pgw#1600
+#: acceptance (d) FORBIDS wiring it: the number ships with provably zero
+#: admission consumers because a formula that has never been falsified is a
+#: guess, and the fleet's formulas still label themselves "⚠️ UNFITTED PRIOR".
+#: Swapping a documented over-charge for an unfalsified under-charge is the
+#: direction that OOMs a rented card instead of refusing it — which is
+#: pgw#1590's own finding. The enforcer is pgw#1601's measured stamp, and
+#: `tests/test_demand_no_enforcement_pgw1600.py` is the guard that holds the
+#: line until it exists.
+#:
+#: THE FALSIFIER, already built and already firing: pgw#1600's `demand_miss`
+#: counts every serve whose measured arena exceeded the prediction. When the
+#: stamps land, this constant is DELETED — not re-tuned.
+HEADROOM_DIVISOR = 4
+
+#: What the admission confession calls this number, so an operator reading a
+#: `NeverFits` sees a policy with a name rather than an unexplained fraction.
+HEADROOM_BASIS = (
+    f"{100 // HEADROOM_DIVISOR}% of the stored tree — an UNMEASURED "
+    f"author-declared fraction of the WEIGHTS standing in for an activation "
+    f"nobody has measured on this lane; it dies with pgw#1601's stamp "
+    f"(pgw#1649)"
+)
+
+
 def admission_charge(weight_bytes: int, headroom_bytes: int) -> Charge:
     """The bytes to reserve for one instance: the tree's weights + headroom."""
 
@@ -41,12 +85,13 @@ def admission_charge(weight_bytes: int, headroom_bytes: int) -> Charge:
         weights,
         headroom,
         f"charged from the STORED TREE: {weights} weight bytes at the "
-        f"checkpoint's on-disk precision + {headroom} activation headroom. "
-        f"This is an UPPER BOUND (pgw#1599): a lane that holds less resident "
-        f"— a setup()-time quantize, an offloaded or unused component — is "
-        f"charged for bytes it never puts on the card, and the fix is a lane "
-        f"whose CONTRACT states the precision the weights land at, never a "
-        f"hand-written floor",
+        f"checkpoint's on-disk precision + {headroom} activation headroom "
+        f"({HEADROOM_BASIS}). "
+        f"The WEIGHT half is an UPPER BOUND (pgw#1599): a lane that holds less "
+        f"resident — a setup()-time quantize, an offloaded or unused component "
+        f"— is charged for bytes it never puts on the card, and the fix is a "
+        f"lane whose CONTRACT states the precision the weights land at, never "
+        f"a hand-written floor",
     )
 
 
@@ -79,6 +124,7 @@ class InstanceSizer(Protocol):
     def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
         """The serving-time activation estimate (per model type / resolution class) reserved alongside the weights."""
         ...
+
 
 
 class Tier(StrEnum):

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -53,7 +53,12 @@ from .serving.envelope import EnvelopeError
 from .serving.host import ServeDispatchError
 from .serving.loader import EndpointLoadError, LoadedEndpoint
 from .serving.model import ModelDeclarationError, lane_handle, model_lanes, model_type
-from .serving.residency import NeverFits, ResidencyError, ResidencyManager
+from .serving.residency import (
+    HEADROOM_DIVISOR,
+    NeverFits,
+    ResidencyError,
+    ResidencyManager,
+)
 from .serving.serve_loop import ServeLoop
 from .transport import (
     DEFAULT_QUEUE_MAXSIZE as _DEFAULT_QUEUE_MAXSIZE,
@@ -69,8 +74,6 @@ logger = logging.getLogger(__name__)
 HEARTBEAT_INTERVAL_MS = 10_000
 
 _SIGNAL_DRAIN_DEADLINE_MS = 30_000
-
-_HEADROOM_DIVISOR = 4
 
 EVENT_CONTENT_TYPE = "application/x-request-event+json"
 
@@ -386,7 +389,22 @@ class _Admission:
 
 
 class SnapshotSizer:
-    """Weight bytes from the materialized tree's manifest — the WHOLE tree."""
+    """Weight bytes from the materialized tree's manifest — the WHOLE tree.
+
+    The ACTIVATION half is `residency.HEADROOM_DIVISOR`, and pgw#1649 leaves it
+    standing DELIBERATELY. The obvious replacement — evaluate the lane's
+    declared `request=` demand at the advertised envelope, the identical
+    `weight bytes + demand(envelope)` expression tensorhub evaluates to BUY
+    this pod (pgw#1598 §2, pgw#1600) — is REFUSED BY A RATIFIED POSTURE, not by
+    difficulty: pgw#1600 acceptance (d) ships the demand number with provably
+    zero admission consumers, because a formula that has never been falsified
+    is a guess, and the fleet's formulas still say "⚠️ UNFITTED PRIOR" of
+    themselves. Wiring one in would swap a documented over-charge for an
+    under-charge, which is the direction that OOMs a rented card instead of
+    refusing it (pgw#1590's own finding). The enforcer is pgw#1601's measured
+    stamp; `tests/test_demand_no_enforcement_pgw1600.py` is the guard that says
+    so, and it is edited in the same commit as that wiring, not before.
+    """
 
     def __init__(self, resolver: HubBindingResolver) -> None:
         self._resolver = resolver
@@ -405,7 +423,7 @@ class SnapshotSizer:
         return self._bytes(checkpoint_ref)
 
     def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
-        return max(self._bytes(checkpoint_ref) // _HEADROOM_DIVISOR, 1)
+        return max(self._bytes(checkpoint_ref) // HEADROOM_DIVISOR, 1)
 
 
 class Worker:

--- a/tests/test_admission_lane_declaration_pgw1590.py
+++ b/tests/test_admission_lane_declaration_pgw1590.py
@@ -249,3 +249,48 @@ def test_a_smaller_card_is_still_refused_typed_before_any_byte_moves(
     with pytest.raises(NeverFits):
         manager.lease(*H3_KEY, lambda: Backend(journal))
     assert journal == []
+
+
+# --- pgw#1649: ONE OWNER for the 25%, and the confession names it -----------
+
+
+def test_the_25_percent_has_exactly_ONE_producer() -> None:
+    """pgw#1649. `worker.SnapshotSizer` and `serving/__main__.py`'s local
+    envelope path each spelled `weight // 4` as a bare literal, with the
+    reasoning written at neither — two producers of one policy, which is how
+    the two drift. Both import `residency.HEADROOM_DIVISOR` now.
+
+    The red arm is real: re-introduce a literal at either site and the two
+    numbers below stop being the same object.
+    """
+    import ast
+    from pathlib import Path as _Path
+
+    import gen_worker
+    from gen_worker.serving.residency import HEADROOM_DIVISOR
+
+    src = _Path(gen_worker.__file__).resolve().parent
+    for relative in ("worker.py", "serving/__main__.py"):
+        tree = ast.parse((src / relative).read_text(encoding="utf-8"))
+        names = {
+            node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+        }
+        assert "HEADROOM_DIVISOR" in names, (
+            f"{relative} no longer charges through the owner"
+        )
+    assert HEADROOM_DIVISOR == 4
+
+
+def test_the_admission_confession_names_the_policy_and_its_DEATH_condition(
+    h3_manager: Any,
+) -> None:
+    """An operator reading a `NeverFits` must be able to tell an unmeasured
+    author-declared fraction from a measurement. The basis says which it is,
+    and what deletes it (pgw#1601's stamp) — so nobody re-tunes it instead."""
+    sizer, _ = h3_manager
+    charge = admission_charge(
+        sizer.resident_bytes(*H3_KEY), sizer.activation_headroom_bytes(*H3_KEY)
+    )
+    assert "UNMEASURED" in charge.basis
+    assert "pgw#1601" in charge.basis
+    assert "25% of the stored tree" in charge.basis


### PR DESCRIPTION
The RESOURCE/POLICY half of `research/magic-constants-census.md`, executed in the
census's risk order. Six duplicate producers deleted, four constants gain the
derivation or the written justification they were missing, and one row is
REFUSED with its reason rather than fixed.

**The 2 GiB VRAM margin had SEVEN producers; three more of them are gone.**
`grant.COLD_REQUEST_BYTES` already states it consolidated this quantity ("there
is now ONE of it instead of three") and is the only member carrying a
measurement — pgw#1586's green arm banked 1847 MiB of activations over resident
weights, pgw#1604 independently ~2058 MiB. `residency._VRAM_MARGIN_BYTES`,
`loading._EMERGENCY_MARGIN_GB` and `loading._STREAMED_HYDRATION_VRAM_MARGIN_GB`
were producers four, five and six, all bare. They import the owner now; the
values do not move, and the constant can only be changed by evidence.

`store._DISK_GC_MARGIN_BYTES` is deliberately NOT collapsed into it. Same
number, different physical quantity — slack against the loader's own scratch on
a disk, not against an allocator — and the site now says so, because the next
reader would otherwise "finish the job".

**The host-RAM floor's fourth producer.** pgw#973 named
`memory.effective_ram_floor_gb` the sole owner and left a comment warning about
exactly this shape; `loading._staging_floor_bytes` then re-derived
`min(8, max(1, total*0.2))` byte-identically one file over. It calls the owner
now, proven equivalent across the whole domain (0 GiB to 1 TiB).

**The 1.0 GB card overhead.** `serving/gguf_fit._OVERHEAD_GB` was a bare copy of
`memory.GPU_VRAM_OVERHEAD_GB`, which carries the reasoning. Imports it.

**The 25% admission charge (census top-5 #2) — ONE owner and a written
confession, and its derivation is REFUSED on purpose.** `worker.SnapshotSizer`
and `serving/__main__.py` each spelled `weight // 4` as a bare literal.
`residency.HEADROOM_DIVISOR` is now the single producer, and it states its
casualty at the site: minimax-h3's DiT lane refused as needing 180,063,706,300
bytes on an 84 GB H100 that had been serving it, of which 36 GB is this divisor
charging a third of a phantom.

The obvious replacement — evaluate the lane's declared `request=` demand at the
advertised envelope, the identical `weight bytes + demand(envelope)` expression
tensorhub already evaluates to BUY the pod — was built and then REVERTED, because
pgw#1600 acceptance (d) forbids it: the demand number ships with provably zero
admission consumers until a stamp has falsified it, and the fleet's formulas
still label themselves "UNFITTED PRIOR". Wiring one in trades a documented
over-charge for an unfalsified under-charge, the direction that OOMs a rented
card instead of refusing it. The row is BLOCKED on pgw#1601, and both the
constant and the admission confession now say so rather than leaving the next
reader to rediscover it.

**oom_ladder.py had 13 deciding constants and zero comments.** `ACTIVATION_BUFFERS
= 17` is DERIVED — it reproduces ComfyUI's hand-measured sd15/SDXL coefficient to
0.1% and Wan-2.1's to ~1.5x — and pgw#1628's comment purge left the site bare;
the derivation is restored. The 25% tile overlap had two producers sixty lines
apart (`edge // 4` and a literal `tile_overlap_factor=0.25`) and is now one
`TILE_OVERLAP_FRACTION`. `BUDGET_FRACTION`, `ATTENTION_LADDER`, the
`base_edge/min_edge/max_rungs` geometry and the VAE-config fallbacks get their
arithmetic stated; `BUDGET_FRACTION`'s derivation is explicitly refused, because
the only measured neighbour (`_TRANSIENT_RESERVE_BYTES`) prices an onload
transient and importing it would launder one measurement into a claim about a
different quantity.

Tests: 385 targeted green (residency/loading/staging/store/gguf/oom/admission/
demand/memory/vram), incl. two new arms on the pgw#1590 record — one proving the
divisor has a single producer over the AST at both sites, one proving the
admission confession names the policy as UNMEASURED and names what deletes it.
ruff + mypy clean on every changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)