### PR TITLE
pgw#1661: the graph-blob weight guard asks about STORAGE, not TYPE — h3's 300 virtual weights are not 23 GB of anything

### DIFF
--- a/changelog.d/pgw1661.md
+++ b/changelog.d/pgw1661.md
@@ -1,0 +1,15 @@
+- **pgw#1661: the graph-blob weight guard asked about TYPE, and refused a hollow derive over 23 GB of tensors nothing had allocated.**
+  `release/derive.py`'s program sink is the last thing between a hollow derive and a graph
+  blob, and it exempted a virtual tensor with `isinstance(..., FakeTensor)`. A `torch.Tensor`
+  **wrapper subclass** over fake data — what a `setup()`-time quantizer leaves on a hollow
+  denoiser — is a `FakeTensor` to nobody, and it prices itself off its OUTER metadata. So
+  minimax-h3's derive stated its graph identity
+  (`cg-graph-v1-80f309eb…`) and then refused it: *"about to serialize 300 REAL tensor(s)"*,
+  ≈23 GB, on an 8 GiB card whose own line one frame earlier read `allocated=0.0GiB`. The tree
+  was config-only; there were no weights on disk to load. This is pgw#1198's ruling —
+  *virtuality is a question about STORAGE, never about TYPE* — re-broken at a second site, and
+  the fix is the predicate that ruling already produced: `meta_instantiation.is_virtual`, which
+  recurses through `__tensor_flatten__` and answers `meta` too (so the guard's separate meta arm
+  is gone with the type check). The fence is unchanged in the direction that matters — a real
+  weight still refuses, the same subclass over REAL storage still refuses, and a real weight
+  hiding among 300 virtual ones is still the one tensor the message names.

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -333,15 +333,23 @@ def _refuse_a_dead_accelerator(
 
 
 def _assert_weights_free(torch: Any, program: Any) -> None:
+    """The last thing between a hollow derive and a graph blob.
 
-    from torch._subclasses.fake_tensor import FakeTensor
+    Asked of the STORAGE, never of the TYPE (pgw#1198, re-broken here and fixed
+    in pgw#1661). `isinstance(..., FakeTensor)` cannot see a wrapper subclass
+    over fake data — what a `setup()`-time quantizer leaves on a hollow denoiser
+    — and such a tensor prices itself off its OUTER metadata, so h3's 300
+    virtual weights read as ~23 GB of weights on a card holding 0.0 GiB.
+    `is_virtual` recurses through `__tensor_flatten__` and answers meta too,
+    which is why the separate meta arm that stood here is gone.
+    """
+
+    from ..meta_instantiation import is_virtual
 
     heavy = []
     for holder in ("state_dict", "constants"):
         for name, value in (getattr(program, holder, None) or {}).items():
-            if not isinstance(value, torch.Tensor) or isinstance(value, FakeTensor):
-                continue
-            if value.device.type == "meta":
+            if not isinstance(value, torch.Tensor) or is_virtual(value):
                 continue
             if value.numel() * value.element_size() > _REAL_TENSOR_BYTES_CEILING:
                 heavy.append(f"{holder}.{name} ({value.numel() * value.element_size()} bytes)")

--- a/tests/test_graph_blob_virtuality_pgw1661.py
+++ b/tests/test_graph_blob_virtuality_pgw1661.py
@@ -1,0 +1,130 @@
+"""The graph-blob weight guard asks about STORAGE, never about TYPE (pgw#1661).
+
+pgw#1198's ruling, re-proved at the site that re-broke it: `_assert_weights_free`
+is the last thing between a hollow derive and a graph blob, and it read
+`isinstance(..., FakeTensor)`. A wrapper subclass over fake data is a FakeTensor
+to nobody, so minimax-h3's ~300 virtual denoiser weights priced out at ~23 GB of
+"REAL" tensors on an 8 GiB card that reported `allocated=0.0GiB`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("accelerate")
+
+from gen_worker.release.derive import (  # noqa: E402
+    _REAL_TENSOR_BYTES_CEILING,
+    _assert_weights_free,
+    DeriveError,
+)
+from test_wrapper_subclass_virtuality_pgw1198 import (  # noqa: E402
+    Quantized,
+    real_quantized,
+)
+
+#: bf16 over this shape is 128 MiB — twice the guard's ceiling, so a tensor of
+#: this shape is heavy whichever side of the predicate it lands on.
+HEAVY = (8192, 8192)
+
+
+class _Program:
+    """`torch.export.ExportedProgram`'s two weight-bearing holders, and nothing
+    else — the guard reads `state_dict` and `constants` and asks no more."""
+
+    def __init__(self, state_dict: Optional[Dict[str, Any]] = None,
+                 constants: Optional[Dict[str, Any]] = None) -> None:
+        self.state_dict = dict(state_dict or {})
+        self.constants = dict(constants or {})
+
+
+def _fake(shape: Any, dtype: Any) -> Any:
+    with torch._subclasses.fake_tensor.FakeTensorMode():
+        return torch.empty(tuple(shape), dtype=dtype)
+
+
+def _quantized_over_fake(shape: Any) -> Any:
+    """What a `setup()`-time quantizer leaves on a hollow denoiser."""
+    return Quantized(
+        _fake(shape, torch.float8_e4m3fn),
+        _fake((shape[0], 1), torch.float32),
+        torch.bfloat16,
+    )
+
+
+def test_a_wrapper_subclass_over_fake_data_is_not_a_weight() -> None:
+    """h3's sink death, in one tensor."""
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    virtual = _quantized_over_fake(HEAVY)
+    assert not isinstance(virtual, FakeTensor), (
+        "the premise: the object the old predicate could not see")
+    assert virtual.numel() * virtual.element_size() > _REAL_TENSOR_BYTES_CEILING, (
+        "and it prices heavy off its OUTER metadata, which is the whole hazard")
+
+    _assert_weights_free(torch, _Program({"transformer_blocks.0.attn.to_q.weight": virtual}))
+
+
+def test_a_plain_fake_tensor_is_not_a_weight() -> None:
+    _assert_weights_free(torch, _Program({"w": _fake(HEAVY, torch.bfloat16)}))
+
+
+def test_a_meta_tensor_is_not_a_weight() -> None:
+    _assert_weights_free(torch, _Program({"w": torch.empty(HEAVY, dtype=torch.bfloat16,
+                                                           device="meta")}))
+
+
+def test_a_hollow_denoiser_of_three_hundred_such_weights_stores() -> None:
+    """The measured shape of the refusal: 300 tensors, ~23 GB of nothing."""
+    program = _Program({
+        f"transformer_blocks.{i}.attn.to_q.weight": _quantized_over_fake(HEAVY)
+        for i in range(300)
+    })
+
+    _assert_weights_free(torch, program)
+
+
+def test_the_guard_still_FIRES_on_a_real_weight() -> None:
+    """The fence must stay able to go red — that is the point of pgw#1198's fence."""
+    program = _Program({"transformer_blocks.0.attn.to_q.weight":
+                        torch.empty(HEAVY, dtype=torch.bfloat16)})
+
+    with pytest.raises(DeriveError) as caught:
+        _assert_weights_free(torch, program)
+    assert "1 REAL tensor(s)" in str(caught.value)
+    assert "transformer_blocks.0.attn.to_q.weight" in str(caught.value)
+
+
+def test_the_guard_still_FIRES_on_a_wrapper_subclass_over_REAL_data() -> None:
+    """Storage, not type, in the other direction too: the same subclass over
+    real bytes IS weights, and a type-blind predicate would have to keep saying
+    so."""
+    program = _Program(constants={"quantized": real_quantized(HEAVY)})
+
+    with pytest.raises(DeriveError) as caught:
+        _assert_weights_free(torch, program)
+    assert "constants.quantized" in str(caught.value)
+
+
+def test_a_real_weight_is_still_found_BESIDE_three_hundred_virtual_ones() -> None:
+    """The mixed case is the one a coarse fix would lose: exempting the holder
+    because most of it is virtual would silently pass a checkpoint."""
+    state = {
+        f"transformer_blocks.{i}.attn.to_q.weight": _quantized_over_fake(HEAVY)
+        for i in range(300)
+    }
+    state["transformer_blocks.7.ff.net.2.weight"] = torch.empty(
+        HEAVY, dtype=torch.bfloat16)
+
+    with pytest.raises(DeriveError) as caught:
+        _assert_weights_free(torch, _Program(state))
+    assert "1 REAL tensor(s)" in str(caught.value)
+    assert "transformer_blocks.7.ff.net.2.weight" in str(caught.value)
+
+
+def test_a_small_real_tensor_is_a_config_derived_buffer_and_passes() -> None:
+    _assert_weights_free(torch, _Program({"rope.freqs": torch.empty(
+        (16, 16), dtype=torch.float32)}))


### PR DESCRIPTION
`release/derive.py`'s program sink is the last thing between a hollow derive and a graph blob, and it exempted a virtual tensor with `isinstance(..., FakeTensor)`. A `torch.Tensor` **wrapper subclass** over fake data — what a `setup()`-time quantizer leaves on a hollow denoiser — is a `FakeTensor` to nobody, and it prices itself off its OUTER metadata.

So minimax-h3's derive stated its graph identity — `cg-graph-v1-80f309eb…` — and then refused it:

```
DeriveError: the derive is about to serialize 300 REAL tensor(s) far too large to be
config-derived buffers into a graph blob:
['state_dict.transformer_blocks.0.attn.to_q.weight (77070336 bytes)', …]
```

≈23 GB, on an 8 GiB card whose own line one frame earlier read `allocated=0.0GiB free=6.8GiB`. The tree is config-only; there were no weights on disk to load.

This is **pgw#1198's ruling re-broken at a second site** — *virtuality is a question about STORAGE, never about TYPE* — so the fix is the predicate that ruling already produced: `meta_instantiation.is_virtual`, which recurses through `__tensor_flatten__` and answers `meta` too. The guard's separate `device.type == "meta"` arm goes with the type check: two spellings of one fact is how this drifted in the first place.

## Measured, not assumed

A probe over h3's own sink census, 1442 tensors:

| kind | count | `isinstance(FakeTensor)` | `is_virtual` |
|---|---|---|---|
| `FakeTensor` | 1138 | ✅ | ✅ |
| **`Float8Tensor`** (torchao) | **300** | ❌ | ✅ |
| `Tensor` (small real config buffers) | 4 | ❌ | ❌ |

torchao's `Float8Tensor` is exactly the subclass the filing named, and the 4 genuinely real tensors are correctly still under the 64 MiB ceiling.

## Red proofs

- `tests/test_graph_blob_virtuality_pgw1661.py` (8) is **red on `8bd75832`** in exactly the three arms the predicate decides. The other five pass on master — the control that the test is not merely asserting the new code.
- **h3's REAL derive** at the pin `d0dcd331`, config-only tree, `ENUM_CAP=1`: the same command that refuses `300 REAL tensor(s)` on master now **passes the weight guard**, with the graph key **unmoved**, and dies one statement later inside `torch.export.save` (`AttributeError: Can't get local object 'WeakValueDictionary.__init__.<locals>.remove'`) — pgw#1662, a different defect, filed with an 8-line stdlib reproducer.

**The fence stays able to fire**, which is the whole point of pgw#1198's fence: a real 128 MiB weight refuses; the SAME subclass over REAL storage refuses (storage, not type, in both directions); and one real weight hidden among 300 virtual ones is still the one tensor the message names.

## Sweep

First-party `src/` holds exactly one other `isinstance(…, FakeTensor)` — `is_virtual` itself, the producer.

**Three VENDORED torchcg sites do ask storage with a type predicate** and are handed to pgw#1656/tcg#90, which is moving both modules first-party this week (the snapshot is digest-fenced by `tests/test_vendored_snapshot_pgw1310.py`, and pgw#1659 already paid a second PR for patching it):

- `_vendor/torchcg/hollow.py:831 is_hollow` — a quantized hollow module reads as real, so author `.to("cuda")` takes torch's real path
- `_vendor/torchcg/hollow.py:945` — the host-egress shim would `.cpu()` a tensor with no storage
- `_vendor/torchcg/discovery.py:271 _assert_literal_values_are_real` — a subclass over fake is a table of zeros too

Left alone with reasons: the two `_fake_mode_of` helpers (`discovery.py:155`, `bind.py:36`) and `hollow.py:516` read `.fake_mode`, which only a `FakeTensor` has — genuine type questions. `structure_only.fake_mode_of{,_program}` duck-type for a MODE OBJECT, not a verdict. `serving/streaming/census.py`'s six `device.type == "meta"` reads are PLACEMENT questions on the real serving path, where meta means "never filled" and is the thing they must keep reporting.

Closes pgw#1661.