### PR TITLE
pgw#1660: pin the relay arms' clock — one failed ~1 run in 5 for a reason that was never about the relay

### DIFF
--- a/changelog.d/pgw1660-relay-arm-clock.md
+++ b/changelog.d/pgw1660-relay-arm-clock.md
@@ -1,0 +1,6 @@
+- **A pgw#1660 relay arm read the wall clock per snapshot and failed about 1 run in 5.** The arms
+  in `test_lifecycle_relay_pgw1660.py` compare projections for CHANGE; two snapshots built a
+  millisecond apart differ in their intents' `since`/`updated` stamps without differing in
+  anything the comparison is about, so `test_an_unchanged_projection_is_not_resent` reddened for a
+  reason that says nothing about the relay. Pinned to a fixed clock — 20/20 green after, and the
+  arm still goes red when the resend suppression is actually removed.

--- a/tests/test_lifecycle_relay_pgw1660.py
+++ b/tests/test_lifecycle_relay_pgw1660.py
@@ -8,14 +8,19 @@ what the parent emitted, not about what the child said.
 
 from __future__ import annotations
 
-import time
-
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.procsplit import merge
 from gen_worker.procsplit.lifecycle_relay import LifecycleRelay
 
 SESSION = "sess-pgw1660"
 RELEASE = "rel-pgw1660"
+
+#: A FIXED clock. These arms compare projections for CHANGE, and two snapshots
+#: built a millisecond apart differ in their intents' `since`/`updated` stamps
+#: without differing in anything the comparison is about. Reading the wall clock
+#: per snapshot made `test_an_unchanged_projection_is_not_resent` fail about 1
+#: run in 5 — a red that says nothing about the relay.
+AT = 1_700_000_000_000
 
 
 def _snapshot(
@@ -25,8 +30,8 @@ def _snapshot(
     capability_state: "pb.FunctionCapabilityState" = pb.FUNCTION_CAPABILITY_STATE_APPLYING,
     session: str = "child-session",
     intent_id: str = "intent-a",
+    at: int = AT,
 ) -> pb.LifecycleSnapshot:
-    at = int(time.time() * 1000)
     return pb.LifecycleSnapshot(
         worker_session_id=session,
         state_seq=state_seq,


### PR DESCRIPTION
Caught on the **merged tree**, not on the branch: the post-merge verification run of `01568c03` reddened `test_an_unchanged_projection_is_not_resent`, which had passed every time on the lane branch. Reproduced 1-in-5 on master.

`_snapshot()` read `time.time()` per call, so two snapshots built either side of a millisecond boundary differ in their intents' `since_unix_ms`/`updated_at_unix_ms`. The arm asks whether the relay re-sends an *unchanged* projection; a timestamp the test itself moved is not a change in the thing the arm is about. Production never has this problem — the registry only re-stamps when state actually changed — so this is a defect in the fixture, not in the relay.

Pinned to a fixed constant. **20/20 green** after, and the arm **still fails** when the resend suppression is genuinely removed, so it is still measuring something.