### PR TITLE
pgw#1659: a hollow drive must not run COMPILED kernels — h3's own torch.compile killed the CUDA context and the digest took the blame

### DIFF
--- a/src/gen_worker/_vendor/torchcg/declaration.py
+++ b/src/gen_worker/_vendor/torchcg/declaration.py
@@ -335,6 +335,26 @@ def _literal_digest(program: object) -> str:
     return _literal_digest_for(program, _literal_names(program))
 
 
+def _reading_a_device_is_not_the_constant(value: Any) -> str:
+    """The sentence that keeps a sticky accelerator fault off a constant's name.
+
+    Reading a constant that lives on an accelerator is a real copy to host, so
+    it is one of the first places a fault raised EARLIER surfaces -- the fault
+    is process-wide and sticky, and every later touch reports it identically.
+    pgw#1659 cost a lane a day because this message named ``lifted_tensor_0``
+    and nothing was wrong with ``lifted_tensor_0``.
+    """
+
+    device = getattr(value, "device", None)
+    if device is None or device.type == "cpu":
+        return ""
+    return (
+        f" — reading a constant off {device.type} is a copy to host, so a "
+        f"fault raised EARLIER in this process surfaces here: check whether "
+        f"the {device.type} context is dead before suspecting this constant"
+    )
+
+
 def _literal_digest_for(program: object, names: Iterable[str]) -> str:
     names = tuple(sorted({str(name) for name in names}))
     if not names:
@@ -358,7 +378,8 @@ def _literal_digest_for(program: object, names: Iterable[str]) -> str:
             )
         except Exception as exc:
             raise DeclarationError(
-                f"literal constant {name!r} could not be digested: {type(exc).__name__}: {exc}"
+                f"literal constant {name!r} (on {value.device}) could not be "
+                f"digested: {type(exc).__name__}: {exc}{_reading_a_device_is_not_the_constant(value)}"
             ) from exc
     return digest.hexdigest()[:32]
 

--- a/src/gen_worker/_vendor/torchcg/discovery.py
+++ b/src/gen_worker/_vendor/torchcg/discovery.py
@@ -280,6 +280,37 @@ def _assert_literal_values_are_real(contract: str, path: str, program: Any) -> N
     )
 
 
+def _assert_the_drive_left_the_accelerator_alive(contract: str, session: Any) -> None:
+    """A dead accelerator is the DRIVE's fault, never a later victim's.
+
+    An accelerator fault is sticky and process-wide: once it happens every
+    later touch raises the same error, wherever it happens to be. Author code
+    catches broadly -- minimax-h3's compiled-decoder fallback and diffusers'
+    modular block runner both swallow any ``Exception`` and carry on -- so a
+    fault raised mid-drive can be reported as a degrade and the drive finishes
+    green against a corpse. The next thing to touch the device then wears the
+    blame: in pgw#1659 that was the literal digest, and the derive's whole
+    refusal named a constant nothing was wrong with.
+
+    Probed HERE, once, right after the drive, so the refusal names the drive.
+    """
+
+    from .hollow import accelerator_is_alive
+
+    if session is None or accelerator_is_alive(session.drive_device):
+        return
+    raise DiscoveryError(
+        f"lane {contract!r}: the drive left this process's "
+        f"{session.drive_device_type} context DEAD — a real kernel faulted "
+        f"while the pipeline was being driven and author code swallowed it, "
+        f"so nothing after this point can touch the device. The graphs are "
+        f"NOT the cause and re-running the export will not help: find what "
+        f"launched a real kernel during a hollow drive (a `torch.compile`d "
+        f"module handed FAKE tensors is the known one, pgw#1659) or drive on "
+        f"cpu. Re-run with CUDA_LAUNCH_BLOCKING=1 to place the fault."
+    )
+
+
 def discover_modules(
     lane: LaneRef | str,
     modules: Mapping[str, Any],
@@ -413,6 +444,7 @@ def discover_modules(
     finally:
         for handle in handles:
             handle.remove()
+    _assert_the_drive_left_the_accelerator_alive(contract, session)
 
     records: list[GraphRecord] = []
     seen_graphs: set[str] = set()

--- a/src/gen_worker/_vendor/torchcg/hollow.py
+++ b/src/gen_worker/_vendor/torchcg/hollow.py
@@ -64,6 +64,12 @@ supplies the session that makes that code run hollow:
   ids) are untouched -- the whole-pipeline ambient-fake drive was measured
   non-viable precisely because scheduler ``.item()`` needs real values.
 
+* **Eager-only compile** (pgw#1659) -- ``torch.compile`` is IDENTITY inside a
+  session. An author who arms a compiled module in ``load()`` would otherwise
+  have inductor generate a real kernel and launch it on a FAKE data pointer,
+  which kills the process's accelerator context for everything after it. What
+  author code compiles at load reaches neither the exported graph nor its key.
+
 The session deliberately does NOT wrap the run in an ambient
 ``FakeTensorMode``: only tensors DERIVED from hollow parameters are fake, so
 the author's control flow keeps its real values.
@@ -868,6 +874,78 @@ def _hollow_module_moves(device: str) -> Iterator[None]:
         torch.nn.Module.cuda = original_cuda  # type: ignore[method-assign]
 
 
+@contextlib.contextmanager
+def _eager_only_compile() -> Iterator[None]:
+    """``torch.compile`` is IDENTITY for the life of a hollow session.
+
+    Authors arm compiled modules in ``load()`` -- minimax-h3 does, on its VAE
+    decoder -- and a hollow drive then hands that compiled callable FAKE
+    tensors. dynamo/inductor compile against them and the generated wrapper
+    reads a FAKE data pointer, so a real kernel launches on a pointer that
+    addresses nothing:
+
+        Warning: Accessing the data pointer of FakeTensor ...
+        AcceleratorError: CUDA error: an illegal memory access was encountered
+
+    A CUDA fault is STICKY and process-wide, and the author caught this one
+    broadly and carried on ("serving eager for the life of this process"), so
+    the derive kept running against a dead accelerator and died hundreds of
+    frames later in the literal digest -- naming a constant that had nothing
+    wrong with it (pgw#1659).
+
+    Nothing is lost by making it identity. The derive's product is a
+    ``torch.export`` of the MARKED module; what author code compiles at load
+    reaches neither the graph nor its key. What it cost was minutes of
+    inductor work per session and, on a real card, the accelerator.
+    """
+
+    import torch
+
+    original_compile = torch.compile
+    original_module_compile = torch.nn.Module.compile
+
+    def eager_compile(model: Any = None, *args: Any, **kwargs: Any) -> Any:
+        if model is None:
+            # `@torch.compile(mode=...)` -- the decorator-factory spelling.
+            return lambda inner: inner
+        return model
+
+    def eager_module_compile(module: Any, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    torch.compile = eager_compile  # type: ignore[assignment]
+    torch.nn.Module.compile = eager_module_compile  # type: ignore[method-assign, assignment]
+    try:
+        yield
+    finally:
+        torch.compile = original_compile  # type: ignore[assignment]
+        torch.nn.Module.compile = original_module_compile  # type: ignore[method-assign]
+
+
+def accelerator_is_alive(device: Any) -> bool:
+    """Can this process still round-trip ONE real byte through ``device``?
+
+    The one probe for a fault that has already happened. It is not a device
+    availability check -- ``torch.cuda.is_available()`` keeps answering True
+    on a context an illegal access killed -- it is a real allocation and a
+    real copy to host, which is exactly what every later victim does.
+    """
+
+    import torch
+
+    if str(device).split(":", 1)[0] == "cpu":
+        return True
+    try:
+        # Outside the session's own redirection: `OneTraceDevice` answers
+        # `Tensor.cpu`/a `cpu` ask with the trace device, which would make the
+        # probe a no-op that proves nothing.
+        with torch._C.DisableTorchFunction():
+            torch.empty(1, device=device).detach().to("cpu")
+    except Exception:
+        return False
+    return True
+
+
 #: Device spellings author code uses that the session redirects to its own.
 _DEVICE_TYPES = ("cuda", "cpu", "mps", "xpu")
 
@@ -1041,6 +1119,7 @@ def hollow_session(
     with (
         _loader_interception(session),
         _hollow_module_moves(session.drive_device),
+        _eager_only_compile(),
         observation_shims(session.drive_device),
     ):
         yield session
@@ -1049,6 +1128,7 @@ def hollow_session(
 __all__ = [
     "DEFAULT_TRACE_DEVICE",
     "HollowError",
+    "accelerator_is_alive",
     "attach_lazy_components",
     "HollowSession",
     "TraceDeviceUnavailable",

--- a/tests/test_hollow_eager_compile_pgw1659.py
+++ b/tests/test_hollow_eager_compile_pgw1659.py
@@ -70,9 +70,9 @@ def test_an_authors_torch_compile_is_identity_inside_a_session() -> None:
         assert torch.compile(module) is module
         # `@torch.compile(mode=...)` -- the decorator FACTORY, no model given.
         assert torch.compile(mode="max-autotune")(eager) is eager
-        # `Module.compile()` mutates in place and returns None either way.
-        assert module.compile() is None
-        assert type(module.forward.__self__) is Decoder
+        # `Module.compile()` mutates in place -- and must not.
+        module.compile()
+        assert getattr(module.forward, "__self__", None) is module
 
     assert torch.compile is outside
 
@@ -95,7 +95,10 @@ def test_a_compiled_module_in_a_hollow_drive_returns_the_eager_answer() -> None:
 
     with hollow_session("cpu"):
         module = Decoder()
-        module.forward = torch.compile(module.forward, dynamic=False)
+        # h3's own spelling, verbatim (`_compile_with_eager_fallback`).
+        module.forward = torch.compile(  # type: ignore[method-assign]
+            module.forward, dynamic=False
+        )
         observed: list[tuple[int, ...]] = []
         module.register_forward_pre_hook(
             lambda _m, args: observed.append(tuple(args[0].shape))

--- a/tests/test_hollow_eager_compile_pgw1659.py
+++ b/tests/test_hollow_eager_compile_pgw1659.py
@@ -1,0 +1,181 @@
+"""A hollow drive must not run compiled kernels, and must not blame constants.
+
+pgw#1659. minimax-h3's `load()` arms `torch.compile` on its VAE decoder. Inside
+a hollow session that compiled callable is handed FAKE tensors, inductor's
+generated wrapper reads a fake data pointer and launches a real kernel on it:
+
+    Warning: Accessing the data pointer of FakeTensor ...
+    minimax-h3: compiled vae.decoder failed (AcceleratorError: CUDA error: an
+    illegal memory access was encountered); serving eager for the life of this
+    process
+
+The author caught it and carried on, so the drive finished against a dead CUDA
+context and the derive died hundreds of frames later in the literal digest:
+
+    target 'transformer': observed call cannot state its identity: literal
+    constant 'lifted_tensor_0' could not be digested: AcceleratorError: CUDA
+    error: an illegal memory access was encountered
+
+Nothing was wrong with `lifted_tensor_0`. Three properties keep that
+misdiagnosis from happening again: compile is IDENTITY in a session, a drive
+that kills the accelerator is refused AT THE DRIVE, and a constant that cannot
+be read refuses BY NAME with its device stated.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+
+from gen_worker._vendor.torchcg.declaration import (  # noqa: E402
+    DeclarationError,
+    _literal_digest_for,
+)
+from gen_worker._vendor.torchcg.discovery import (  # noqa: E402
+    DiscoveryError,
+    _assert_the_drive_left_the_accelerator_alive,
+)
+from gen_worker._vendor.torchcg.hollow import (  # noqa: E402
+    accelerator_is_alive,
+    hollow_session,
+)
+
+
+class Decoder(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = torch.nn.Linear(4, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x)
+
+
+def test_an_authors_torch_compile_is_identity_inside_a_session() -> None:
+    """The whole prevention in one assertion, in every spelling authors use."""
+
+    outside = torch.compile
+    module = Decoder()
+
+    eager = module.forward  # a bound method is a fresh object per attribute read
+    with hollow_session("cpu"):
+        assert torch.compile is not outside
+        # h3's spelling: a bound method, with kwargs.
+        assert torch.compile(eager, dynamic=False) is eager
+        # The module spelling.
+        assert torch.compile(module) is module
+        # `@torch.compile(mode=...)` -- the decorator FACTORY, no model given.
+        assert torch.compile(mode="max-autotune")(eager) is eager
+        # `Module.compile()` mutates in place and returns None either way.
+        assert module.compile() is None
+        assert type(module.forward.__self__) is Decoder
+
+    assert torch.compile is outside
+
+
+def test_the_session_restores_torch_compile_even_when_the_body_raises() -> None:
+    outside = torch.compile
+    with pytest.raises(ZeroDivisionError):
+        with hollow_session("cpu"):
+            assert torch.compile is not outside
+            raise ZeroDivisionError
+    assert torch.compile is outside
+
+
+def test_a_compiled_module_in_a_hollow_drive_returns_the_eager_answer() -> None:
+    """Identity is not just a type check: the drive still gets its structure.
+
+    A no-op compile has to leave the drive able to observe the call, which is
+    the only thing the drive is for.
+    """
+
+    with hollow_session("cpu"):
+        module = Decoder()
+        module.forward = torch.compile(module.forward, dynamic=False)
+        observed: list[tuple[int, ...]] = []
+        module.register_forward_pre_hook(
+            lambda _m, args: observed.append(tuple(args[0].shape))
+        )
+        out = module(torch.zeros(2, 4))
+
+    assert observed == [(2, 4)]
+    assert tuple(out.shape) == (2, 4)
+
+
+class _Session:
+    """The two attributes the drive probe reads, and nothing else."""
+
+    def __init__(self, device: str) -> None:
+        self.drive_device = device
+
+    @property
+    def drive_device_type(self) -> str:
+        return self.drive_device.split(":", 1)[0]
+
+
+def test_a_device_that_cannot_round_trip_a_byte_is_not_alive() -> None:
+    """The RED arm of the probe, on any host: no backend is registered here.
+
+    `torch.cuda.is_available()` keeps answering True on a context an illegal
+    access killed, which is exactly why the probe is a real allocation and a
+    real copy to host rather than an availability check.
+    """
+
+    assert accelerator_is_alive("cpu") is True
+    assert accelerator_is_alive("privateuseone") is False
+
+
+def test_a_drive_that_killed_the_accelerator_is_refused_AT_THE_DRIVE() -> None:
+    with pytest.raises(DiscoveryError) as refusal:
+        _assert_the_drive_left_the_accelerator_alive(
+            "minimax-h3.diffusers@1+plain.bf16@1", _Session("privateuseone")
+        )
+
+    said = str(refusal.value)
+    assert "the drive left this process's privateuseone context DEAD" in said
+    assert "The graphs are NOT the cause" in said
+    # It must point at the known producer, not leave the reader guessing.
+    assert "`torch.compile`d module handed FAKE tensors" in said
+    assert "CUDA_LAUNCH_BLOCKING=1" in said
+
+
+def test_a_live_drive_device_is_not_refused() -> None:
+    _assert_the_drive_left_the_accelerator_alive("lane", _Session("cpu"))
+    _assert_the_drive_left_the_accelerator_alive("lane", None)
+
+
+class _Program:
+    def __init__(self, constants: dict[str, Any]) -> None:
+        self.constants = constants
+
+
+def test_an_unreadable_literal_refuses_BY_NAME_and_states_its_device() -> None:
+    """A meta constant has no storage, so this is undigestable on every host."""
+
+    program = _Program({"lifted_tensor_0": torch.zeros(2, 2, device="meta")})
+
+    with pytest.raises(DeclarationError) as refusal:
+        _literal_digest_for(program, ["lifted_tensor_0"])
+
+    said = str(refusal.value)
+    assert "literal constant 'lifted_tensor_0' (on meta) could not be digested" in said
+    # And it says the copy-to-host is where a fault SURFACES, not where it is.
+    assert "a fault raised EARLIER in this process surfaces here" in said
+
+
+def test_a_readable_cpu_literal_carries_no_accelerator_sentence() -> None:
+    """The hint is for off-host constants only -- noise on a cpu one."""
+
+    program = _Program({"table": torch.arange(4, dtype=torch.float32)})
+    assert _literal_digest_for(program, ["table"])
+
+    broken = _Program({"table": torch.zeros(2, 2).to_sparse()})
+    with pytest.raises(DeclarationError) as refusal:
+        _literal_digest_for(broken, ["table"])
+    said = str(refusal.value)
+    assert "literal constant 'table' (on cpu) could not be digested" in said
+    assert "surfaces here" not in said


### PR DESCRIPTION
## The defect

h3's derive died at graph identity, deterministically:

```
target 'transformer': observed call cannot state its identity: literal
constant 'lifted_tensor_0' could not be digested: AcceleratorError: CUDA
error: an illegal memory access was encountered
```

Nothing was wrong with `lifted_tensor_0`. Two lines earlier in the same log:

```
Warning: Accessing the data pointer of FakeTensor ...
minimax-h3: compiled vae.decoder failed (AcceleratorError: CUDA error: an
illegal memory access was encountered); serving eager for the life of this process
```

h3's `load()` arms `torch.compile` on the VAE decoder. Inside a hollow session
that compiled callable is handed FAKE tensors, so inductor's generated wrapper
reads a fake data pointer and launches a real kernel on it. A CUDA fault is
STICKY and process-wide; the author caught it, logged a degrade and carried on,
so the drive finished against a corpse and the first thing to touch the card
afterwards — the literal digest's `value.detach().cpu()` — wore the blame.

## The fix

* **`torch.compile` is IDENTITY inside a hollow session.** The derive's product
  is a `torch.export` of the MARKED module; what author code compiles at load
  reaches neither the graph nor its key. Not a special case for h3 or arange.
* **A drive that leaves the accelerator DEAD is refused at the drive**, naming
  the known producer and suggesting `CUDA_LAUNCH_BLOCKING=1`. The probe is a
  real allocation plus a real copy to host — `torch.cuda.is_available()` keeps
  answering True on a killed context.
* **The literal-digest refusal states the constant's DEVICE** and says that
  reading an off-host constant is where an earlier fault SURFACES.
  `_assert_literal_values_are_real` was never the gap: the constant was real.

## Evidence

* Red, on real endpoint code: h3 at `d0dcd331`, its config-only HF snapshot,
  a config-only Rife tree — dies at the first VAE decode, ~60 s in.
* Post-fix, same command: the drive runs clean through repeated auto-enumerated
  combinations, no `Accessing the data pointer of FakeTensor`, no
  `Error in block`, no illegal access.
* 8 new tests; dropping `_eager_only_compile()` from the session turns 3 of
  them red.
* `tests/test_release_derive.py` + `tests/test_release_derive_modular.py`
  (27 tests) still green.

Carries to tcg#90's rebuild as a banked fact: an undigestable literal refuses
by name at discovery, never crashes at digest.