### PR TITLE
pgw#1659 follow-up: the fix belonged in the DERIVE, not in the vendored snapshot — and it now has an end-to-end arm that proves the wiring

### DIFF
--- a/src/gen_worker/_vendor/torchcg/declaration.py
+++ b/src/gen_worker/_vendor/torchcg/declaration.py
@@ -335,26 +335,6 @@ def _literal_digest(program: object) -> str:
     return _literal_digest_for(program, _literal_names(program))
 
 
-def _reading_a_device_is_not_the_constant(value: Any) -> str:
-    """The sentence that keeps a sticky accelerator fault off a constant's name.
-
-    Reading a constant that lives on an accelerator is a real copy to host, so
-    it is one of the first places a fault raised EARLIER surfaces -- the fault
-    is process-wide and sticky, and every later touch reports it identically.
-    pgw#1659 cost a lane a day because this message named ``lifted_tensor_0``
-    and nothing was wrong with ``lifted_tensor_0``.
-    """
-
-    device = getattr(value, "device", None)
-    if device is None or device.type == "cpu":
-        return ""
-    return (
-        f" — reading a constant off {device.type} is a copy to host, so a "
-        f"fault raised EARLIER in this process surfaces here: check whether "
-        f"the {device.type} context is dead before suspecting this constant"
-    )
-
-
 def _literal_digest_for(program: object, names: Iterable[str]) -> str:
     names = tuple(sorted({str(name) for name in names}))
     if not names:
@@ -378,8 +358,7 @@ def _literal_digest_for(program: object, names: Iterable[str]) -> str:
             )
         except Exception as exc:
             raise DeclarationError(
-                f"literal constant {name!r} (on {value.device}) could not be "
-                f"digested: {type(exc).__name__}: {exc}{_reading_a_device_is_not_the_constant(value)}"
+                f"literal constant {name!r} could not be digested: {type(exc).__name__}: {exc}"
             ) from exc
     return digest.hexdigest()[:32]
 

--- a/src/gen_worker/_vendor/torchcg/discovery.py
+++ b/src/gen_worker/_vendor/torchcg/discovery.py
@@ -280,37 +280,6 @@ def _assert_literal_values_are_real(contract: str, path: str, program: Any) -> N
     )
 
 
-def _assert_the_drive_left_the_accelerator_alive(contract: str, session: Any) -> None:
-    """A dead accelerator is the DRIVE's fault, never a later victim's.
-
-    An accelerator fault is sticky and process-wide: once it happens every
-    later touch raises the same error, wherever it happens to be. Author code
-    catches broadly -- minimax-h3's compiled-decoder fallback and diffusers'
-    modular block runner both swallow any ``Exception`` and carry on -- so a
-    fault raised mid-drive can be reported as a degrade and the drive finishes
-    green against a corpse. The next thing to touch the device then wears the
-    blame: in pgw#1659 that was the literal digest, and the derive's whole
-    refusal named a constant nothing was wrong with.
-
-    Probed HERE, once, right after the drive, so the refusal names the drive.
-    """
-
-    from .hollow import accelerator_is_alive
-
-    if session is None or accelerator_is_alive(session.drive_device):
-        return
-    raise DiscoveryError(
-        f"lane {contract!r}: the drive left this process's "
-        f"{session.drive_device_type} context DEAD — a real kernel faulted "
-        f"while the pipeline was being driven and author code swallowed it, "
-        f"so nothing after this point can touch the device. The graphs are "
-        f"NOT the cause and re-running the export will not help: find what "
-        f"launched a real kernel during a hollow drive (a `torch.compile`d "
-        f"module handed FAKE tensors is the known one, pgw#1659) or drive on "
-        f"cpu. Re-run with CUDA_LAUNCH_BLOCKING=1 to place the fault."
-    )
-
-
 def discover_modules(
     lane: LaneRef | str,
     modules: Mapping[str, Any],
@@ -444,7 +413,6 @@ def discover_modules(
     finally:
         for handle in handles:
             handle.remove()
-    _assert_the_drive_left_the_accelerator_alive(contract, session)
 
     records: list[GraphRecord] = []
     seen_graphs: set[str] = set()

--- a/src/gen_worker/_vendor/torchcg/hollow.py
+++ b/src/gen_worker/_vendor/torchcg/hollow.py
@@ -64,12 +64,6 @@ supplies the session that makes that code run hollow:
   ids) are untouched -- the whole-pipeline ambient-fake drive was measured
   non-viable precisely because scheduler ``.item()`` needs real values.
 
-* **Eager-only compile** (pgw#1659) -- ``torch.compile`` is IDENTITY inside a
-  session. An author who arms a compiled module in ``load()`` would otherwise
-  have inductor generate a real kernel and launch it on a FAKE data pointer,
-  which kills the process's accelerator context for everything after it. What
-  author code compiles at load reaches neither the exported graph nor its key.
-
 The session deliberately does NOT wrap the run in an ambient
 ``FakeTensorMode``: only tensors DERIVED from hollow parameters are fake, so
 the author's control flow keeps its real values.
@@ -874,78 +868,6 @@ def _hollow_module_moves(device: str) -> Iterator[None]:
         torch.nn.Module.cuda = original_cuda  # type: ignore[method-assign]
 
 
-@contextlib.contextmanager
-def _eager_only_compile() -> Iterator[None]:
-    """``torch.compile`` is IDENTITY for the life of a hollow session.
-
-    Authors arm compiled modules in ``load()`` -- minimax-h3 does, on its VAE
-    decoder -- and a hollow drive then hands that compiled callable FAKE
-    tensors. dynamo/inductor compile against them and the generated wrapper
-    reads a FAKE data pointer, so a real kernel launches on a pointer that
-    addresses nothing:
-
-        Warning: Accessing the data pointer of FakeTensor ...
-        AcceleratorError: CUDA error: an illegal memory access was encountered
-
-    A CUDA fault is STICKY and process-wide, and the author caught this one
-    broadly and carried on ("serving eager for the life of this process"), so
-    the derive kept running against a dead accelerator and died hundreds of
-    frames later in the literal digest -- naming a constant that had nothing
-    wrong with it (pgw#1659).
-
-    Nothing is lost by making it identity. The derive's product is a
-    ``torch.export`` of the MARKED module; what author code compiles at load
-    reaches neither the graph nor its key. What it cost was minutes of
-    inductor work per session and, on a real card, the accelerator.
-    """
-
-    import torch
-
-    original_compile = torch.compile
-    original_module_compile = torch.nn.Module.compile
-
-    def eager_compile(model: Any = None, *args: Any, **kwargs: Any) -> Any:
-        if model is None:
-            # `@torch.compile(mode=...)` -- the decorator-factory spelling.
-            return lambda inner: inner
-        return model
-
-    def eager_module_compile(module: Any, *args: Any, **kwargs: Any) -> None:
-        return None
-
-    torch.compile = eager_compile  # type: ignore[assignment]
-    torch.nn.Module.compile = eager_module_compile  # type: ignore[method-assign, assignment]
-    try:
-        yield
-    finally:
-        torch.compile = original_compile  # type: ignore[assignment]
-        torch.nn.Module.compile = original_module_compile  # type: ignore[method-assign]
-
-
-def accelerator_is_alive(device: Any) -> bool:
-    """Can this process still round-trip ONE real byte through ``device``?
-
-    The one probe for a fault that has already happened. It is not a device
-    availability check -- ``torch.cuda.is_available()`` keeps answering True
-    on a context an illegal access killed -- it is a real allocation and a
-    real copy to host, which is exactly what every later victim does.
-    """
-
-    import torch
-
-    if str(device).split(":", 1)[0] == "cpu":
-        return True
-    try:
-        # Outside the session's own redirection: `OneTraceDevice` answers
-        # `Tensor.cpu`/a `cpu` ask with the trace device, which would make the
-        # probe a no-op that proves nothing.
-        with torch._C.DisableTorchFunction():
-            torch.empty(1, device=device).detach().to("cpu")
-    except Exception:
-        return False
-    return True
-
-
 #: Device spellings author code uses that the session redirects to its own.
 _DEVICE_TYPES = ("cuda", "cpu", "mps", "xpu")
 
@@ -1119,7 +1041,6 @@ def hollow_session(
     with (
         _loader_interception(session),
         _hollow_module_moves(session.drive_device),
-        _eager_only_compile(),
         observation_shims(session.drive_device),
     ):
         yield session
@@ -1128,7 +1049,6 @@ def hollow_session(
 __all__ = [
     "DEFAULT_TRACE_DEVICE",
     "HollowError",
-    "accelerator_is_alive",
     "attach_lazy_components",
     "HollowSession",
     "TraceDeviceUnavailable",

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -106,6 +106,11 @@ from ..serving.model import (
 )
 from ..serving.lane_spec import DYNAMIC
 from ..serving.model import model_type as _strict_model_type
+from .drive_hygiene import (
+    accelerator_is_alive,
+    dead_accelerator_sentence,
+    eager_only_compile,
+)
 from .trace_context import (
     StepBudgetReached,
     TraceLoadContext,
@@ -307,6 +312,24 @@ def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
 def _trace_device() -> str:
 
     return "cuda"
+
+
+def _refuse_a_dead_accelerator(
+    said: str, session: Any, cause: Optional[BaseException] = None
+) -> None:
+    """A drive that killed the card is refused BY THE DRIVE (pgw#1659).
+
+    Asked right after discovery, so the refusal names what happened instead of
+    whatever touched the device next. ``cause`` is the message discovery
+    produced; it stays as the chained exception because it is real evidence,
+    just not a diagnosis.
+    """
+
+    if session is None or accelerator_is_alive(session.drive_device):
+        return
+    raise DeriveError(
+        f"{said}: {dead_accelerator_sentence(session.drive_device_type)}"
+    ) from cause
 
 
 def _assert_weights_free(torch: Any, program: Any) -> None:
@@ -1332,7 +1355,11 @@ def _derive_lane_item(
             checkpoint_ref=f"trace:{checkpoint_dir.name}",
             step_budget=TRACE_STEP_BUDGET,
         )
-        with hollow.hollow_session(
+        # pgw#1659: `torch.compile` is IDENTITY for the whole drive. An author
+        # arming a compiled module in `load()` would otherwise have inductor
+        # generate a real kernel and launch it on a FAKE data pointer, which
+        # kills this process's accelerator for everything after it.
+        with eager_only_compile(), hollow.hollow_session(
             _trace_device(), dtype_for=load_ctx.component_dtype
         ) as session:
             try:
@@ -1455,9 +1482,15 @@ def _derive_lane_item(
                         session=session, dynamic_dims=dynamic_dims,
                         static_bind=static_bind, notes=notes,
                     )
+                _refuse_a_dead_accelerator(said, session)
             except DeriveError:
                 raise
             except torchcg.DiscoveryError as exc:
+                # pgw#1659: a sticky accelerator fault raised mid-drive and
+                # swallowed by author code surfaces as whatever discovery
+                # touched the card next — a literal constant, most of the time.
+                # Ask the machine before relaying the message.
+                _refuse_a_dead_accelerator(said, session, exc)
                 raise DeriveError(f"{said}: {exc}") from exc
             # pgw#1603 acceptance (c): an axis that dropped to per-bucket
             # tracing is said in the LOCK, never only in a logger.

--- a/src/gen_worker/release/drive_hygiene.py
+++ b/src/gen_worker/release/drive_hygiene.py
@@ -1,0 +1,107 @@
+"""What a hollow drive is allowed to do to the machine it runs on (pgw#1659).
+
+A hollow derive runs the AUTHOR's `load()` and the author's pipeline against
+FAKE weights. Two things follow, and neither is torchcg's to decide -- the
+derive owns the drive, so the derive owns its hygiene.
+
+**No compiled kernels.** Authors arm compiled modules in `load()`: minimax-h3
+does, on its VAE decoder (`engine.py::_compile_with_eager_fallback`, a real
+1.68x serve win). Inside a hollow session that compiled callable is handed FAKE
+tensors, so dynamo/inductor compile against them and the generated wrapper
+reads a fake data pointer and launches a real kernel on it:
+
+    Warning: Accessing the data pointer of FakeTensor ...
+    minimax-h3: compiled vae.decoder failed (AcceleratorError: CUDA error: an
+    illegal memory access was encountered); serving eager for the life of this
+    process
+
+Nothing is lost by making `torch.compile` identity here. What the derive
+produces is a `torch.export` of the MARKED module; what author code compiles at
+load reaches neither the graph nor its key. What it cost was minutes of
+inductor work per session and, on a real card, the accelerator.
+
+**A dead accelerator is the drive's fault, and must say so.** A CUDA fault is
+STICKY and process-wide: afterwards every touch of the device raises the same
+error, wherever it is. Author code catches broadly -- h3's compiled-decoder
+fallback and diffusers' modular block runner both swallow any `Exception` and
+carry on -- so a fault raised mid-drive can be logged as a degrade while the
+drive finishes green against a corpse. The next thing to touch the card then
+wears the blame. In pgw#1659 that was torchcg's literal digest, and a P1 spent
+its life named after `lifted_tensor_0`, a constant with nothing wrong with it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Iterator
+
+__all__ = [
+    "accelerator_is_alive",
+    "dead_accelerator_sentence",
+    "eager_only_compile",
+]
+
+
+@contextlib.contextmanager
+def eager_only_compile() -> Iterator[None]:
+    """`torch.compile` and `Module.compile` are IDENTITY for this block."""
+
+    import torch
+
+    original_compile = torch.compile
+    original_module_compile = torch.nn.Module.compile
+
+    def eager_compile(model: Any = None, *args: Any, **kwargs: Any) -> Any:
+        if model is None:
+            # `@torch.compile(mode=...)` -- the decorator-factory spelling.
+            return lambda inner: inner
+        return model
+
+    def eager_module_compile(module: Any, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    torch.compile = eager_compile
+    torch.nn.Module.compile = eager_module_compile  # type: ignore[method-assign, assignment]
+    try:
+        yield
+    finally:
+        torch.compile = original_compile
+        torch.nn.Module.compile = original_module_compile  # type: ignore[method-assign]
+
+
+def accelerator_is_alive(device: Any) -> bool:
+    """Can this process still round-trip ONE real byte through ``device``?
+
+    Not an availability check: `torch.cuda.is_available()` keeps answering True
+    on a context an illegal access killed. This is a real allocation and a real
+    copy to host -- exactly what every later victim does.
+    """
+
+    import torch
+
+    if str(device).split(":", 1)[0] == "cpu":
+        return True
+    try:
+        # Outside the hollow session's own redirection: its `OneTraceDevice`
+        # shim answers a `cpu` ask with the trace device, which would make the
+        # probe a no-op that proves nothing.
+        with torch._C.DisableTorchFunction():
+            torch.empty(1, device=device).detach().to("cpu")
+    except Exception:
+        return False
+    return True
+
+
+def dead_accelerator_sentence(device_type: str) -> str:
+    """The refusal that names the DRIVE instead of the drive's next victim."""
+
+    return (
+        f"the drive left this process's {device_type} context DEAD — a real "
+        f"kernel faulted while the pipeline was being driven and author code "
+        f"swallowed it, so nothing after this point can touch the device. The "
+        f"graphs are NOT the cause and re-running the export will not help: "
+        f"find what launched a real kernel during a hollow drive (a "
+        f"`torch.compile`d module handed FAKE tensors is the known one, "
+        f"pgw#1659) or drive on cpu. Re-run with CUDA_LAUNCH_BLOCKING=1 to "
+        f"place the fault."
+    )

--- a/tests/release_fixtures/modular_tiny_endpoint.py
+++ b/tests/release_fixtures/modular_tiny_endpoint.py
@@ -37,6 +37,12 @@ class LatentOutput(msgspec.Struct):
     model_used: str
 
 
+def _compile_probe(x: Any) -> Any:
+    """A callable whose only job is to be handed to `torch.compile` (pgw#1659)."""
+
+    return x
+
+
 class ModularModel(
     Model[SDXL],
     lanes={TINY_DIFFUSERS_FP32: lane(
@@ -48,6 +54,17 @@ class ModularModel(
 
     def load(self, ctx: LoadContext[SDXL]) -> None:
         self.pipe = ctx.load(TinyStreamingPipeline)
+        # pgw#1659, asserted from INSIDE a real derive's `load()` because that
+        # is the only place the property is real. An author arming a compiled
+        # module here (minimax-h3 does, on its VAE decoder) must get the eager
+        # callable back: a compiled one is handed FAKE tensors by the hollow
+        # drive and launches a real kernel on a fake data pointer, which kills
+        # the process's accelerator for everything after it.
+        if torch.compile(_compile_probe, dynamic=False) is not _compile_probe:
+            raise AssertionError(
+                "pgw#1659: torch.compile is LIVE inside the derive's hollow "
+                "drive — `eager_only_compile()` is not wrapping the session"
+            )
         self.pipe.unet = ctx.compile(self.pipe.unet)
 
 

--- a/tests/test_hollow_eager_compile_pgw1659.py
+++ b/tests/test_hollow_eager_compile_pgw1659.py
@@ -1,7 +1,7 @@
 """A hollow drive must not run compiled kernels, and must not blame constants.
 
 pgw#1659. minimax-h3's `load()` arms `torch.compile` on its VAE decoder. Inside
-a hollow session that compiled callable is handed FAKE tensors, inductor's
+a hollow session that compiled callable is handed FAKE tensors, so inductor's
 generated wrapper reads a fake data pointer and launches a real kernel on it:
 
     Warning: Accessing the data pointer of FakeTensor ...
@@ -10,21 +10,20 @@ generated wrapper reads a fake data pointer and launches a real kernel on it:
     process
 
 The author caught it and carried on, so the drive finished against a dead CUDA
-context and the derive died hundreds of frames later in the literal digest:
+context and the derive died hundreds of frames later in torchcg's literal
+digest:
 
     target 'transformer': observed call cannot state its identity: literal
     constant 'lifted_tensor_0' could not be digested: AcceleratorError: CUDA
     error: an illegal memory access was encountered
 
-Nothing was wrong with `lifted_tensor_0`. Three properties keep that
-misdiagnosis from happening again: compile is IDENTITY in a session, a drive
-that kills the accelerator is refused AT THE DRIVE, and a constant that cannot
-be read refuses BY NAME with its device stated.
+Nothing was wrong with `lifted_tensor_0`. Two properties keep that
+misdiagnosis from happening again, and both live in the DERIVE rather than in
+the vendored snapshot -- the derive owns the drive, and a vendored snapshot is
+fixed upstream and re-vendored, never patched here.
 """
 
 from __future__ import annotations
-
-from typing import Any
 
 import pytest
 
@@ -32,17 +31,10 @@ pytest.importorskip("torch")
 
 import torch  # noqa: E402
 
-from gen_worker._vendor.torchcg.declaration import (  # noqa: E402
-    DeclarationError,
-    _literal_digest_for,
-)
-from gen_worker._vendor.torchcg.discovery import (  # noqa: E402
-    DiscoveryError,
-    _assert_the_drive_left_the_accelerator_alive,
-)
-from gen_worker._vendor.torchcg.hollow import (  # noqa: E402
+from gen_worker.release.drive_hygiene import (  # noqa: E402
     accelerator_is_alive,
-    hollow_session,
+    dead_accelerator_sentence,
+    eager_only_compile,
 )
 
 
@@ -55,14 +47,14 @@ class Decoder(torch.nn.Module):
         return self.proj(x)
 
 
-def test_an_authors_torch_compile_is_identity_inside_a_session() -> None:
+def test_an_authors_torch_compile_is_identity_under_the_drive() -> None:
     """The whole prevention in one assertion, in every spelling authors use."""
 
     outside = torch.compile
     module = Decoder()
-
     eager = module.forward  # a bound method is a fresh object per attribute read
-    with hollow_session("cpu"):
+
+    with eager_only_compile():
         assert torch.compile is not outside
         # h3's spelling: a bound method, with kwargs.
         assert torch.compile(eager, dynamic=False) is eager
@@ -77,25 +69,20 @@ def test_an_authors_torch_compile_is_identity_inside_a_session() -> None:
     assert torch.compile is outside
 
 
-def test_the_session_restores_torch_compile_even_when_the_body_raises() -> None:
+def test_torch_compile_is_restored_even_when_the_body_raises() -> None:
     outside = torch.compile
     with pytest.raises(ZeroDivisionError):
-        with hollow_session("cpu"):
+        with eager_only_compile():
             assert torch.compile is not outside
             raise ZeroDivisionError
     assert torch.compile is outside
 
 
-def test_a_compiled_module_in_a_hollow_drive_returns_the_eager_answer() -> None:
-    """Identity is not just a type check: the drive still gets its structure.
+def test_a_compiled_module_still_gives_the_drive_its_structure() -> None:
+    """Identity is not just a type check: the observation still has to work."""
 
-    A no-op compile has to leave the drive able to observe the call, which is
-    the only thing the drive is for.
-    """
-
-    with hollow_session("cpu"):
+    with eager_only_compile():
         module = Decoder()
-        # h3's own spelling, verbatim (`_compile_with_eager_fallback`).
         module.forward = torch.compile(  # type: ignore[method-assign]
             module.forward, dynamic=False
         )
@@ -107,17 +94,6 @@ def test_a_compiled_module_in_a_hollow_drive_returns_the_eager_answer() -> None:
 
     assert observed == [(2, 4)]
     assert tuple(out.shape) == (2, 4)
-
-
-class _Session:
-    """The two attributes the drive probe reads, and nothing else."""
-
-    def __init__(self, device: str) -> None:
-        self.drive_device = device
-
-    @property
-    def drive_device_type(self) -> str:
-        return self.drive_device.split(":", 1)[0]
 
 
 def test_a_device_that_cannot_round_trip_a_byte_is_not_alive() -> None:
@@ -132,53 +108,53 @@ def test_a_device_that_cannot_round_trip_a_byte_is_not_alive() -> None:
     assert accelerator_is_alive("privateuseone") is False
 
 
-def test_a_drive_that_killed_the_accelerator_is_refused_AT_THE_DRIVE() -> None:
-    with pytest.raises(DiscoveryError) as refusal:
-        _assert_the_drive_left_the_accelerator_alive(
-            "minimax-h3.diffusers@1+plain.bf16@1", _Session("privateuseone")
-        )
+def test_the_dead_accelerator_refusal_names_the_drive_and_the_known_producer() -> None:
+    said = dead_accelerator_sentence("cuda")
 
-    said = str(refusal.value)
-    assert "the drive left this process's privateuseone context DEAD" in said
+    assert "the drive left this process's cuda context DEAD" in said
     assert "The graphs are NOT the cause" in said
     # It must point at the known producer, not leave the reader guessing.
     assert "`torch.compile`d module handed FAKE tensors" in said
     assert "CUDA_LAUNCH_BLOCKING=1" in said
 
 
+class _Session:
+    """The two attributes the derive's probe reads, and nothing else."""
+
+    def __init__(self, device: str) -> None:
+        self.drive_device = device
+
+    @property
+    def drive_device_type(self) -> str:
+        return self.drive_device.split(":", 1)[0]
+
+
+def test_the_derive_refuses_a_dead_accelerator_instead_of_relaying_the_victim() -> None:
+    """The misdiagnosis, reproduced and then refused correctly.
+
+    `cause` is the sentence pgw#1659 actually shipped — a constant's name. The
+    derive must NOT relay it as the diagnosis, and must keep it chained.
+    """
+
+    from gen_worker.release.derive import DeriveError, _refuse_a_dead_accelerator
+
+    victim = RuntimeError(
+        "literal constant 'lifted_tensor_0' could not be digested: "
+        "AcceleratorError: CUDA error: an illegal memory access was encountered"
+    )
+
+    with pytest.raises(DeriveError) as refusal:
+        _refuse_a_dead_accelerator("derive: class H3Model", _Session("privateuseone"), victim)
+
+    said = str(refusal.value)
+    assert "derive: class H3Model" in said
+    assert "context DEAD" in said
+    assert "lifted_tensor_0" not in said
+    assert refusal.value.__cause__ is victim
+
+
 def test_a_live_drive_device_is_not_refused() -> None:
-    _assert_the_drive_left_the_accelerator_alive("lane", _Session("cpu"))
-    _assert_the_drive_left_the_accelerator_alive("lane", None)
+    from gen_worker.release.derive import _refuse_a_dead_accelerator
 
-
-class _Program:
-    def __init__(self, constants: dict[str, Any]) -> None:
-        self.constants = constants
-
-
-def test_an_unreadable_literal_refuses_BY_NAME_and_states_its_device() -> None:
-    """A meta constant has no storage, so this is undigestable on every host."""
-
-    program = _Program({"lifted_tensor_0": torch.zeros(2, 2, device="meta")})
-
-    with pytest.raises(DeclarationError) as refusal:
-        _literal_digest_for(program, ["lifted_tensor_0"])
-
-    said = str(refusal.value)
-    assert "literal constant 'lifted_tensor_0' (on meta) could not be digested" in said
-    # And it says the copy-to-host is where a fault SURFACES, not where it is.
-    assert "a fault raised EARLIER in this process surfaces here" in said
-
-
-def test_a_readable_cpu_literal_carries_no_accelerator_sentence() -> None:
-    """The hint is for off-host constants only -- noise on a cpu one."""
-
-    program = _Program({"table": torch.arange(4, dtype=torch.float32)})
-    assert _literal_digest_for(program, ["table"])
-
-    broken = _Program({"table": torch.zeros(2, 2).to_sparse()})
-    with pytest.raises(DeclarationError) as refusal:
-        _literal_digest_for(broken, ["table"])
-    said = str(refusal.value)
-    assert "literal constant 'table' (on cpu) could not be digested" in said
-    assert "surfaces here" not in said
+    _refuse_a_dead_accelerator("derive", _Session("cpu"))
+    _refuse_a_dead_accelerator("derive", None)


### PR DESCRIPTION
`29bf9bf0` (PR #1199) landed pgw#1659's fix inside `_vendor/torchcg/`, which
`tests/test_vendored_snapshot_pgw1310.py` refuses by design:

> A vendored snapshot is fixed upstream and re-vendored, never patched here.

`tests` is not a required context on pgw's live ruleset, so the queue landed it
and the fence fired on master. It was right, and it caught a real
mis-placement.

## What changed

1. **The three vendored files are restored byte-for-byte.** The behaviour moved
   to `gen_worker/release/drive_hygiene.py`, entered by `derive.py` around its
   own `hollow_session`. A better home, not a workaround: the derive owns the
   drive, so it owns its hygiene. torchcg's `hollow` is on tcg#90's deletion
   list and pgw#1656 is mid-flight on the five-module re-vendor, so patching
   the old snapshot would have fought both. The literal-digest message change
   is dropped — naming the fault AT THE DRIVE supersedes it.
2. **The tests now prove the WIRING.** The first pass tested the helper in
   isolation and passed with the derive not calling it at all (measured, by
   deleting the call). `modular_tiny_endpoint`'s `load()` now asserts, from
   inside a real derive, that `torch.compile` handed the eager callable back.

## Red arms, both re-measured

| arm | result |
|---|---|
| wiring removed from `derive.py` | `test_a_modular_endpoint_derives_its_marked_denoiser` **FAILS** |
| `accelerator_is_alive("privateuseone")` | False on any host — the probe can go red |
| `test_vendored_snapshot_pgw1310.py` | 15 green (was 1 failed on master) |

24 tests green across `test_release_derive_modular.py`,
`test_hollow_eager_compile_pgw1659.py`, `test_vendored_snapshot_pgw1310.py`;
ruff and `mypy --strict` clean on the changed files.