### PR TITLE
pgw#1650: a release derives EVERY compile-marking model class

### DIFF
--- a/src/gen_worker/cli/compile.py
+++ b/src/gen_worker/cli/compile.py
@@ -670,7 +670,7 @@ def _rederive_programs(
             checkpoint_dir=endpoint_dir,
             lockfile=lockfile or lockfile_beside(str(endpoint_dir)),
             graph_cas=Path(cas_root),
-            slot_checkpoints={},
+            checkpoint_trees={},
         )
     except DeriveError as exc:
         raise CompileError(f"re-derive failed: {exc}") from exc

--- a/src/gen_worker/cli/lock.py
+++ b/src/gen_worker/cli/lock.py
@@ -39,20 +39,22 @@ def add_subparser(sub: Any) -> None:
         "--checkpoint-ref",
         action="append",
         default=[],
-        metavar="[SLOT=]OWNER/NAME@REV",
+        metavar="[CLASS=]OWNER/NAME@REV",
         help="owner/name@revision to trace against. Required for an endpoint "
              "that declares a model slot; a weightless endpoint needs none. "
-             "Repeat with `slot=ref` to give a SECONDARY model slot its own "
-             "checkpoint; the bare form is the primary model's.",
+             "Repeat with `ModelClass=ref` to give one model class its own "
+             "checkpoint — a release derives EVERY compile-marking class "
+             "(pgw#1650); an entrypoint slot name keys a tree too, and the "
+             "bare form is every model that names neither.",
     )
     parser.add_argument(
         "--checkpoint",
         action="append",
         default=[],
-        metavar="[SLOT=]PATH",
+        metavar="[CLASS=]PATH",
         help="a local checkpoint tree, INSTEAD of resolving --checkpoint-ref "
              "through the weight CAS (for a tree the store does not hold). "
-             "Repeatable as `slot=path`, same rule as --checkpoint-ref.",
+             "Repeatable as `ModelClass=path`, same rule as --checkpoint-ref.",
     )
     parser.add_argument(
         "--graph-cas",
@@ -393,7 +395,7 @@ def _trace(
             checkpoint_dir=tree if tree is not None else root,
             lockfile=lockfile if lockfile is not None else lockfile_beside(root),
             graph_cas=graph_cas_root,
-            slot_checkpoints=slot_trees or {},
+            checkpoint_trees=slot_trees or {},
         )
     except DeriveError as exc:
         _say(f"error: derive: {exc}")

--- a/src/gen_worker/cli/release.py
+++ b/src/gen_worker/cli/release.py
@@ -44,11 +44,13 @@ def add_subparser(sub: Any) -> None:
         required=True,
         action="append",
         default=[],
-        metavar="[SLOT=]PATH",
+        metavar="[CLASS=]PATH",
         help="CONFIG-ONLY checkpoint tree the author's load path resolves "
         "(subset snapshot; weights never transit the derive). Repeat as "
-        "`slot=path` to give a SECONDARY model slot its own tree (pgw#1508); "
-        "the bare form is the primary model's.",
+        "`ModelClass=path` to give one model class its own tree — a release "
+        "derives EVERY compile-marking class (pgw#1650) and they bind "
+        "different checkpoints. An entrypoint SLOT name also keys a tree "
+        "(pgw#1508); the bare form is every class that names neither.",
     )
     derive.add_argument(
         "--lockfile",
@@ -88,7 +90,7 @@ def _run_derive(args: argparse.Namespace) -> int:
         if not (_sep and slot.isidentifier()):
             slot, rest = "", raw
         if slot in trees:
-            owner = f"slot {slot!r}" if slot else "the primary model"
+            owner = f"{slot!r}" if slot else "the primary model"
             print(f"error: --checkpoint given twice for {owner}", file=sys.stderr)
             return 2
         resolved = Path(rest).resolve()
@@ -98,8 +100,8 @@ def _run_derive(args: argparse.Namespace) -> int:
         trees[slot] = resolved
     if "" not in trees:
         print(
-            "error: --checkpoint names only secondary slots; the primary "
-            "model's tree is the bare form",
+            "error: --checkpoint names only classes/slots; the tree every "
+            "other model loads from is the bare form",
             file=sys.stderr,
         )
         return 2
@@ -122,7 +124,7 @@ def _run_derive(args: argparse.Namespace) -> int:
             checkpoint_dir=checkpoint,
             lockfile=lockfile,
             graph_cas=Path(args.graph_cas).resolve() if args.graph_cas else None,
-            slot_checkpoints=trees,
+            checkpoint_trees=trees,
         )
     except DeriveError as exc:
         print(f"derive error: {exc}", file=sys.stderr)
@@ -146,10 +148,26 @@ def _run_derive(args: argparse.Namespace) -> int:
             else "no graphs -- load() marks no ctx.compile target"
         )
         print(f"{result.endpoint}: {why}", file=sys.stderr)
-    for lane_name, hashes in result.lane_graphs.items():
-        print(f"lane {lane_name}: {len(hashes)} graph specialization(es)", file=sys.stderr)
+    if result.classes:
+        print(
+            f"{len(result.classes)} model class(es) derived: "
+            f"{', '.join(result.classes)}",
+            file=sys.stderr,
+        )
+    for class_name, lane_name, hashes in result.class_lane_graphs:
+        print(
+            f"{class_name} lane {lane_name}: {len(hashes)} graph "
+            f"specialization(es)",
+            file=sys.stderr,
+        )
         for graph in hashes:
             print(f"  {graph}", file=sys.stderr)
+    for lane_name, hashes in result.lane_graphs.items():
+        print(
+            f"lane {lane_name}: {len(hashes)} graph specialization(es) "
+            f"release-wide",
+            file=sys.stderr,
+        )
     print(f"document sha256: {result.digest}", file=sys.stderr)
     return 0
 

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -8,6 +8,21 @@ instrumented discovery, and stamp the observed graph set -- plus the lane
 contracts and the model type's checkpoint-defaults schema -- as the static
 release metadata document.
 
+**A RELEASE DERIVES EVERY COMPILE-MARKING MODEL CLASS** (Paul's ruling,
+2026-08-21; pgw#1650): *"Of course both qwen image and qwen image edit can
+exist in the same endpoint. Why wouldn't they be able to? Just compile each
+component and swap them in and out of the pipeline."* Each subject class
+traces its OWN entrypoints against its OWN checkpoint tree
+(``checkpoint_trees``, keyed by class name) and states its own graph set; the
+document carries them in ``classes[]``, keyed by (class x lane), and
+``graphs``/``lane_contracts`` are the release-wide UNION over those rows (every
+merge rule is stated in :func:`_merge_lanes`). Two classes CAN declare the same
+lane — the two qwen arms do, because their checkpoints are byte-layout
+identical — which is why the union is a merge and not a concatenation. The
+serving side already routes per class: ``serving/serve_loop.py`` keys backends
+``(model_cls, checkpoint_ref, lane)`` and resolves a ``DeployBinding`` per
+class, so swapping the arms in and out is existing machinery, not new.
+
 **pgw#1621 re-keyed every lane spelling in this document onto the tensor-layout
 v2 STAMP PAIR** — ``"<topology>@N+<quant>@N"``, th#1809's ``LayoutId.render()``,
 byte-shared with the hub's ``tensorfs.LayoutID.String``. Three fields carry it
@@ -72,7 +87,7 @@ import json
 import types
 import traceback
 import typing
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType, ModuleType
@@ -196,6 +211,13 @@ class ReleaseDeriveResult:
     unmarked_lanes: tuple[str, ...] = ()
     unenumerable_entrypoints: tuple[tuple[str, str], ...] = ()
     unservable_payloads: tuple[str, ...] = ()
+    #: Every subject class this release derived (pgw#1650) — a release derives
+    #: EVERY compile-marking class, not one.
+    classes: tuple[str, ...] = ()
+    #: ``(class, lane stamp, graph identities)`` — the per-class graph sets
+    #: BEFORE the release-wide union, which is what a pipeline log wants to
+    #: read when two classes share a lane.
+    class_lane_graphs: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
 
     @property
     def eager_permanent(self) -> bool:
@@ -268,9 +290,9 @@ def _assert_weights_free(torch: Any, program: Any) -> None:
         )
 
 
-def _lane_model_class(module: ModuleType) -> tuple[Optional[type], str]:
+def _module_model_classes(module: ModuleType) -> tuple[list[type], list[type]]:
 
-    found: list[type] = []
+    marked: list[type] = []
     unmarked: list[type] = []
     for value in vars(module).values():
         if not (
@@ -289,31 +311,69 @@ def _lane_model_class(module: ModuleType) -> tuple[Optional[type], str]:
             # were fully read at class definition — dtype and sm floor off the
             # ratified quant rule — so there is nothing left here to re-read.
             model_declared_lanes(value)
-            marked = model_marks_compile(value)
+            marks = model_marks_compile(value)
         except ModelDeclarationError as exc:
             raise DeriveError(str(exc)) from exc
-        (found if marked else unmarked).append(value)
-    if len(found) > 1:
-        raise DeriveError(
-            f"module {module.__name__!r} has more than one COMPILE-MARKING "
-            f"model class ({[cls.__name__ for cls in found]!r}); a release "
-            f"derives ONE. An auxiliary model that another slot drives simply "
-            f"calls no `ctx.compile()` in its `load()` — that is the entire "
-            f"eager declaration (Paul, 2026-08-20), and there is no keyword "
-            f"for it."
-        )
-    if found:
-        return (found[0], "")
+        (marked if marks else unmarked).append(value)
+    return (
+        sorted(marked, key=lambda cls: cls.__name__),
+        sorted(unmarked, key=lambda cls: cls.__name__),
+    )
+
+
+def _subject_classes(module: ModuleType) -> tuple[type, ...]:
+    """The classes this release DERIVES — every compile-marking one (pgw#1650).
+
+    Paul, 2026-08-21: *"Of course both qwen image and qwen image edit can exist
+    in the same endpoint. Why wouldn't they be able to? Just compile each
+    component and swap them in and out of the pipeline."* Each subject traces
+    its own entrypoints against its own checkpoint tree and states its own
+    graph set; the document carries them keyed by (class x lane).
+
+    THE ONE REFUSAL LEFT is the case that is still genuinely unreadable:
+    several classes and NOT ONE of them marks a compile target. Subjecthood is
+    read off the MARK (pgw#1597/#1599: "compilation participation is the
+    MARK"), so with no mark anywhere there is nothing to distinguish a release
+    subject from an auxiliary model another slot drives.
+    """
+
+    marked, unmarked = _module_model_classes(module)
+    if marked:
+        return tuple(marked)
     if len(unmarked) > 1:
         raise DeriveError(
             f"module {module.__name__!r} has more than one model class "
             f"({[cls.__name__ for cls in unmarked]!r}) and NONE of them marks "
             f"a compile target, so which one the release is ABOUT cannot be "
-            f"read. Mark the compiled one via `ctx.compile()` in its `load()`; "
-            f"an auxiliary model that another slot drives marks nothing and is "
-            f"then unambiguous."
+            f"read. A release derives every COMPILE-MARKING class (pgw#1650), "
+            f"and there are none here. Mark each compiled one via "
+            f"`ctx.compile()` in its `load()`; an auxiliary model that another "
+            f"slot drives marks nothing and is then unambiguous."
         )
-    return (unmarked[0] if unmarked else None, "")
+    return tuple(unmarked)
+
+
+def _checkpoint_tree(
+    trees: Mapping[str, Path],
+    primary: Path,
+    cls: Optional[type],
+    slot_name: str = "",
+) -> Path:
+    """The tree ONE model class loads from: its class name, then its slot name.
+
+    pgw#1650: a release has several subject classes, and two of them can hold
+    the same slot NAME in their own entrypoints (both qwen arms take
+    ``model:``) while binding different checkpoints. The class is the thing
+    that owns a checkpoint, so the class name is the key; the slot name stays
+    readable for an auxiliary model, which is how se#794's second tree is
+    spelled today.
+    """
+
+    if cls is not None and cls.__name__ in trees:
+        return trees[cls.__name__]
+    if slot_name and slot_name in trees:
+        return trees[slot_name]
+    return primary
 
 
 @dataclass(frozen=True)
@@ -1009,6 +1069,7 @@ def _derive_lane(
 
     hollow = _hollow()
     handle = lane_contract_handle(f"class {cls.__name__!r}", lane)
+    said = f"class {cls.__name__} lane {handle!r}"
     resolved = _resolve_lane(torchcg, lane)
     model_type = model_model_type(cls)
     merged: dict[str, Any] = {}
@@ -1036,10 +1097,10 @@ def _derive_lane(
             try:
                 model.load(load_ctx)
             except hollow.HollowError as exc:
-                raise DeriveError(f"lane {handle!r}: {exc}") from exc
+                raise DeriveError(f"{said}: {exc}") from exc
             except Exception as exc:
                 raise DeriveError(
-                    f"lane {handle!r}: load() failed under the trace "
+                    f"{said}: load() failed under the trace "
                     f"session: {type(exc).__name__}: {exc}"
                 ) from exc
             if not load_ctx.marked_modules:
@@ -1051,7 +1112,9 @@ def _derive_lane(
                 for slot_name, slot_cls in plan.model_slots:
                     if slot_cls is cls or slot_name in aides:
                         continue
-                    slot_tree = slot_checkpoints.get(slot_name, checkpoint_dir)
+                    slot_tree = _checkpoint_tree(
+                        slot_checkpoints, checkpoint_dir, slot_cls, slot_name
+                    )
                     aide = slot_cls()
                     try:
                         aide.load(
@@ -1063,16 +1126,20 @@ def _derive_lane(
                             )
                         )
                     except Exception as exc:
+                        named = (
+                            slot_cls.__name__ in slot_checkpoints
+                            or slot_name in slot_checkpoints
+                        )
                         shared = (
-                            " (the PRIMARY checkpoint — this slot has no "
-                            "--checkpoint-ref of its own; an auxiliary model "
-                            "with a separate checkpoint needs "
-                            f"`--checkpoint-ref {slot_name}=<ref>`)"
-                            if slot_name not in slot_checkpoints
+                            " (the PRIMARY checkpoint — this class has no "
+                            "--checkpoint-ref of its own; a model with a "
+                            "separate checkpoint needs "
+                            f"`--checkpoint-ref {slot_cls.__name__}=<ref>`)"
+                            if not named
                             else ""
                         )
                         raise DeriveError(
-                            f"lane {handle!r}: entrypoint {plan.name!r} slot "
+                            f"{said}: entrypoint {plan.name!r} slot "
                             f"{slot_name!r} ({slot_cls.__name__}) failed to "
                             f"load from {slot_tree}{shared} under the trace "
                             f"session: "
@@ -1108,7 +1175,7 @@ def _derive_lane(
                                 frame = deepest_endpoint_frame(exc, endpoint_root)
                                 if frame is None or unservable is None:
                                     raise DeriveError(
-                                        f"lane {handle!r}: entrypoint "
+                                        f"{said}: entrypoint "
                                         f"{plan.name!r} failed on auto-enumerated "
                                         f"payload {index} ({payload!r}) with "
                                         f"binding {dict(binding)!r} under the "
@@ -1147,7 +1214,7 @@ def _derive_lane(
             except DeriveError:
                 raise
             except torchcg.DiscoveryError as exc:
-                raise DeriveError(f"lane {handle!r}: {exc}") from exc
+                raise DeriveError(f"{said}: {exc}") from exc
         all_targets.update(lane_graphs.targets)
         for record in lane_graphs.graphs:
             merged.setdefault(record.graph, record)
@@ -1155,64 +1222,102 @@ def _derive_lane(
 
     if refused:
         warnings.append(
-            f"lane {handle}: {refused}/{total_combos} enumerated "
+            f"{said}: {refused}/{total_combos} enumerated "
             f"combination(s) refused by the author's own validation "
             f"(impossible servings; skipped)"
         )
     unobserved = tuple(sorted(all_targets - observed_targets))
-    if unobserved:
+    if unobserved and total_combos:
         raise DeriveError(
-            f"lane {handle!r}: marked module(s) {list(unobserved)!r} were "
+            f"{said}: marked module(s) {list(unobserved)!r} were "
             f"never CALLED while driving {total_combos} auto-enumerated "
             f"combination(s). ctx.compile must mark the module the code "
             f"actually CALLS (e.g. the vae's .decoder, not the vae, when "
             f"only .decode() runs) -- silent zero-graph discovery is not an "
             f"outcome."
         )
+    if unobserved:
+        # ZERO combinations is a DIFFERENT fact from a mark that survived real
+        # driving, and reading them as one refusal is what pgw#1650 found:
+        # every entrypoint this class owns refused enumeration (a required
+        # payload field the derive cannot synthesize — an input image, say), so
+        # nothing was ever called and the mark could not be observed. That is
+        # the outcome this module already states for an unenumerable
+        # entrypoint: no traced coverage, eager serving, mint on first
+        # encounter. The lane is DECLARED with its targets stated UNOBSERVED,
+        # which is exactly what `LaneGraphs.unobserved_targets` is for; killing
+        # the whole release's derive over it would take the OTHER classes'
+        # graphs down with it.
+        warnings.append(
+            f"{said}: marked module(s) {list(unobserved)!r} were never driven "
+            f"— this class's entrypoint(s) enumerate NOTHING, so the lane is "
+            f"declared with its targets UNOBSERVED. They serve eager and mint "
+            f"on first encounter; every other class is unaffected."
+        )
     return torchcg.LaneGraphs(
         contract=handle,
         targets=tuple(sorted(all_targets)),
         graphs=tuple(merged.values()),
-        unobserved_targets=(),
+        unobserved_targets=unobserved,
     )
 
 
-def derive_release(
+@dataclass(frozen=True)
+class _ClassDerivation:
+    """One subject class's whole view of the release (pgw#1650)."""
+
+    name: str
+    model_type: Optional[str]
+    defaults_schema: Optional[dict[str, Any]]
+    lanes: tuple[Any, ...]
+    lane_contracts: dict[str, Any]
+    entrypoints: dict[str, Any]
+    fork_axes: dict[str, Any]
+    unmarked_lanes: tuple[str, ...]
+    unenumerable: tuple[tuple[str, str], ...]
+    unservable: tuple[dict[str, Any], ...]
+    traced_entrypoints: int
+
+    def as_document(self, stack: tuple[tuple[str, str], ...]) -> dict[str, Any]:
+        return {
+            "class": self.name,
+            "model_type": self.model_type,
+            "checkpoint_defaults_schema": self.defaults_schema,
+            "graphs": _torchcg().GraphSetDocument(
+                stack=stack, lanes=self.lanes
+            ).as_dict(),
+            "lane_contracts": self.lane_contracts,
+            "entrypoints": self.entrypoints,
+            "fork_axes": self.fork_axes,
+        }
+
+
+def _derive_class(
+    torchcg: ModuleType,
     module: ModuleType,
+    cls: Optional[type],
     *,
     checkpoint_dir: Path,
-    lockfile: Optional[Path] = None,
-    graph_cas: Optional[Path] = None,
-    slot_checkpoints: Mapping[str, Path] = MappingProxyType({}),
-) -> ReleaseDeriveResult:
-    """Derive the release metadata document for one endpoint module."""
+    checkpoint_trees: Mapping[str, Path],
+    program_sink: Optional[Any],
+    warnings: list[str],
+) -> _ClassDerivation:
+    """Trace and derive ONE subject class, exactly as a lone class derives."""
 
-    torchcg = _torchcg()
-    program_sink = _program_sink(graph_cas)
-
-    if lockfile is None:
-        raise DeriveError(
-            "a derive states the compile stack it traced under, and that is "
-            "read from the endpoint's uv.lock: pass `lockfile=`. Restating "
-            "the installed set instead is what pgw#1489 deleted — it is a "
-            "second representation of the environment the lock already pins"
-        )
-    stack = _compile_stack_from_lockfile(lockfile)
-
-    cls, _ = _lane_model_class(module)
-    endpoint_name = f"{module.__name__}:{cls.__name__ if cls else ''}".rstrip(":")
-
+    owner_tree = _checkpoint_tree(checkpoint_trees, checkpoint_dir, cls)
+    said = f"class {cls.__name__!r}: " if cls is not None else ""
     lanes: list[Any] = []
     unmarked_lanes: list[str] = []
     lane_contracts: dict[str, Any] = {}
     entrypoints: dict[str, Any] = {}
-    warnings: list[str] = []
     plans: list[tuple[_Entrypoint, tuple[Any, ...]]] = []
     unenumerable: list[tuple[str, str]] = []
     unservable_payloads: list[dict[str, Any]] = []
+
     for plan in _entrypoints(module, cls):
         owner = f"@entrypoint {plan.name}"
         refusal: Optional[PayloadEnumerationRefused] = None
+        capped = False
         if cls is None:
             payloads: tuple[Any, ...] = ()
         else:
@@ -1223,10 +1328,9 @@ def derive_release(
             except PayloadEnumerationRefused as exc:
                 refusal = exc
                 payloads = ()
-                capped = False
             if capped:
                 warnings.append(
-                    f"{owner}: enum cross-product exceeds the cap "
+                    f"{said}{owner}: enum cross-product exceeds the cap "
                     f"({ENUM_CAP}); tracing the deterministic prefix -- the "
                     f"rest is first-encounter discovery (eager + background "
                     f"mint)"
@@ -1249,7 +1353,7 @@ def derive_release(
             }
             unenumerable.append((plan.name, str(refusal)))
             warnings.append(
-                f"{owner}: NOT enumerated — {refusal.field!r} "
+                f"{said}{owner}: NOT enumerated — {refusal.field!r} "
                 f"({refusal.annotation}) cannot be synthesized. This "
                 f"entrypoint has no traced coverage; it serves eager and "
                 f"mints on first encounter. Every other entrypoint is "
@@ -1274,9 +1378,9 @@ def derive_release(
         requires = model_requires(cls)
         for lane in model_declared_lanes(cls):
             lane_graphs = _derive_lane(
-                torchcg, cls, lane, plans, checkpoint_dir, warnings,
+                torchcg, cls, lane, plans, owner_tree, warnings,
                 program_sink=program_sink,
-                slot_checkpoints=slot_checkpoints,
+                slot_checkpoints=checkpoint_trees,
                 endpoint_root=endpoint_source_root(module),
                 unservable=unservable_payloads,
                 dynamic_dims=dynamic_dim_policy(model_shapes(cls)),
@@ -1305,9 +1409,9 @@ def derive_release(
             # term list plus the closed vocabulary it is written against, so
             # tensorhub (Go) evaluates `worst_case = manifest weight bytes +
             # demand(advertised envelope)` at pod-buy time without running any
-            # of ours. The envelope is taken over EVERY entrypoint this
-            # release serves, because the pod must hold the worst case of the
-            # whole advertised surface, not of one function.
+            # of ours. The envelope is taken over EVERY entrypoint THIS CLASS
+            # serves, because the pod must hold the worst case of the whole
+            # advertised surface, not of one function.
             entry["demand"] = demand_document(
                 lane.request,
                 advertised_envelope(*(plan.payload_type for plan, _ in plans)),
@@ -1325,13 +1429,252 @@ def derive_release(
         skipped.append({k: v for k, v in row.items() if k != "entrypoint"})
     for row in unservable_payloads:
         warnings.append(
-            f"@entrypoint {row['entrypoint']}: payload {row['payload']} is "
-            f"UNSERVABLE and was skipped — {row['error']} (at {row['frame']}). "
-            f"Its graphs are not in this document; every other payload is "
-            f"unaffected."
+            f"{said}@entrypoint {row['entrypoint']}: payload {row['payload']} "
+            f"is UNSERVABLE and was skipped — {row['error']} (at "
+            f"{row['frame']}). Its graphs are not in this document; every "
+            f"other payload is unaffected."
         )
 
-    graphs_document = torchcg.GraphSetDocument(stack=stack, lanes=tuple(lanes))
+    model_type_cls = model_model_type(cls) if cls is not None else None
+    return _ClassDerivation(
+        name=cls.__name__ if cls is not None else "",
+        model_type=getattr(model_type_cls, "__name__", None),
+        defaults_schema=_defaults_schema(model_type_cls),
+        lanes=tuple(lanes),
+        lane_contracts=lane_contracts,
+        entrypoints=entrypoints,
+        fork_axes={
+            "structural": [
+                declaration.as_document(axis)
+                for axis, declaration in (
+                    model_structural(cls) if cls is not None else {}
+                ).items()
+            ],
+            "shapes": model_shapes(cls) if cls is not None else {},
+        },
+        unmarked_lanes=tuple(unmarked_lanes),
+        unenumerable=tuple(unenumerable),
+        unservable=tuple(unservable_payloads),
+        traced_entrypoints=len(plans),
+    )
+
+
+def _merge_lanes(
+    torchcg: ModuleType,
+    derivations: Sequence[_ClassDerivation],
+    warnings: list[str],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """The RELEASE-WIDE view of a per-class graph set (pgw#1650).
+
+    Two subject classes legitimately declare the SAME lane — both qwen arms
+    are ``qwen-image.diffusers@1+plain.bf16@1``, because the two checkpoints
+    are byte-layout identical. The hub keys
+    ``release_compiled_graph_documents.lanes`` by the STAMP ALONE and refuses a
+    ``lane_contracts`` key that is not its own entry's stamp
+    (``release_compiled_graphs_invalid_lane``), and ``GraphSetDocument`` itself
+    refuses a repeated lane contract — so one row per stamp is not a choice.
+    Every merge rule is stated here rather than implied:
+
+    * ``targets`` and ``graphs`` UNION (a graph identity is the whole trace, so
+      two classes that produce the same identity produced the same graph);
+    * ``requires`` must AGREE — it is derived from the contract's own dtype,
+      never hand-written, so a disagreement is a producer bug and refuses;
+    * ``demand`` keeps the block with the largest ``worst_case_request_bytes``
+      and NAMES the class it came from (``worst_case_class``). A pod running
+      this lane must hold the worst case of what it serves, which is exactly
+      the rule the block already applies across entrypoints.
+
+    Per-class fidelity is never lost: ``classes[]`` carries each class's own
+    lanes, contracts and demand verbatim. The union exists so today's hub
+    decodes an accurate superset with no hub change (th#2277 owns the
+    release-doc shape; a per-class lane row is theirs to add).
+    """
+
+    targets: dict[str, set[str]] = {}
+    unobserved: dict[str, set[str]] = {}
+    graphs: dict[str, dict[str, Any]] = {}
+    passes: dict[str, tuple[str, ...]] = {}
+    entries: dict[str, dict[str, Any]] = {}
+    owners: dict[str, list[str]] = {}
+    for derivation in derivations:
+        for lane in derivation.lanes:
+            stamp = lane.contract
+            owners.setdefault(stamp, []).append(derivation.name)
+            targets.setdefault(stamp, set()).update(lane.targets)
+            unobserved.setdefault(stamp, set()).update(lane.unobserved_targets)
+            for record in lane.graphs:
+                graphs.setdefault(stamp, {}).setdefault(record.graph, record)
+            seen_passes = passes.setdefault(stamp, tuple(lane.passes))
+            if tuple(lane.passes) != seen_passes:
+                raise DeriveError(
+                    f"lane {stamp!r} is declared by "
+                    f"{owners[stamp]!r} with DIFFERENT transform passes "
+                    f"({list(seen_passes)!r} vs {list(lane.passes)!r}). A "
+                    f"serving boot adopts one lane document, and a graph "
+                    f"derived under a different pass set is a graph for a "
+                    f"module the boot does not have."
+                )
+            entry = dict(derivation.lane_contracts.get(stamp) or {})
+            if not entry:
+                continue
+            merged = entries.get(stamp)
+            if merged is None:
+                entries[stamp] = entry
+                continue
+            if merged.get("requires") != entry.get("requires"):
+                raise DeriveError(
+                    f"lane {stamp!r} is declared by {owners[stamp]!r} with "
+                    f"DIFFERENT capability floors ({merged.get('requires')!r} "
+                    f"vs {entry.get('requires')!r}). A floor is derived from "
+                    f"the contract's own dtype and is never written by hand, "
+                    f"so this cannot be an authoring difference."
+                )
+            if _worst_case(entry) > _worst_case(merged):
+                entries[stamp] = entry
+                merged = entry
+    for stamp, names in owners.items():
+        if len(names) < 2 or stamp not in entries:
+            continue
+        winner = max(
+            names,
+            key=lambda name: _worst_case(
+                next(
+                    (
+                        d.lane_contracts.get(stamp) or {}
+                        for d in derivations
+                        if d.name == name
+                    ),
+                    {},
+                )
+            ),
+        )
+        entries[stamp]["worst_case_class"] = winner
+        warnings.append(
+            f"lane {stamp}: declared by {len(names)} model classes "
+            f"({', '.join(sorted(names))}); the release-wide `demand` row is "
+            f"{winner}'s (the largest worst case). Each class's own row is in "
+            f"`classes[]`."
+        )
+    lanes = tuple(
+        torchcg.LaneGraphs(
+            contract=stamp,
+            targets=tuple(sorted(targets[stamp])),
+            graphs=tuple(graphs.get(stamp, {}).values()),
+            # A target another class OBSERVED is observed for the lane: the
+            # release-wide row states unobserved only what NO class reached.
+            unobserved_targets=tuple(sorted(
+                unobserved[stamp]
+                - {record.target for record in graphs.get(stamp, {}).values()}
+            )),
+            passes=passes[stamp],
+        )
+        for stamp in sorted(owners)
+    )
+    return lanes, entries
+
+
+def _worst_case(entry: Mapping[str, Any]) -> int:
+
+    demand = entry.get("demand")
+    if not isinstance(demand, Mapping):
+        return -1
+    value = demand.get("worst_case_request_bytes")
+    return int(value) if isinstance(value, int) else -1
+
+
+def _agreed(values: Sequence[Any]) -> Optional[Any]:
+    """The one value every subject class states, or None when they differ."""
+
+    distinct = [value for index, value in enumerate(values)
+                if value not in values[:index]]
+    return distinct[0] if len(distinct) == 1 else None
+
+
+def derive_release(
+    module: ModuleType,
+    *,
+    checkpoint_dir: Path,
+    lockfile: Optional[Path] = None,
+    graph_cas: Optional[Path] = None,
+    checkpoint_trees: Mapping[str, Path] = MappingProxyType({}),
+) -> ReleaseDeriveResult:
+    """Derive the release metadata document for one endpoint module.
+
+    ``checkpoint_trees`` names the tree ONE model needs when it is not the
+    primary one — keyed by MODEL CLASS, or by entrypoint slot name.
+    """
+
+    torchcg = _torchcg()
+    program_sink = _program_sink(graph_cas)
+
+    if lockfile is None:
+        raise DeriveError(
+            "a derive states the compile stack it traced under, and that is "
+            "read from the endpoint's uv.lock: pass `lockfile=`. Restating "
+            "the installed set instead is what pgw#1489 deleted — it is a "
+            "second representation of the environment the lock already pins"
+        )
+    stack = _compile_stack_from_lockfile(lockfile)
+
+    subjects = _subject_classes(module)
+    marked, unmarked = _module_model_classes(module)
+    known = {cls.__name__ for cls in marked + unmarked}
+    slots = {
+        slot_name
+        for cls in (subjects or (None,))
+        for plan in _entrypoints(module, cls)
+        for slot_name, _slot_cls in plan.model_slots
+    }
+    unknown = sorted(set(checkpoint_trees) - known - slots)
+    if unknown:
+        raise DeriveError(
+            f"--checkpoint/--checkpoint-ref names {unknown!r}, which is "
+            f"neither a model class of {module.__name__!r} "
+            f"({sorted(known)!r}) nor an entrypoint model slot "
+            f"({sorted(slots)!r}). A tree nothing loads from is a typo, not a "
+            f"spare."
+        )
+
+    endpoint_name = (
+        f"{module.__name__}:{'+'.join(cls.__name__ for cls in subjects)}"
+    ).rstrip(":")
+
+    warnings: list[str] = []
+    derivations = [
+        _derive_class(
+            torchcg, module, cls,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_trees=checkpoint_trees,
+            program_sink=program_sink,
+            warnings=warnings,
+        )
+        for cls in (subjects or (None,))
+    ]
+
+    lanes, lane_contracts = _merge_lanes(torchcg, derivations, warnings)
+    graphs_document = torchcg.GraphSetDocument(stack=stack, lanes=lanes)
+
+    entrypoints: dict[str, Any] = {}
+    for derivation in derivations:
+        for name, block in derivation.entrypoints.items():
+            entrypoints.setdefault(name, block)
+
+    defaults_schema = _agreed([d.defaults_schema for d in derivations])
+    model_type_name = _agreed([d.model_type for d in derivations])
+    if len(derivations) > 1 and model_type_name is None:
+        # NOT silently overloaded: the release is about several model TYPES
+        # (wan-2.2 is the live case), the hub's release document holds ONE
+        # defaults schema, and `classes[]` holds each class's own. th#2277
+        # owns the release-doc shape and the per-class field is theirs.
+        warnings.append(
+            "this release's subject classes declare DIFFERENT model types "
+            f"({sorted(str(d.model_type) for d in derivations)}), so the "
+            "release-wide `model_type` and `checkpoint_defaults_schema` are "
+            "null — one release document holds one of each. Every class's own "
+            "type and schema are in `classes[]` (th#2277 owns the per-class "
+            "hub field)."
+        )
+
     payload_dict: dict[str, Any] = {
         "v": 1,
         "kind": DOCUMENT_KIND,
@@ -1345,23 +1688,31 @@ def derive_release(
         "graphs": graphs_document.as_dict(),
         "lane_contracts": lane_contracts,
         "entrypoints": entrypoints,
+        # pgw#1650: THE PER-CLASS BREAKDOWN, and the authoritative one. A
+        # release derives EVERY compile-marking class (Paul, 2026-08-21), each
+        # against its own checkpoint tree, so `graphs`/`lane_contracts` above
+        # are the UNION over these rows — see `_merge_lanes` for every merge
+        # rule. `fork_axes`, `model_type` and the defaults schema are class
+        # facts and live here undiluted.
+        "classes": [
+            derivation.as_document(stack)
+            for derivation in derivations
+            if derivation.name
+        ],
         "fork_axes": {
             "structural": [
-                declaration.as_document(axis)
-                for axis, declaration in (
-                    model_structural(cls) if cls is not None else {}
-                ).items()
+                row
+                for derivation in derivations
+                for row in derivation.fork_axes["structural"]
             ],
-            "shapes": model_shapes(cls) if cls is not None else {},
+            "shapes": {
+                axis: value
+                for derivation in derivations
+                for axis, value in derivation.fork_axes["shapes"].items()
+            },
         },
-        "checkpoint_defaults_schema": _defaults_schema(
-            model_model_type(cls) if cls is not None else None
-        ),
-        "model_type": (
-            getattr(model_model_type(cls), "__name__", None)
-            if cls is not None
-            else None
-        ),
+        "checkpoint_defaults_schema": defaults_schema,
+        "model_type": model_type_name,
     }
     document = json.dumps(
         payload_dict, sort_keys=True, separators=(",", ":"), ensure_ascii=True
@@ -1375,12 +1726,21 @@ def derive_release(
             for lane in graphs_document.lanes
         },
         warnings=tuple(warnings),
-        weightless=cls is None and bool(plans),
-        unmarked_lanes=tuple(unmarked_lanes),
-        unenumerable_entrypoints=tuple(unenumerable),
+        weightless=not subjects and any(d.traced_entrypoints for d in derivations),
+        unmarked_lanes=tuple(
+            name for d in derivations for name in d.unmarked_lanes
+        ),
+        unenumerable_entrypoints=tuple(
+            row for d in derivations for row in d.unenumerable
+        ),
         unservable_payloads=tuple(
             f"{r['entrypoint']}[{r['payload']}]: {r['error']} (at {r['frame']})"
-            for r in unservable_payloads
+            for d in derivations for r in d.unservable
+        ),
+        classes=tuple(d.name for d in derivations if d.name),
+        class_lane_graphs=tuple(
+            (d.name, lane.contract, tuple(record.graph for record in lane.graphs))
+            for d in derivations for lane in d.lanes
         ),
     )
 

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -146,15 +146,35 @@ class EndpointHost:
                     "declared lanes; an eager-permanent endpoint has nothing "
                     "to adopt"
                 )
-            if len(lane_bearing) > 1:
-                raise RuntimeError(
-                    "setup(): release metadata offered for a multi-model "
-                    "endpoint; per-slot adoption sessions are not designed "
-                    "yet (one lane-bearing model class per endpoint for now)"
-                )
             from .model import lane_handle
 
-            lane_contract = lane_handle(self.lanes[lane_bearing[0]])
+            # pgw#1650: SEVERAL lane-bearing classes are supported when they
+            # resolve to the SAME lane. That is the qwen shape — both arms
+            # declare `qwen-image.diffusers@1+plain.bf16@1` because the two
+            # checkpoints are byte-layout identical — and one AdoptSession
+            # serves them: the derive's document carries both classes' graphs
+            # under that stamp, and a mark claims a graph by STRUCTURE, so
+            # each class arms its own. What is still undesigned is one boot
+            # holding TWO lanes, because a boot fetches ONE lane document.
+            contracts = {
+                cls: lane_handle(self.lanes[cls]) for cls in lane_bearing
+            }
+            distinct = sorted(set(contracts.values()))
+            if len(distinct) > 1:
+                raise RuntimeError(
+                    "setup(): this endpoint's model classes resolve DIFFERENT "
+                    "lanes ("
+                    + ", ".join(
+                        f"{cls.__name__}={contract}"
+                        for cls, contract in sorted(
+                            contracts.items(), key=lambda row: row[0].__name__
+                        )
+                    )
+                    + "); one boot fetches ONE lane document, so the second "
+                    "lane has nothing to adopt from. Several classes on ONE "
+                    "lane are supported (pgw#1650)."
+                )
+            lane_contract = distinct[0]
             stack_rows = dict(stack) if stack is not None else dict(document.stack)
             for row in installed_stack_drift(dict(document.stack)):
                 logger.warning("adopt: compile-stack drift vs this venv: %s", row)

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -60,9 +60,30 @@ class ServeAdoption:
         self.contract: str = ""
 
     def sink_for(self, model_cls: type, lane: Any) -> Optional[Callable[..., Any]]:
-        """``ctx.compile``'s sink for one model class — the adopt arm."""
+        """``ctx.compile``'s sink for one model class — the adopt arm.
+
+        pgw#1650: a release derives EVERY compile-marking class, so this is
+        called once per class. Classes that share a lane share this session —
+        the document under that stamp carries all of their graphs and a mark
+        claims one by STRUCTURE. A class on a DIFFERENT lane gets no sink and
+        serves eager, LOUDLY: this session was built for one lane, and handing
+        it back for another silently adopts the wrong lane's graphs. Per-lane
+        sessions in one boot are owed (pgw#1650, serving half).
+        """
         with self._lock:
             if self._settled:
+                from .model import lane_handle
+
+                contract = lane_handle(lane) if lane is not None else ""
+                if self.contract and contract and contract != self.contract:
+                    logger.warning(
+                        "adopt: %s declares lane %s, but this boot adopted "
+                        "lane %s — %s serves EAGER. One boot holds one lane "
+                        "document.",
+                        model_cls.__name__, contract, self.contract,
+                        model_cls.__name__,
+                    )
+                    return None
                 return self._sink()
             self._settled = True
             try:

--- a/tests/release_fixtures/two_class_endpoint.py
+++ b/tests/release_fixtures/two_class_endpoint.py
@@ -1,0 +1,93 @@
+"""TWO compile-marking model classes on ONE lane — the qwen-image shape (pgw#1650).
+
+Both classes own ``.unet``, both call ``ctx.compile`` on it, and both declare
+the SAME lane: a compile target is an attribute PATH on one pipeline object, so
+the two arms cannot be one class (pgw#1112's finding), and the two checkpoints
+are the same layout, so they cannot be two lanes either. Each class binds its
+OWN checkpoint tree.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import STATIC, LoadContext, Model, RequestContext, entrypoint, lane
+from gen_worker.demand import MiB, const, per_mp_batch
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class EditIn(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    strength: float = 0.5
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class EditModel(
+    Model[SDXL],
+    lanes={TINY_DIFFUSERS_FP32: lane(
+        request=const(MiB(128)) + per_mp_batch(MiB(16)),
+    )},
+    shapes={"aspect": STATIC},
+):
+    """The edit checkpoint — its own tree, `--checkpoint EditModel=<path>`."""
+
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+class PrimaryModel(
+    Model[SDXL],
+    lanes={TINY_DIFFUSERS_FP32: lane(
+        request=const(MiB(64)) + per_mp_batch(MiB(16)),
+    )},
+    shapes={"aspect": STATIC},
+):
+    """The text-to-image checkpoint — the bare `--checkpoint` tree."""
+
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+def _run(model: Any, ctx: Any, prompt: str) -> None:
+    with torch.inference_mode():
+        model.pipe(
+            prompt=prompt,
+            num_inference_steps=2,
+            guidance_scale=0.0,
+            width=32,
+            height=32,
+            callback_on_step_end=ctx.step_callback(2),
+            output_type="latent",
+        )
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In, model: PrimaryModel) -> Out:
+    ctx.raise_if_cancelled()
+    _run(model, ctx, payload.prompt)
+    return Out(model_used=ctx.checkpoint_ref)
+
+
+@entrypoint
+def edit(ctx: RequestContext, payload: EditIn, model: EditModel) -> Out:
+    ctx.raise_if_cancelled()
+    _run(model, ctx, payload.prompt)
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/release_fixtures/two_unmarked_endpoint.py
+++ b/tests/release_fixtures/two_unmarked_endpoint.py
@@ -1,0 +1,54 @@
+"""TWO model classes and NOT ONE compile mark — the refusal that SURVIVES pgw#1650.
+
+Subjecthood is read off the MARK. With no mark anywhere there is nothing to
+tell a release subject from an auxiliary model another slot drives, so the
+derive refuses rather than guessing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+from diffusers import StableDiffusionPipeline, UNet2DConditionModel
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint, lane
+from gen_worker.demand import MiB, const
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class OneModel(
+    Model[SDXL],
+    lanes={TINY_DIFFUSERS_FP32: lane(request=const(MiB(64)))},
+):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+
+
+class OtherModel(
+    Model[SDXL],
+    lanes={TINY_DIFFUSERS_FP32: lane(request=const(MiB(32)))},
+):
+    net: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.net = ctx.load(UNet2DConditionModel)
+
+
+@entrypoint
+def generate(
+    ctx: RequestContext, payload: In, one: OneModel, other: OtherModel
+) -> Out:
+    ctx.raise_if_cancelled()
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_release_derive_multi_class.py
+++ b/tests/test_release_derive_multi_class.py
@@ -1,0 +1,171 @@
+"""pgw#1650 — a release derives EVERY compile-marking model class.
+
+Paul, 2026-08-21: *"Of course both qwen image and qwen image edit can exist in
+the same endpoint. Why wouldn't they be able to? Just compile each component
+and swap them in and out of the pipeline."*
+
+The REAL derive runs here — the shipped CLI, the shipped trace session, the
+shipped document writer — over a two-class endpoint on ONE lane with a separate
+checkpoint tree per class, which is the qwen-image shape exactly.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+LANE = "sd15.diffusers@1+plain.f32@1"
+
+LOCK = (
+    'version = 1\n'
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+
+@pytest.fixture(scope="module")
+def primary_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    import sys
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return tiny_tree.save_config_only(tmp_path_factory.mktemp("primary-config-only"))
+
+
+@pytest.fixture(scope="module")
+def edit_tree(primary_tree: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A DIFFERENT checkpoint: same family, a wider unet.
+
+    The width is what makes this tree falsifiable — a derive that quietly used
+    the primary tree for both classes produces the same graph twice, and the
+    disjointness assertion below fails.
+    """
+
+    tree = tmp_path_factory.mktemp("edit-root") / "config-only"
+    shutil.copytree(primary_tree, tree)
+    config_path = tree / "unet" / "config.json"
+    config = json.loads(config_path.read_text())
+    config["block_out_channels"] = [8, 24]
+    config_path.write_text(json.dumps(config))
+    return tree
+
+
+def _derive(module: str, tree: Path, out: Path, *extra: str) -> int:
+    from gen_worker.cli import main
+
+    lockfile = out.parent / "uv.lock"
+    lockfile.write_text(LOCK)
+    return main([
+        "release", "derive",
+        "--dir", str(FIXTURES),
+        "--module", module,
+        "--checkpoint", str(tree),
+        "--lockfile", str(lockfile),
+        "--out", str(out),
+        *extra,
+    ])
+
+
+def test_a_release_derives_every_compile_marking_class(
+    primary_tree: Path, edit_tree: Path, tmp_path: Path
+) -> None:
+    out = tmp_path / "release.json"
+    assert _derive(
+        "two_class_endpoint", primary_tree, out,
+        "--checkpoint", f"EditModel={edit_tree}",
+    ) == 0
+    document = json.loads(out.read_bytes())
+
+    # BOTH classes are the release, and the endpoint name says so.
+    assert document["endpoint"].endswith(":EditModel+PrimaryModel")
+    classes = {row["class"]: row for row in document["classes"]}
+    assert sorted(classes) == ["EditModel", "PrimaryModel"]
+
+    # Each class states its own graph set, under its own lane row.
+    per_class: dict[str, set[str]] = {}
+    for name, row in classes.items():
+        (lane,) = row["graphs"]["lanes"]
+        assert lane["contract"] == LANE, name
+        assert lane["graphs"], f"{name} derived no graph"
+        assert {record["target"] for record in lane["graphs"]} == {"unet"}, name
+        assert row["lane_contracts"][LANE]["stamp"] == LANE
+        per_class[name] = {record["graph"] for record in lane["graphs"]}
+
+    # A separate tree per class is REAL: same lane, same target, disjoint
+    # graphs, because the two unets are not the same module.
+    assert per_class["EditModel"].isdisjoint(per_class["PrimaryModel"])
+
+    # BOTH entrypoints reach the document. Master derived one class and DROPPED
+    # every entrypoint that class did not own, which is what took `edit` with
+    # it.
+    assert sorted(document["entrypoints"]) == ["edit", "generate"]
+    assert document["entrypoints"]["edit"]["model_slots"] == {"model": "EditModel"}
+    assert document["entrypoints"]["generate"]["traced_passes"] >= 1
+    assert document["entrypoints"]["edit"]["traced_passes"] >= 1
+
+    # The release-wide view is the UNION over the classes, on ONE lane row —
+    # the hub keys `release_compiled_graph_documents.lanes` by the stamp alone.
+    (merged,) = document["graphs"]["lanes"]
+    assert merged["contract"] == LANE
+    assert {record["graph"] for record in merged["graphs"]} == (
+        per_class["EditModel"] | per_class["PrimaryModel"]
+    )
+    assert merged["unobserved_targets"] == []
+
+    # `lane_contracts` keys BY STAMP and its entry stamps itself the same, or
+    # the hub refuses `release_compiled_graphs_invalid_lane`. The `demand` row
+    # it carries is the largest worst case, and it NAMES the class it is.
+    (contract_key,) = document["lane_contracts"]
+    assert contract_key == LANE
+    entry = document["lane_contracts"][LANE]
+    assert entry["stamp"] == LANE
+    assert entry["worst_case_class"] == "EditModel"
+    assert entry["demand"]["worst_case_request_bytes"] == max(
+        row["lane_contracts"][LANE]["demand"]["worst_case_request_bytes"]
+        for row in classes.values()
+    )
+
+    # One model type across both classes, so the release still states one.
+    assert document["model_type"] == "SDXL"
+    assert document["checkpoint_defaults_schema"] is not None
+
+
+def test_two_classes_and_no_compile_mark_still_refuses(
+    primary_tree: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The refusal that SURVIVES: no mark anywhere, so no subject is readable."""
+
+    out = tmp_path / "release.json"
+    assert _derive("two_unmarked_endpoint", primary_tree, out) == 1
+    stderr = capsys.readouterr().err
+    assert "has more than one model class" in stderr
+    assert "NONE of them marks" in stderr
+    assert not out.exists()
+
+
+def test_a_checkpoint_tree_nothing_loads_from_is_a_typo(
+    primary_tree: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A key that names neither a class nor a slot used to be silently ignored."""
+
+    out = tmp_path / "release.json"
+    assert _derive(
+        "two_class_endpoint", primary_tree, out,
+        "--checkpoint", f"EditModal={primary_tree}",
+    ) == 1
+    stderr = capsys.readouterr().err
+    assert "EditModal" in stderr and "EditModel" in stderr

--- a/tests/test_release_derive_slot_checkpoints.py
+++ b/tests/test_release_derive_slot_checkpoints.py
@@ -86,7 +86,10 @@ def test_the_aide_pointed_at_the_PRIMARY_tree_refuses_naming_slot_and_tree(
     assert "slot 'aide'" in message
     assert str(primary_tree) in message
     assert "the PRIMARY checkpoint" in message
-    assert "--checkpoint-ref aide=<ref>" in message
+    # pgw#1650: the remedy names the CLASS, which is what owns a checkpoint —
+    # two entrypoints can hold the same slot NAME over different classes (both
+    # qwen arms take `model:`). The slot name still keys a tree.
+    assert "--checkpoint-ref AideModel=<ref>" in message
 
 
 def test_an_eager_only_slot_STILL_hydrates(

--- a/tests/test_release_derive_slot_checkpoints.py
+++ b/tests/test_release_derive_slot_checkpoints.py
@@ -113,7 +113,9 @@ def test_a_slot_named_twice_refuses(
         tmp_path, str(primary_tree), f"aide={aide_tree}", f"aide={primary_tree}"
     )
     assert code == 2
-    assert "given twice for slot 'aide'" in capsys.readouterr().err
+    # pgw#1650: the key namespace is classes AND slots, so the message names
+    # the KEY rather than asserting which of the two it was.
+    assert "given twice for 'aide'" in capsys.readouterr().err
 
 
 def test_only_secondary_slots_named_refuses(
@@ -123,7 +125,9 @@ def test_only_secondary_slots_named_refuses(
 
     code, _out = _derive(tmp_path, f"aide={aide_tree}")
     assert code == 2
-    assert "the primary model's tree is the bare form" in capsys.readouterr().err
+    assert "the tree every other model loads from is the bare form" in (
+        capsys.readouterr().err
+    )
 
 
 def test_the_slot_spelling_never_eats_a_ref_or_a_path() -> None:


### PR DESCRIPTION
## pgw#1650 — a release derives EVERY compile-marking model class

Paul's ruling, verbatim (2026-08-21): *"Of course both qwen image and qwen image edit can
exist in the same endpoint. Why wouldn't they be able to? Just compile each component and
swap them in and out of the pipeline."*

The refusal this deletes:

> `module 'qwen_image.main' has more than one COMPILE-MARKING model class
> (['QwenImageT2iModel','QwenImageEditModel']); a release derives ONE`

It was an artifact of a one-class assumption in `release/derive.py`, not architecture:
`_lane_model_class` returned a single `cls` and `_entrypoints(module, cls)` then DROPPED
every entrypoint that class did not own — which is what took qwen's `edit` with it. It
blocks se#816's qwen-image 0.6.3 promotion (derive is required per publish, th#2251 Half B).

**This supersedes pgw#1112's split-endpoints conclusion**, not its finding. The finding
stands — a compile target is an attribute PATH on one pipeline object, so one class holding
both arms could never compile the edit arm — and it is exactly why qwen writes TWO classes.
The conclusion predates the two-arena model (pgw#1598 §2 / pgw#1599), under which
co-residency is priced rather than feared.

### What changed

* `_subject_classes` replaces `_lane_model_class`: every compile-marking class is a subject.
  Each traces its OWN entrypoints against its OWN checkpoint tree and states its own graph
  set (`_derive_class`).
* The document gains `classes[]` — the authoritative per-class breakdown (graphs,
  lane_contracts, entrypoints, fork_axes, model_type, defaults schema), keyed by
  (class × lane).
* `graphs` / `lane_contracts` stay as the release-wide UNION so the hub's
  `derive_document.go` decodes an accurate superset with NO hub change. Two classes
  legitimately share one lane stamp (both qwen arms are
  `qwen-image.diffusers@1+plain.bf16@1`, because the checkpoints are byte-layout identical)
  and `GraphSetDocument` refuses a repeated contract, so the merge rules are stated in
  `_merge_lanes`: targets/graphs UNION, `requires` must AGREE (it is derived from the
  contract's dtype, never hand-written), `demand` keeps the largest
  `worst_case_request_bytes` and NAMES its class in `worst_case_class`.
* Checkpoint trees key by MODEL CLASS, then by entrypoint slot name
  (`--checkpoint QwenImageEditModel=<tree>`). Both qwen arms name their slot `model` and
  bind different checkpoints, so slot-name keying cannot address them. A key that names
  neither is now a refusal instead of a silent no-op.
* A lane whose class enumerated ZERO combinations is DECLARED with its targets stated
  UNOBSERVED instead of killing the release. That is this module's own stated outcome for an
  unenumerable entrypoint (no traced coverage, eager serving, mint on first encounter); the
  "never CALLED" refusal keeps firing whenever combinations were actually driven, which is
  the mis-marked-module case it exists for. qwen's `edit` is the live instance — its payload
  carries `images: list[ImageAsset]`, which the derive cannot synthesize.
* Lane messages name the class (`class QwenImageT2iModel lane '…'`) — with several classes
  on one stamp, a stamp alone cannot say which class a failure is about.
* Serving: `EndpointHost.setup()` accepted release metadata for exactly one lane-bearing
  class. Several classes on ONE lane are now supported and share the AdoptSession (the
  document under that stamp carries all their graphs; a mark claims one by structure).
  Several classes on DIFFERENT lanes still refuse — one boot fetches one lane document — and
  `ServeAdoption.sink_for` now says so per class and serves that class eager instead of
  silently handing back another lane's session.

### Proof

Red/green against the canonical qwen-image endpoint source (`serverless-endpoints/qwen-image`
0.6.3, its own env, CPU fake-tensor trace, no mint, no GPU) — with se#816 wave-2's pair
re-key applied to a scratch copy, since master gen-worker refuses the v1 `contracts.*` lane
keys the shipped source still carries:

```
RED  (origin/master 0d59aed7)
derive error: module 'qwen_image.main' has more than one COMPILE-MARKING model class
(['QwenImageT2iModel', 'QwenImageEditModel']); a release derives ONE.

GREEN (this branch) — the class refusal is GONE and BOTH classes trace:
  QwenImageEditModel  -> lane 'qwen-image.diffusers@1+plain.bf16@1' derived, target
     'transformer' stated UNOBSERVED (its `images: list[ImageAsset]` payload enumerates
     nothing), entrypoint `edit` in the document
  QwenImageT2iModel   -> enters its own drive and dies on a DIFFERENT, pre-existing wall:
     entrypoint 'generate' ... DynamicOutputShapeException: aten.nonzero.default
     (diffusers `pipeline_qwenimage._extract_masked_hidden`, boolean-mask indexing under
     fake tensors). Nothing to do with class count; se#816's to own, se#834's genre.
```

The full two-class document is proven by a committed integration test that runs the REAL
CLI over a two-compile-marking-class endpoint on one lane with a separate tree per class
(`tests/test_release_derive_multi_class.py`): two `classes[]` rows, disjoint per-class graph
sets (the second tree is a wider unet, so a derive that quietly used the primary tree fails
the assertion), both entrypoints in the document, one merged lane row carrying the union,
`worst_case_class` named. Verified RED on master (`assert 1 == 0` — the derive refuses).

### Hub-side follow-up (NOT in this PR; th#2277 owns release-doc shape)

`release_compiled_graph_documents.lanes` is keyed by stamp alone, so when classes on one
stamp disagree the union must pick: `demand` takes the largest worst case, and
`checkpoint_defaults_schema` / `model_type` go NULL (with a loud derive warning) when the
subject classes' model types differ — wan-2.2 is the real case (`Wan22` classes plus
`Rife`). Per-class fidelity is in `classes[]` and is waiting for a hub field.
