### PR TITLE
pgw#1645 (3b/4): the rung vocabulary claimed a wire contract that does not exist, and the decline named the wrong door

### DIFF
--- a/changelog.d/pgw1645-rung-honesty.md
+++ b/changelog.d/pgw1645-rung-honesty.md
@@ -1,0 +1,24 @@
+- **pgw#1645: the layout-rung vocabulary stopped claiming a wire contract that does not
+  exist.** `LayoutState`'s docstring said "the hub groups activity rows on them", copied
+  from `EagerPhase`, where it is true. Traced: the rungs reach `ServeAdoption.facts()` →
+  `worker.mint_facts()` → a `logger.debug` call, and no hub query groups on them. The
+  spellings are still worth freezing — they are cheap to fix now and unfixable once a query
+  does exist — but the docstring says INTENDED, and says plainly that nothing consumes them
+  yet. Found by auditing the merged change rather than by a test, which is the only way this
+  class of defect is ever found.
+
+- **pgw#1645: the decline names the lanes that are actually building a fill client.** It
+  named varena#13, filed hours earlier on the belief that a varena-side `FillSink` was the
+  only route to a Python-reachable fill. tensorfs#159 and pgw#1648 were already building
+  one over a raw destination address, and the coordinator has since ruled that form
+  sufficient for tensorfs#154's acceptance (b), re-classifying varena#13 to non-gating
+  mechanism-hardening. The verdict was right; the reason was pointing at the wrong door.
+
+- **pgw#1645: `fill_path()` now says out loud that it is aimed at the wrong surface.** It
+  probes the vendored tensorfs for a `fill` attribute; the real client is
+  `serving.streaming.fill_client.client_for` over the native `CudaFillClient`, and this
+  probe could never go true regardless, because that class lives in the COMPILED extension
+  and the vendored tensorfs deliberately carries none (pgw#1310). It is left aimed here and
+  labelled rather than pointed at a module that does not exist yet: the verdict it produces
+  is correct either way — there is no fill in reach — and a probe that lies about which
+  absence it found is worse than one that names its own aim.

--- a/src/gen_worker/serving/layout_rung.py
+++ b/src/gen_worker/serving/layout_rung.py
@@ -50,8 +50,9 @@ __all__ = [
 #:
 #: WHAT REPLACES THIS, and it is not a guess: `FillStats::runs_per_element` is
 #: the number, computed by the one implementation that folds the runs. The
-#: moment the fill path is reachable from Python (varena#13) this constant dies
-#: and the decision is read from the stats of the fill that would be performed.
+#: moment the fill path is reachable from Python (tensorfs#159 / pgw#1648) this
+#: constant dies and the decision is read from the stats of the fill that would
+#: be performed.
 #: gen-worker deliberately does NOT compute a run count of its own -- that would
 #: be a second implementation of the fold, which is the defect this whole
 #: program keeps removing.
@@ -66,9 +67,13 @@ PER_ELEMENT_DECLINE = (
 class LayoutState(StrEnum):
     """Where a serving artifact sits against the layout it wished for.
 
-    The values are a wire contract in the same way `EagerPhase`'s are: the hub
-    groups activity rows on them, so a member may be added and must not be
-    renamed.
+    The values are INTENDED as a wire contract in the same way `EagerPhase`'s
+    are -- a member may be added, and renaming one would orphan history the day
+    something joins to them. **Nothing consumes them yet**, and saying otherwise
+    would be a claim about a contract that does not exist: today the rungs reach
+    `ServeAdoption.facts()` -> `worker.mint_facts()` -> a `logger.debug` call,
+    and no hub query groups on them. Freeze the spellings anyway -- they are
+    cheap to fix now and unfixable once a query does.
     """
 
     #: The mint asked for no layout change. This artifact IS at its ideal.
@@ -189,14 +194,25 @@ def fill_path() -> Any:
     A PROBE of what is installed, not a flag: the transform has exactly one
     implementation (`tensorfs_core::fill`, one plan, two backends behind the
     `FillSink` trait), and a worker either has it in reach or it does not.
-    Today it does not -- `tensorfs-py` exports no `fill` and varena implements
-    no sink (varena#13) -- so every non-identity arrangement is declined for
-    the plainest possible reason: nothing in this process can apply one.
+    Today it does not, so every non-identity arrangement is declined for the
+    plainest possible reason: nothing in this process can apply one.
 
-    The day varena#13 lands, this returns a callable and the decline moves from
-    "there is no fill" to the per-arrangement judgement
+    **THIS PROBE IS AIMED AT THE WRONG SURFACE AND IS OWED A REPOINT** (pgw#1648).
+    It asks the vendored tensorfs for a `fill` attribute. The real client is
+    `serving.streaming.fill_client.client_for` over tensorfs' native
+    `CudaFillClient` / `HostFillClient` (tensorfs#159) -- and this probe could
+    never go true anyway, because those live in the COMPILED extension and the
+    vendored tensorfs deliberately carries none (pgw#1310, which is why
+    `tensors.py` has a pure-Python `_MappedObject`). It is left aimed here, and
+    said out loud, rather than pointed at a module that does not exist on this
+    branch: the VERDICT it produces is correct today either way -- there is no
+    fill in reach -- and a probe that lies about which absence it found is
+    worse than one that names its own aim.
+
+    Once `fill_client` lands, this returns that client and the decline moves
+    from "there is no fill" to the per-arrangement judgement
     :data:`PER_ELEMENT_DECLINE` describes, priced by the fill's own
-    `runs_per_element`. Neither reason is ever a silent drop.
+    `runs_per_element` rather than by anything computed here.
     """
 
     try:
@@ -212,10 +228,10 @@ def _delivery(handle: str) -> str:
     if fill_path() is None:
         return (
             f"no layout-applying fill is reachable from this process, so "
-            f"{handle!r} cannot be delivered to VRAM at all (varena#13: "
-            f"tensorfs owns the plan and the transform, varena implements the "
-            f"sink over a reservation, and neither is exposed to Python yet). "
-            f"{PER_ELEMENT_DECLINE}"
+            f"{handle!r} cannot be delivered to VRAM at all (pgw#1648 + "
+            f"tensorfs#159: tensorfs owns the plan and the transform and is "
+            f"being bound to Python as a fill client; varena hands it the "
+            f"destination address). {PER_ELEMENT_DECLINE}"
         )
     return ""
 

--- a/tests/test_layout_rung_pgw1645.py
+++ b/tests/test_layout_rung_pgw1645.py
@@ -4,9 +4,9 @@ Every arm reads the rung off ARTIFACT METADATA, which is where both facts
 actually live (`declared_input_layout` and `layout_wishlist`, tcg#83), and
 never off a caller's belief about the artifact. The deliverability arms move
 the one real source of truth there is today: whether a layout-applying fill is
-REACHABLE FROM THIS PROCESS. It is not (varena#13), so the decline arm is what
-production takes; installing the capability is what makes EARNING reachable,
-and that is the same branch production will take the day varena#13 lands.
+REACHABLE FROM THIS PROCESS. It is not, so the decline arm is what production
+takes; installing the capability is what makes EARNING reachable, and that is
+the same branch production will take the day pgw#1648's fill client lands.
 """
 
 from __future__ import annotations
@@ -41,9 +41,9 @@ def fill_installed(monkeypatch: pytest.MonkeyPatch) -> None:
     """Put a layout-applying fill in this process's reach.
 
     Moves the SOURCE the probe reads -- the vendored tensorfs module's own
-    surface -- rather than handing the predicate an argument. varena#13 makes
-    this attribute real; until then this is the only way the EARNING branch can
-    be reached, and it must be reachable or the vocabulary carries a member
+    surface -- rather than handing the predicate an argument. pgw#1648's fill
+    client makes a real one; until then this is the only way the EARNING branch
+    can be reached, and it must be reachable or the vocabulary carries a member
     nothing can produce.
     """
 
@@ -119,11 +119,11 @@ def test_two_ratified_wishes_are_NO_SINGLE_IDEAL_not_a_coin_flip() -> None:
 
 
 def test_with_no_fill_in_reach_a_ratified_wish_is_a_TYPED_DECLINE() -> None:
-    """What production does TODAY, and it must not be silent. `tensorfs-py`
-    exports no `fill` and varena implements no sink, so the arrangement cannot
-    be delivered to VRAM at all -- and the confession says exactly that, names
-    varena#13, and carries the tensorfs#157 measurement that will price the
-    decision once a fill exists."""
+    """What production does TODAY, and it must not be silent. No fill client is
+    reachable from a worker process, so the arrangement cannot be delivered to
+    VRAM at all -- and the confession says exactly that, names the lanes
+    building one (pgw#1648 / tensorfs#159), and carries the tensorfs#157
+    measurement that will price the decision once one exists."""
 
     assert rung_mod.fill_path() is None, "a fill became reachable; retire this arm"
     rung = read_rung(
@@ -132,7 +132,7 @@ def test_with_no_fill_in_reach_a_ratified_wish_is_a_TYPED_DECLINE() -> None:
     assert rung.state is LayoutState.DECLINED
     assert rung.ideal == CHANNELS_LAST
     assert rung.settled and not rung.earning
-    assert "varena#13" in rung.detail
+    assert "pgw#1648" in rung.detail and "tensorfs#159" in rung.detail
     assert "tensorfs#157" in rung.detail
     # A decline is a SETTLED position with a stated cause. Reading it as
     # pending would make a permanent state look like a stuck mint queue.


### PR DESCRIPTION
Three corrections to code this lane merged four hours ago, all found by
AUDITING THE MERGED CHANGE rather than by a test — which is the only way this
class of defect is ever found, because every one of them is a true-sounding
sentence with nothing behind it.

1. `LayoutState`'s docstring said "the hub groups activity rows on them",
   copied from `EagerPhase`, where it IS true. Traced on this branch:
   `ServeAdoption.facts()` -> `worker.mint_facts()` -> `worker.py`'s
   `logger.debug`, and no hub query groups on these values. The spellings are
   still worth freezing — cheap to fix now, unfixable once a query exists — so
   the docstring says INTENDED, and says plainly that nothing consumes them
   yet.

2. The decline named `varena#13`, filed hours earlier on the belief that a
   varena-side `FillSink` was the only route to a Python-reachable fill.
   tensorfs#159 and pgw#1648 were already building one over a raw destination
   ADDRESS, and the coordinator has since ruled that form sufficient for
   tensorfs#154's acceptance (b) — `Reservation.base_ptr` IS varena handing
   tensorfs a destination pointer — re-classifying varena#13 to non-gating
   mechanism-hardening. The VERDICT was right and stays; the REASON was
   pointing at the wrong door. It now names pgw#1648 + tensorfs#159.

3. `fill_path()` now says out loud that it is aimed at the wrong surface. It
   probes the vendored tensorfs for a `fill` attribute; the real client is
   `serving.streaming.fill_client.client_for` over the native
   `CudaFillClient`, and this probe could never go true regardless, because
   that class lives in the COMPILED extension and the vendored tensorfs
   deliberately carries none (pgw#1310 — which is why `tensors.py` has a
   pure-Python `_MappedObject` rewrite).

   It is left AIMED HERE AND LABELLED rather than repointed at a module that
   does not exist on this branch. The verdict is correct either way — there is
   no fill in reach — and a probe that lies about which absence it found is
   worse than one that names its own aim. pgw#1648's tracker entry carries the
   repoint, and asks that lane not to add a `fill` attribute to the vendored
   tree to satisfy this.

Tests: 10 green, and the changed assertion FALSIFIED by moving the source
rather than the path — breaking the reason string in `layout_rung.py` turns
`test_with_no_fill_in_reach_a_ratified_wish_is_a_TYPED_DECLINE` red, and
restoring it turns it green. Worth recording why that check was run: an earlier
attempt to falsify by pointing PYTHONPATH at the pre-change checkout PASSED,
because pytest resolves `gen_worker` from the worktree regardless of
PYTHONPATH. A falsification that cannot fail proves nothing.

ruff + mypy clean. No behaviour changes: docstrings, one refusal string, and
the assertions that read it.

---
Docstrings, one refusal string, and the assertions that read it — no behaviour change. Coordinator-approved correction to pgw#1190, which merged four hours ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)