### PR TITLE
pgw#1645 (3a/4): a worker on a lower layout RUNG reads as EARNING — and the decline that stands today names what is missing rather than dropping the wish

### DIFF
--- a/changelog.d/pgw1645-layout-rung.md
+++ b/changelog.d/pgw1645-layout-rung.md
@@ -1,0 +1,20 @@
+- **pgw#1645: a worker on a lower layout rung now reads as EARNING rather than as a
+  slow pod nobody can explain.** A mint declares the byte layout it compiled against and,
+  while compiling, records the layout inductor actually asked for. Those two facts, read
+  off the artifact that is answering requests right now, are a POSITION:
+  `no_wish` (this is the ideal), `at_ideal`, `earning` (a ratified wish is outstanding and
+  deliverable), `declined` (ratified, and the platform will not deliver it yet — with the
+  reason), `candidate` (outside the catalog, emitted for a human to ratify, never
+  invented), `no_single_ideal` (two constants want two arrangements, so a re-mint would
+  move the copies rather than delete them). The values are a wire contract in the same way
+  `EagerPhase`'s are; they ride out in `ServeAdoption.facts()` beside the counts.
+
+- **pgw#1645: the decline is TYPED and names what is missing, because today it is
+  everything.** `tensorfs-py` exports no `fill` and varena implements no `FillSink`
+  (varena#13), so no layout-applying transform is reachable from a worker process at all —
+  and the confession says exactly that rather than dropping the wish. It also carries the
+  measurement that will price the decision once a fill exists (tensorfs#157: an identity
+  fill runs at 5.15 GiB/s and a `channels_last` fill at 0.12 GiB/s, ~31 ns/element,
+  extrapolating to ~5 s of host time for SDXL's 635 MiB conv set). gen-worker deliberately
+  computes no run count of its own — that would be a second implementation of the fold, and
+  `FillStats::runs_per_element` is the number.

--- a/src/gen_worker/serving/layout_rung.py
+++ b/src/gen_worker/serving/layout_rung.py
@@ -1,0 +1,333 @@
+"""The layout rung a worker is ON, and the one it is EARNING (pgw#1645).
+
+`research/layout-morphisms/0-DESIGN.md` §3, the worker half. A mint compiles
+against a byte layout and DECLARES it (tcg#83); while compiling it also records
+the layout inductor actually asked for, as a wishlist. Those two facts, read off
+the artifact that is serving RIGHT NOW, are the whole of this module:
+
+* the artifact declares `torch.contiguous@1` and wished for nothing — this IS
+  the ideal layout and there is no rung above it;
+* it declares one layout and wished for another — the worker is serving the
+  stored layout and EARNING the ideal one. That is a rung it has not reached
+  yet, not a fault, and it must read that way in the status or an operator
+  chasing a slow pod will chase this instead;
+* the wish is outside the ratified catalog — it is a CANDIDATE, emitted for a
+  human to ratify. Machines derive along ratified morphisms and never invent
+  one;
+* the wish is ratified and the platform will not deliver it yet — a DECLINE,
+  typed and named, never a silently dropped wish.
+
+**Nothing here transforms anything.** The rung is a reading.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Dict, Mapping, Sequence, Tuple
+
+__all__ = [
+    "LayoutRung",
+    "LayoutState",
+    "LayoutWish",
+    "PER_ELEMENT_DECLINE",
+    "fill_path",
+    "read_rung",
+    "rungs_of",
+]
+
+#: The reason a ratified, compiler-wished arrangement is not delivered TODAY,
+#: stated once and dated so it can be retired rather than accumulated.
+#:
+#: tensorfs#157, MEASURED on a 4070 (release, best of 10): an identity fill runs
+#: at 5.15 GiB/s and a `torch.channels_last-2d@1` fill at 0.12 GiB/s -- ~31 ns
+#: per element, because that arrangement's innermost storage axis is the channel
+#: and its source stride is H*W, so the fold in `Plan::for_each_run` folds
+#: NOTHING and the copy becomes one run per element. Extrapolated over SDXL's
+#: 635 MiB conv-weight set that is ~5 s of host time per load, against a step
+#: cost the same arrangement saves single-digit percent of. Paying it by default
+#: would be a regression wearing an optimization's name.
+#:
+#: WHAT REPLACES THIS, and it is not a guess: `FillStats::runs_per_element` is
+#: the number, computed by the one implementation that folds the runs. The
+#: moment the fill path is reachable from Python (varena#13) this constant dies
+#: and the decision is read from the stats of the fill that would be performed.
+#: gen-worker deliberately does NOT compute a run count of its own -- that would
+#: be a second implementation of the fold, which is the defect this whole
+#: program keeps removing.
+PER_ELEMENT_DECLINE = (
+    "tensorfs#157: this arrangement's fill is a per-element gather "
+    "(0.12 GiB/s measured, ~5 s host-side for SDXL's conv set), so the "
+    "platform declines to deliver it. The wish stands and the candidate is "
+    "recorded; it is the DELIVERY that is withheld, not the ratification"
+)
+
+
+class LayoutState(StrEnum):
+    """Where a serving artifact sits against the layout it wished for.
+
+    The values are a wire contract in the same way `EagerPhase`'s are: the hub
+    groups activity rows on them, so a member may be added and must not be
+    renamed.
+    """
+
+    #: The mint asked for no layout change. This artifact IS at its ideal.
+    NO_WISH = "no_wish"
+    #: Served layout == wished layout. The delivery already happened.
+    AT_IDEAL = "at_ideal"
+    #: A ratified wish is outstanding and deliverable: serving the stored
+    #: layout while the ideal-layout mint is pending. EARNING, not broken.
+    EARNING = "earning"
+    #: Ratified, and the platform will not deliver it yet. See
+    #: :data:`PER_ELEMENT_DECLINE`.
+    DECLINED = "declined"
+    #: The wish names no ratified morphism. It rides out as a candidate for
+    #: ratification and the mint keeps the stored layout -- the permanent
+    #: fallback the design forbids removing.
+    CANDIDATE = "candidate"
+    #: Two constants want two different ratified arrangements. There is no
+    #: single ideal layout for this graph, so there is no rung to earn: a
+    #: re-mint would move the copies rather than delete them.
+    NO_SINGLE_IDEAL = "no_single_ideal"
+
+
+@dataclass(frozen=True)
+class LayoutWish:
+    """One constant whose layout the mint asked to change.
+
+    `morphism` is a ratified handle or `""`. An empty handle carries only the
+    stride order inductor asked for: a name is never invented for it.
+    """
+
+    fqn: str
+    morphism: str
+    stride_order: Tuple[int, ...]
+
+    @property
+    def ratified(self) -> bool:
+        return bool(self.morphism)
+
+
+@dataclass(frozen=True)
+class LayoutRung:
+    """One graph's layout position: what it serves, what it wants, and why."""
+
+    graph: str
+    served: str
+    ideal: str
+    state: LayoutState
+    detail: str
+    wishes: Tuple[LayoutWish, ...] = ()
+
+    @property
+    def earning(self) -> bool:
+        """Whether a re-mint against a better layout is owed to this graph."""
+
+        return self.state is LayoutState.EARNING
+
+    @property
+    def settled(self) -> bool:
+        """Whether no RE-MINT is owed -- for any reason, including a decline
+        and including an unratified candidate.
+
+        Settled is not the same as ideal. A decline is a settled position with
+        a stated cause and a candidate is settled pending a HUMAN, not a
+        machine; conflating either with EARNING makes a permanent state look
+        like a stuck mint queue, which is the reading this whole confession
+        exists to prevent."""
+
+        return self.state is not LayoutState.EARNING
+
+    def line(self) -> str:
+        """The confession, one line, in the shape `rung.transition_line` uses."""
+
+        head = f"LAYOUT_RUNG={self.state} graph={self.graph} served={self.served}"
+        if self.ideal:
+            head = f"{head} ideal={self.ideal}"
+        if self.wishes:
+            head = f"{head} wishes={len(self.wishes)}"
+        return f"{head}: {self.detail}" if self.detail else head
+
+    def facts(self) -> Dict[str, Any]:
+        return {
+            "graph": self.graph,
+            "served": self.served,
+            "ideal": self.ideal,
+            "state": str(self.state),
+            "detail": self.detail,
+            "wishes": [
+                {
+                    "fqn": wish.fqn,
+                    "morphism": wish.morphism,
+                    "stride_order": list(wish.stride_order),
+                }
+                for wish in self.wishes
+            ],
+        }
+
+
+def _wishes(raw: object) -> Tuple[LayoutWish, ...]:
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)):
+        return ()
+    out = []
+    for row in raw:
+        if not isinstance(row, Mapping):
+            continue
+        out.append(
+            LayoutWish(
+                fqn=str(row.get("fqn", "")),
+                morphism=str(row.get("morphism", "")),
+                stride_order=tuple(int(v) for v in (row.get("stride_order") or ())),
+            )
+        )
+    return tuple(out)
+
+
+def fill_path() -> Any:
+    """The layout-applying fill this process can reach, or `None`.
+
+    A PROBE of what is installed, not a flag: the transform has exactly one
+    implementation (`tensorfs_core::fill`, one plan, two backends behind the
+    `FillSink` trait), and a worker either has it in reach or it does not.
+    Today it does not -- `tensorfs-py` exports no `fill` and varena implements
+    no sink (varena#13) -- so every non-identity arrangement is declined for
+    the plainest possible reason: nothing in this process can apply one.
+
+    The day varena#13 lands, this returns a callable and the decline moves from
+    "there is no fill" to the per-arrangement judgement
+    :data:`PER_ELEMENT_DECLINE` describes, priced by the fill's own
+    `runs_per_element`. Neither reason is ever a silent drop.
+    """
+
+    try:
+        from .._vendor import tensorfs as _tensorfs
+    except ImportError:  # pragma: no cover - the vendored package is always present
+        return None
+    return getattr(_tensorfs, "fill", None)
+
+
+def _delivery(handle: str) -> str:
+    """`""` when the platform will deliver this arrangement, else the reason."""
+
+    if fill_path() is None:
+        return (
+            f"no layout-applying fill is reachable from this process, so "
+            f"{handle!r} cannot be delivered to VRAM at all (varena#13: "
+            f"tensorfs owns the plan and the transform, varena implements the "
+            f"sink over a reservation, and neither is exposed to Python yet). "
+            f"{PER_ELEMENT_DECLINE}"
+        )
+    return ""
+
+
+def read_rung(graph: str, metadata: Mapping[str, Any]) -> LayoutRung:
+    """Read one serving artifact's layout position off its OWN metadata.
+
+    Both facts come from the artifact -- never from a caller's belief about it,
+    and never from this repository's idea of what the fleet declares. An
+    artifact that states no ratified `declared_input_layout` cannot be read
+    here at all; `torchcg.artifact.validate_metadata` already refuses it before
+    the bytes are ever loaded, which is why this function has no arm for it.
+    """
+
+    served = str(metadata.get("declared_input_layout", ""))
+    wishes = _wishes(metadata.get("layout_wishlist"))
+    if not wishes:
+        return LayoutRung(
+            graph=graph,
+            served=served,
+            ideal="",
+            state=LayoutState.NO_WISH,
+            detail="the mint asked for no layout change",
+        )
+
+    ratified = sorted({wish.morphism for wish in wishes if wish.ratified})
+    if not ratified:
+        return LayoutRung(
+            graph=graph,
+            served=served,
+            ideal="",
+            state=LayoutState.CANDIDATE,
+            detail=(
+                f"{len(wishes)} constant(s) want an arrangement no ratified "
+                f"morphism names; the orders ride out as candidates and the "
+                f"mint keeps {served!r}"
+            ),
+            wishes=wishes,
+        )
+    if len(ratified) > 1:
+        return LayoutRung(
+            graph=graph,
+            served=served,
+            ideal="",
+            state=LayoutState.NO_SINGLE_IDEAL,
+            detail=(
+                f"constants want {ratified!r}: there is no single ideal layout "
+                f"for this graph, so a re-mint would move the copies rather "
+                f"than delete them"
+            ),
+            wishes=wishes,
+        )
+
+    ideal = ratified[0]
+    if ideal == served:
+        return LayoutRung(
+            graph=graph,
+            served=served,
+            ideal=ideal,
+            state=LayoutState.AT_IDEAL,
+            detail="the delivered layout is the wished one",
+            wishes=wishes,
+        )
+    refusal = _delivery(ideal)
+    if refusal:
+        return LayoutRung(
+            graph=graph,
+            served=served,
+            ideal=ideal,
+            state=LayoutState.DECLINED,
+            detail=refusal,
+            wishes=wishes,
+        )
+    return LayoutRung(
+        graph=graph,
+        served=served,
+        ideal=ideal,
+        state=LayoutState.EARNING,
+        detail=(
+            f"serving {served!r} while the {ideal!r} mint is pending; this pod "
+            f"is EARNING that rung, not failing to reach it"
+        ),
+        wishes=wishes,
+    )
+
+
+def rungs_of(session: Any) -> Tuple[LayoutRung, ...]:
+    """Every armed graph's layout position, read from the artifact SERVING it.
+
+    Walks the adopt session's own dispatcher registry and reads each armed
+    runner's verified metadata -- the block the loader already validated on the
+    way in. Nothing is re-materialized and nothing is re-derived: the artifact
+    that is answering requests right now is the artifact that answers here.
+    """
+
+    home = getattr(session, "_home", None)
+    if not isinstance(home, Mapping):
+        return ()
+    out = []
+    for graph, dispatcher in sorted(home.items()):
+        for record, compiled in tuple(getattr(dispatcher, "_entries", ())):
+            if record.graph != graph:
+                continue
+            metadata = _metadata_of(compiled)
+            if metadata is None:
+                continue
+            out.append(read_rung(graph, metadata))
+    return tuple(out)
+
+
+def _metadata_of(compiled: Any) -> Mapping[str, Any] | None:
+    runner = getattr(compiled, "runner", None)
+    graph = getattr(runner, "_graph", None)
+    metadata = getattr(graph, "metadata", None)
+    return metadata if isinstance(metadata, Mapping) else None

--- a/src/gen_worker/serving/serve_adoption.py
+++ b/src/gen_worker/serving/serve_adoption.py
@@ -5,6 +5,7 @@ import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
+from . import layout_rung
 from .host import CompileStack
 
 from .. import activity as activity_mod
@@ -272,11 +273,19 @@ class ServeAdoption:
         """The ordered mint work-list, in canonical document order."""
         return tuple(self.adoption.holes) if self.adoption is not None else ()
 
+    @property
+    def layout_rungs(self) -> Tuple[Any, ...]:
+        """Each armed graph's layout position, read off the artifact serving it."""
+        if self.adoption is None:
+            return ()
+        return layout_rung.rungs_of(self.adoption)
+
     def facts(self) -> Dict[str, Any]:
         """Counted, and never silent: `adopted`/`holes` are absent (not zero) when no session was ever built, and `refusal` says why."""
         if self.adoption is None:
             return {"adopting": False, "refusal": self.refusal or "not_attempted"}
         marks = tuple(self.adoption.unclaimed_marks)
+        rungs = self.layout_rungs
         return {
             "adopting": True,
             "adopted": len(self.adoption.adopted),
@@ -285,6 +294,11 @@ class ServeAdoption:
             "unmatched_marks": len(marks),
             "unmatched": [mark.describe() for mark in marks],
             "ambiguous": len(self.adoption.ambiguous),
+            # pgw#1645. Counted the same way everything else here is, and the
+            # rows carry BOTH layouts: a pod on a lower rung must read as
+            # EARNING rather than as a slow pod nobody can explain.
+            "layout_earning": sum(1 for rung in rungs if rung.earning),
+            "layout_rungs": [rung.facts() for rung in rungs],
         }
 
 

--- a/tests/test_layout_rung_pgw1645.py
+++ b/tests/test_layout_rung_pgw1645.py
@@ -1,0 +1,255 @@
+"""pgw#1645 -- the layout rung a worker is ON, and the one it is EARNING.
+
+Every arm reads the rung off ARTIFACT METADATA, which is where both facts
+actually live (`declared_input_layout` and `layout_wishlist`, tcg#83), and
+never off a caller's belief about the artifact. The deliverability arms move
+the one real source of truth there is today: whether a layout-applying fill is
+REACHABLE FROM THIS PROCESS. It is not (varena#13), so the decline arm is what
+production takes; installing the capability is what makes EARNING reachable,
+and that is the same branch production will take the day varena#13 lands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, cast
+
+import pytest
+
+from gen_worker.serving import layout_rung as rung_mod
+from gen_worker.serving.layout_rung import LayoutState, read_rung
+
+IDENTITY = "torch.contiguous@1"
+CHANNELS_LAST = "torch.channels_last-2d@1"
+
+
+def _metadata(
+    *, declared: str = IDENTITY, wishlist: List[Dict[str, Any]] | None = None
+) -> Dict[str, Any]:
+    return {
+        "declared_input_layout": declared,
+        "layout_wishlist": [] if wishlist is None else wishlist,
+    }
+
+
+def _wish(fqn: str, morphism: str, order: List[int]) -> Dict[str, Any]:
+    return {"fqn": fqn, "morphism": morphism, "stride_order": order}
+
+
+@pytest.fixture()
+def fill_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Put a layout-applying fill in this process's reach.
+
+    Moves the SOURCE the probe reads -- the vendored tensorfs module's own
+    surface -- rather than handing the predicate an argument. varena#13 makes
+    this attribute real; until then this is the only way the EARNING branch can
+    be reached, and it must be reachable or the vocabulary carries a member
+    nothing can produce.
+    """
+
+    from gen_worker._vendor import tensorfs as vendored
+
+    monkeypatch.setattr(vendored, "fill", lambda *a, **k: None, raising=False)
+
+
+# -- the four settled positions ----------------------------------------------
+
+
+def test_no_wish_is_the_ideal_not_an_absence() -> None:
+    """An artifact whose mint asked for nothing IS at its ideal layout. There
+    is no rung above it, so nothing is owed and nothing should read as
+    pending."""
+
+    rung = read_rung("g", _metadata())
+    assert rung.state is LayoutState.NO_WISH
+    assert rung.settled and not rung.earning
+    assert rung.ideal == ""
+    assert rung.served == IDENTITY
+
+
+def test_a_wish_the_artifact_already_satisfies_is_AT_IDEAL() -> None:
+    rung = read_rung(
+        "g",
+        _metadata(
+            declared=CHANNELS_LAST,
+            wishlist=[_wish("conv.weight", CHANNELS_LAST, [3, 0, 2, 1])],
+        ),
+    )
+    assert rung.state is LayoutState.AT_IDEAL
+    assert rung.settled and not rung.earning
+
+
+def test_an_unratified_wish_is_a_CANDIDATE_and_no_name_is_invented() -> None:
+    """The permanent fallback path. The mint compiled against the stored layout
+    and the order rides out for a human to ratify -- machines derive along
+    ratified morphisms and never invent one."""
+
+    rung = read_rung(
+        "g", _metadata(wishlist=[_wish("w", "", [1, 0, 2, 3])])
+    )
+    assert rung.state is LayoutState.CANDIDATE
+    assert rung.ideal == ""
+    assert rung.settled and not rung.earning
+    # The order survives, unnamed, so ratification has something to read.
+    assert rung.wishes[0].stride_order == (1, 0, 2, 3)
+    assert not rung.wishes[0].ratified
+
+
+def test_two_ratified_wishes_are_NO_SINGLE_IDEAL_not_a_coin_flip() -> None:
+    """A re-mint against one of two wanted arrangements MOVES the copies rather
+    than deleting them, which is worse than not re-minting. Picking silently is
+    the failure; saying there is no single ideal is the fix."""
+
+    rung = read_rung(
+        "g",
+        _metadata(
+            wishlist=[
+                _wish("a", CHANNELS_LAST, [3, 0, 2, 1]),
+                _wish("b", "torch.channels_last-3d@1", [4, 0, 3, 2, 1]),
+            ]
+        ),
+    )
+    assert rung.state is LayoutState.NO_SINGLE_IDEAL
+    assert rung.ideal == ""
+    assert rung.settled and not rung.earning
+    assert CHANNELS_LAST in rung.detail
+
+
+# -- deliverability: the two arms of one predicate ---------------------------
+
+
+def test_with_no_fill_in_reach_a_ratified_wish_is_a_TYPED_DECLINE() -> None:
+    """What production does TODAY, and it must not be silent. `tensorfs-py`
+    exports no `fill` and varena implements no sink, so the arrangement cannot
+    be delivered to VRAM at all -- and the confession says exactly that, names
+    varena#13, and carries the tensorfs#157 measurement that will price the
+    decision once a fill exists."""
+
+    assert rung_mod.fill_path() is None, "a fill became reachable; retire this arm"
+    rung = read_rung(
+        "g", _metadata(wishlist=[_wish("conv.weight", CHANNELS_LAST, [3, 0, 2, 1])])
+    )
+    assert rung.state is LayoutState.DECLINED
+    assert rung.ideal == CHANNELS_LAST
+    assert rung.settled and not rung.earning
+    assert "varena#13" in rung.detail
+    assert "tensorfs#157" in rung.detail
+    # A decline is a SETTLED position with a stated cause. Reading it as
+    # pending would make a permanent state look like a stuck mint queue.
+    assert rung.settled
+
+
+def test_with_a_fill_in_reach_the_same_wish_is_EARNING(fill_installed: None) -> None:
+    """The rung the design exists to make expressible: serving the stored
+    layout while the ideal-layout mint is pending reads as EARNING, not as
+    broken. Same metadata, same branch, one real capability moved."""
+
+    assert rung_mod.fill_path() is not None
+    rung = read_rung(
+        "g", _metadata(wishlist=[_wish("conv.weight", CHANNELS_LAST, [3, 0, 2, 1])])
+    )
+    assert rung.state is LayoutState.EARNING
+    assert rung.earning and not rung.settled
+    assert rung.served == IDENTITY and rung.ideal == CHANNELS_LAST
+    assert "EARNING" in rung.detail
+
+
+def test_the_confession_names_both_layouts_and_survives_serialization(
+    fill_installed: None,
+) -> None:
+    """An operator reading a slow pod's status has to be able to tell "on a
+    lower rung, earning the higher one" from "broken", and the hub groups on
+    the state value, so it has to reach the wire intact."""
+
+    rung = read_rung(
+        "g", _metadata(wishlist=[_wish("conv.weight", CHANNELS_LAST, [3, 0, 2, 1])])
+    )
+    line = rung.line()
+    assert "LAYOUT_RUNG=earning" in line
+    assert f"served={IDENTITY}" in line and f"ideal={CHANNELS_LAST}" in line
+
+    facts = rung.facts()
+    assert facts["state"] == "earning"
+    assert facts["served"] == IDENTITY and facts["ideal"] == CHANNELS_LAST
+    assert facts["wishes"] == [
+        {"fqn": "conv.weight", "morphism": CHANNELS_LAST, "stride_order": [3, 0, 2, 1]}
+    ]
+
+
+def test_the_state_values_are_the_wire_contract_the_hub_groups_on() -> None:
+    """`EagerPhase`'s rule, applied to this vocabulary before anything joins to
+    it: a member may be ADDED, and renaming one orphans history."""
+
+    assert sorted(str(state) for state in LayoutState) == [
+        "at_ideal",
+        "candidate",
+        "declined",
+        "earning",
+        "no_single_ideal",
+        "no_wish",
+    ]
+
+
+# -- the walk, against REAL torchcg structure --------------------------------
+
+
+def test_the_rungs_are_read_off_the_ARTIFACT_THAT_IS_SERVING(tmp_path: Path) -> None:
+    """`rungs_of` walks the adopt session's own dispatcher registry and reads
+    each armed runner's VERIFIED metadata — the block the loader already
+    validated on the way in. Nothing is re-materialized and nothing is
+    re-derived, so the artifact answering requests is the artifact answering
+    here.
+
+    Driven through torchcg's real `_ForwardDispatcher` and a real packed
+    artifact's real metadata rather than a hand-written dict, because the whole
+    claim is about reaching the right object.
+    """
+
+    import tcg_artifacts
+
+    from gen_worker._vendor.torchcg.adopt import _ForwardDispatcher
+    from gen_worker._vendor.torchcg.artifact import read_metadata
+
+    artifact = tcg_artifacts.build(tmp_path / "graph.tcg")
+    metadata = read_metadata(artifact)
+    # A real mint's real metadata: the layout axis is present because tcg#83
+    # made it mandatory, and this build wished for nothing.
+    assert metadata["declared_input_layout"] == IDENTITY
+    assert metadata["layout_wishlist"] == []
+
+    class _Module:
+        def forward(self, *args: Any, **kwargs: Any) -> Any:
+            return None
+
+    class _Record:
+        graph = "g0"
+        lora_bucket = 0
+        specialization_dims: tuple = ()
+        fork: tuple = ()
+
+    class _Graph:
+        pass
+
+    module = _Module()
+    dispatcher = _ForwardDispatcher(module)
+    graph = _Graph()
+    graph.metadata = metadata  # type: ignore[attr-defined]
+    runner = type("R", (), {"_graph": graph})()
+    compiled = type("C", (), {"runner": runner})()
+    dispatcher._entries.append((cast(Any, _Record()), compiled))
+
+    session = type("S", (), {"_home": {"g0": dispatcher}})()
+    rungs = rung_mod.rungs_of(session)
+    assert len(rungs) == 1
+    assert rungs[0].graph == "g0"
+    assert rungs[0].state is LayoutState.NO_WISH
+    assert rungs[0].served == IDENTITY
+
+
+def test_a_session_that_never_armed_anything_reports_no_rungs() -> None:
+    """Absent, not zero-with-a-shrug: a worker with nothing armed has no layout
+    position, and inventing one would put a row in the status for a graph that
+    is serving eager."""
+
+    assert rung_mod.rungs_of(object()) == ()
+    assert rung_mod.rungs_of(type("S", (), {"_home": {}})()) == ()


### PR DESCRIPTION
`research/layout-morphisms/0-DESIGN.md` §3's confession half. A mint DECLARES
the byte layout it compiled against (tcg#83) and, while compiling, records the
layout inductor actually asked for. Both facts live in the artifact's own
metadata; `serving/layout_rung.py` reads them off the artifact that is
ANSWERING REQUESTS RIGHT NOW and states the position:

  no_wish          this IS the ideal; there is no rung above it
  at_ideal         the delivered layout is the wished one
  earning          a ratified wish is outstanding and deliverable
  declined         ratified, and the platform will not deliver it yet
  candidate        outside the catalog; emitted for a human, never invented
  no_single_ideal  two constants want two arrangements

The values are a wire contract in the same way `EagerPhase`'s are -- the hub
groups activity rows on them, so a member may be ADDED and renaming one orphans
history. They ride out through `ServeAdoption.facts()` beside the existing
counts, with `layout_earning` counted the same way `holes` is.

WHY THE VOCABULARY IS THIS SHAPE. An operator looking at a pod that is slower
than its sibling has to be able to tell "on a lower rung, earning the higher
one" from "broken", and "settled with a stated cause" from "stuck in a mint
queue". `settled` is therefore NOT the same as at-ideal: a decline is settled
(the cause is stated), and a candidate is settled pending a HUMAN rather than a
machine. Only `earning` owes a re-mint.

THE DECLINE THAT STANDS TODAY, and it is bigger than a cost decision:
`tensorfs-py` exports NO `fill`, `LayoutMorphism` or `Plan`, and
`grep -rn "Sink" ~/cozy/varena/src` is empty with no `tensorfs-core` dependency
in its Cargo.toml. So no layout-applying transform is reachable from a worker
process AT ALL. `fill_path()` is a PROBE of that -- not a flag -- and its
absence is the honest reason every non-identity arrangement is declined right
now. Filed as varena#13. The confession also carries the number that will price
the decision once a fill exists (tensorfs#157: identity fill 5.15 GiB/s,
`torch.channels_last-2d@1` 0.12 GiB/s, ~31 ns/element, ~5 s host-side for
SDXL's 635 MiB conv set) -- against a step cost the same arrangement saves
single-digit percent of. Paying that by default would be a regression wearing
an optimization's name.

gen-worker computes NO run count of its own. `FillStats::runs_per_element` is
that number and it is computed by the one implementation that folds the runs; a
second fold here is the exact defect this program keeps removing.

BOTH ARMS OF THE PREDICATE ARE DRIVEN, by moving a real capability rather than
by handing a predicate an argument: with no `fill` in reach the wish is a typed
DECLINE naming varena#13 and tensorfs#157; with one installed on the vendored
package the SAME metadata through the SAME branch is EARNING. A state nothing
can produce is a state that cannot go red, so EARNING is reachable in test
today and reachable in production the day varena#13 lands, with no change here.

`rungs_of` walks the adopt session's own dispatcher registry and reads each
armed runner's VERIFIED metadata -- the block the loader already validated on
the way in. Nothing is re-materialized and nothing re-derived. Exercised
through torchcg's real `_ForwardDispatcher` and a real packed artifact's real
metadata, because the whole claim is about reaching the right object.

Tests: 10 new, all green; 66 across the adopt path green; ruff + mypy clean.

NOT HERE, and named so nobody reads its absence as done: the re-mint against
the ideal layout and the adopt of the result (the mint machinery exists --
`BackgroundMint`, `SelfMint`, `AdoptSession.arm` -- and the layout upgrade is a
new work item beside the hole list), and the ephemeral H2D transform itself,
which is varena#13's to make possible.

---
Slice 3a of the pgw#1645 lane. Slice 1 merged as #1189. Slice 2 (the one-producer reconciliation) is tensorfs#158 + tcg#87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)