### PR TITLE
pgw#1655 follow-up: a sourceless `load()` is its own refusal — the first one misnamed its cause

### DIFF
--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -199,6 +199,9 @@ def load_compile_mark(definition: Any) -> CompileMark:
     return CompileMark(UNMARKED)
 
 
+SOURCELESS = "sourceless"
+
+
 def _read_load(fn: Any) -> CompileMark:
     """:func:`load_compile_mark` over a LIVE ``load``, via its own source."""
 
@@ -207,11 +210,11 @@ def _read_load(fn: Any) -> CompileMark:
     try:
         source = textwrap.dedent(inspect.getsource(fn))
     except (OSError, TypeError):
-        return CompileMark(UNREADABLE, 0, "its source is not on disk to read")
+        return CompileMark(SOURCELESS)
     try:
         tree = ast.parse(source)
     except SyntaxError:  # pragma: no cover - dedent of a nested def
-        return CompileMark(UNREADABLE, 0, "its source does not parse alone")
+        return CompileMark(SOURCELESS)
     definition = tree.body[0] if tree.body else None
     return load_compile_mark(definition)
 
@@ -230,8 +233,25 @@ def _class_compile_mark(cls: type) -> CompileMark:
 
 
 def _refuse_unreadable_mark(cls: type, mark: CompileMark) -> None:
-    """State the one answer the platform cannot read, at the site that owns it."""
+    """State the one answer the platform cannot read, at the site that owns it.
 
+    TWO causes, and they get DIFFERENT sentences (pgw#1655 follow-up). The
+    first refusal shipped one message for both and told a class whose `load`
+    simply had no file that it "hands the LOAD CONTEXT away", which it did
+    not. A refusal that misnames its cause sends the reader to the wrong line.
+    """
+
+    if mark.state == SOURCELESS:
+        raise ModelDeclarationError(
+            f"{cls.__qualname__}: `load()` has no readable source, so whether "
+            f"this class marks a compile target cannot be read — and it is "
+            f"not guessed (pgw#1655). Every model class an endpoint ships is "
+            f"defined in a module ON DISK, which is the only thing the "
+            f"release derive can import; a class built by `exec()` or "
+            f"`type()` could never be a release subject anyway. Define it in "
+            f"a real module — or, in a test rig, `compile()` the source with "
+            f"a filename and seed `linecache` so the header stays readable."
+        )
     where = f" (line {mark.lineno}: `{mark.spelling}`)" if mark.lineno else ""
     raise ModelDeclarationError(
         f"{cls.__qualname__}: `load()` hands the LOAD CONTEXT itself "
@@ -537,7 +557,7 @@ class Model(Generic[MT]):
         # mark is refused HERE, where the author can make it readable,
         # instead of being answered "no" at both call sites.
         mark = _class_compile_mark(cls)
-        if mark.state == UNREADABLE:
+        if mark.state in (UNREADABLE, SOURCELESS):
             _refuse_unreadable_mark(cls, mark)
         marks_compile = mark.marked
 

--- a/tests/test_endpoint_discovery.py
+++ b/tests/test_endpoint_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import linecache
 import types
 
 import pytest
@@ -164,11 +165,23 @@ def _marked_model(reason="bespoke pipeline.json loader; ctx.load drives neither 
     from gen_worker.serving.model import Model
 
     namespace = {"Model": Model, "Trellis2": Trellis2, "LANES": _TRELLIS_LANES}
-    exec(  # noqa: S102 - the class header IS the thing under test
+    source = (
         "class Marked(Model[Trellis2], lanes=LANES, self_loading=%r):\n"
         "    def load(self, ctx):\n"
-        "        self.pipe = object()\n" % reason,
-        namespace,
+        "        self.pipe = object()\n" % reason
+    )
+    # pgw#1655: the header is READ, so it has to stay readable. `exec` of a
+    # bare string leaves `load` with no source at all — `inspect.getsource`
+    # raises, compile subjecthood cannot be stated, and a class header the
+    # platform cannot read is a refusal, not an eager declaration. Seeding
+    # linecache under a synthetic filename is what a real module gets for
+    # free.
+    filename = "<pgw1655-marked-model>"
+    linecache.cache[filename] = (
+        len(source), None, source.splitlines(keepends=True), filename
+    )
+    exec(  # noqa: S102 - the class header IS the thing under test
+        compile(source, filename, "exec"), namespace
     )
     return namespace["Marked"]
 

--- a/tests/test_model_authoring.py
+++ b/tests/test_model_authoring.py
@@ -369,6 +369,36 @@ def test_model_header_declarations_and_refusals() -> None:
 
     assert model_marks_compile(EagerReadable) is False
 
+    # A `load()` with NO SOURCE AT ALL is its own refusal with its own
+    # sentence. The first pgw#1655 refusal told this class it "hands the LOAD
+    # CONTEXT away" — it does not even name `ctx` — and a refusal that
+    # misnames its cause sends the reader to the wrong line.
+    sourceless = (
+        "class Sourceless(Model[SDXL], lanes=LANES):\n"
+        "    def load(self, ctx):\n"
+        "        self.pipe = object()\n"
+    )
+    with pytest.raises(ModelDeclarationError, match="no readable source"):
+        exec(  # noqa: S102 - a header with no file is the thing under test
+            sourceless,
+            {"Model": Model, "SDXL": SDXL, "LANES": {_sdxl_contract(): _lane()}},
+        )
+
+    # …and the same header IS readable once its source can be found, which is
+    # the falsifier for the arm above: it is the missing SOURCE that refuses,
+    # not the `exec`.
+    import linecache
+
+    where = "<pgw1655-sourceless-falsifier>"
+    linecache.cache[where] = (
+        len(sourceless), None, sourceless.splitlines(keepends=True), where
+    )
+    seen: dict[str, Any] = {
+        "Model": Model, "SDXL": SDXL, "LANES": {_sdxl_contract(): _lane()},
+    }
+    exec(compile(sourceless, where, "exec"), seen)  # noqa: S102
+    assert model_marks_compile(seen["Sourceless"]) is False
+
     with pytest.raises(LaneDeclarationError, match="at least TWO variant"):
         class OneVariant(
             Model[SDXL],


### PR DESCRIPTION
CI's non-required `tests` job on the pgw#1655 merge commit (`0bfb0f87`) came back **1 failed, 2844 passed**: `test_a_marked_slot_states_its_reason_instead_of_a_pipeline_class`.

Its rig builds a model class with a bare `exec(str)`, so `load` has **no source on disk**, `inspect.getsource` raises, and the single `UNREADABLE` refusal told it:

```
Marked: `load()` hands the LOAD CONTEXT itself away
```

which is **false** — that `load()` is `self.pipe = object()` and never names `ctx`. A refusal that misnames its cause sends the reader to the wrong line, and this one pointed at a fix that does not exist for the actual problem.

## The verdict does not change; the sentence does

Subjecthood that cannot be read is still never guessed. The two causes are now separate states with separate messages:

| state | cause | the fix it names |
|---|---|---|
| `UNREADABLE` | the source IS readable and it hands the CONTEXT away | hand the mark: `helper(ctx.compile, …)` |
| `SOURCELESS` | there is no source to read at all | define the class in a module ON DISK — the only thing the release derive can import; an `exec()`/`type()` class could never be a release subject anyway |

## The rig

It now `compile()`s with a filename and seeds `linecache`, which is what a real module gets for free. That file's own comment calls the class header "the thing under test" — being readable is now part of what a valid header means.

## Red arm, with its own falsifier

`test_model_authoring` asserts the SAME source refuses under bare `exec` **and** reads `marks_compile is False` once `linecache` can find it — so it is the missing SOURCE that refuses, not the `exec`.

No `src/` site builds a `Model` subclass dynamically (checked); this was test-rig-only.

Verified: `tests/test_endpoint_discovery.py` + `tests/test_model_authoring.py` 30 passed, ruff clean, mypy clean.