### PR TITLE
pgw#1655: compile subjecthood is READ TOTALLY — a delegated mark is a mark, an unfollowable one is refused at the declaration

### DIFF
--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -377,6 +377,15 @@ def _subject_classes(module: ModuleType) -> tuple[type, ...]:
     read off the MARK (pgw#1597/#1599: "compilation participation is the
     MARK"), so with no mark anywhere there is nothing to distinguish a release
     subject from an auxiliary model another slot drives.
+
+    That refusal is only sound because the mark is read TOTALLY (pgw#1655).
+    ``model_marks_compile`` used to answer ``False`` for "does not compile"
+    and for "cannot see it" alike, so a DELEGATED mark
+    (``engine.compile_dit(ctx.compile)``) read as auxiliary — minimax-h3 fell
+    into the refusal below while both its lanes declared correctly, and
+    wan-2.2's two MoE classes were dropped from the subject set without a
+    word. An unreadable mark is now a refusal at the class DECLARATION, so
+    every class that reaches this gate has an answer that was stated.
     """
 
     marked, unmarked = _module_model_classes(module)
@@ -388,8 +397,12 @@ def _subject_classes(module: ModuleType) -> tuple[type, ...]:
             f"({[cls.__name__ for cls in unmarked]!r}) and NONE of them marks "
             f"a compile target, so which one the release is ABOUT cannot be "
             f"read. A release derives every COMPILE-MARKING class (pgw#1650), "
-            f"and there are none here. Mark each compiled one via "
-            f"`ctx.compile()` in its `load()`; an auxiliary model that another "
+            f"and there are none here. The mark is read TOTALLY (pgw#1655) — "
+            f"a mark HANDED ON, `engine.compile_dit(ctx.compile)`, counts as "
+            f"much as one called in place, and a `load()` that hides the "
+            f"context is refused at its own declaration — so this is a real "
+            f"absence, not an unreadable one. Mark each compiled class via "
+            f"`ctx.compile` in its `load()`; an auxiliary model that another "
             f"slot drives marks nothing and is then unambiguous."
         )
     return tuple(unmarked)

--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -5,6 +5,7 @@ import inspect
 import textwrap
 import typing
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
 from .lane_spec import (
@@ -104,38 +105,147 @@ def lane_dtype(lane: Any, *, where: str) -> str:
         raise ModelDeclarationError(f"{where}: {exc}") from exc
 
 
-def _calls_ctx_compile(fn: Any) -> bool:
+MARKED = "marked"
+UNMARKED = "unmarked"
+UNREADABLE = "unreadable"
 
+
+@dataclass(frozen=True)
+class CompileMark:
+    """One TOTAL read of a ``load``'s compile subjecthood — never a guess.
+
+    ``state`` is :data:`MARKED`, :data:`UNMARKED` or :data:`UNREADABLE`.
+    ``lineno``/``spelling`` carry the site that decided it, so a refusal can
+    name the line instead of the class.
+    """
+
+    state: str
+    lineno: int = 0
+    spelling: str = ""
+
+    @property
+    def marked(self) -> bool:
+        return self.state == MARKED
+
+
+def _enclosing_statement(definition: Any, target: Any) -> str:
+    """The smallest statement holding ``target``, re-rendered for a refusal."""
+
+    parents: dict[int, Any] = {}
+    for parent in ast.walk(definition):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+    node = target
+    while node is not None and not isinstance(node, ast.stmt):
+        node = parents.get(id(node))
+    if node is None:
+        return ""
+    rendered = ast.unparse(node).splitlines()[0]
+    return rendered if len(rendered) <= 120 else rendered[:117] + "..."
+
+
+def load_compile_mark(definition: Any) -> CompileMark:
+    """Read one ``load`` DEFINITION's compile subjecthood, TOTALLY (pgw#1655).
+
+    ONE PRODUCER, and it is the ``ctx.compile`` NAME in ``load()``. Naming it
+    is the mark whether it is called here (``ctx.compile(self.unet)``) or
+    handed to the component that owns the partition
+    (``engine.compile_dit(ctx.compile)``) — se#827's design, where the engine
+    and not the model knows which DiT partition is called. Never naming it,
+    and never handing the CONTEXT itself away, is :data:`UNMARKED`: the absent
+    mark IS the eager declaration (Paul, 2026-08-20), and there is no keyword.
+
+    Handing ``ctx`` ITSELF to something this reader cannot follow —
+    ``helper(ctx)``, ``getattr(ctx, "compile")``, a rebinding — is
+    :data:`UNREADABLE`. That answer is STATED at the declaration
+    (:meth:`Model.__init_subclass__` refuses it) rather than reported as
+    "does not compile".
+
+    pgw#1655: the reader this replaces answered ``False`` for both of the
+    last two states. That was safe while every consumer was permissive and
+    became a REFUSAL the day pgw#1650 gave it gate weight — minimax-h3, whose
+    only mark is delegated, could not derive at all, and wan-2.2's two MoE
+    classes were silently dropped from the subject set. "Cannot tell" is not
+    "does not", and it is never answered by guessing.
+    """
+
+    if not isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return CompileMark(UNMARKED)
+    names = {argument.arg for argument in definition.args.args[1:2]}
+    if not names:
+        return CompileMark(UNMARKED)
+    borne: set[int] = set()
+    for node in ast.walk(definition):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in names
+        ):
+            borne.add(id(node.value))
+            if node.attr == "compile":
+                return CompileMark(
+                    MARKED, node.lineno, f"{node.value.id}.compile"
+                )
+    for node in ast.walk(definition):
+        if (
+            isinstance(node, ast.Name)
+            and node.id in names
+            and isinstance(node.ctx, ast.Load)
+            and id(node) not in borne
+        ):
+            return CompileMark(
+                UNREADABLE, node.lineno, _enclosing_statement(definition, node)
+            )
+    return CompileMark(UNMARKED)
+
+
+def _read_load(fn: Any) -> CompileMark:
+    """:func:`load_compile_mark` over a LIVE ``load``, via its own source."""
+
+    if fn is None:
+        return CompileMark(UNMARKED)
     try:
         source = textwrap.dedent(inspect.getsource(fn))
     except (OSError, TypeError):
-        return False
+        return CompileMark(UNREADABLE, 0, "its source is not on disk to read")
     try:
         tree = ast.parse(source)
     except SyntaxError:  # pragma: no cover - dedent of a nested def
-        return False
+        return CompileMark(UNREADABLE, 0, "its source does not parse alone")
     definition = tree.body[0] if tree.body else None
-    if not isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        return False
-    return load_marks_compile(definition)
+    return load_compile_mark(definition)
 
 
-def load_marks_compile(definition: Any) -> bool:
-    """Whether this ``load`` DEFINITION marks a compile target — the AST half of :func:`_calls_ctx_compile`, taking the parsed node instead of a live function."""
+def _class_compile_mark(cls: type) -> CompileMark:
+    """A class's compile mark: its own ``load``, else the one it inherits."""
 
-    if not isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        return False
-    names = {argument.arg for argument in definition.args.args[1:2]}
-    for node in ast.walk(definition):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "compile"
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id in names
-        ):
-            return True
-    return False
+    for owner in cls.__mro__:
+        definition = owner.__dict__.get("load")
+        if definition is None:
+            continue
+        mark = _read_load(definition)
+        if mark.state != UNMARKED:
+            return mark
+    return CompileMark(UNMARKED)
+
+
+def _refuse_unreadable_mark(cls: type, mark: CompileMark) -> None:
+    """State the one answer the platform cannot read, at the site that owns it."""
+
+    where = f" (line {mark.lineno}: `{mark.spelling}`)" if mark.lineno else ""
+    raise ModelDeclarationError(
+        f"{cls.__qualname__}: `load()` hands the LOAD CONTEXT itself "
+        f"away{where}, so whether this class marks a compile target cannot "
+        f"be read — and it is not guessed. Compile subjecthood decides "
+        f"whether the release DERIVES this class (pgw#1650) and whether "
+        f"`shapes=` is required, so an unreadable mark is a refusal here "
+        f"rather than a wrong answer there (pgw#1655). Hand the MARK, never "
+        f"the context: `helper(ctx.compile, ...)` and call it inside — that "
+        f"is se#827's shape, `engine.compile_dit(ctx.compile)`, and it keeps "
+        f"partition ownership with the component while leaving the "
+        f"declaration readable. Marking nothing is also readable: name "
+        f"neither `ctx.compile` nor bare `ctx`."
+    )
 
 
 def _parse_lanes(
@@ -343,7 +453,8 @@ class Model(Generic[MT]):
     any ctx.compile() invocations in your model's 'load' method."*
     ``eager_only=`` is DELETED; the presence or absence of a ``ctx.compile``
     mark in ``load()`` is the entire statement, and it is statically readable
-    by AST (:func:`load_marks_compile`) with no author code executed.
+    by AST (:func:`load_compile_mark`) with no author code executed, and
+    a mark this reader cannot see is a REFUSAL rather than a silent "no".
 
     **THE AUTHOR DECLARES ONLY WHAT ONLY THE AUTHOR KNOWS.** Demand SCALING,
     fork AXES, "my VAE decode will thrash if streamed". The platform derives
@@ -420,7 +531,15 @@ class Model(Generic[MT]):
             cls.__cozy_model_type__ = declared_type
 
         concrete = getattr(cls, MODEL_TYPE_ATTR, None) is not None
-        marks_compile = _calls_ctx_compile(cls.__dict__.get("load"))
+        # pgw#1655: ONE read of compile subjecthood, and it is TOTAL. The
+        # `shapes=` requirement below and pgw#1650's subject gate in
+        # `release/derive.py` are the same fact asked twice — an unreadable
+        # mark is refused HERE, where the author can make it readable,
+        # instead of being answered "no" at both call sites.
+        mark = _class_compile_mark(cls)
+        if mark.state == UNREADABLE:
+            _refuse_unreadable_mark(cls, mark)
+        marks_compile = mark.marked
 
         if lanes is not None:
             declared_lanes = _parse_lanes(cls, lanes)
@@ -532,14 +651,16 @@ def model_requires(cls: type) -> dict[str, Any]:
 
 
 def model_marks_compile(cls: type) -> bool:
-    """Whether this class's own ``load()`` marks a compile target."""
+    """Whether this class marks a compile target — a FACT, not a guess.
+
+    The answer is a bool and not a tri-state because the third state cannot
+    reach here: a class whose mark is unreadable is refused at its own
+    definition (:func:`_refuse_unreadable_mark`), so every class that EXISTS
+    has a readable one. That is what makes this safe to gate on (pgw#1655).
+    """
 
     model_type(cls)
-    return _calls_ctx_compile(cls.__dict__.get("load")) or any(
-        _calls_ctx_compile(base.__dict__.get("load"))
-        for base in cls.__mro__[1:]
-        if "load" in base.__dict__
-    )
+    return _class_compile_mark(cls).marked
 
 
 _DELETED_KWARGS: dict[str, str] = {
@@ -568,6 +689,7 @@ _DELETED_KWARGS: dict[str, str] = {
 
 
 __all__ = [
+    "CompileMark",
     "DECLARED_LANES_ATTR",
     "DYNAMIC",
     "LANES_ATTR",
@@ -584,7 +706,7 @@ __all__ = [
     "lane_dtype",
     "lane_handle",
     "lane_requirements",
-    "load_marks_compile",
+    "load_compile_mark",
     "model_declared_lanes",
     "model_lane_spec",
     "model_lanes",

--- a/tests/release_fixtures/delegated_mark_endpoint.py
+++ b/tests/release_fixtures/delegated_mark_endpoint.py
@@ -1,0 +1,92 @@
+"""minimax-h3's SHAPE, in miniature — pgw#1655.
+
+TWO model classes in one module. One compiles, and its mark is DELEGATED: the
+ENGINE owns the partition (se#827 — the engine, not the model, knows which DiT
+this checkpoint carries), so `load()` hands `ctx.compile` on rather than calling
+it in place. The other is an auxiliary model another slot drives and marks
+nothing.
+
+Before pgw#1655 the AST reader could not see the delegated mark, so BOTH classes
+read as unmarked and pgw#1650's subject gate refused the whole release:
+
+    error: derive: module '...' has more than one model class
+    (['AuxModel', 'EngineDrivenModel']) and NONE of them marks a compile target
+
+The mark did not change; the reader's weight did. This fixture is that refusal's
+red arm.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import STATIC, LoadContext, Model, RequestContext, entrypoint, lane
+from gen_worker.demand import MiB, const
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+class Engine:
+    """Owns the partition, so it applies the mark — and takes the MARK."""
+
+    def __init__(self, pipeline: Any) -> None:
+        self.pipeline = pipeline
+
+    def compile_dit(self, mark: Any) -> None:
+        for name in ("unet", "unet_ref"):
+            module = getattr(self.pipeline, name, None)
+            if module is not None:
+                setattr(self.pipeline, name, mark(module))
+                return
+
+
+class EngineDrivenModel(
+    Model[SDXL],
+    lanes={TINY_DIFFUSERS_FP32: lane(request=const(MiB(64)))},
+    shapes={"aspect": STATIC},
+):
+    engine: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.engine = Engine(ctx.load(StableDiffusionPipeline))
+        self.engine.compile_dit(ctx.compile)
+
+
+class AuxModel(
+    Model[SDXL],
+    lanes={TINY_DIFFUSERS_FP32: lane(request=const(MiB(32)))},
+):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+
+
+@entrypoint
+def generate(
+    ctx: RequestContext, payload: In, model: EngineDrivenModel, aux: AuxModel
+) -> Out:
+    ctx.raise_if_cancelled()
+    with torch.inference_mode():
+        model.engine.pipeline(
+            prompt=payload.prompt,
+            num_inference_steps=2,
+            guidance_scale=0.0,
+            width=32,
+            height=32,
+            callback_on_step_end=ctx.step_callback(2),
+            output_type="latent",
+        )
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/release_fixtures/engine_wrapper_endpoint.py
+++ b/tests/release_fixtures/engine_wrapper_endpoint.py
@@ -6,7 +6,7 @@ import msgspec
 import torch
 from diffusers import StableDiffusionPipeline
 
-from gen_worker import LoadContext, Model, RequestContext, entrypoint, lane
+from gen_worker import STATIC, LoadContext, Model, RequestContext, entrypoint, lane
 from gen_worker.demand import MiB, const, per_mp_batch
 from gen_worker.models import SDXL
 from lane_contracts import TINY_DIFFUSERS_FP32
@@ -28,11 +28,14 @@ class Engine:
         self.pipeline = pipeline
         self.step_cache: dict[str, Any] = {}
 
-    def compile_dit(self, ctx: Any) -> None:
+    def compile_dit(self, mark: Any) -> None:
+        # se#827/pgw#1655: the ENGINE owns the partition, so the engine applies
+        # the mark -- and it takes the MARK, never the load context, so the
+        # class's compile subjecthood stays readable at its declaration.
         for name in ("unet", "unet_ref"):
             module = getattr(self.pipeline, name, None)
             if module is not None:
-                setattr(self.pipeline, name, ctx.compile(module))
+                setattr(self.pipeline, name, mark(module))
                 return
 
 
@@ -41,12 +44,13 @@ class EngineModel(
     lanes={TINY_DIFFUSERS_FP32: lane(
         request=const(MiB(64)) + per_mp_batch(MiB(16)),
     )},
+    shapes={"aspect": STATIC},
 ):
     engine: Any
 
     def load(self, ctx: LoadContext[SDXL]) -> None:
         self.engine = Engine(self, ctx.load(StableDiffusionPipeline))
-        self.engine.compile_dit(ctx)
+        self.engine.compile_dit(ctx.compile)
 
 
 @entrypoint

--- a/tests/release_fixtures/hidden_mark_endpoint.py
+++ b/tests/release_fixtures/hidden_mark_endpoint.py
@@ -1,0 +1,50 @@
+"""wan-2.2's SHAPE — the mark exists and the reader CANNOT follow it (pgw#1655).
+
+`load()` hands the LOAD CONTEXT ITSELF to a helper, so no reader that does not
+execute author code can say whether this class compiles. Before pgw#1655 that
+"cannot tell" was answered `False`: wan-2.2's two MoE classes were dropped from
+the subject set silently, and a module whose only marks were this shape refused
+outright. It is now STATED at the class declaration, so the module does not
+import until the author hands the MARK instead of the context.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import LoadContext, Model, RequestContext, entrypoint, lane
+from gen_worker.demand import MiB, const
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+def _mark_moe_targets(ctx: Any, pipeline: Any) -> None:
+    pipeline.unet = ctx.compile(pipeline.unet)
+
+
+class HiddenMarkModel(
+    Model[SDXL],
+    lanes={TINY_DIFFUSERS_FP32: lane(request=const(MiB(64)))},
+):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        _mark_moe_targets(ctx, self.pipe)
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In, model: HiddenMarkModel) -> Out:
+    ctx.raise_if_cancelled()
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_endpoint_lock_gate.py
+++ b/tests/test_endpoint_lock_gate.py
@@ -175,6 +175,56 @@ def test_check_refuses_when_there_is_no_lock_to_check(
     assert _lock(endpoint, checkpoint, tmp_path / "graph-cas", "--check")[0] == 2
 
 
+#: A second model class, no mark on either — pgw#1650's surviving refusal, the
+#: cheapest derive REFUSAL this fixture can produce.
+_SECOND_CLASS = '''
+
+class OtherModel(
+    Model[Unlaned],
+    lanes={SDXL_BF16: lane(request=const(GiB(1)))},
+    self_loading="the second class that makes the subject unreadable",
+):
+    def load(self, ctx: LoadContext[Unlaned]) -> None:
+        self.ready = True
+'''
+
+
+def test_a_derive_refusal_exits_NONZERO_and_writes_nothing(
+    endpoint: Path, checkpoint: Path, tmp_path: Path
+) -> None:
+    """se#838 reported `lock` exiting 0 on a refusal. It must never.
+
+    A lock-regeneration loop reads the exit status, so a refusal that exits 0
+    reports a clean sweep having changed nothing. Both arms are asserted here
+    — refusal nonzero AND success zero — because a status that is always
+    nonzero is no more useful than one that is always zero.
+    """
+
+    graph_cas = tmp_path / "graph-cas"
+    lock = endpoint / "endpoint.lock"
+
+    assert _lock(endpoint, checkpoint, graph_cas)[0] == 0
+    assert lock.is_file()
+    good = lock.read_bytes()
+
+    source = endpoint / "src" / "lockcheck_fixture" / "main.py"
+    source.write_text(
+        source.read_text(encoding="utf-8") + _SECOND_CLASS, encoding="utf-8"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "gen_worker.cli", "lock", str(endpoint),
+         "--checkpoint", str(checkpoint), "--graph-cas", str(graph_cas),
+         "--force"],
+        capture_output=True, text=True, check=False,
+    )
+    assert completed.returncode != 0, completed.stderr
+    assert "has more than one model class" in completed.stderr
+    # Nothing was written, and the previous good lock is untouched.
+    assert lock.read_bytes() == good
+    assert completed.stdout.strip() == ""
+
+
 def _safetensors(path: Path, dtypes: dict[str, int]) -> None:
 
     import struct

--- a/tests/test_model_authoring.py
+++ b/tests/test_model_authoring.py
@@ -141,6 +141,12 @@ def _engine_marks(ctx: Any) -> None:
     ctx.compile(object())
 
 
+def _engine_marks_with(mark: Any) -> None:
+    """se#827's shape: the component that OWNS the partition applies the mark."""
+
+    mark(object())
+
+
 def _lane() -> Any:
 
     return lane(request=const(GiB(1)))
@@ -316,16 +322,52 @@ def test_model_header_declarations_and_refusals() -> None:
 
     assert model_shapes(DynamicAspect) == {"aspect": DYNAMIC}
 
+    # pgw#1655. A mark HANDED ON is a mark: the component that owns the
+    # partition applies it (se#827), and the declaration stays readable
+    # because `ctx.compile` is still NAMED in `load()`. This assertion was
+    # `is False` until pgw#1655, and that False is what refused minimax-h3.
     class DelegatedMark(
         Model[SDXL],
         lanes={_sdxl_contract(): _lane()},
         shapes={"aspect": STATIC},
     ):
         def load(self, ctx: object) -> None:
-            _engine_marks(ctx)
+            _engine_marks_with(ctx.compile)  # type: ignore[attr-defined]
 
-    assert model_marks_compile(DelegatedMark) is False
+    assert model_marks_compile(DelegatedMark) is True
     assert model_shapes(DelegatedMark) == {"aspect": STATIC}
+
+    # A delegated mark also carries the `shapes=` requirement with it — the
+    # same one fact, asked by the other consumer.
+    with pytest.raises(LaneDeclarationError, match="shapes= is REQUIRED"):
+        class DelegatedNoShapes(Model[SDXL], lanes={_sdxl_contract(): _lane()}):
+            def load(self, ctx: object) -> None:
+                _engine_marks_with(ctx.compile)  # type: ignore[attr-defined]
+
+    # Handing the CONTEXT away is the one thing the reader cannot follow, and
+    # it is STATED here rather than answered "does not compile" at the gate.
+    with pytest.raises(ModelDeclarationError, match="hands the LOAD CONTEXT"):
+        class HiddenMark(
+            Model[SDXL],
+            lanes={_sdxl_contract(): _lane()},
+            shapes={"aspect": STATIC},
+        ):
+            def load(self, ctx: object) -> None:
+                _engine_marks(ctx)
+
+    # The refusal names the LINE, not just the class.
+    with pytest.raises(ModelDeclarationError, match="_engine_marks\\(ctx\\)"):
+        class HiddenMarkAgain(Model[SDXL], lanes={_sdxl_contract(): _lane()}):
+            def load(self, ctx: object) -> None:
+                _engine_marks(ctx)
+
+    # An eager class that never names `ctx` at all stays readable and unmarked
+    # — the absent mark IS the declaration, and it needs no keyword.
+    class EagerReadable(Model[SDXL], lanes={_sdxl_contract(): _lane()}):
+        def load(self, ctx: object) -> None:
+            self.pipe = object()
+
+    assert model_marks_compile(EagerReadable) is False
 
     with pytest.raises(LaneDeclarationError, match="at least TWO variant"):
         class OneVariant(

--- a/tests/test_release_derive_multi_class.py
+++ b/tests/test_release_derive_multi_class.py
@@ -157,6 +157,50 @@ def test_two_classes_and_no_compile_mark_still_refuses(
     assert not out.exists()
 
 
+def test_a_delegated_mark_is_a_mark_and_names_its_class_the_subject(
+    primary_tree: Path, tmp_path: Path
+) -> None:
+    """pgw#1655 — minimax-h3's shape: two classes, one DELEGATED mark.
+
+    RED ARM: before pgw#1655 this derive died in
+    `test_two_classes_and_no_compile_mark_still_refuses`'s refusal, because
+    `engine.compile_dit(ctx.compile)` was invisible to the reader pgw#1650
+    gates on. h3 was refused with 14 real graphs already in its committed lock.
+    """
+
+    out = tmp_path / "release.json"
+    assert _derive("delegated_mark_endpoint", primary_tree, out) == 0
+    document = json.loads(out.read_bytes())
+
+    # The delegated mark makes ONE class the subject, and the auxiliary class
+    # another slot drives is not one — exactly as a literal mark would.
+    assert [row["class"] for row in document["classes"]] == ["EngineDrivenModel"]
+    assert document["endpoint"].endswith(":EngineDrivenModel")
+
+    (lane,) = document["graphs"]["lanes"]
+    assert lane["contract"] == LANE
+    assert {record["target"] for record in lane["graphs"]} == {"unet"}
+    assert lane["unobserved_targets"] == []
+
+
+def test_a_mark_the_reader_cannot_follow_is_refused_at_the_declaration(
+    primary_tree: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """pgw#1655 — wan-2.2's shape: `load()` hands the CONTEXT away.
+
+    Not answerable without executing author code, so it is STATED where the
+    author can fix it instead of being reported as "does not compile" at the
+    gate. The refusal names the line.
+    """
+
+    out = tmp_path / "release.json"
+    assert _derive("hidden_mark_endpoint", primary_tree, out) == 1
+    stderr = capsys.readouterr().err
+    assert "hands the LOAD CONTEXT" in stderr
+    assert "_mark_moe_targets(ctx, self.pipe)" in stderr
+    assert not out.exists()
+
+
 def test_a_checkpoint_tree_nothing_loads_from_is_a_typo(
     primary_tree: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
Closes the P1 regression filed as pgw#1655 by the se#816 lane, measured on the live endpoint.

## The defect

`model_marks_compile` answered `False` for two different facts — "does not compile" and "cannot see whether it does". That was safe while every consumer was permissive (pgw#1599 built `parse_shapes` to PERMIT `shapes=` wherever a mark is not provable, for exactly this reason). pgw#1650 gave the same reader GATE weight, and "cannot tell" became a refusal:

```
error: derive: module 'minimax_h3.main' has more than one model class
(['H3Model', 'RifeModel']) and NONE of them marks a compile target
```

`H3Model` does mark one — `main.py:340` is `self.engine.compile_dit(ctx.compile)`, se#827's partition-ownership design. The reader did not change; the weight on it did.

## The fix

Subjecthood is a TOTAL read of `load()` with ONE producer, the `ctx.compile` NAME:

| spelling | read |
|---|---|
| `ctx.compile(self.unet)` | MARKED |
| `engine.compile_dit(ctx.compile)` | MARKED — same declaration, handed on |
| `ctx` never named bare, `ctx.compile` never named | UNMARKED — the absent mark IS the eager declaration |
| `helper(ctx)` / `getattr(ctx, "compile")` | **UNREADABLE → typed refusal at the class declaration, naming the line** |

"Cannot tell" is now STATABLE at the site that can fix it and can never reach a gate as a silent `False`. No new keyword — `eager_only=` stays deleted and no `subject=` is born (Paul: *"compilation participation is the MARK"*). Because an unreadable mark cannot be DEFINED, `model_marks_compile` stays a bool and is now a fact, which is what makes both its consumers (pgw#1650's subject gate and the `shapes=` requirement) sound.

## Measured across the whole fleet — 31 model classes in serverless-endpoints

- **1 delegated mark that was invisible**: minimax-h3 `H3Model`.
- **2 marks the reader cannot follow**: wan-2.2 `WanT2VModel`/`WanI2VModel` (`_mark_moe_compile_targets(ctx, self.pipeline)`). These never refused — they were **silently dropped from the subject set**, so wan's release derived 1 of 3 compile-marking classes and said nothing. Worse half of the same defect, closed by the same read.
- sdxl / sd15 / anima and everything else: unchanged, they mark literally.

Companion author-side declarations for h3 and wan: serverless-endpoints branch `838-readable-compile-marks`.

## Red arms — both through the shipped CLI on a real config-only tree

- `delegated_mark_endpoint` (h3's shape: two classes, one delegated mark) — **on master's reader: exit 1 with h3's verbatim refusal**. On this branch: exit 0, one subject, one lane, `unet` traced.
- `hidden_mark_endpoint` (wan's shape) — refused at import, naming `_mark_moe_targets(ctx, self.pipe)`.
- `tests/release_fixtures/engine_wrapper_endpoint.py` was the fixture the old reader was built against; it handed the context away and its model therefore skipped a REQUIRED `shapes=`. It now hands the mark, like h3's real code.

## The exit-status half — NOT REPRODUCED, and now fenced

se#838 reported `gen-worker lock` exiting 0 on a derive refusal. It does **not**. Measured three ways at h3's own pin `d0dcd331` — console script, `uv run`, `python -m gen_worker.cli` — all exit **1**, no lock written. The report is a pipeline exit-status artifact (`… 2>&1 | tail` reads `tail`'s status). `test_a_derive_refusal_exits_NONZERO_and_writes_nothing` asserts **both** arms so it cannot be re-litigated from a shell transcript.