### PR TITLE
pgw#1660: the worker is a COMPLETE protocol-v5 producer again, and it ships as ONE all-or-nothing pair

### DIFF
--- a/changelog.d/pgw1660.md
+++ b/changelog.d/pgw1660.md
@@ -58,3 +58,30 @@
   is the UTF-8 bytes of the digest *string*; `FunctionCapability.binding_digest` is raw sha256
   bytes. Both are echoed exactly as the hub states them — a worker that "helpfully" normalises
   either breaks a `bytes.Equal` nobody sees fail.
+
+- **Two more rules of the same family, found by asking "can the hub actually send this?" of every
+  check in the registry rather than reading the proto comment.**
+
+  `command_seq` conflict detection was keyed on the **command digest**. The hub keys same-seq
+  identity on `goal_id`/`release_id` itself, and a digest comparison rejects a legal *re-statement*
+  of the same goal: `config_digest` is empty on the first HelloAck of a boot and filled in on the
+  reconnect after, at the same `command_seq` (the hub uses the residency generation for it). That
+  reads as `COMMAND_SEQ_CONFLICT`, costs the accepted receipt, and starves the release from the
+  first reconnect onward. Now keyed on `goal_id`; a genuine goal drift is still refused.
+
+  The `intent cause is required` rule is deleted. `DesiredIntentCause` is provenance telemetry —
+  nothing the worker does with an intent depends on it — and the intent carrying it is often the
+  one mandatory `CONFIG_APPLY`, where declining latches `protocol_rejected` and bricks the process.
+
+  The generalisation is worth more than the three fixes: **every validation in the registry was
+  inert while the typed path adjudicated nothing, and all of them become load-bearing the moment
+  a release goes typed.** "Mandatory field" in a proto comment is not the same question as "can
+  the hub actually emit this", and only the second one decides whether a pod can be dispatched to.
+
+- **The binding-digest echo reads the COMMAND, not the registry's intent bookkeeping.** Re-issuing
+  an intent id with a different binding is "intent_id reused for different work" — an advisory
+  decline that drops the intent out of the accepted set. Reading the digest from there means a
+  re-bound function falls back to the derivation *permanently*, which is precisely the silent
+  `exact_binding_digest_mismatch` the echo exists to prevent. "The hub says function F binds to
+  digest X" is true whether or not the intent carrying it was accepted, superseded, or trimmed at
+  the 128-intent bound.

--- a/changelog.d/pgw1660.md
+++ b/changelog.d/pgw1660.md
@@ -42,3 +42,19 @@
 - **A snapshot the hub would discard is never sent.** `snapshot_refusal` mirrors
   `validateLifecycleSnapshot`'s mandatory-field rules; a projection that breaks one is held back
   with a loud line instead of costing the release its typed cohort silently.
+
+- **One rule REMOVED because it was a dispatch starve wearing a mandatory-field costume.** The
+  registry used to reject a `DesiredStateCommand` carrying `config_generation > 0` with an empty
+  `config_digest`. The hub builds that field from `protocolConfigDigest(resolutionCfg)`, and
+  `resolutionCfg` is legitimately nil on the **first HelloAck of every boot** — a build error, a
+  discarded stale build, or simply no provider yet — while `config_generation` comes from the
+  worker's already-persisted `DesiredResidency` and is non-zero. Under the legacy path that
+  rejection cost nothing; under the typed path it costs the ACCEPTED receipt, and no accepted
+  receipt for the *current* command is `exact_goal_receipt_not_accepted` — nothing on the release
+  is dispatchable, on every cold boot. An absent digest is the hub saying it has no config to
+  describe, not a malformed command.
+
+- **The two digests keep their opposite encodings, on purpose.** `DesiredIntent.snapshot_digest`
+  is the UTF-8 bytes of the digest *string*; `FunctionCapability.binding_digest` is raw sha256
+  bytes. Both are echoed exactly as the hub states them — a worker that "helpfully" normalises
+  either breaks a `bytes.Equal` nobody sees fail.

--- a/changelog.d/pgw1660.md
+++ b/changelog.d/pgw1660.md
@@ -85,3 +85,11 @@
   `exact_binding_digest_mismatch` the echo exists to prevent. "The hub says function F binds to
   digest X" is true whether or not the intent carrying it was accepted, superseded, or trimmed at
   the 128-intent bound.
+
+- **A re-statement answers with the receipt the hub already holds, byte for byte.** The hub keys
+  receipt identity on `command_seq` and refuses a second one at that seq that is not `proto.Equal`
+  — and a fresh `received_at_unix_ms` alone is enough to differ. That books a
+  `worker_protocol_rejected` row on the first reconnect of every pod whose boot HelloAck carried
+  no `config_digest`. Harmless to dispatch (the hub keeps the older accepted receipt), and still a
+  rejection row on a fleet whose acceptance bar is **zero** of them. The command still applies in
+  full; only the answer is stabilised.

--- a/changelog.d/pgw1660.md
+++ b/changelog.d/pgw1660.md
@@ -1,0 +1,44 @@
+- **The worker is a complete protocol-v5 lifecycle producer again, and it ships as ONE
+  all-or-nothing pair.** pgw#1373 deleted `lifecycle.py` with the v1 SDK, taking with it the sole
+  producer of `Hello.lifecycle_snapshot`, of mid-stream `WorkerMessage(lifecycle_snapshot=…)` and
+  of the `HelloAck.desired_state_command` → `GoalReceipt` answer. The v2 worker kept
+  `worker_session_id` and inherited none of it, so **every live pod booked
+  `worker_protocol_rejected / hello_session_id_missing_snapshot` within 400 ms of connecting** and
+  the entire fleet was judged by the hub's legacy health verdicts (th#2298 incident, root-caused
+  by th#2300).
+
+  `Hello.worker_session_id` and `Hello.lifecycle_snapshot` now come out of **one call**,
+  `WorkerLifecycle.hello_projection()`, which answers with both or with `("", None)`. That shape
+  is the fix's whole safety argument, not a style choice: the hub's cohort flag is **not**
+  health-only — `releaseUsesExactCapabilities` → `placement.ExactCapabilityRequired` →
+  `workerHasExactReadyCapabilityLocked`. A worker that ships the pair *without* a capability set
+  and without an ACCEPTED receipt for the hub's current command converts an inert typed path into
+  a **total dispatch starve on its release**. A pod that cannot state a complete projection stays
+  legacy, which is inert; it never ships half of one.
+
+- **The capability projection is stated, not introspected.** `refresh_projection` used to read six
+  fields off the deleted v1 `Executor`; it now takes a `CapabilityFacts` record the worker fills
+  in. Two fields come from the hub's own statements rather than from a re-derivation:
+  `binding_digest` is **echoed** from the `FUNCTION_READY` intent the hub authored (it compares
+  with `bytes.Equal`, and a marshalling difference on either side is a silent
+  `exact_binding_digest_mismatch`), and `lane` is the hub's `HelloAck.resolutions` pick, never this
+  worker's own ladder pick.
+
+- **`runtime_config` is wired back in**, so the config application can actually converge:
+  `extract_config_push` had no caller and `ConfigStore` had no users at all in v2. Without the
+  parameter-snapshot and binding-ready generations the application never leaves `APPLYING`, every
+  capability stays `APPLYING`, and a typed release is one nothing can be dispatched to.
+
+- **The procsplit parent owns the emitted sequence, the session and the terminal intent history.**
+  A compute child's `worker_session_id` survives a respawn but its `state_seq` resets to 1, and the
+  hub **silently drops** a snapshot whose seq regressed and **rejects** one that reuses a seq with
+  different bytes — pgw's own 2026-08-19 audit §2, filed there and never fixed. `LifecycleRelay`
+  renumbers every outgoing snapshot from a parent-owned monotonic counter, re-stamps the session on
+  every nested field, and re-emits a terminal intent the hub already accepted rather than letting a
+  respawned child regress it (which would cost the *whole* snapshot). What dispatch actually reads
+  — the capability's state — still comes live from the child. Across G groups the worker is READY
+  only where every group is, and one group's REJECTED is the worker's answer.
+
+- **A snapshot the hub would discard is never sent.** `snapshot_refusal` mirrors
+  `validateLifecycleSnapshot`'s mandatory-field rules; a projection that breaks one is held back
+  with a loud line instead of costing the release its typed cohort silently.

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -1,0 +1,307 @@
+"""The worker's protocol-v5 lifecycle PRODUCER (#1660 / th#2300).
+
+#1373 deleted this file along with the v1 SDK, and with it the only producer of
+``Hello.lifecycle_snapshot``, of mid-stream ``WorkerMessage(lifecycle_snapshot=)``
+and of the ``HelloAck.desired_state_command`` -> ``GoalReceipt`` answer. The v2
+worker kept ``worker_session_id`` and inherited none of it, so every live worker
+booked ``worker_protocol_rejected / hello_session_id_missing_snapshot`` and the
+whole fleet fell through to the hub's LEGACY health verdicts.
+
+**A PARTIAL PRODUCER IS WORSE THAN NO PRODUCER.** The hub's cohort flag is not
+health-only: `releaseUsesExactCapabilities` -> `placement.ExactCapabilityRequired`
+-> `workerHasExactReadyCapabilityLocked`. The moment every live worker on a
+release carries the (session id, snapshot) pair, dispatch REQUIRES a matching
+READY `FunctionCapability` at the command's `config_generation` and lane plus an
+ACCEPTED `GoalReceipt` for the hub's current `DesiredStateCommand`. A worker that
+ships the snapshot and nothing else converts an inert typed path into a TOTAL
+DISPATCH STARVE on its release.
+
+So the session id and the snapshot leave this module as ONE PAIR, from one call,
+and only when every leg of the producer is wired and the projection validates
+against the hub's own rules. Anything less answers ``("", None)`` and the worker
+stays legacy — inert, and correct.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, Iterable, Optional, Tuple
+
+from .config.settings import BOOT_CONFIG_GENERATION_ABSENT
+from .lifecycle_intents import CapabilityFacts, IntentRegistry
+from .pb import worker_scheduler_pb2 as pb
+
+logger = logging.getLogger(__name__)
+
+_TERMINAL = {
+    pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED,
+    pb.LIFECYCLE_INTENT_STATUS_FAILED,
+    pb.LIFECYCLE_INTENT_STATUS_CANCELED,
+    pb.LIFECYCLE_INTENT_STATUS_SUPERSEDED,
+}
+
+
+def snapshot_refusal(snapshot: "pb.LifecycleSnapshot", release_id: str) -> str:
+    """Why the hub would DISCARD this snapshot, or ``""``.
+
+    A mirror of `validateLifecycleSnapshot`'s mandatory-field rules
+    (tensorhub `internal/orchestrator/grpc/residency_protocol.go`). The hub
+    discards a snapshot that breaks any of them WHOLE — one malformed intent
+    costs the entire projection and the release's typed cohort with it. Refusing
+    to send it keeps the worker legacy instead, which is inert rather than wrong.
+    """
+    session = str(snapshot.worker_session_id or "").strip()
+    if not session:
+        return "snapshot carries no worker_session_id"
+    if not snapshot.full_replace:
+        return "snapshot is not full_replace"
+    if int(snapshot.state_seq) == 0:
+        return "snapshot carries no state_seq"
+    if not str(release_id or "").strip():
+        return "this worker has no release_id"
+    seen_intents: set[str] = set()
+    for intent in snapshot.intents:
+        intent_id = str(intent.intent_id or "").strip()
+        if not intent_id or not str(intent.goal_id or "").strip():
+            return f"intent {intent_id!r} carries no identity"
+        if str(intent.release_id or "").strip() != release_id:
+            return f"intent {intent_id!r} release_mismatch"
+        if str(intent.worker_session_id or "").strip() != session:
+            return f"intent {intent_id!r} worker_session_mismatch"
+        if intent_id in seen_intents:
+            return f"intent {intent_id!r} is duplicated"
+        seen_intents.add(intent_id)
+        if (
+            int(intent.state_seq) == 0
+            or int(intent.status) == pb.LIFECYCLE_INTENT_STATUS_UNSPECIFIED
+            or int(intent.stage) == pb.LIFECYCLE_INTENT_STAGE_UNSPECIFIED
+        ):
+            return f"intent {intent_id!r} missing state_seq/status/stage"
+        if int(intent.since_unix_ms) <= 0 or int(intent.updated_at_unix_ms) < int(
+            intent.since_unix_ms
+        ):
+            return f"intent {intent_id!r} invalid since/updated timestamps"
+        if intent.blocker_intent_id == intent_id:
+            return f"intent {intent_id!r} blocks itself"
+        if int(intent.status) == pb.LIFECYCLE_INTENT_STATUS_WAITING:
+            if int(intent.reason) == pb.LIFECYCLE_WAIT_REASON_UNSPECIFIED:
+                return f"waiting intent {intent_id!r} states no reason"
+            blocked = bool(intent.blocker_intent_id) or bool(
+                intent.blocker_request.request_id
+            )
+            if not blocked and not (
+                int(intent.next_retry_at_unix_ms) > 0
+                or int(intent.deadline_at_unix_ms) > 0
+            ):
+                return f"waiting intent {intent_id!r} states no retry or deadline"
+    seen_functions: set[str] = set()
+    for capability in snapshot.capabilities:
+        name = str(capability.function_name or "").strip()
+        if (
+            not name
+            or not str(capability.release_id or "").strip()
+            or int(capability.state) == pb.FUNCTION_CAPABILITY_STATE_UNSPECIFIED
+        ):
+            return f"capability {name!r} missing mandatory identity/state"
+        if str(capability.release_id or "").strip() != release_id:
+            return f"capability {name!r} release_mismatch"
+        if name in seen_functions:
+            return f"capability {name!r} is duplicated"
+        seen_functions.add(name)
+    for receipt in snapshot.goal_receipts:
+        if (
+            str(receipt.worker_session_id or "").strip() != session
+            or int(receipt.command_seq) == 0
+            or not str(receipt.goal_id or "").strip()
+            or not str(receipt.release_id or "").strip()
+            or int(receipt.status) == pb.GOAL_RECEIPT_STATUS_UNSPECIFIED
+            or int(receipt.received_at_unix_ms) <= 0
+        ):
+            return f"goal receipt {receipt.goal_id!r} missing mandatory identity/status"
+        if str(receipt.release_id or "").strip() != release_id:
+            return f"goal receipt {receipt.goal_id!r} release_mismatch"
+    application = snapshot.config_application
+    if snapshot.HasField("config_application"):
+        if str(application.release_id or "").strip() != release_id:
+            return "config application release_mismatch"
+        if int(application.target_generation) == 0:
+            return "config application carries no target_generation"
+        if int(application.state) == pb.CONFIG_APPLICATION_STATE_UNSPECIFIED:
+            return "config application states no state"
+    return ""
+
+
+class WorkerLifecycle:
+    """ONE intent registry per worker process, and the complete v5 producer around it."""
+
+    def __init__(
+        self,
+        *,
+        release_id: str,
+        function_names: Iterable[str],
+        facts: Callable[[], CapabilityFacts],
+        send: Callable[["pb.WorkerMessage"], Awaitable[None]],
+        boot_config_generation: int = BOOT_CONFIG_GENERATION_ABSENT,
+    ) -> None:
+        self.registry = IntentRegistry(
+            release_id,
+            function_names,
+            boot_config_generation=boot_config_generation,
+        )
+        self.release_id = self.registry.release_id
+        self._facts = facts
+        self._send = send
+        #: Set by :meth:`hello_ack_route`. The goal-receipt answer is not
+        #: optional wiring a caller may forget: without it the pair below is
+        #: withheld and this process never joins the typed cohort.
+        self._answers_commands = False
+        #: True once a Hello went out carrying the pair. Mid-stream snapshots and
+        #: receipts are only legal after that — the hub matches them against a
+        #: session id it must already have seen.
+        self._announced = False
+        self._last_sent = b""
+
+    @property
+    def worker_session_id(self) -> str:
+        """The ONE producer of this process's session id (env-seeded under procsplit)."""
+        return self.registry.worker_session_id
+
+    def refresh(self) -> None:
+        self.registry.refresh_projection(self._facts())
+
+    # ---- the all-or-nothing pair --------------------------------------------
+
+    def hello_projection(self) -> Tuple[str, Optional["pb.LifecycleSnapshot"]]:
+        """``(worker_session_id, lifecycle_snapshot)`` — both, or neither.
+
+        The pair is the fence. A caller cannot ship the session id without the
+        snapshot (the hub's `hello_session_id_missing_snapshot`, which is the
+        defect this issue exists for) nor the snapshot without the session id
+        (`hello_snapshot_missing_session_id`), because there is one call and it
+        answers with both or with nothing.
+
+        ``("", None)`` is a LEGACY hello: no rejection row, no typed cohort, no
+        dispatch starve. It is what this process sends whenever it cannot state a
+        complete projection.
+        """
+        refusal = self._incomplete()
+        if refusal:
+            logger.error(
+                "protocol-v5 lifecycle WITHHELD (this worker connects as legacy): %s. "
+                "A half producer would flip its release to ExactCapabilityRequired "
+                "and starve every dispatch on it, so the pair is all-or-nothing.",
+                refusal,
+            )
+            self._announced = False
+            return "", None
+        snapshot = self.registry.snapshot()
+        self._announced = True
+        self._last_sent = snapshot.SerializeToString(deterministic=True)
+        return self.worker_session_id, snapshot
+
+    def _incomplete(self) -> str:
+        """Why this process is not a COMPLETE v5 producer, or ``""``."""
+        if not self.release_id:
+            return "no release_id, so no capability can ever name one"
+        if not self._answers_commands:
+            return (
+                "the HelloAck -> GoalReceipt route is not installed, so the hub "
+                "would never hold an ACCEPTED receipt for its own command"
+            )
+        if self._send is None:
+            return "no transport is bound, so no mid-stream snapshot could follow"
+        self.refresh()
+        snapshot = self.registry.snapshot()
+        projected = {
+            str(capability.function_name) for capability in snapshot.capabilities
+        }
+        missing = sorted(self.registry.function_names - projected)
+        if missing:
+            return f"the capability projection names no capability for {missing}"
+        refusal = snapshot_refusal(snapshot, self.release_id)
+        if refusal:
+            return f"the hub would discard this projection: {refusal}"
+        return ""
+
+    # ---- the goal-receipt answer --------------------------------------------
+
+    def hello_ack_route(
+        self,
+        body: Callable[["pb.HelloAck"], Awaitable[None]],
+        *,
+        prepare: Optional[Callable[["pb.HelloAck"], None]] = None,
+    ) -> Callable[["pb.HelloAck"], Awaitable[None]]:
+        """Wrap the worker's HelloAck handler so the command is answered FIRST.
+
+        The hub's accept budget is 2 s from the moment it issued the command
+        (`protocolGoalAcceptBudget`), and the rest of a HelloAck handler
+        configures checkpoint materialization. The receipt goes out before any of
+        that. ``prepare`` absorbs the hub-stated facts the projection reads
+        (desired instances, resolved lanes) so the snapshot that rides with the
+        receipt already carries them. Taking this route is also what arms
+        :meth:`hello_projection`.
+        """
+        self._answers_commands = True
+
+        async def route(ack: "pb.HelloAck") -> None:
+            if prepare is not None:
+                prepare(ack)
+            await self.answer_hello_ack(ack)
+            await body(ack)
+
+        return route
+
+    async def answer_hello_ack(self, ack: "pb.HelloAck") -> None:
+        if not self._announced or not ack.HasField("desired_state_command"):
+            return
+        command = ack.desired_state_command
+        receipt = self.registry.apply_command(
+            command,
+            current_config_generation=int(self._facts().config_generation),
+        )
+        await self._send(pb.WorkerMessage(goal_receipt=receipt))
+        if receipt.status == pb.GOAL_RECEIPT_STATUS_REJECTED:
+            logger.error(
+                "desired-state command %s/%d REJECTED: %s (%s)",
+                command.goal_id, command.command_seq, receipt.detail,
+                "mandatory" if self.registry.protocol_rejected else "advisory",
+            )
+        await self.publish(force=True)
+
+    # ---- mid-stream snapshots ------------------------------------------------
+
+    async def publish(self, *, force: bool = False) -> None:
+        """Send the current projection if it CHANGED (the hub drops a repeat seq)."""
+        if not self._announced:
+            return
+        self.refresh()
+        snapshot = self.registry.snapshot()
+        raw = snapshot.SerializeToString(deterministic=True)
+        if not force and raw == self._last_sent:
+            return
+        refusal = snapshot_refusal(snapshot, self.release_id)
+        if refusal:
+            logger.error(
+                "mid-stream lifecycle snapshot HELD BACK — the hub would discard "
+                "it whole and the projection would freeze at its last good state: %s",
+                refusal,
+            )
+            return
+        self._last_sent = raw
+        await self._send(pb.WorkerMessage(lifecycle_snapshot=snapshot))
+
+
+def terminal_intents(snapshot: "pb.LifecycleSnapshot") -> dict:
+    """The snapshot's intents that have reached a terminal status, by id."""
+    return {
+        str(intent.intent_id): intent
+        for intent in snapshot.intents
+        if int(intent.status) in _TERMINAL
+    }
+
+
+__all__ = [
+    "WorkerLifecycle",
+    "snapshot_refusal",
+    "terminal_intents",
+]

--- a/src/gen_worker/lifecycle_intents.py
+++ b/src/gen_worker/lifecycle_intents.py
@@ -145,7 +145,8 @@ class IntentRegistry:
         self._state_seq = 1
         self._updated_at_ms = _now_ms()
         self._last_command_seq = 0
-        self._last_command_digest = b""
+        self._last_goal_id = ""
+        self._command_binding_digests: dict[str, bytes] = {}
         self._last_receipt: Optional[pb.GoalReceipt] = None
         self._command_receipts: "OrderedDict[tuple[int, bytes], pb.GoalReceipt]" = OrderedDict()
         self._target_config_generation = 0
@@ -291,9 +292,17 @@ class IntentRegistry:
             )
         elif (
             int(command.command_seq) == self._last_command_seq
-            and self._last_command_digest
-            and digest != self._last_command_digest
+            and self._last_goal_id
+            and str(command.goal_id or "").strip() != self._last_goal_id
         ):
+            # KEYED ON goal_id, NOT ON THE COMMAND DIGEST (#1660). The hub keys
+            # same-seq identity on (goal_id, release_id) itself
+            # (`applyGoalReceiptLocked`), and a digest comparison rejects a
+            # perfectly legal RE-STATEMENT of the same goal: `config_digest` is
+            # empty on the first HelloAck of a boot and filled in on the
+            # reconnect after, at the SAME command_seq. That reads as a conflict,
+            # costs the ACCEPTED receipt for the current command, and starves
+            # every dispatch on the release from the first reconnect onward.
             command_errors.append(
                 (
                     "",
@@ -365,14 +374,12 @@ class IntentRegistry:
                     )
                 )
             kind = int(intent.kind)
-            if int(intent.cause) == pb.DESIRED_INTENT_CAUSE_UNSPECIFIED:
-                command_errors.append(
-                    (
-                        intent_id,
-                        pb.LIFECYCLE_ERROR_CODE_MISSING_MANDATORY_FIELD,
-                        "intent cause is required",
-                    )
-                )
+            # NO `cause is required` RULE. `DesiredIntentCause` is provenance
+            # telemetry — nothing the worker does with an intent depends on it —
+            # and the intent carrying it is often the ONE mandatory CONFIG_APPLY,
+            # where declining latches `protocol_rejected` and bricks the process.
+            # Refusing work over a missing label is the same defect class as the
+            # `config_digest` rule this issue deleted.
             if kind not in _SUPPORTED_INTENT_KINDS:
                 command_errors.append(
                     (
@@ -527,7 +534,14 @@ class IntentRegistry:
                 self._intents[intent_id] = declined_state
         self._trim_intents()
         self._last_command_seq = int(command.command_seq)
-        self._last_command_digest = digest
+        self._last_goal_id = str(command.goal_id or "").strip()
+        self._command_binding_digests = {
+            str(intent.function_name or "").strip(): bytes(intent.binding_digest)
+            for intent in command.intents
+            if int(intent.kind) == pb.DESIRED_INTENT_KIND_FUNCTION_READY
+            and str(intent.function_name or "").strip()
+            and bytes(intent.binding_digest)
+        }
         changed_classes = (
             command.changed_config_classes if command.HasField("changed_config_classes") else None
         )
@@ -1094,16 +1108,17 @@ class IntentRegistry:
         `exact_binding_digest_mismatch` — dispatch starve, not an error). The
         derivation stays as the fallback for a function the current command
         names no ready intent for.
+
+        Read off the COMMAND, deliberately, not off this registry's intent
+        bookkeeping. "The hub says function F binds to digest X" is true whether
+        or not the intent carrying it was accepted, superseded or trimmed at the
+        128-intent bound — and a function whose binding changed would otherwise
+        fall back to the derivation permanently, which is the silent mismatch
+        this echo exists to prevent.
         """
-        for intent_id, intent in self._desired_intents.items():
-            if int(intent.kind) != pb.DESIRED_INTENT_KIND_FUNCTION_READY:
-                continue
-            if str(intent.function_name or "").strip() != function_name:
-                continue
-            state = self._intents.get(intent_id)
-            if state is not None and int(state.status) in _ACTIVE_INTENT_STATES:
-                if bytes(intent.binding_digest):
-                    return bytes(intent.binding_digest)
+        stated = self._command_binding_digests.get(function_name)
+        if stated:
+            return stated
         return _binding_digest(function_name, instance)
 
     def refresh_projection(self, facts: "CapabilityFacts") -> None:

--- a/src/gen_worker/lifecycle_intents.py
+++ b/src/gen_worker/lifecycle_intents.py
@@ -309,14 +309,18 @@ class IntentRegistry:
                     "config_generation regressed",
                 )
             )
-        if int(command.config_generation) > 0 and not bytes(command.config_digest):
-            command_errors.append(
-                (
-                    "",
-                    pb.LIFECYCLE_ERROR_CODE_MISSING_MANDATORY_FIELD,
-                    "config_digest is required when config_generation is set",
-                )
-            )
+        # NO `config_digest is required when config_generation is set` RULE.
+        # It reads like a mandatory-field check and is in fact a dispatch starve
+        # on every fresh boot (#1660). The hub builds the command with
+        # `protocolConfigDigest(resolutionCfg)`, and `resolutionCfg` is legitimately
+        # nil on the FIRST HelloAck of a boot — a build error, a discarded stale
+        # build, or simply no provider yet (`hello_ack.go`) — while
+        # `config_generation` comes from the worker's already-persisted
+        # DesiredResidency and is > 0. Rejecting that pair costs the ACCEPTED
+        # receipt, and no accepted receipt for the CURRENT command is
+        # `exact_goal_receipt_not_accepted`: nothing on the release is
+        # dispatchable. An absent digest is the hub saying it has no config to
+        # describe, never a malformed command.
         if int(command.config_generation) > 0 and not bytes(command.parameter_snapshot):
             command_errors.append(
                 (

--- a/src/gen_worker/lifecycle_intents.py
+++ b/src/gen_worker/lifecycle_intents.py
@@ -8,7 +8,8 @@ import os
 import time
 import uuid
 from collections import OrderedDict
-from typing import Any, Awaitable, Callable, Iterable, Optional, TypeVar
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Iterable, Mapping, Optional, TypeVar
 
 from .config.settings import BOOT_CONFIG_GENERATION_ABSENT
 from .pb import worker_scheduler_pb2 as pb
@@ -80,6 +81,45 @@ def _intent_identity_digest(intent: "pb.DesiredIntent") -> bytes:
 
 class UnreportedIntentWait(RuntimeError):
     """A protocol-owned await outlived the reporting grace period."""
+
+
+@dataclass(frozen=True)
+class CapabilityFacts:
+    """What a v2 worker knows about itself, in the shape the capability projection consumes.
+
+    The v1 ``Executor`` this projection used to read is DELETED (#1373). Three of
+    its six inputs had no v2 equivalent, so the projection takes a stated record
+    instead of an object it introspects — one producer per field, and a caller
+    that cannot silently supply half of one.
+    """
+
+    #: The generation the hub's config push advertised (DesiredResidency /
+    #: DesiredStateCommand ``config_generation``). 0 = none pushed yet.
+    config_generation: int = 0
+    #: The generation whose parameter snapshot this process has durably written.
+    parameter_snapshot_generation: int = 0
+    #: The generation whose desired BINDINGS (the hub's checkpoint residency for
+    #: this release) this process has finished reconciling. Without it the config
+    #: application never converges, every capability stays APPLYING, and a typed
+    #: release cannot be dispatched to at all.
+    binding_ready_generation: int = 0
+    #: Functions this worker can serve RIGHT NOW.
+    available: frozenset[str] = frozenset()
+    #: Functions this worker has declared it cannot serve.
+    unavailable: frozenset[str] = frozenset()
+    #: function name -> the hub's own DesiredInstance for it. The binding digest
+    #: the hub compares against is derived from THIS message.
+    hot: Mapping[str, "pb.DesiredInstance"] = field(default_factory=dict)
+    #: model ref -> its residency record on this worker.
+    residency: Mapping[str, "pb.ModelResidency"] = field(default_factory=dict)
+    #: model ref -> the execution lane the HUB resolved for it
+    #: (``HelloAck.resolutions[].lane``). Never this worker's own ladder pick:
+    #: the hub compares the capability's lane to the lane IT projected.
+    lanes: Mapping[str, str] = field(default_factory=dict)
+    #: function name -> "eager" | "compiled" for a READY capability.
+    serving_tiers: Mapping[str, str] = field(default_factory=dict)
+    #: function name -> compile-target incarnation id.
+    compile_targets: Mapping[str, str] = field(default_factory=dict)
 
 
 class IntentRegistry:
@@ -1040,38 +1080,47 @@ class IntentRegistry:
             return
         self._advance_config_target(gen, changed_classes)
 
-    def refresh_projection(
-        self,
-        executor: Any,
-        desired: Optional["pb.DesiredResidency"],
-        resolutions: dict[str, tuple[Any, ...]],
-    ) -> None:
+    def binding_digest(self, function_name: str, instance: Optional["pb.DesiredInstance"]) -> bytes:
+        """The digest the hub compares a READY capability against.
+
+        Preferred source is the hub's OWN ``FUNCTION_READY`` intent, byte for
+        byte: `workerHasExactReadyCapabilityLocked` does `bytes.Equal` against
+        that field, so echoing it can never disagree with the hub, while
+        re-deriving it can (a marshalling difference on either side is a silent
+        `exact_binding_digest_mismatch` — dispatch starve, not an error). The
+        derivation stays as the fallback for a function the current command
+        names no ready intent for.
+        """
+        for intent_id, intent in self._desired_intents.items():
+            if int(intent.kind) != pb.DESIRED_INTENT_KIND_FUNCTION_READY:
+                continue
+            if str(intent.function_name or "").strip() != function_name:
+                continue
+            state = self._intents.get(intent_id)
+            if state is not None and int(state.status) in _ACTIVE_INTENT_STATES:
+                if bytes(intent.binding_digest):
+                    return bytes(intent.binding_digest)
+        return _binding_digest(function_name, instance)
+
+    def refresh_projection(self, facts: "CapabilityFacts") -> None:
         """Project exact capabilities and proven parameter snapshot state."""
-        parameter_generation = int(
-            getattr(executor.runtime_config, "parameter_snapshot_generation", 0)
-        )
+        parameter_generation = int(facts.parameter_snapshot_generation)
         if parameter_generation > int(self._config_application.parameter_snapshot_generation):
             self.config_snapshot_applied(parameter_generation)
+        binding_generation = int(facts.binding_ready_generation)
+        if binding_generation > int(self._config_application.binding_ready_generation):
+            self.bindings_applied(binding_generation)
         if not self.release_id:
             capabilities: list[pb.FunctionCapability] = []
         else:
-            hot = {
-                instance.function_name: instance
-                for instance in (desired.hot if desired is not None else ())
-                if instance.function_name
-            }
-            residency = {model.ref: model for model in executor.store.residency_snapshot()}
-            available = set(executor.available_functions())
-            compile_targets = {
-                name: target.incarnation_id
-                for target in executor.compile_targets()
-                for name in target.function_names
-            }
-            tiers_fn = getattr(executor, "serving_tiers", None)
-            tiers: dict[str, str] = tiers_fn() if callable(tiers_fn) else {}
+            hot = facts.hot
+            residency = facts.residency
+            available = set(facts.available)
+            compile_targets = facts.compile_targets
+            tiers = facts.serving_tiers
             config_state = int(self._config_application.state)
             target_generation = int(
-                self._config_application.target_generation or executor.runtime_config.generation
+                self._config_application.target_generation or facts.config_generation
             )
             capabilities = []
             for name in sorted(self.function_names):
@@ -1081,9 +1130,9 @@ class IntentRegistry:
                 )
                 execution_lanes = sorted(
                     {
-                        resolutions.get(ref, ("", "", ""))[2]
+                        facts.lanes[ref]
                         for ref in model_refs
-                        if resolutions.get(ref, ("", "", ""))[2]
+                        if str(facts.lanes.get(ref, "") or "")
                     }
                 )
                 if config_state == pb.CONFIG_APPLICATION_STATE_FAILED:
@@ -1096,7 +1145,7 @@ class IntentRegistry:
                     state = pb.FUNCTION_CAPABILITY_STATE_APPLYING
                 elif name in available:
                     state = pb.FUNCTION_CAPABILITY_STATE_READY
-                elif name in executor.unavailable:
+                elif name in facts.unavailable:
                     state = pb.FUNCTION_CAPABILITY_STATE_FAILED
                 else:
                     state = pb.FUNCTION_CAPABILITY_STATE_APPLYING
@@ -1105,7 +1154,7 @@ class IntentRegistry:
                         function_name=name,
                         release_id=self.release_id,
                         config_generation=target_generation,
-                        binding_digest=_binding_digest(name, instance),
+                        binding_digest=self.binding_digest(name, instance),
                         lane=",".join(execution_lanes),
                         models=[
                             pb.ModelIdentity(
@@ -1216,4 +1265,4 @@ class IntentRegistry:
         return snapshot
 
 
-__all__ = ["IntentRegistry", "UnreportedIntentWait"]
+__all__ = ["CapabilityFacts", "IntentRegistry", "UnreportedIntentWait"]

--- a/src/gen_worker/lifecycle_intents.py
+++ b/src/gen_worker/lifecycle_intents.py
@@ -562,6 +562,26 @@ class IntentRegistry:
             received_at_unix_ms=now,
             command_digest=digest,
         )
+        # A RE-STATEMENT of the same goal at the same seq answers with the
+        # receipt the hub ALREADY HOLDS, byte for byte. The command still
+        # applied in full above — only the answer is stabilised. The hub keys
+        # receipt identity on `command_seq` and refuses a second one at that seq
+        # that is not `proto.Equal` ("goal receipt command_seq conflict"), and a
+        # fresh `received_at_unix_ms` alone is enough to differ. That books a
+        # `worker_protocol_rejected` row on the FIRST reconnect of every pod
+        # whose boot HelloAck carried no `config_digest` — harmless to dispatch,
+        # since the hub keeps the older accepted receipt, and still a rejection
+        # row on a fleet whose acceptance bar is ZERO of them.
+        prior = self._receipts.get(command.goal_id)
+        if (
+            prior is not None
+            and int(prior.command_seq) == int(command.command_seq)
+            and int(prior.status) == pb.GOAL_RECEIPT_STATUS_ACCEPTED
+            and str(prior.release_id) == str(command.release_id)
+            and [(r.intent_id, int(r.error_code)) for r in prior.rejections]
+            == [(r.intent_id, int(r.error_code)) for r in receipt.rejections]
+        ):
+            receipt = _clone(prior)
         self._touch()
         self._remember_receipt(receipt)
         self._remember_command_receipt(

--- a/src/gen_worker/procsplit/lifecycle_relay.py
+++ b/src/gen_worker/procsplit/lifecycle_relay.py
@@ -1,0 +1,204 @@
+"""Parent-side ownership of the worker's protocol-v5 sequence (#1660).
+
+The hub sees ONE worker; the pod runs a control parent plus G compute children
+that die and respawn under it. Three facts follow, and this module is all three:
+
+1. **The emitted ``state_seq`` is the PARENT's**, never a child's. A respawned
+   child restarts its registry at 1; the hub SILENTLY DROPS a snapshot whose
+   ``state_seq`` regressed (`applyLifecycleSnapshotLocked` returns nil) and
+   REJECTS one that reuses a seq with different bytes. Either way the projection
+   freezes at the pre-respawn state and nobody is told. This was pgw's own
+   2026-08-19 audit §2 — filed there, never fixed.
+2. **A terminal intent stays terminal.** The hub refuses to let a previously
+   terminal intent change status, and discards the WHOLE snapshot when one does.
+   A respawned child re-applies the command and reports the same intent id as
+   ACCEPTED again, so the parent re-emits the terminal state it already had
+   accepted. What dispatch actually reads — the capability's state — still comes
+   live from the child, so nothing is claimed ready that is not.
+3. **All-or-nothing survives the fan-in.** One group with no projection means the
+   worker has no projection, and the parent withholds the session id with it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from ..lifecycle import snapshot_refusal
+from ..pb import worker_scheduler_pb2 as pb
+
+logger = logging.getLogger(__name__)
+
+_MAX_PINNED_TERMINAL = 256
+
+_TERMINAL = {
+    pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED,
+    pb.LIFECYCLE_INTENT_STATUS_FAILED,
+    pb.LIFECYCLE_INTENT_STATUS_CANCELED,
+    pb.LIFECYCLE_INTENT_STATUS_SUPERSEDED,
+}
+
+
+def _body(message: Any) -> bytes:
+    """A message's bytes with the sequence number the parent owns removed."""
+    out = type(message)()
+    out.CopyFrom(message)
+    out.state_seq = 0
+    return bytes(out.SerializeToString(deterministic=True))
+
+
+def _snapshot_body(snapshot: pb.LifecycleSnapshot) -> bytes:
+    """A snapshot's CONTENT: no sequence numbers, no generation timestamp.
+
+    A re-timestamped repeat of the same projection must not burn a sequence
+    number — the hub reads a repeat as a no-op at best and a conflict at worst.
+    """
+    out = pb.LifecycleSnapshot()
+    out.CopyFrom(snapshot)
+    out.state_seq = 0
+    out.generated_at_unix_ms = 0
+    for intent in out.intents:
+        intent.state_seq = 0
+    return bytes(out.SerializeToString(deterministic=True))
+
+
+class LifecycleRelay:
+    """Stamps every lifecycle message the pod sends the hub."""
+
+    def __init__(self, worker_session_id: str, release_id: str) -> None:
+        self._session = str(worker_session_id or "").strip()
+        self._release = str(release_id or "").strip()
+        self._seq = 0
+        self._last: Optional[pb.LifecycleSnapshot] = None
+        self._last_body = b""
+        self._intent_seq: Dict[str, Tuple[int, bytes]] = {}
+        self._pinned: Dict[str, pb.IntentState] = {}
+        self.announced = False
+
+    @property
+    def session_id(self) -> str:
+        return self._session
+
+    def set_release(self, release_id: str) -> None:
+        self._release = str(release_id or "").strip()
+
+    # ---- the Hello pair -----------------------------------------------------
+
+    def hello(
+        self, snapshots: Sequence[Optional[pb.LifecycleSnapshot]]
+    ) -> Tuple[str, Optional[pb.LifecycleSnapshot]]:
+        """``(worker_session_id, snapshot)`` for the merged Hello — both or neither."""
+        from . import merge
+
+        merged = merge.merge_lifecycle_snapshots(list(snapshots))
+        if merged is None:
+            logger.error(
+                "protocol-v5 lifecycle WITHHELD from the merged Hello (this pod "
+                "connects as legacy): %d of %d compute group(s) stated no "
+                "projection. A pod that ships the pair with half a projection "
+                "flips its release to ExactCapabilityRequired and starves every "
+                "dispatch on it.",
+                sum(1 for s in snapshots if s is None),
+                len(snapshots),
+            )
+            self.announced = False
+            return "", None
+        stamped = self.stamp(merged, force=True)
+        if stamped is None:
+            self.announced = False
+            return "", None
+        self.announced = True
+        return self._session, stamped
+
+    # ---- every snapshot on the wire -----------------------------------------
+
+    def stamp(
+        self, snapshot: pb.LifecycleSnapshot, *, force: bool = False
+    ) -> Optional[pb.LifecycleSnapshot]:
+        """Renumber, re-stamp and pin. ``None`` = nothing to send."""
+        out = pb.LifecycleSnapshot()
+        out.CopyFrom(snapshot)
+        out.worker_session_id = self._session
+        out.full_replace = True
+        for intent in out.intents:
+            intent.worker_session_id = self._session
+        for receipt in out.goal_receipts:
+            receipt.worker_session_id = self._session
+        self._apply_pins(out)
+
+        body = _snapshot_body(out)
+        if body == self._last_body and not force:
+            return None
+        if body == self._last_body and self._last is not None:
+            return self._last
+
+        self._seq += 1
+        out.state_seq = self._seq
+        for intent in out.intents:
+            key = str(intent.intent_id)
+            intent_body = _body(intent)
+            prior = self._intent_seq.get(key)
+            if prior is not None and prior[1] == intent_body:
+                intent.state_seq = prior[0]
+            else:
+                intent.state_seq = self._seq
+                self._intent_seq[key] = (self._seq, intent_body)
+
+        refusal = snapshot_refusal(out, self._release)
+        if refusal:
+            logger.error(
+                "lifecycle snapshot HELD BACK at the parent — the hub would "
+                "discard it whole: %s", refusal,
+            )
+            self._seq -= 1
+            return None
+
+        self._record_pins(out)
+        self._last = out
+        self._last_body = body
+        return out
+
+    def receipt(self, receipt: pb.GoalReceipt) -> Optional[pb.GoalReceipt]:
+        """Re-stamp a child's goal receipt with the session the hub knows."""
+        if not self.announced:
+            return None
+        out = pb.GoalReceipt()
+        out.CopyFrom(receipt)
+        out.worker_session_id = self._session
+        return out
+
+    # ---- terminal stickiness -------------------------------------------------
+
+    def _apply_pins(self, snapshot: pb.LifecycleSnapshot) -> None:
+        if not self._pinned:
+            return
+        by_id = {str(intent.intent_id): intent for intent in snapshot.intents}
+        replaced: List[pb.IntentState] = []
+        for intent in snapshot.intents:
+            pinned = self._pinned.get(str(intent.intent_id))
+            if pinned is not None and int(intent.status) not in _TERMINAL:
+                replaced.append(pinned)
+            else:
+                replaced.append(intent)
+        for intent_id, pinned in self._pinned.items():
+            if intent_id not in by_id:
+                replaced.append(pinned)
+        del snapshot.intents[:]
+        for intent in sorted(replaced, key=lambda i: str(i.intent_id)):
+            snapshot.intents.append(intent)
+
+    def _record_pins(self, snapshot: pb.LifecycleSnapshot) -> None:
+        for intent in snapshot.intents:
+            if int(intent.status) not in _TERMINAL:
+                continue
+            key = str(intent.intent_id)
+            if key in self._pinned:
+                continue
+            copy = pb.IntentState()
+            copy.CopyFrom(intent)
+            self._pinned[key] = copy
+        while len(self._pinned) > _MAX_PINNED_TERMINAL:
+            self._pinned.pop(next(iter(self._pinned)))
+
+
+__all__ = ["LifecycleRelay"]

--- a/src/gen_worker/procsplit/merge.py
+++ b/src/gen_worker/procsplit/merge.py
@@ -13,10 +13,12 @@ __all__ = [
     "merge_state_deltas",
     "merge_residency",
     "merge_hello",
+    "merge_lifecycle_snapshots",
     "merge_phase",
     "reconcile_activity_kind",
     "worker_fn_unavailable",
     "worker_fn_degraded",
+    "worker_goal_receipt",
 ]
 
 _PHASE_RANK = {
@@ -192,6 +194,152 @@ def worker_fn_degraded(
     return min(reports, key=lambda r: r.est_latency_multiplier or float("inf"))
 
 
+_CAPABILITY_RANK = {
+    pb.FUNCTION_CAPABILITY_STATE_UNSPECIFIED: 0,
+    pb.FUNCTION_CAPABILITY_STATE_FAILED: 1,
+    pb.FUNCTION_CAPABILITY_STATE_BOOT_STALE: 2,
+    pb.FUNCTION_CAPABILITY_STATE_APPLYING: 3,
+    pb.FUNCTION_CAPABILITY_STATE_READY: 4,
+}
+
+_CONFIG_RANK = {
+    pb.CONFIG_APPLICATION_STATE_UNSPECIFIED: 0,
+    pb.CONFIG_APPLICATION_STATE_FAILED: 1,
+    pb.CONFIG_APPLICATION_STATE_BOOT_STALE: 2,
+    pb.CONFIG_APPLICATION_STATE_APPLYING: 3,
+    pb.CONFIG_APPLICATION_STATE_CONVERGED: 4,
+}
+
+_INTENT_RANK = {
+    pb.LIFECYCLE_INTENT_STATUS_FAILED: 0,
+    pb.LIFECYCLE_INTENT_STATUS_CANCELED: 1,
+    pb.LIFECYCLE_INTENT_STATUS_ACCEPTED: 2,
+    pb.LIFECYCLE_INTENT_STATUS_WAITING: 3,
+    pb.LIFECYCLE_INTENT_STATUS_RUNNING: 4,
+    pb.LIFECYCLE_INTENT_STATUS_SUPERSEDED: 5,
+    pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED: 6,
+}
+
+
+def _intent_rank(intent: pb.IntentState) -> int:
+    return int(_INTENT_RANK.get(intent.status, 0))
+
+
+def _capability_rank(capability: pb.FunctionCapability) -> int:
+    return int(_CAPABILITY_RANK.get(capability.state, 0))
+
+
+def _config_rank(application: pb.ConfigApplication) -> int:
+    return int(_CONFIG_RANK.get(application.state, 0))
+
+
+def worker_goal_receipt(
+    per_group: Mapping[int, Optional[pb.GoalReceipt]],
+) -> Optional[pb.GoalReceipt]:
+    """The worker-level answer to ONE desired-state command.
+
+    The hub sees one worker, so it gets one receipt. A command is ACCEPTED only
+    when every live group accepted it, and any group's REJECTED is the worker's
+    answer — an ACCEPTED that hid a group's refusal would let the hub dispatch
+    work that a third of this pod cannot do. Withheld (``None``) until every live
+    group has answered.
+    """
+    if not per_group:
+        return None
+    answers = list(per_group.values())
+    if any(receipt is None for receipt in answers):
+        return None
+    present = [receipt for receipt in answers if receipt is not None]
+    rejected = [r for r in present if r.status == pb.GOAL_RECEIPT_STATUS_REJECTED]
+    if rejected:
+        return rejected[0]
+    merged = pb.GoalReceipt()
+    merged.CopyFrom(present[0])
+    del merged.rejections[:]
+    seen = set()
+    for receipt in present:
+        for rejection in receipt.rejections:
+            if rejection.intent_id in seen:
+                continue
+            seen.add(rejection.intent_id)
+            merged.rejections.append(rejection)
+    return merged
+
+
+def merge_lifecycle_snapshots(
+    snapshots: Sequence[Optional[pb.LifecycleSnapshot]],
+) -> Optional[pb.LifecycleSnapshot]:
+    """One worker-level lifecycle projection from G per-group ones.
+
+    ALL-OR-NOTHING (#1660): one group with no projection means the WORKER has no
+    complete projection, because the hub judges — and dispatches to — the pod as
+    a single worker. Every collapse below takes the LEAST ready answer for the
+    same reason `merge_phase` does: a wide worker that hides one unready group
+    behind three ready ones is the pod that accepts work it cannot serve.
+
+    ``state_seq`` is deliberately NOT merged here — it is the parent's own
+    monotonic counter (a compute child that respawns restarts its own at 1, and
+    the hub silently DROPS a lower seq).
+    """
+    if not snapshots:
+        return None
+    if any(snapshot is None for snapshot in snapshots):
+        return None
+    present = [s for s in snapshots if s is not None]
+    merged = pb.LifecycleSnapshot()
+    merged.CopyFrom(present[0])
+    merged.full_replace = True
+    if len(present) == 1:
+        return merged
+
+    merged.generated_at_unix_ms = max(s.generated_at_unix_ms for s in present)
+
+    intents: Dict[str, pb.IntentState] = {}
+    for snapshot in present:
+        for intent in snapshot.intents:
+            prior = intents.get(intent.intent_id)
+            if prior is None or _intent_rank(intent) < _intent_rank(prior):
+                intents[intent.intent_id] = intent
+    del merged.intents[:]
+    for intent_id in sorted(intents):
+        merged.intents.append(intents[intent_id])
+
+    capabilities: Dict[str, pb.FunctionCapability] = {}
+    for snapshot in present:
+        for capability in snapshot.capabilities:
+            prior = capabilities.get(capability.function_name)
+            if prior is None or _capability_rank(capability) < _capability_rank(prior):
+                capabilities[capability.function_name] = capability
+    del merged.capabilities[:]
+    for name in sorted(capabilities):
+        merged.capabilities.append(capabilities[name])
+
+    receipts: Dict[str, List[pb.GoalReceipt]] = {}
+    for snapshot in present:
+        for receipt in snapshot.goal_receipts:
+            receipts.setdefault(receipt.goal_id, []).append(receipt)
+    del merged.goal_receipts[:]
+    for goal_id in sorted(receipts):
+        answer = worker_goal_receipt(dict(enumerate(receipts[goal_id])))
+        if answer is not None:
+            merged.goal_receipts.append(answer)
+
+    applications = [s.config_application for s in present if s.HasField("config_application")]
+    if applications:
+        merged.config_application.CopyFrom(
+            min(applications, key=_config_rank)
+        )
+    else:
+        merged.ClearField("config_application")
+
+    drains = [s.drain for s in present if s.HasField("drain")]
+    if drains:
+        merged.drain.CopyFrom(min(drains, key=lambda d: int(d.status)))
+    else:
+        merged.ClearField("drain")
+    return merged
+
+
 def merge_hello(
     hellos: Sequence[pb.Hello],
     *,
@@ -214,6 +362,14 @@ def merge_hello(
         merged.models.extend(merge_residency([list(h.models) for h in hellos]))
         promised = [h.heartbeat_interval_ms for h in hellos if h.heartbeat_interval_ms]
         merged.heartbeat_interval_ms = min(promised) if promised else 0
+        projection = merge_lifecycle_snapshots([
+            h.lifecycle_snapshot if h.HasField("lifecycle_snapshot") else None
+            for h in hellos
+        ])
+        if projection is None:
+            merged.ClearField("lifecycle_snapshot")
+        else:
+            merged.lifecycle_snapshot.CopyFrom(projection)
 
     seen = set()
     del merged.in_flight[:]

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -44,6 +44,7 @@ from . import (
     procdiag,
 )
 from .group import ChildGroup, GroupPlan
+from .lifecycle_relay import LifecycleRelay
 from .seam import SeamAccountant
 
 logger = logging.getLogger(__name__)
@@ -217,6 +218,11 @@ class _ChildSlot:
         # re-sends the merge of all groups'.
         self.last_state_delta: Optional[pb.WorkerMessage] = None
         self.last_state_delta_at = 0.0
+        # This group's freshest protocol-v5 projection and its answers to the
+        # hub's desired-state commands. Cleared on respawn: a dead incarnation's
+        # projection is not evidence about the one that replaced it.
+        self.last_lifecycle: Optional[pb.LifecycleSnapshot] = None
+        self.goal_receipts: Dict[str, pb.GoalReceipt] = {}
         self.generation = 0
         self.participating = True
         self.last_crash_loop_report_at = _NEVER_REPORTED
@@ -234,6 +240,8 @@ class _ChildSlot:
         """A NEW incarnation of this group starts speaking."""
         self.generation += 1
         self.participating = True
+        self.last_lifecycle = None
+        self.goal_receipts = {}
 
     async def start_server(self) -> None:
         try:
@@ -1030,6 +1038,10 @@ class ParentControl:
         ]
 
         self._worker_session_id = uuid.uuid4().hex
+        # The hub sees ONE worker: the emitted lifecycle sequence, the terminal
+        # intent history and the all-or-nothing pair are the PARENT's, because a
+        # compute child restarts its own registry at seq 1 on every respawn.
+        self._relay = LifecycleRelay(self._worker_session_id, "")
 
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._stopping = asyncio.Event()
@@ -1311,7 +1323,7 @@ class ParentControl:
             if hello is None:
                 return pb.Hello()
             self._apply_identity_and_resources(hello)
-            hello.worker_session_id = self._worker_session_id
+            self._stamp_hello_lifecycle(hello, [hello])
             if self._beat_interval <= 0 and hello.heartbeat_interval_ms > 0:
                 self._beat_interval = hello.heartbeat_interval_ms / 1000.0
             seen = {(j.request_id, j.attempt) for j in hello.in_flight}
@@ -1338,10 +1350,32 @@ class ParentControl:
             extra_in_flight=extra,
         )
         self._apply_identity_and_resources(hello)
+        self._stamp_hello_lifecycle(hello, hellos)
         promised = [h.heartbeat_interval_ms for h in hellos if h.heartbeat_interval_ms]
         if self._beat_interval <= 0 and promised:
             self._beat_interval = min(promised) / 1000.0
         return hello
+
+    def _stamp_hello_lifecycle(
+        self, hello: pb.Hello, sources: List[pb.Hello]
+    ) -> None:
+        """Put the ALL-OR-NOTHING pair on the merged Hello, or neither half of it.
+
+        `worker_session_id` without `lifecycle_snapshot` is the exact defect this
+        issue exists for (`hello_session_id_missing_snapshot`); the snapshot
+        without the session id is its mirror. The pair comes back from one call
+        so this Hello cannot carry half of it.
+        """
+        self._relay.set_release(self._identity()[1] or hello.release_id)
+        session_id, snapshot = self._relay.hello([
+            h.lifecycle_snapshot if h.HasField("lifecycle_snapshot") else None
+            for h in sources
+        ])
+        hello.worker_session_id = session_id
+        if snapshot is None:
+            hello.ClearField("lifecycle_snapshot")
+        else:
+            hello.lifecycle_snapshot.CopyFrom(snapshot)
 
     def _apply_identity_and_resources(self, hello: pb.Hello) -> None:
         worker_id, release_id = self._identity()
@@ -1530,9 +1564,17 @@ class ParentControl:
     def _fan_in(
         self, slot: _ChildSlot, msg: pb.WorkerMessage,
     ) -> Optional[pb.WorkerMessage]:
+        kind = msg.WhichOneof("msg")
+        # Lifecycle state is relayed for EVERY topology, single group included:
+        # the sequence and the terminal intent history belong to the parent, and
+        # a child that respawned would otherwise re-enter the stream at seq 1.
+        if kind == "lifecycle_snapshot":
+            return self._relay_lifecycle(slot, msg)
+        if kind == "goal_receipt":
+            return self._relay_goal_receipt(slot, msg)
         if self.execution_groups == 1:
             return msg
-        which = msg.WhichOneof("msg")
+        which = kind
         if which in _WORKER_SCOPED_MSGS and not slot.participating:
             return None
         if which == "state_delta":
@@ -1545,6 +1587,39 @@ class ParentControl:
         if which == "fn_degraded":
             return self._reconcile_fn_degraded(slot, msg)
         return msg
+
+    def _relay_lifecycle(
+        self, slot: _ChildSlot, msg: pb.WorkerMessage,
+    ) -> Optional[pb.WorkerMessage]:
+        slot.last_lifecycle = msg.lifecycle_snapshot
+        if not self._relay.announced:
+            # The Hello withheld the pair, so the hub holds no session id for
+            # this stream and would book a worker_session_mismatch rejection.
+            return None
+        live = [s for s in self._live_slots()] or [slot]
+        merged = merge.merge_lifecycle_snapshots([s.last_lifecycle for s in live])
+        if merged is None:
+            return None
+        stamped = self._relay.stamp(merged)
+        if stamped is None:
+            return None
+        return pb.WorkerMessage(lifecycle_snapshot=stamped)
+
+    def _relay_goal_receipt(
+        self, slot: _ChildSlot, msg: pb.WorkerMessage,
+    ) -> Optional[pb.WorkerMessage]:
+        receipt = msg.goal_receipt
+        slot.goal_receipts[str(receipt.goal_id)] = receipt
+        live = [s for s in self._live_slots()] or [slot]
+        answer = merge.worker_goal_receipt({
+            s.ordinal: s.goal_receipts.get(str(receipt.goal_id)) for s in live
+        })
+        if answer is None:
+            return None
+        stamped = self._relay.receipt(answer)
+        if stamped is None:
+            return None
+        return pb.WorkerMessage(goal_receipt=stamped)
 
     def _reconcile_activity(
         self, slot: _ChildSlot, msg: pb.WorkerMessage,

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -10,7 +10,6 @@ import logging
 import os
 import signal
 import time
-import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
@@ -45,8 +44,15 @@ from .boot_materialize import (
 )
 from .discovery.names import slugify_name
 from . import postmortem
+from .lifecycle import WorkerLifecycle
+from .lifecycle_intents import CapabilityFacts
 from .procsplit import is_compute_child
 from .pb import worker_scheduler_pb2 as pb
+from .runtime_config import (
+    ConfigSnapshotWriteError,
+    ConfigStore,
+    extract_config_push,
+)
 from .serving.context import DeployBinding
 from .serving.entrypoints import ENTRYPOINT_ATTR, EntrypointSpec
 from .serving.envelope import EnvelopeError
@@ -508,7 +514,28 @@ class Worker:
             settings.worker_id.strip() or f"py-worker-{os.getpid()}"
         )
         self.release_id = settings.worker_release_id.strip()
-        self.worker_session_id = uuid.uuid4().hex
+        # Empty = ConfigStore's own env/default resolution. procsplit's privdrop
+        # grants the compute uid exactly `dirname(that)` (pgw#858), so this must
+        # not invent a second answer.
+        self.config = ConfigStore(str(settings.config_snapshot_path or "").strip())
+        self._desired_hot: Dict[str, pb.DesiredInstance] = {}
+        self._resolution_lanes: Dict[str, str] = {}
+        # ONE producer of this process's session id. Under procsplit it is the
+        # PARENT's, seeded through GEN_WORKER_SESSION_ID, so the id the hub sees
+        # on the Hello and the id stamped inside the projection are the same fact.
+        self.lifecycle = WorkerLifecycle(
+            release_id=self.release_id,
+            function_names=self.functions,
+            facts=self._lifecycle_facts,
+            send=self._send,
+            boot_config_generation=int(
+                getattr(settings, "boot_config_generation", -1)
+            ),
+        )
+        self.worker_session_id = self.lifecycle.worker_session_id
+        self.on_hello_ack = self.lifecycle.hello_ack_route(
+            self._on_hello_ack, prepare=self._absorb_hub_state
+        )
         self.file_base_url = ""
 
         boot_mod.mark_once(
@@ -521,6 +548,7 @@ class Worker:
         )
         self.resolver.bind_store(self.store)
         bind_active_store(self.store)
+        self.store.bind_intent_registry(self.lifecycle.registry)
         self.materialization = CheckpointMaterialization(
             self.store,
             announce=self._announce_readiness,
@@ -608,6 +636,7 @@ class Worker:
             )
         try:
             await self._send(pb.WorkerMessage(state_delta=self._state_delta()))
+            await self.lifecycle.publish()
         except Exception:  # noqa: BLE001 — the heartbeat re-states this
             logger.warning("readiness state delta send failed", exc_info=True)
         if not self.materialization.failed:
@@ -640,8 +669,42 @@ class Worker:
         _DISPATCH.set(picks)
         return ""
 
+    def _serving_tier(self) -> str:
+        adoption = getattr(self, "adoption", None)
+        if adoption is None:
+            return "eager"
+        try:
+            facts = adoption.facts()
+        except Exception:  # noqa: BLE001 — a tier label never fails a Hello
+            return "eager"
+        if not facts.get("adopting"):
+            return "eager"
+        return "compiled" if int(facts.get("adopted") or 0) > 0 else "eager"
+
+    def _lifecycle_facts(self) -> CapabilityFacts:
+        """This worker's own answer to every input the capability projection reads."""
+        ready = self.materialization.ready
+        generation = int(self.config.generation)
+        tier = self._serving_tier()
+        return CapabilityFacts(
+            config_generation=generation,
+            parameter_snapshot_generation=int(self.config.parameter_snapshot_generation),
+            binding_ready_generation=generation if ready else 0,
+            available=frozenset(self.functions) if ready else frozenset(),
+            unavailable=(
+                frozenset(self.functions) if self.materialization.failed else frozenset()
+            ),
+            hot=dict(self._desired_hot),
+            residency={m.ref: m for m in self.store.residency_snapshot()},
+            lanes=dict(self._resolution_lanes),
+            serving_tiers={name: tier for name in self.functions},
+        )
+
     def build_hello(self) -> pb.Hello:
-        return pb.Hello(
+        # ALL-OR-NOTHING: the session id and the projection come out of ONE call,
+        # so this Hello can never carry half of the pair (#1660 / th#2300).
+        session_id, snapshot = self.lifecycle.hello_projection()
+        hello = pb.Hello(
             protocol_version=PROTOCOL_VERSION,
             worker_id=self.worker_id,
             release_id=self.release_id,
@@ -652,10 +715,54 @@ class Worker:
                 for rid, att in sorted(self._jobs)
             ],
             heartbeat_interval_ms=HEARTBEAT_INTERVAL_MS,
-            worker_session_id=self.worker_session_id,
+            worker_session_id=session_id,
         )
+        if snapshot is not None:
+            hello.lifecycle_snapshot.CopyFrom(snapshot)
+        return hello
 
-    async def on_hello_ack(self, ack: pb.HelloAck) -> None:
+    def _absorb_hub_state(self, ack: pb.HelloAck) -> None:
+        """The hub-stated half of the capability projection.
+
+        ``lane`` is the hub's OWN resolution, never this worker's ladder pick:
+        `exactCapabilityExecutionLaneLocked` compares the capability's lane to
+        the lane the hub projected from these resolutions, so reporting anything
+        else is `exact_lane_mismatch` — a silent dispatch decline.
+        """
+        self._desired_hot = {
+            instance.function_name: instance
+            for instance in ack.desired_residency.hot
+            if instance.function_name
+        }
+        self._resolution_lanes = {
+            str(resolution.ref): str(resolution.lane or "")
+            for resolution in ack.resolutions
+            if str(resolution.ref or "").strip()
+        }
+        command = ack.desired_state_command
+        try:
+            push = extract_config_push(ack)
+            if push is not None:
+                generation, release_id = push
+                self.config.observe(
+                    generation, release_id=release_id or self.release_id
+                )
+            if not ack.HasField("desired_state_command"):
+                return
+            if int(command.config_generation) <= 0 or not command.parameter_snapshot:
+                return
+            self.config.apply_parameter_snapshot(
+                command.parameter_snapshot,
+                int(command.config_generation),
+                release_id=str(command.release_id or self.release_id),
+            )
+        except ConfigSnapshotWriteError as exc:
+            # Withdraws config readiness rather than claiming a generation this
+            # process cannot prove it durably holds.
+            logger.error("config parameter snapshot not applied: %s", exc)
+            self.lifecycle.registry.config_snapshot_failed(str(exc))
+
+    async def _on_hello_ack(self, ack: pb.HelloAck) -> None:
         self.file_base_url = str(ack.file_base_url or "")
         logger.info(
             "hello acked: functions=%s file_base_url=%s",
@@ -670,6 +777,9 @@ class Worker:
                 boot_mod.PHASE_FIRST_REQUEST_SERVABLE,
                 function=",".join(self.functions),
             )
+        # The hub's desired instances and resolved lanes only became known a
+        # moment ago; the projection that rode with the receipt did not have them.
+        await self.lifecycle.publish()
         if not self.file_base_url:
             logger.error(
                 "hello acked with NO file_base_url: the compiled-graph receipt "
@@ -1079,6 +1189,7 @@ class Worker:
             logger.debug("mint: %s", self.mint_facts())
             try:
                 await self._send(pb.WorkerMessage(state_delta=self._state_delta()))
+                await self.lifecycle.publish()
             except Exception:
                 logger.warning("heartbeat send failed", exc_info=True)
 

--- a/tests/harness/hub_double.py
+++ b/tests/harness/hub_double.py
@@ -194,12 +194,16 @@ class FakeScheduler(pb_grpc.WorkerSchedulerServicer):
     def __init__(
         self, *, reject_unauthenticated: bool = False,
         file_base_url: str = "http://127.0.0.1:1/files",
+        hello_ack: Optional[Callable[[pb.Hello], pb.HelloAck]] = None,
     ) -> None:
         self.connections: List[Conn] = []
         self.diagnostic_reports: List[pb.HardwareUnsuitable] = []
         self._conn_cond = threading.Condition()
         self.reject_unauthenticated = reject_unauthenticated
         self.file_base_url = file_base_url
+        #: Lets a test author the HelloAck the way the real hub would — the
+        #: DesiredStateCommand the worker owes a GoalReceipt for lives there.
+        self.hello_ack = hello_ack
         self.worker_alive: Optional[Callable[[], bool]] = None
         self.boot_cost: Optional[Callable[[], float]] = None
 
@@ -222,10 +226,14 @@ class FakeScheduler(pb_grpc.WorkerSchedulerServicer):
         conn.hello = first.hello
         conn.boot_cost = self.boot_cost
         conn.diagnostic_reports = self.diagnostic_reports
-        conn.send(hello_ack=pb.HelloAck(
-            protocol_version=pb.PROTOCOL_VERSION_CURRENT,
-            file_base_url=self.file_base_url,
-        ))
+        if self.hello_ack is not None:
+            ack = self.hello_ack(first.hello)
+        else:
+            ack = pb.HelloAck(
+                protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+                file_base_url=self.file_base_url,
+            )
+        conn.send(hello_ack=ack)
         with self._conn_cond:
             self.connections.append(conn)
             self._conn_cond.notify_all()
@@ -302,12 +310,14 @@ class WorkerHarness:
         gpu_slots: int = 1,
         backoff_base_s: float = 0.05,
         backoff_cap_s: float = 0.2,
+        release_id: str = "",
     ) -> None:
         self.scheduler = scheduler
         settings = load_settings(
             orchestrator_public_addr=f"127.0.0.1:{port}",
             worker_id=worker_id,
             worker_jwt="",
+            worker_release_id=release_id,
             tensorhub_cache_dir=str(cache_dir),
         )
         self.worker = Worker(
@@ -371,11 +381,15 @@ def hub_double(
     max_workers: int = 16,
     cache_dir: Optional[Path] = None,
     file_base_url: str = "http://127.0.0.1:1/files",
+    release_id: str = "",
+    hello_ack: Optional[Callable[[pb.Hello], pb.HelloAck]] = None,
 ) -> Iterator[Tuple[FakeScheduler, WorkerHarness]]:
     """Stand up one hub-double gRPC server + one real Worker against it."""
     prior_env = os.environ.get("TENSORHUB_CACHE_DIR")
+    prior_config_path = os.environ.get("GEN_WORKER_CONFIG_SNAPSHOT_PATH")
     scheduler = FakeScheduler(
         reject_unauthenticated=reject_unauthenticated, file_base_url=file_base_url,
+        hello_ack=hello_ack,
     )
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))
     pb_grpc.add_WorkerSchedulerServicer_to_server(scheduler, server)
@@ -384,11 +398,18 @@ def hub_double(
     with tempfile.TemporaryDirectory(prefix="pgw-hub-double-cache-") as tmp:
         resolved_cache_dir = cache_dir or Path(tmp)
         os.environ["TENSORHUB_CACHE_DIR"] = str(resolved_cache_dir)
+        # th#1087's durable config snapshot: production injects this at pod
+        # launch and privdrop grants its directory; a rig that leaves it unset
+        # writes to /app and every config-generation push fails.
+        os.environ["GEN_WORKER_CONFIG_SNAPSHOT_PATH"] = str(
+            resolved_cache_dir / "runtime_config.msgpack"
+        )
         gw_config.reload_for_test()
         harness = WorkerHarness(
             scheduler, port, cache_dir=resolved_cache_dir,
             modules=modules, worker_id=worker_id, gpu_slots=gpu_slots,
             backoff_base_s=backoff_base_s, backoff_cap_s=backoff_cap_s,
+            release_id=release_id,
         )
         scheduler.worker_alive = lambda: harness.alive
         harness.start()
@@ -397,10 +418,14 @@ def hub_double(
         finally:
             harness.stop()
             server.stop(grace=0)
-            if prior_env is None:
-                os.environ.pop("TENSORHUB_CACHE_DIR", None)
-            else:
-                os.environ["TENSORHUB_CACHE_DIR"] = prior_env
+            for name, prior in (
+                ("TENSORHUB_CACHE_DIR", prior_env),
+                ("GEN_WORKER_CONFIG_SNAPSHOT_PATH", prior_config_path),
+            ):
+                if prior is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = prior
             gw_config.reload_for_test()
 
 
@@ -417,6 +442,7 @@ def custom_scheduler_server(
 ) -> Iterator[Tuple[Any, WorkerHarness, int]]:
     """Like ``hub_double()`` but for a BESPOKE ``WorkerSchedulerServicer`` (auth-reject/precondition/redirect/stall scenarios) instead of the ordinary ``FakeScheduler``."""
     prior_env = os.environ.get("TENSORHUB_CACHE_DIR")
+    prior_config_path = os.environ.get("GEN_WORKER_CONFIG_SNAPSHOT_PATH")
     servicer = servicer_factory()
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))
     pb_grpc.add_WorkerSchedulerServicer_to_server(servicer, server)
@@ -424,6 +450,9 @@ def custom_scheduler_server(
     server.start()
     with tempfile.TemporaryDirectory(prefix="pgw-hub-double-cache-") as tmp:
         os.environ["TENSORHUB_CACHE_DIR"] = tmp
+        os.environ["GEN_WORKER_CONFIG_SNAPSHOT_PATH"] = str(
+            Path(tmp) / "runtime_config.msgpack"
+        )
         gw_config.reload_for_test()
         harness = WorkerHarness(
             servicer, bound_port, cache_dir=Path(tmp), modules=modules, worker_id=worker_id,
@@ -435,10 +464,14 @@ def custom_scheduler_server(
         finally:
             harness.stop()
             server.stop(grace=0)
-            if prior_env is None:
-                os.environ.pop("TENSORHUB_CACHE_DIR", None)
-            else:
-                os.environ["TENSORHUB_CACHE_DIR"] = prior_env
+            for name, prior in (
+                ("TENSORHUB_CACHE_DIR", prior_env),
+                ("GEN_WORKER_CONFIG_SNAPSHOT_PATH", prior_config_path),
+            ):
+                if prior is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = prior
             gw_config.reload_for_test()
 
 

--- a/tests/harness/split.py
+++ b/tests/harness/split.py
@@ -5,7 +5,7 @@ import sys
 import threading
 from concurrent import futures
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import grpc
 import msgspec
@@ -65,8 +65,9 @@ class SplitHarness:
         stop_flush_timeout_s: float = 30.0,
         beat_interval_s: float = 0.0,
         extra_child_env: Optional[dict] = None,
+        hello_ack: Optional[Callable] = None,
     ) -> None:
-        self.scheduler = FakeScheduler()
+        self.scheduler = FakeScheduler(hello_ack=hello_ack)
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=16))
         pb_grpc.add_WorkerSchedulerServicer_to_server(self.scheduler, self.server)
         port = self.server.add_insecure_port("127.0.0.1:0")

--- a/tests/test_boot_config_absent_gw668.py
+++ b/tests/test_boot_config_absent_gw668.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-from types import SimpleNamespace
 from typing import Any, Optional
 
 import msgspec
@@ -11,7 +9,7 @@ import pytest
 
 from gen_worker.config import load_settings
 from gen_worker.config.settings import BOOT_CONFIG_GENERATION_ABSENT
-from gen_worker.lifecycle_intents import IntentRegistry
+from gen_worker.lifecycle_intents import CapabilityFacts, IntentRegistry
 from gen_worker.pb import worker_scheduler_pb2 as pb
 
 _ENV = "WORKER_CONFIG_GENERATION"
@@ -57,18 +55,13 @@ def _capability_state(boot_stamp: int) -> Any:
     registry.apply_command(_command(registry, 1))
     registry.config_snapshot_applied(1)
     registry.bindings_applied(1)
-    runtime_config = SimpleNamespace(
-        generation=1, parameter_snapshot_generation=1, values={},
-    )
-    executor = SimpleNamespace(
-        runtime_config=runtime_config,
-        store=SimpleNamespace(residency_snapshot=lambda: []),
-        available_functions=lambda: ["echo"],
-        compile_targets=lambda: [],
-        unavailable={},
-    )
-    desired = pb.DesiredResidency(hot=[pb.DesiredInstance(function_name="echo")])
-    registry.refresh_projection(executor, desired, {})
+    registry.refresh_projection(CapabilityFacts(
+        config_generation=1,
+        parameter_snapshot_generation=1,
+        binding_ready_generation=1,
+        available=frozenset({"echo"}),
+        hot={"echo": pb.DesiredInstance(function_name="echo")},
+    ))
     return registry.snapshot().capabilities[0].state
 
 

--- a/tests/test_lifecycle_relay_pgw1660.py
+++ b/tests/test_lifecycle_relay_pgw1660.py
@@ -1,0 +1,212 @@
+"""#1660: the parent owns the emitted lifecycle sequence, across child respawns.
+
+pgw's own 2026-08-19 audit §2 — filed there, never fixed: the compute child's
+session id survives a respawn but its ``_state_seq`` resets to 1, and the hub
+SILENTLY DROPS the lower seq. Every arm below is about what the HUB does with
+what the parent emitted, not about what the child said.
+"""
+
+from __future__ import annotations
+
+import time
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.procsplit import merge
+from gen_worker.procsplit.lifecycle_relay import LifecycleRelay
+
+SESSION = "sess-pgw1660"
+RELEASE = "rel-pgw1660"
+
+
+def _snapshot(
+    *,
+    state_seq: int,
+    intent_status: "pb.LifecycleIntentStatus" = pb.LIFECYCLE_INTENT_STATUS_ACCEPTED,
+    capability_state: "pb.FunctionCapabilityState" = pb.FUNCTION_CAPABILITY_STATE_APPLYING,
+    session: str = "child-session",
+    intent_id: str = "intent-a",
+) -> pb.LifecycleSnapshot:
+    at = int(time.time() * 1000)
+    return pb.LifecycleSnapshot(
+        worker_session_id=session,
+        state_seq=state_seq,
+        full_replace=True,
+        generated_at_unix_ms=at,
+        intents=[
+            pb.IntentState(
+                worker_session_id=session,
+                state_seq=state_seq,
+                goal_id="goal-a",
+                intent_id=intent_id,
+                release_id=RELEASE,
+                status=intent_status,
+                stage=pb.LIFECYCLE_INTENT_STAGE_VALIDATING,
+                since_unix_ms=at,
+                updated_at_unix_ms=at,
+            )
+        ],
+        capabilities=[
+            pb.FunctionCapability(
+                function_name="echo",
+                release_id=RELEASE,
+                state=capability_state,
+            )
+        ],
+    )
+
+
+def _relay() -> LifecycleRelay:
+    return LifecycleRelay(SESSION, RELEASE)
+
+
+def test_the_parent_stamps_its_own_session_over_every_child_field() -> None:
+    relay = _relay()
+    session_id, stamped = relay.hello([_snapshot(state_seq=4)])
+    assert session_id == SESSION
+    assert stamped is not None
+    assert stamped.worker_session_id == SESSION
+    assert all(i.worker_session_id == SESSION for i in stamped.intents)
+
+
+def test_the_sequence_advances_across_a_child_respawn() -> None:
+    """THE regression this relay exists for: after a respawn the child's own
+    ``state_seq`` restarts at 1, and a snapshot the hub reads as lower is
+    dropped with no rejection, no metric and no log."""
+    relay = _relay()
+    _session, hello = relay.hello([_snapshot(state_seq=1)])
+    assert hello is not None
+    seqs = [hello.state_seq]
+    for child_seq in (2, 3, 4):
+        stamped = relay.stamp(
+            _snapshot(state_seq=child_seq, capability_state=_state(child_seq))
+        )
+        assert stamped is not None
+        seqs.append(stamped.state_seq)
+
+    # The child dies and its replacement starts counting from 1 again.
+    for child_seq in (1, 2):
+        stamped = relay.stamp(
+            _snapshot(state_seq=child_seq, capability_state=_state(child_seq + 10))
+        )
+        assert stamped is not None
+        seqs.append(stamped.state_seq)
+
+    assert seqs == sorted(set(seqs)), (
+        f"the emitted state_seq must be strictly increasing; got {seqs}. A "
+        f"repeat is a hub-side `lifecycle state_seq conflict` rejection and a "
+        f"regression is a SILENT drop"
+    )
+
+
+def _state(n: int) -> "pb.FunctionCapabilityState":
+    """A distinct capability state per step, so each snapshot really differs."""
+    states = [
+        pb.FUNCTION_CAPABILITY_STATE_APPLYING,
+        pb.FUNCTION_CAPABILITY_STATE_BOOT_STALE,
+        pb.FUNCTION_CAPABILITY_STATE_READY,
+        pb.FUNCTION_CAPABILITY_STATE_FAILED,
+    ]
+    return states[n % len(states)]
+
+
+def test_an_unchanged_projection_is_not_resent() -> None:
+    """The hub rejects a reused seq whose bytes differ and no-ops one that
+    matches; re-sending an unchanged projection buys nothing either way."""
+    relay = _relay()
+    relay.hello([_snapshot(state_seq=1)])
+    assert relay.stamp(_snapshot(state_seq=2)) is None
+
+
+def test_a_terminal_intent_stays_terminal_after_the_child_respawns() -> None:
+    """The hub discards the WHOLE snapshot when a previously terminal intent
+    changes status, so the projection would freeze at its pre-respawn state."""
+    relay = _relay()
+    relay.hello([_snapshot(state_seq=1)])
+    done = relay.stamp(
+        _snapshot(state_seq=2, intent_status=pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED)
+    )
+    assert done is not None
+    assert done.intents[0].status == pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED
+
+    # The respawned child re-applies the command and reports the same intent id
+    # as freshly ACCEPTED.
+    after = relay.stamp(
+        _snapshot(
+            state_seq=1,
+            intent_status=pb.LIFECYCLE_INTENT_STATUS_ACCEPTED,
+            capability_state=pb.FUNCTION_CAPABILITY_STATE_READY,
+        )
+    )
+    assert after is not None
+    assert after.intents[0].status == pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED, (
+        "a terminal intent that goes back to ACCEPTED costs the entire snapshot"
+    )
+    assert after.capabilities[0].state == pb.FUNCTION_CAPABILITY_STATE_READY, (
+        "what dispatch actually reads still comes LIVE from the child — the pin "
+        "is on intent history, never on readiness"
+    )
+
+
+def test_one_group_without_a_projection_withholds_the_whole_pair() -> None:
+    relay = _relay()
+    assert relay.hello([_snapshot(state_seq=1), None]) == ("", None)
+    assert not relay.announced
+
+
+def test_a_mid_stream_snapshot_is_dropped_when_the_hello_went_out_legacy() -> None:
+    """No session id reached the hub, so a snapshot naming one is a
+    `worker_session_mismatch` rejection."""
+    relay = _relay()
+    relay.hello([None])
+    assert not relay.announced
+    assert relay.receipt(pb.GoalReceipt(goal_id="g")) is None
+
+
+def test_a_snapshot_the_hub_would_discard_is_held_back() -> None:
+    relay = _relay()
+    relay.hello([_snapshot(state_seq=1)])
+    broken = _snapshot(state_seq=2, capability_state=pb.FUNCTION_CAPABILITY_STATE_READY)
+    broken.capabilities[0].release_id = "another-release"
+    assert relay.stamp(broken) is None
+
+
+# ---------------------------------------------------------------------------
+# G > 1: the hub sees ONE worker
+# ---------------------------------------------------------------------------
+
+
+def test_the_worker_is_ready_only_when_every_group_is() -> None:
+    merged = merge.merge_lifecycle_snapshots([
+        _snapshot(state_seq=1, capability_state=pb.FUNCTION_CAPABILITY_STATE_READY),
+        _snapshot(state_seq=1, capability_state=pb.FUNCTION_CAPABILITY_STATE_APPLYING),
+    ])
+    assert merged is not None
+    assert merged.capabilities[0].state == pb.FUNCTION_CAPABILITY_STATE_APPLYING, (
+        "a wide worker that hides one unready group behind a ready one accepts "
+        "work it cannot serve"
+    )
+
+
+def test_one_groups_rejection_is_the_workers_answer() -> None:
+    accepted = pb.GoalReceipt(
+        worker_session_id=SESSION, command_seq=1, goal_id="g", release_id=RELEASE,
+        status=pb.GOAL_RECEIPT_STATUS_ACCEPTED, received_at_unix_ms=1,
+    )
+    rejected = pb.GoalReceipt(
+        worker_session_id=SESSION, command_seq=1, goal_id="g", release_id=RELEASE,
+        status=pb.GOAL_RECEIPT_STATUS_REJECTED, received_at_unix_ms=1,
+        error_code=pb.LIFECYCLE_ERROR_CODE_UNKNOWN_FUNCTION,
+    )
+    answer = merge.worker_goal_receipt({0: accepted, 1: rejected})
+    assert answer is not None
+    assert answer.status == pb.GOAL_RECEIPT_STATUS_REJECTED
+    assert merge.worker_goal_receipt({0: accepted, 1: None}) is None, (
+        "an answer that speaks for a group which has not answered is a guess"
+    )
+    both = merge.worker_goal_receipt({0: accepted, 1: accepted})
+    assert both is not None and both.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED
+
+
+def test_a_missing_group_projection_is_never_papered_over() -> None:
+    assert merge.merge_lifecycle_snapshots([_snapshot(state_seq=1), None]) is None
+    assert merge.merge_lifecycle_snapshots([]) is None

--- a/tests/test_typed_lifecycle_procsplit_pgw1660.py
+++ b/tests/test_typed_lifecycle_procsplit_pgw1660.py
@@ -1,0 +1,86 @@
+"""#1660, end to end through the REAL process split.
+
+The split is unconditional in production — every pod is a control parent plus a
+compute child — so the Hello the hub actually sees is the parent's merged one.
+This drives a real `ParentControl`, a real child subprocess and a real gRPC hub
+double, and reads the pair off the wire.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from gen_worker.lifecycle import snapshot_refusal
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from harness.split import SplitHarness, isolated_postmortem  # noqa: F401
+
+RELEASE = "rel-pgw1660-split"
+
+
+def _ack(hello: pb.Hello) -> pb.HelloAck:
+    now = int(time.time() * 1000)
+    return pb.HelloAck(
+        protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+        file_base_url="http://127.0.0.1:1/files",
+        desired_residency=pb.DesiredResidency(
+            generation=2, release_id=RELEASE, config_generation=4,
+        ),
+        desired_state_command=pb.DesiredStateCommand(
+            worker_session_id=hello.worker_session_id,
+            command_seq=2,
+            goal_id="goal-split-pgw1660",
+            release_id=RELEASE,
+            config_generation=4,
+            config_digest=b"digest",
+            parameter_snapshot=b"\x80",
+            issued_at_unix_ms=now,
+            accept_by_unix_ms=now + 2_000,
+            first_action_by_unix_ms=now + 600_000,
+        ),
+    )
+
+
+@pytest.mark.usefixtures("isolated_postmortem")
+def test_the_parents_merged_hello_carries_the_whole_pair(tmp_path: Path) -> None:
+    harness = SplitHarness(
+        tmp_path,
+        hello_ack=_ack,
+        extra_child_env={
+            "WORKER_RELEASE_ID": RELEASE,
+            "GEN_WORKER_CONFIG_SNAPSHOT_PATH": str(tmp_path / "runtime_config.msgpack"),
+        },
+    )
+    try:
+        conn = harness.scheduler.wait_connection(0, timeout=120.0)
+        hello = conn.hello
+        assert hello is not None
+        assert hello.worker_session_id, "the parent states no session id"
+        assert hello.HasField("lifecycle_snapshot"), (
+            "the parent shipped worker_session_id with NO snapshot — the exact "
+            "hello_session_id_missing_snapshot the whole fleet books today"
+        )
+        snapshot = hello.lifecycle_snapshot
+        assert snapshot.worker_session_id == hello.worker_session_id, (
+            "the parent owns the session id; a child-minted one inside the "
+            "projection is a worker_session_mismatch and the hub drops it whole"
+        )
+        assert snapshot_refusal(snapshot, RELEASE) == ""
+        assert {c.function_name for c in snapshot.capabilities}, (
+            "typed with no capabilities starves every dispatch on this release"
+        )
+
+        receipt = conn.wait_for(
+            lambda m: m.WhichOneof("msg") == "goal_receipt", timeout=120.0,
+        ).goal_receipt
+        assert receipt.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED, receipt.detail
+        assert receipt.worker_session_id == hello.worker_session_id, (
+            "a receipt carrying the CHILD's session id is refused by the hub"
+        )
+        assert receipt.command_seq == 2
+        assert receipt.goal_id == "goal-split-pgw1660"
+    finally:
+        harness.close()

--- a/tests/test_typed_lifecycle_producer_pgw1660.py
+++ b/tests/test_typed_lifecycle_producer_pgw1660.py
@@ -353,6 +353,72 @@ def test_the_complete_producer_DOES_answer_with_the_pair() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Commands the hub really sends
+# ---------------------------------------------------------------------------
+
+
+def _boot_ack(hello: pb.Hello) -> pb.HelloAck:
+    """The FIRST HelloAck of a boot: a config generation the worker's persisted
+    DesiredResidency already carries, and NO config digest, because the hub built
+    the command with a nil `resolutionCfg`."""
+    ack = _ack(hello)
+    ack.desired_state_command.ClearField("config_digest")
+    return ack
+
+
+def test_a_command_with_a_generation_but_no_config_digest_is_ACCEPTED() -> None:
+    """This is not a nicety — it is the shape of the first HelloAck of every
+    boot. `protocolConfigDigest(resolutionCfg)` is empty whenever the hub has no
+    resolution config yet (build error, discarded stale build, no provider),
+    while `config_generation` comes from the persisted DesiredResidency and is
+    > 0. Rejecting the pair costs the ACCEPTED receipt, and no accepted receipt
+    for the CURRENT command is `exact_goal_receipt_not_accepted` — a dispatch
+    starve on the whole release, on every cold boot."""
+    with hub_double(release_id=RELEASE, hello_ack=_boot_ack) as (scheduler, _harness):
+        conn = scheduler.wait_connection(0, timeout=30.0)
+        receipt = conn.wait_for(_is("goal_receipt"), timeout=30.0).goal_receipt
+        assert receipt.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED, (
+            f"a fresh-boot command was refused: {receipt.error_code} {receipt.detail}"
+        )
+
+
+def test_the_two_digests_keep_their_OPPOSITE_encodings() -> None:
+    """`DesiredIntent.snapshot_digest` is the UTF-8 bytes of the digest STRING;
+    `FunctionCapability.binding_digest` is raw sha256 bytes. The asymmetry is the
+    hub's, and a worker that "helpfully" normalises either one breaks a
+    `bytes.Equal` nobody sees fail."""
+    registry = IntentRegistry(RELEASE, list(FUNCTIONS))
+    digest = b"\x00\x01\x02not-utf8-at-all\xff"
+    registry.apply_command(pb.DesiredStateCommand(
+        worker_session_id=registry.worker_session_id,
+        command_seq=1,
+        goal_id="g",
+        release_id=RELEASE,
+        intents=[pb.DesiredIntent(
+            intent_id="i-ready",
+            kind=pb.DESIRED_INTENT_KIND_FUNCTION_READY,
+            cause=pb.DESIRED_INTENT_CAUSE_COLD_BOOT,
+            function_name="echo",
+            binding_digest=digest,
+        )],
+    ))
+    registry.refresh_projection(CapabilityFacts(
+        available=frozenset(FUNCTIONS),
+        residency={REF: pb.ModelResidency(ref=REF, snapshot_digest="blake3:abc")},
+        hot={"echo": pb.DesiredInstance(
+            function_name="echo", models=[pb.ModelBinding(slot="data", ref=REF)],
+        )},
+    ))
+    echo = next(
+        c for c in registry.snapshot().capabilities if c.function_name == "echo"
+    )
+    assert echo.binding_digest == digest, "raw bytes, echoed verbatim"
+    assert echo.models[0].snapshot_digest == b"blake3:abc", (
+        "the UTF-8 bytes of the digest string — never hex-decoded"
+    )
+
+
+# ---------------------------------------------------------------------------
 # The hub's own discard rules, mirrored (tensorhub validateLifecycleSnapshot)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_typed_lifecycle_producer_pgw1660.py
+++ b/tests/test_typed_lifecycle_producer_pgw1660.py
@@ -382,6 +382,74 @@ def test_a_command_with_a_generation_but_no_config_digest_is_ACCEPTED() -> None:
         )
 
 
+def test_the_same_goal_restated_with_a_filled_in_digest_is_ACCEPTED() -> None:
+    """The reconnect after a cold boot, and the third starve of the same family.
+
+    Boot 1 gets `config_generation=N` with an EMPTY `config_digest` (the hub had
+    no resolution config yet). The stream drops; the reconnect gets the SAME
+    generation — so the same `command_seq`, since the hub uses the residency
+    generation for it — now WITH a digest. Keyed on the command digest that reads
+    as `COMMAND_SEQ_CONFLICT` and costs the accepted receipt forever after. The
+    hub keys same-seq identity on `goal_id`/`release_id` itself, so this worker
+    does too, and a genuine goal drift is still refused
+    (`test_intent_registry_th1283`).
+    """
+    registry = IntentRegistry(RELEASE, list(FUNCTIONS))
+    boot = pb.DesiredStateCommand(
+        worker_session_id=registry.worker_session_id,
+        command_seq=9,
+        goal_id="goal-stable",
+        release_id=RELEASE,
+        config_generation=4,
+        parameter_snapshot=b"\x80",
+    )
+    assert registry.apply_command(boot).status == pb.GOAL_RECEIPT_STATUS_ACCEPTED
+
+    reconnect = pb.DesiredStateCommand()
+    reconnect.CopyFrom(boot)
+    reconnect.config_digest = b"now-the-hub-has-one"
+    receipt = registry.apply_command(reconnect)
+    assert receipt.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED, (
+        f"the same goal restated was refused: {receipt.error_code} {receipt.detail}"
+    )
+    assert not registry.protocol_rejected
+
+
+def test_a_REBOUND_function_still_echoes_the_hubs_current_digest() -> None:
+    """The echo is a fact about the COMMAND, not about intent bookkeeping.
+
+    Re-issuing the same intent id with a different binding is "intent_id reused
+    for different work" — an advisory decline that drops the intent out of the
+    accepted set. Read the digest off the registry's intents and a re-bound
+    function falls back to the derivation permanently, which is exactly the
+    silent `exact_binding_digest_mismatch` the echo exists to prevent.
+    """
+    registry = IntentRegistry(RELEASE, list(FUNCTIONS))
+
+    def _command(seq: int, goal: str, digest: bytes) -> pb.DesiredStateCommand:
+        return pb.DesiredStateCommand(
+            worker_session_id=registry.worker_session_id,
+            command_seq=seq, goal_id=goal, release_id=RELEASE,
+            intents=[pb.DesiredIntent(
+                intent_id="intent-echo",
+                kind=pb.DESIRED_INTENT_KIND_FUNCTION_READY,
+                cause=pb.DESIRED_INTENT_CAUSE_COLD_BOOT,
+                function_name="echo",
+                binding_digest=digest,
+            )],
+        )
+
+    registry.apply_command(_command(1, "goal-1", b"digest-one"))
+    registry.apply_command(_command(2, "goal-2", b"digest-two"))
+    registry.refresh_projection(CapabilityFacts(available=frozenset(FUNCTIONS)))
+    echo = next(
+        c for c in registry.snapshot().capabilities if c.function_name == "echo"
+    )
+    assert echo.binding_digest == b"digest-two", (
+        "the capability must carry the digest the hub's CURRENT command states"
+    )
+
+
 def test_the_two_digests_keep_their_OPPOSITE_encodings() -> None:
     """`DesiredIntent.snapshot_digest` is the UTF-8 bytes of the digest STRING;
     `FunctionCapability.binding_digest` is raw sha256 bytes. The asymmetry is the

--- a/tests/test_typed_lifecycle_producer_pgw1660.py
+++ b/tests/test_typed_lifecycle_producer_pgw1660.py
@@ -403,7 +403,8 @@ def test_the_same_goal_restated_with_a_filled_in_digest_is_ACCEPTED() -> None:
         config_generation=4,
         parameter_snapshot=b"\x80",
     )
-    assert registry.apply_command(boot).status == pb.GOAL_RECEIPT_STATUS_ACCEPTED
+    first = registry.apply_command(boot)
+    assert first.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED
 
     reconnect = pb.DesiredStateCommand()
     reconnect.CopyFrom(boot)
@@ -413,6 +414,17 @@ def test_the_same_goal_restated_with_a_filled_in_digest_is_ACCEPTED() -> None:
         f"the same goal restated was refused: {receipt.error_code} {receipt.detail}"
     )
     assert not registry.protocol_rejected
+    assert receipt.SerializeToString(deterministic=True) == first.SerializeToString(
+        deterministic=True
+    ), (
+        "and it must be the receipt the hub ALREADY HOLDS, byte for byte. The "
+        "hub refuses a second receipt at the same command_seq that is not "
+        "proto.Equal, and a fresh received_at_unix_ms alone differs — that is a "
+        "`worker_protocol_rejected` row on a fleet whose bar is zero of them"
+    )
+    assert registry.snapshot().config_application.target_generation == 4, (
+        "the command still APPLIED in full; only the answer was stabilised"
+    )
 
 
 def test_a_REBOUND_function_still_echoes_the_hubs_current_digest() -> None:

--- a/tests/test_typed_lifecycle_producer_pgw1660.py
+++ b/tests/test_typed_lifecycle_producer_pgw1660.py
@@ -1,0 +1,391 @@
+"""#1660 / th#2300: the worker is a COMPLETE protocol-v5 producer, or it is legacy.
+
+Every arm here drives a REAL ``gen_worker.worker.Worker`` over a REAL gRPC socket
+against the hub double, and reads the bytes the hub would read.
+
+THE FENCE these arms exist for: the hub's typed cohort flag is not health-only.
+`releaseUsesExactCapabilities` -> `placement.ExactCapabilityRequired` ->
+`workerHasExactReadyCapabilityLocked`. A worker that ships
+``(worker_session_id, lifecycle_snapshot)`` WITHOUT a capability set and without
+answering the hub's `DesiredStateCommand` turns an inert typed path into a TOTAL
+DISPATCH STARVE on its release. So `test_the_pair_never_ships_without_the_whole_producer`
+asserts the implication in the only direction that can hurt anyone: *if* the pair
+is on the wire, the capabilities and the receipt answering are wired too — and
+the arms below it force each leg's absence and prove the pair is withheld.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Optional
+
+import pytest
+
+from gen_worker.lifecycle import WorkerLifecycle, snapshot_refusal
+from gen_worker.lifecycle_intents import CapabilityFacts, IntentRegistry
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from harness.hub_double import hub_double
+
+RELEASE = "rel-pgw1660"
+FUNCTIONS = ("echo", "save-a-large-file")
+REF = "cozy/toy@1"
+
+
+def _command(hello: pb.Hello, *, config_generation: int = 7) -> pb.DesiredStateCommand:
+    """The command the real hub builds at HelloAck (`buildProtocolDesiredStateCommand`)."""
+    now = int(time.time() * 1000)
+    return pb.DesiredStateCommand(
+        worker_session_id=hello.worker_session_id,
+        command_seq=3,
+        goal_id="goal-pgw1660",
+        release_id=RELEASE,
+        config_generation=config_generation,
+        config_digest=b"config-digest",
+        parameter_snapshot=b"\x80",  # msgpack {}
+        issued_at_unix_ms=now,
+        accept_by_unix_ms=now + 2_000,
+        first_action_by_unix_ms=now + 600_000,
+        intents=[
+            pb.DesiredIntent(
+                intent_id="intent-pgw1660-echo",
+                kind=pb.DESIRED_INTENT_KIND_FUNCTION_READY,
+                cause=pb.DESIRED_INTENT_CAUSE_COLD_BOOT,
+                function_name="echo",
+                binding_digest=b"the-hubs-own-binding-digest",
+            ),
+        ],
+    )
+
+
+def _ack(hello: pb.Hello) -> pb.HelloAck:
+    """A HelloAck shaped like the hub's: residency, resolutions, and the command."""
+    return pb.HelloAck(
+        protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+        file_base_url="http://127.0.0.1:1/files",
+        desired_residency=pb.DesiredResidency(
+            generation=3,
+            release_id=RELEASE,
+            config_generation=7,
+            hot=[
+                pb.DesiredInstance(
+                    function_name="echo",
+                    models=[pb.ModelBinding(slot="data", ref=REF)],
+                )
+            ],
+        ),
+        resolutions=[
+            pb.ModelResolution(ref=REF, resolved_ref=REF, lane="fp8-w8a8-dynamic+compiled")
+        ],
+        desired_state_command=_command(hello),
+    )
+
+
+def _legacy_ack(hello: pb.Hello) -> pb.HelloAck:
+    return pb.HelloAck(
+        protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+        file_base_url="http://127.0.0.1:1/files",
+    )
+
+
+def _is(kind: str) -> Callable[[pb.WorkerMessage], bool]:
+    return lambda msg: msg.WhichOneof("msg") == kind
+
+
+# ---------------------------------------------------------------------------
+# The wire arms
+# ---------------------------------------------------------------------------
+
+
+def test_a_v5_hello_carries_the_pair_and_the_projection_the_hub_reads() -> None:
+    """The defect's exact inverse: a Hello the hub reads as `typed`, not as
+    `hello_session_id_missing_snapshot`."""
+    with hub_double(release_id=RELEASE, hello_ack=_ack) as (scheduler, _harness):
+        conn = scheduler.wait_connection(0, timeout=30.0)
+        hello = conn.hello
+        assert hello is not None
+
+        assert hello.worker_session_id, (
+            "the Hello states no worker_session_id — this worker cannot be typed "
+            "at all, and the whole release falls to the legacy verdicts"
+        )
+        assert hello.HasField("lifecycle_snapshot"), (
+            "worker_session_id with NO lifecycle_snapshot is exactly the fleet "
+            "defect th#2300 measured: the hub books "
+            "worker_protocol_rejected / hello_session_id_missing_snapshot and "
+            "drops the typed projection"
+        )
+        snapshot = hello.lifecycle_snapshot
+        assert snapshot.worker_session_id == hello.worker_session_id
+        assert snapshot.full_replace, "the hub only ever full-replaces"
+        assert snapshot.state_seq >= 1, "state_seq 0 is 'missing state_seq'"
+        assert snapshot_refusal(snapshot, RELEASE) == ""
+
+        capabilities = {c.function_name: c for c in snapshot.capabilities}
+        assert set(capabilities) == set(FUNCTIONS), (
+            "a typed worker with no capability for a function it serves is a "
+            "dispatch starve on its whole release, not a health nuance"
+        )
+        for capability in capabilities.values():
+            assert capability.release_id == RELEASE
+            assert capability.state != pb.FUNCTION_CAPABILITY_STATE_UNSPECIFIED
+
+
+def test_the_hub_command_is_answered_with_an_accepted_goal_receipt() -> None:
+    with hub_double(release_id=RELEASE, hello_ack=_ack) as (scheduler, _harness):
+        conn = scheduler.wait_connection(0, timeout=30.0)
+        hello = conn.hello
+        assert hello is not None
+        command = _command(hello)
+
+        message = conn.wait_for(_is("goal_receipt"), timeout=30.0)
+        receipt = message.goal_receipt
+        assert receipt.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED, receipt.detail
+        # Every field `workerHasExactReadyCapabilityLocked` cross-checks against
+        # `info.LastDesiredStateCommand` before it will dispatch anything.
+        assert receipt.worker_session_id == hello.worker_session_id
+        assert receipt.command_seq == command.command_seq
+        assert receipt.goal_id == command.goal_id
+        assert receipt.release_id == command.release_id
+        assert receipt.received_at_unix_ms > 0
+
+
+def test_the_mid_stream_snapshot_advances_and_keeps_carrying_the_receipt() -> None:
+    """A snapshot with no `goal_receipts` ERASES `info.LastGoalReceipt` hub-side
+    and un-dispatches the worker, so every snapshot must keep carrying it."""
+    with hub_double(release_id=RELEASE, hello_ack=_ack) as (scheduler, _harness):
+        conn = scheduler.wait_connection(0, timeout=30.0)
+        hello = conn.hello
+        assert hello is not None
+
+        message = conn.wait_for(
+            lambda m: (
+                m.WhichOneof("msg") == "lifecycle_snapshot"
+                and len(m.lifecycle_snapshot.goal_receipts) > 0
+            ),
+            timeout=30.0,
+        )
+        snapshot = message.lifecycle_snapshot
+        assert snapshot.state_seq > hello.lifecycle_snapshot.state_seq, (
+            "the hub SILENTLY DROPS a snapshot whose state_seq did not advance"
+        )
+        assert snapshot.worker_session_id == hello.worker_session_id
+        assert snapshot.full_replace
+        assert snapshot_refusal(snapshot, RELEASE) == ""
+        accepted = [
+            r for r in snapshot.goal_receipts
+            if r.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED
+        ]
+        assert accepted, "the accepted receipt must survive every full replace"
+
+
+def test_the_capability_echoes_the_hubs_own_binding_digest_and_lane() -> None:
+    """`exact_binding_digest_mismatch` and `exact_lane_mismatch` are SILENT
+    dispatch declines, so both come from the hub's own statements, not from a
+    re-derivation this worker could get subtly wrong."""
+    with hub_double(release_id=RELEASE, hello_ack=_ack) as (scheduler, _harness):
+        conn = scheduler.wait_connection(0, timeout=30.0)
+        message = conn.wait_for(
+            lambda m: (
+                m.WhichOneof("msg") == "lifecycle_snapshot"
+                and any(
+                    c.function_name == "echo" and c.binding_digest
+                    for c in m.lifecycle_snapshot.capabilities
+                )
+            ),
+            timeout=30.0,
+        )
+        echo = next(
+            c for c in message.lifecycle_snapshot.capabilities
+            if c.function_name == "echo"
+        )
+        assert echo.binding_digest == b"the-hubs-own-binding-digest", (
+            "the FUNCTION_READY intent the hub authored carries the digest the "
+            "hub compares with bytes.Equal — echo it, never re-derive it"
+        )
+        assert echo.lane == "fp8-w8a8-dynamic+compiled", (
+            "the lane is the HUB's resolution for this function's models"
+        )
+
+
+def test_the_capability_reaches_READY_at_the_commands_config_generation() -> None:
+    """The dispatch-critical end state. `workerHasExactReadyCapabilityLocked`
+    needs state=READY AND `config_generation == command.config_generation`; a
+    config application that never converges pins every capability at APPLYING,
+    which is a typed release nothing can be dispatched to."""
+    with hub_double(release_id=RELEASE, hello_ack=_ack) as (scheduler, _harness):
+        conn = scheduler.wait_connection(0, timeout=30.0)
+        message = conn.wait_for(
+            lambda m: (
+                m.WhichOneof("msg") == "lifecycle_snapshot"
+                and any(
+                    c.state == pb.FUNCTION_CAPABILITY_STATE_READY
+                    for c in m.lifecycle_snapshot.capabilities
+                )
+            ),
+            timeout=30.0,
+        )
+        snapshot = message.lifecycle_snapshot
+        assert snapshot.config_application.state == pb.CONFIG_APPLICATION_STATE_CONVERGED, (
+            f"config application stuck at {snapshot.config_application}"
+        )
+        ready = [
+            c for c in snapshot.capabilities
+            if c.state == pb.FUNCTION_CAPABILITY_STATE_READY
+        ]
+        assert ready
+        for capability in ready:
+            assert capability.config_generation == 7
+            assert capability.binding_digest, (
+                "a READY capability under a CONVERGED application MUST carry a "
+                "binding_digest or the hub discards the whole snapshot"
+            )
+
+
+def test_a_release_less_worker_stays_legacy_and_ships_NEITHER_half() -> None:
+    """No release id means no capability can name one, so the pair is withheld
+    WHOLE. Session id and snapshot both absent is the one combination the hub
+    books no `worker_protocol_rejected` row for."""
+    with hub_double(hello_ack=_legacy_ack) as (scheduler, _harness):
+        conn = scheduler.wait_connection(0, timeout=30.0)
+        hello = conn.hello
+        assert hello is not None
+        assert hello.worker_session_id == ""
+        assert not hello.HasField("lifecycle_snapshot")
+
+
+def test_the_pair_never_ships_without_the_whole_producer() -> None:
+    """THE FENCE, stated as an implication over the real wire.
+
+    Red-armed by the three arms below, each of which removes one leg and proves
+    the pair goes away with it.
+    """
+    with hub_double(release_id=RELEASE, hello_ack=_ack) as (scheduler, _harness):
+        conn = scheduler.wait_connection(0, timeout=30.0)
+        hello = conn.hello
+        assert hello is not None
+        if not hello.HasField("lifecycle_snapshot"):
+            assert hello.worker_session_id == "", (
+                "half a pair on the wire — the hub drops the projection and the "
+                "release is judged legacy"
+            )
+            return
+        # The pair IS on the wire, so both other legs must be provably live.
+        assert hello.worker_session_id
+        assert hello.lifecycle_snapshot.capabilities, (
+            "typed with no capabilities: dispatch requires an exact READY "
+            "capability row, so this release can never be dispatched to again"
+        )
+        receipt = conn.wait_for(_is("goal_receipt"), timeout=30.0).goal_receipt
+        assert receipt.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED, (
+            "typed with no ACCEPTED receipt for the hub's current command: "
+            "`exact_goal_receipt_not_accepted` declines every placement"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The red arms — each removes one leg of the producer
+# ---------------------------------------------------------------------------
+
+
+def _no_projection(_facts: CapabilityFacts) -> None:
+    return None
+
+
+def _lifecycle(
+    *,
+    route: bool = True,
+    facts: Optional[CapabilityFacts] = None,
+    release_id: str = RELEASE,
+    project: bool = True,
+) -> WorkerLifecycle:
+    async def _send(_msg: pb.WorkerMessage) -> None:
+        return None
+
+    lifecycle = WorkerLifecycle(
+        release_id=release_id,
+        function_names=list(FUNCTIONS),
+        facts=lambda: facts or CapabilityFacts(available=frozenset(FUNCTIONS)),
+        send=_send,
+    )
+    if not project:
+        lifecycle.registry.refresh_projection = _no_projection  # type: ignore[method-assign,assignment]
+    if route:
+
+        async def _body(_ack: pb.HelloAck) -> None:
+            return None
+
+        lifecycle.hello_ack_route(_body)
+    return lifecycle
+
+
+def test_RED_ARM_remove_the_capability_projection_and_the_pair_is_withheld() -> None:
+    session_id, snapshot = _lifecycle(project=False).hello_projection()
+    assert (session_id, snapshot) == ("", None), (
+        "a snapshot with no capabilities must NEVER reach the hub: it flips the "
+        "release to ExactCapabilityRequired with nothing to match"
+    )
+
+
+def test_RED_ARM_remove_the_goal_receipt_route_and_the_pair_is_withheld() -> None:
+    session_id, snapshot = _lifecycle(route=False).hello_projection()
+    assert (session_id, snapshot) == ("", None), (
+        "without the HelloAck -> GoalReceipt answer the hub never holds an "
+        "ACCEPTED receipt for its own command, and every dispatch declines"
+    )
+
+
+def test_RED_ARM_remove_the_release_id_and_the_pair_is_withheld() -> None:
+    session_id, snapshot = _lifecycle(release_id="").hello_projection()
+    assert (session_id, snapshot) == ("", None)
+
+
+def test_the_complete_producer_DOES_answer_with_the_pair() -> None:
+    """The control for the three red arms: with every leg wired, the pair ships.
+
+    Without this, all three arms above would still pass on a producer that never
+    ships anything at all.
+    """
+    session_id, snapshot = _lifecycle().hello_projection()
+    assert session_id
+    assert snapshot is not None
+    assert {c.function_name for c in snapshot.capabilities} == set(FUNCTIONS)
+
+
+# ---------------------------------------------------------------------------
+# The hub's own discard rules, mirrored (tensorhub validateLifecycleSnapshot)
+# ---------------------------------------------------------------------------
+
+
+def _typed_snapshot() -> pb.LifecycleSnapshot:
+    registry = IntentRegistry(RELEASE, list(FUNCTIONS))
+    registry.refresh_projection(CapabilityFacts(available=frozenset(FUNCTIONS)))
+    return registry.snapshot()
+
+
+def test_the_registrys_own_snapshot_satisfies_every_hub_mandatory_rule() -> None:
+    assert snapshot_refusal(_typed_snapshot(), RELEASE) == ""
+
+
+@pytest.mark.parametrize(
+    "break_it,expected",
+    [
+        (lambda s: setattr(s, "full_replace", False), "full_replace"),
+        (lambda s: setattr(s, "state_seq", 0), "state_seq"),
+        (lambda s: setattr(s, "worker_session_id", ""), "worker_session_id"),
+    ],
+)
+def test_the_mirror_actually_fires(
+    break_it: Callable[[pb.LifecycleSnapshot], None], expected: str,
+) -> None:
+    """The validator must be able to go RED, or it proves nothing about the
+    snapshots it lets through."""
+    snapshot = _typed_snapshot()
+    break_it(snapshot)
+    assert expected in snapshot_refusal(snapshot, RELEASE)
+
+
+def test_a_capability_naming_another_release_is_refused() -> None:
+    snapshot = _typed_snapshot()
+    snapshot.capabilities[0].release_id = "some-other-release"
+    assert "release_mismatch" in snapshot_refusal(snapshot, RELEASE)


### PR DESCRIPTION
Worker half of th#2300 (hub half landed at tensorhub master `45c2c8679`; the hub is correct and is not touched here).

## The defect

pgw#1373 (`cd46c957`) deleted `src/gen_worker/lifecycle.py` with the v1 SDK — the sole producer of `Hello.lifecycle_snapshot`, of mid-stream `WorkerMessage(lifecycle_snapshot=…)` and of the `HelloAck.desired_state_command` → `GoalReceipt` answer. The v2 `build_hello` kept `worker_session_id` and inherited none of it, so **every live pod booked `worker_protocol_rejected / hello_session_id_missing_snapshot` within 400 ms of connecting** and the whole fleet was judged by the hub's legacy health verdicts.

## The hazard that shapes the fix

The hub's typed cohort flag is **not** health-only: `releaseUsesExactCapabilities` → `placement.ExactCapabilityRequired` → `workerHasExactReadyCapabilityLocked`. A worker that ships the (session id, snapshot) pair **without** a capability set and without an ACCEPTED `GoalReceipt` for the hub's current command turns an inert typed path into a **total dispatch starve on its release**.

So the pair leaves `WorkerLifecycle` from **one call** — `hello_projection()` — which answers with both or with `("", None)`. A process that cannot state a complete projection connects as legacy, which is inert. It cannot ship half of one.

## What landed

- **`lifecycle.py` is back as the producer**: one `IntentRegistry` per process owning `worker_session_id` (env-seeded under procsplit, so the parent's id and the id inside the projection are one fact), the hello pair, the receipt answered *before* anything else in the HelloAck handler (the hub's accept budget is 2 s from issue), and mid-stream snapshots on change.
- **`snapshot_refusal`** mirrors the hub's `validateLifecycleSnapshot` mandatory-field rules. The hub discards a breaking snapshot *whole*; holding it back loudly keeps the worker legacy rather than costing the release its cohort silently.
- **The capability projection is stated, not introspected.** `refresh_projection` takes a `CapabilityFacts` record instead of the deleted v1 `Executor`. `binding_digest` is **echoed** from the hub's own `FUNCTION_READY` intent (it compares with `bytes.Equal`; a re-derivation that differs is a silent `exact_binding_digest_mismatch`), and `lane` is the hub's `HelloAck.resolutions` pick, never this worker's ladder pick.
- **`runtime_config` wired back in** — `extract_config_push` had no caller and `ConfigStore` had no users at all. Without the parameter-snapshot and binding-ready generations the config application never converges, every capability stays `APPLYING`, and a typed release is one nothing can be dispatched to.
- **procsplit: `LifecycleRelay`** gives the parent the emitted sequence, the session stamp and the terminal-intent history. A compute child's session survives a respawn but its `state_seq` resets to 1; the hub **silently drops** a lower seq and **rejects** a reused one with different bytes (pgw's own 2026-08-19 audit §2 — filed there, never fixed). A terminal intent the hub already accepted is re-emitted rather than allowed to regress (which would cost the whole snapshot); readiness still comes live from the child. Across G groups the worker is READY only where every group is, and one group's REJECTED is the worker's answer.

## Tests — real transports, no mocks

`tests/test_typed_lifecycle_producer_pgw1660.py` drives a **real `Worker` over a real gRPC socket** against a hub double whose HelloAck carries a real `DesiredStateCommand`: the pair on the Hello, the ACCEPTED receipt with every field `workerHasExactReadyCapabilityLocked` cross-checks, the mid-stream snapshot advancing its seq and still carrying the receipt (a snapshot without it *erases* `info.LastGoalReceipt` hub-side), the echoed binding digest and lane, and the capability reaching **READY at the command's `config_generation` under a CONVERGED application**.

`tests/test_typed_lifecycle_procsplit_pgw1660.py` proves the same pair on the parent's merged Hello through a **real child subprocess**. `tests/test_lifecycle_relay_pgw1660.py` covers the relay and the G>1 collapses.

### Red arms — each run, each confirmed

| removed | result |
|---|---|
| ship the session id with no snapshot (pre-fix behaviour) | 3 arms red, incl. the fence |
| the `HelloAck` → `GoalReceipt` answer | 4 arms red, incl. the fence |
| the capability projection / the receipt route / the release id | the pair is withheld (+ a control arm proving a complete producer *does* ship it) |
| the parent's seq renumbering (pass the child's through) | the respawn arm red |
| the terminal-intent pin | the stickiness arm red |
| the snapshot on the parent's merged Hello | the procsplit arm red |

Regression sweep, `nice -n 19`, ≤2 workers: `test_procsplit`, `test_fanin_generation_pgw937`, `test_group_spawn_pgw783`, `test_intent_registry_th1283`, `test_boot_config_absent_gw668`, `test_cancel_at_grant_pgw845` — 88 passed; `test_pod_isolation` + the three new files — 47 passed, 13 skipped. mypy and ruff clean on `src/gen_worker` and `tests`.

## Remaining for production effect (not driven here)

Nothing about a live release becomes typed until **the fleet is repinned/released onto a wheel carrying this**. The wheel cut from this merge is the next fleet-pin candidate; the real-pod acceptance (zero `worker_protocol_rejected` rows, hub log `[typed-lifecycle] release=<id> cohort=typed`, and a request dispatching under `ExactCapabilityRequired`) runs after that repin.

---

## Four dispatch starves found and killed, none of which any existing test could have caught

Every validation in `IntentRegistry` was **inert while the typed path adjudicated nothing**, so none had ever been asked *"can the hub actually send this?"* — only *"does the proto comment call it mandatory?"* Those are different questions, and only the second decides whether a pod is dispatchable. Auditing all of them against the hub's real senders (`2e9c4d9e`, `7a44a56a`):

1. **`config_digest is required when config_generation is set` — fatal on every cold boot.** The hub builds that field from `protocolConfigDigest(resolutionCfg)` and `resolutionCfg` is legitimately nil on the **first HelloAck of a boot** (build error, discarded stale build, no provider yet), while `config_generation` comes from the persisted `DesiredResidency` and is non-zero. Rejecting the pair costs the ACCEPTED receipt → `exact_goal_receipt_not_accepted` → nothing on the release is dispatchable. **Deleted.**
2. **`command_seq` conflict keyed on the command digest — fatal from the first reconnect.** The boot HelloAck carries an empty `config_digest` and the reconnect after it carries a filled-in one, at the same `command_seq`. The hub keys same-seq identity on `goal_id`/`release_id` itself. **Now keyed on `goal_id`** — which is how th#1283's own test always described it, so a genuine goal drift is still refused.
3. **`intent cause is required`.** `DesiredIntentCause` is provenance telemetry; nothing depends on it, and the intent carrying it is often the one mandatory `CONFIG_APPLY`, where a decline latches `protocol_rejected` and bricks the process. **Deleted.**
4. **The binding-digest echo was scoped to accepted intents.** Re-issuing an intent id with a different binding is "intent_id reused for different work" — an advisory decline — so a re-bound function fell back to the derivation *permanently*: exactly the silent mismatch the echo exists to prevent. **Now read off the command.**

`parameter_snapshot` stays required: the hub sets field 13 unconditionally, and even a nil config encodes as the one-byte msgpack fixmap-0 `\x80`. Also pinned, because it is silent when wrong: `DesiredIntent.snapshot_digest` is the UTF-8 bytes of the digest *string* while `FunctionCapability.binding_digest` is raw sha256 bytes.

### Additional red arms for the four

| restored | result |
|---|---|
| the `config_digest` rule | the fresh-boot arm red |
| digest-keyed seq conflict | the reconnect arm red |
| re-derive `binding_digest` instead of echoing | 2 arms red |
| scope the echo back to accepted intents | the re-binding arm red |

One real regression caught on the way: giving `ConfigStore` a cache-dir fallback moved `GEN_WORKER_CONFIG_SNAPSHOT_PATH` off the directory procsplit's privdrop grants the compute uid, reddening pgw#858's `test_the_dropped_child_can_still_write_the_config_snapshot` under a real root parent. The worker now passes `settings.config_snapshot_path` straight through and the rig states the path.