### PR TITLE
th#2267 §6: a text stream ends on its PRODUCER's death, never on a poll

### DIFF
--- a/src/gen_worker/parallel/group.py
+++ b/src/gen_worker/parallel/group.py
@@ -25,7 +25,9 @@ _STAGING_POLL_S = 1.0
 
 _COLLECTIVE_TIMEOUT_S = 300.0
 
-_FIRST_COMMAND_WAIT_S = 1800.0
+# th#2267 §6 deleted _FIRST_COMMAND_WAIT_S = 1800.0 from here: a half-hour wall
+# that was referenced by nothing. A duration nobody reads is not a bound, it is
+# a claim about how the system behaves that no code has to honour.
 
 _STORE_CONNECT_TIMEOUT_S = 180.0
 

--- a/src/gen_worker/serving/deltas.py
+++ b/src/gen_worker/serving/deltas.py
@@ -41,6 +41,12 @@ class ItemDelta(Delta, frozen=True, kw_only=True):
     error: str = ""
 
 
+# How often the stream RE-LOOKS at whether the generate thread is still alive.
+# It ends nothing: every expiry is a re-check, and only the thread's death ends
+# the stream. Shorter costs a wakeup, longer delays noticing a dead producer.
+_RECHECK_CADENCE_S = 0.5
+
+
 def frame_of(chunk: Any) -> Tuple[bytes, str]:
     """``(data, content_type)`` for any chunk — the one encoder."""
     framer = getattr(chunk, "frame", None)
@@ -57,12 +63,30 @@ def iter_transformers_text_deltas(
     generation_kwargs: Mapping[str, Any],
     cancel_checker: Callable[[], bool] | None = None,
     skip_prompt: bool = True,
-    timeout: float | None = 0.5,
+    timeout: float | None = None,
     join_timeout: float = 2.0,
     streamer_cls: type[Any] | None = None,
     decode_kwargs: Mapping[str, Any] | None = None,
 ) -> Iterator[str]:
-    """Stream text chunks out of a ``transformers`` ``model.generate`` call."""
+    """Stream text chunks out of a ``transformers`` ``model.generate`` call.
+
+    ``timeout`` is a RE-CHECK CADENCE, not a bound on the work (th#2267 §6).
+    It used to default to 0.5 s and be handed straight to the streamer, where
+    expiring it raised a bare ``queue.Empty`` out of this generator — untyped,
+    unattributable, and triggered by the most ordinary thing a decode does:
+    prefill. A long prompt or a large model spends whole seconds before the
+    first token, and half a second of that killed the stream. The opposite
+    spelling was no better: ``timeout=None`` (what joycaption passes) blocks
+    the consumer FOREVER when the generate thread dies, because a dead thread
+    never enqueues the end sentinel.
+
+    Neither shape asks the question that matters. The question is whether the
+    thread producing tokens is still alive, so that is what decides: a poll
+    that expires while the thread is running is prefill and the wait continues;
+    a poll that expires once the thread is gone is the end, and any exception
+    it died of is re-raised. How long the decode takes is governed elsewhere,
+    by the in-call progress gate that any ``ctx`` event re-arms.
+    """
     if model is None:
         raise ValueError("model is required")
     if tokenizer is None:
@@ -109,8 +133,11 @@ def iter_transformers_text_deltas(
         except Exception:
             pass
 
+    # Always poll. A blocking streamer cannot notice a dead producer, and a
+    # streamer that gives up cannot survive a prefill; polling separates them.
+    poll_s = _RECHECK_CADENCE_S if timeout is None else max(float(timeout), 0.0)
     streamer = streamer_cls(
-        tokenizer, skip_prompt=bool(skip_prompt), timeout=timeout,
+        tokenizer, skip_prompt=bool(skip_prompt), timeout=poll_s,
         **local_decode_kwargs,
     )
     local_generation_kwargs["streamer"] = streamer
@@ -131,7 +158,23 @@ def iter_transformers_text_deltas(
     )
     thread.start()
     try:
-        for chunk in streamer:
+        stream = iter(streamer)
+        while True:
+            try:
+                chunk = next(stream)
+            except StopIteration:
+                break
+            except queue.Empty:
+                # NOT a verdict. It says only that no token arrived inside one
+                # poll, which is what prefill looks like from here.
+                if thread.is_alive():
+                    if cancel_checker is not None and cancel_checker():
+                        break
+                    continue
+                # The producer is gone and the queue is drained: this is the
+                # end of the stream, however it ended. If it ended badly the
+                # exception is below, typed and attributable.
+                break
             if cancel_checker is not None and cancel_checker():
                 break
             text = str(chunk or "")

--- a/tests/test_delta_stream_liveness_th2267.py
+++ b/tests/test_delta_stream_liveness_th2267.py
@@ -1,0 +1,139 @@
+"""th#2267 §6: a text stream ends on the PRODUCER's death, never on a poll.
+
+`iter_transformers_text_deltas` handed its `timeout` straight to the streamer,
+where expiring it raised a bare `queue.Empty` out of the generator. The default
+was 0.5 s, and the most ordinary thing a decode does — prefill — takes longer
+than that on a long prompt or a large model. The opposite spelling, `None`
+(what joycaption passes), is the mirror defect: it blocks the consumer forever
+when the generate thread dies, because a dead thread never enqueues the end
+sentinel.
+
+Both sides here run on the same fake streamer, with no model and no GPU.
+"""
+
+from __future__ import annotations
+
+import queue
+import time
+
+import pytest
+
+from gen_worker.serving.deltas import iter_transformers_text_deltas
+
+
+class _SlowPrefillStreamer:
+    """A streamer whose first token is slower than any poll, then streams.
+
+    This is prefill, verbatim: nothing for a while, then tokens.
+    """
+
+    def __init__(self, *_a, timeout=None, **_kw):
+        self.timeout = timeout
+        self._first_at = time.monotonic() + 0.35
+        self._left = ["hello", " ", "world"]
+        self.polls_expired = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if time.monotonic() < self._first_at:
+            time.sleep(min(self.timeout or 0.02, 0.02))
+            self.polls_expired += 1
+            raise queue.Empty
+        if not self._left:
+            raise StopIteration
+        return self._left.pop(0)
+
+
+class _DeadProducerStreamer:
+    """A streamer that never yields, for a generate call that dies at once."""
+
+    def __init__(self, *_a, timeout=None, **_kw):
+        self.timeout = timeout
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        time.sleep(min(self.timeout or 0.02, 0.02))
+        raise queue.Empty
+
+
+def _run(streamer_cls, generate, **kw):
+    class _Model:
+        def generate(self, **kwargs):
+            return generate(**kwargs)
+
+    return list(
+        iter_transformers_text_deltas(
+            model=_Model(),
+            tokenizer=object(),
+            generation_kwargs={"x": 1},
+            streamer_cls=streamer_cls,
+            **kw,
+        )
+    )
+
+
+def test_prefill_longer_than_a_poll_is_not_the_end_of_the_stream():
+    """The false-kill. Every poll expiring while generate RUNS is prefill."""
+
+    def generate(**kwargs):
+        time.sleep(0.5)  # the decode is still going
+
+    out = _run(_SlowPrefillStreamer, generate)
+    assert out == ["hello", " ", "world"], (
+        "a stream whose first token arrived after several expired polls was cut "
+        "short — prefill is the most ordinary thing a decode does, and it is not "
+        "evidence that anything failed"
+    )
+
+
+def test_a_dead_producer_ends_the_stream_instead_of_hanging_forever():
+    """The other side, and the one `timeout=None` could never reach."""
+
+    def generate(**kwargs):
+        return None  # returns immediately, enqueues nothing
+
+    started = time.monotonic()
+    out = _run(_DeadProducerStreamer, generate, timeout=None)
+    assert out == []
+    assert time.monotonic() - started < 5.0, (
+        "the stream blocked on a producer that had already exited — a dead "
+        "thread never enqueues the end sentinel, so nothing but its liveness "
+        "can end this wait"
+    )
+
+
+def test_the_producers_exception_survives_and_is_raised_typed():
+    """A decode that dies must be attributable, not a bare queue.Empty."""
+
+    class _Boom(RuntimeError):
+        pass
+
+    def generate(**kwargs):
+        raise _Boom("CUDA out of memory")
+
+    with pytest.raises(_Boom, match="CUDA out of memory"):
+        _run(_DeadProducerStreamer, generate, timeout=None)
+
+
+def test_a_none_timeout_still_polls_so_liveness_can_be_observed():
+    """`timeout=None` must NOT reach the streamer as a blocking wait.
+
+    joycaption passes None. A streamer that blocks cannot notice a dead
+    producer, which is exactly how that call site hangs.
+    """
+    seen = {}
+
+    class _Recording(_DeadProducerStreamer):
+        def __init__(self, *a, timeout=None, **kw):
+            seen["timeout"] = timeout
+            super().__init__(*a, timeout=timeout, **kw)
+
+    _run(_Recording, lambda **kw: None, timeout=None)
+    assert seen["timeout"] is not None and seen["timeout"] > 0, (
+        f"the streamer was built with timeout={seen['timeout']!r} — a blocking "
+        "streamer can never observe that its producer died"
+    )


### PR DESCRIPTION
`iter_transformers_text_deltas` handed its `timeout` straight to the
`TextIteratorStreamer`, where expiring it raised a bare `queue.Empty` out of the
generator: untyped, unattributable, and triggered by the most ordinary thing a
decode does. The default was 0.5 seconds. A long prompt or a large model spends
whole seconds in prefill before the first token, and half a second of that
killed the stream.

The opposite spelling is the mirror defect, and it is what joycaption actually
passes: `timeout=None` blocks the consumer FOREVER when the generate thread
dies, because a dead thread never enqueues the end sentinel. One spelling kills
healthy work, the other hangs on dead work, and neither asks the question that
matters.

The question is whether the thread producing tokens is still alive, so that is
what decides now. A poll that expires while the thread runs is prefill and the
wait continues; a poll that expires once the thread is gone is the end, and
whatever it died of is re-raised typed. `timeout` becomes a RE-CHECK CADENCE —
`None` no longer reaches the streamer as a blocking wait, because a blocking
streamer can never observe that its producer died. How long a decode may take
is governed where it belongs: the in-call progress gate that any ctx event
re-arms.

`parallel/group.py`'s `_FIRST_COMMAND_WAIT_S = 1800.0` DELETED. It was
referenced by nothing. A duration nobody reads is not a bound, it is a claim
about how the system behaves that no code has to honour.

RED/GREEN, four checks, no model and no GPU — ALL FOUR fail against master and
pass on this commit:
  - a stream whose first token arrives after several expired polls delivers
    every token (master: `_queue.Empty` out of the generator);
  - a producer that has already exited ends the stream instead of blocking;
  - the producer's own exception survives and is raised typed, so a decode that
    dies is attributable rather than a bare queue.Empty;
  - `timeout=None` still reaches the streamer as a positive poll, so joycaption's
    call site can observe a dead producer at all.

NOT in this change, and not silently skipped — see th#2267 §6: `ctx.call`'s flat
1h default, `capability_renewal.py`'s attempt-count give-up, the part-PUT /
download attempt caps, `rigboot.py`'s `capture_output=True` walls,
`_COLLECTIVE_TIMEOUT_S`, `disk_gc.py`'s 6h temp age, and
`_MISSING_SNAPSHOT_WAIT_S` (class B — it waits on pgw#1634/th#2268's re-mint
beat, which has not landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)