### PR TITLE
pgw#1666: a publish stages by REFERENCE, and the disk preflight enumerates every stage instead of a formula

### DIFF
--- a/changelog.d/pgw1666.md
+++ b/changelog.d/pgw1666.md
@@ -1,0 +1,33 @@
+- **A publish no longer writes a second copy of the tree it is publishing.** `publish_v2` used to
+  walk every produced file into the local CAS with `put_bytes` before a byte was uploaded — a
+  full duplicate of the published tree, on the same filesystem, deleted minutes later. It now
+  stages BY REFERENCE (`gen_worker.cas.stage_file`): the same planner grid, the same per-tensor
+  digests, the same identity guard, but the objects are recorded as byte RANGES of the
+  producer's own files and the uploader reads them there. Bytes are re-hashed as they are sent,
+  so a region that no longer holds its declared object fails that transfer instead of installing
+  wrong bytes — the guarantee the CAS gave by verifying before sending, now at one read instead
+  of two. `ingest_file` is unchanged and still admits into the store, which is what a local
+  cache wants; a publish is not a cache.
+
+  **What it cost to find:** a `clone-huggingface` mirror of a 50.19 GB tree with one bf16 cast
+  passed its disk preflight, paid for the whole download and the whole cast, and then died
+  `OSError: [Errno 28] No space left on device` inside `publish_v2 -> cas.ingest_file` — the last
+  step. 250 GPU-s, 41,950 uUSD, nothing published (se#840).
+
+- **The clone's disk preflight enumerates STAGES instead of totalling a formula, and the publish
+  states its own cost.** `plan_disk_demand` returns a named `DiskStage` per thing the pipeline
+  writes — source tree, materialized output trees, de-shard, GGUF intermediate, layout repack,
+  and `publish staging`, whose bytes come from `hubio.publish_staging_bytes` rather than from a
+  guess here. A stage that writes nothing still appears, at zero: the reader has to be able to
+  see that it was ASKED. The refusal names every stage, and free space is now checked per
+  FILESYSTEM, so a CAS root on its own mount is measured against its own disk.
+
+- **The preflight and the run now share ONE producer for what the run will do** (`spec_actions`).
+  They did not, and that hid a second under-count behind the first: for a `transformers`-strategy
+  source the budget read `strategy in _PUBLISH_AS_IS_STRATEGIES`, concluded "publishes the source
+  tree directly" and stopped — while `run_clone` went on to CAST a whole second tree, which the
+  budget had no term for at all. That is exactly the failed mirror's shape, and it means the
+  guard was under-counting by a whole output tree BEFORE the CAS copy is even considered. Two
+  smaller corrections ride along: a de-shard is priced at every shard group it merges rather
+  than the largest one, and a publish-as-is cast is no longer charged for a layout repack it
+  never performs (it keeps the source's layout by construction).

--- a/src/gen_worker/cas/__init__.py
+++ b/src/gen_worker/cas/__init__.py
@@ -1,6 +1,6 @@
 """The worker's own half of the content store."""
 
-from .admission import ingest_file
+from .admission import StagedFile, StagedObject, ingest_file, stage_file
 from .planner import BLOB_V1, GGUF_V1, SAFETENSORS_V1, Plan, Region, plan, plan_chunks
 from .retention import GCReport, collect_garbage
 
@@ -11,8 +11,11 @@ __all__ = [
     "Plan",
     "Region",
     "SAFETENSORS_V1",
+    "StagedFile",
+    "StagedObject",
     "collect_garbage",
     "ingest_file",
     "plan",
     "plan_chunks",
+    "stage_file",
 ]

--- a/src/gen_worker/cas/admission.py
+++ b/src/gen_worker/cas/admission.py
@@ -1,15 +1,106 @@
-"""Admission: bytes on disk become CAS objects and a v1 manifest entry."""
+"""Admission: bytes on disk become CAS objects and a v1 manifest entry.
+
+Two admissions, and the difference is whether the store keeps a COPY.
+
+``ingest_file`` writes every object into the store — that is what a local
+cache wants, because the file it came from is about to disappear.
+
+``stage_file`` writes nothing. It plans the same objects and hashes the same
+bytes, and returns WHERE each object already lives: a byte range of the file
+the producer just wrote. A publish only needs to READ its objects, so a tree
+being published needs no second copy of itself on the same disk (pgw#1666 —
+a 50 GB mirror paid its whole download and cast and then died on ENOSPC in
+`publish_v2`, staging a copy of bytes that were already there).
+"""
 
 from __future__ import annotations
 
 import hashlib
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 from .._vendor.tensorfs.local import LocalCAS
 from .._vendor.tensorfs.manifest import Chunk, FileEntry
 from .._vendor.tensorfs.refs import CASRef
 from .planner import plan_chunks
+
+_READ_BLOCK = 1 << 20
+
+
+@dataclass(frozen=True, slots=True)
+class StagedObject:
+    """One CAS object's bytes, named where they already are on disk."""
+
+    digest: CASRef
+    path: Path
+    offset: int
+    length: int
+
+
+@dataclass(frozen=True, slots=True)
+class StagedFile:
+    """One file's manifest entry and the objects it is made of."""
+
+    entry: FileEntry
+    objects: tuple[StagedObject, ...]
+
+
+def stage_file(
+    source: str | Path,
+    *,
+    manifest_path: str | None = None,
+) -> StagedFile:
+    """Plan one file into CAS objects WITHOUT writing a byte.
+
+    Same grid, same digests and same identity guard as ``ingest_file``; the
+    objects are byte ranges of ``source`` rather than copies of it.
+    """
+
+    path = Path(source)
+    initial = path.stat()
+    whole = hashlib.sha256()
+    chunks: list[Chunk] = []
+    objects: list[StagedObject] = []
+    read = 0
+    with path.open("rb") as handle:
+        before = os.fstat(handle.fileno())
+        chunk_lengths = plan_chunks(handle, initial.st_size)
+        handle.seek(0)
+        for length in chunk_lengths or (initial.st_size,):
+            piece = hashlib.sha256()
+            remaining = length
+            while remaining > 0:
+                data = handle.read(min(remaining, _READ_BLOCK))
+                if not data:
+                    raise OSError(f"{path} ended while it was being staged")
+                remaining -= len(data)
+                whole.update(data)
+                piece.update(data)
+            objects.append(
+                StagedObject(CASRef(piece.hexdigest()), path, read, length))
+            if chunk_lengths:
+                chunks.append(Chunk(CASRef(piece.hexdigest()), length))
+            read += length
+        if handle.read(1):
+            raise OSError(f"{path} grew while it was being staged")
+        after = os.fstat(handle.fileno())
+    if (
+        read != initial.st_size
+        or before.st_size != initial.st_size
+        or after.st_size != initial.st_size
+        or after.st_mtime_ns != before.st_mtime_ns
+    ):
+        raise OSError(f"{path} changed while it was being staged")
+    return StagedFile(
+        FileEntry(
+            manifest_path or path.name,
+            read,
+            CASRef(whole.hexdigest()),
+            tuple(chunks),
+        ),
+        tuple(objects),
+    )
 
 
 def ingest_file(

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -17,8 +17,14 @@ from typing import Any, Iterable, Optional
 from gen_worker.api.errors import ValidationError
 
 from ..serving_facts import OBJECTIVES
-from ..hubio.client import HubClient, _dtype_token, files_from_tree
+from ..hubio.client import (
+    HubClient,
+    _dtype_token,
+    files_from_tree,
+    publish_staging_bytes,
+)
 from ..hubio.publish_state import JOURNAL_NAME, ProducerRecovery
+from ..models.cache_paths import tensorhub_cas_dir
 from .convert import run_inline_conversion
 from .dtype_pins import (
     DTYPE_BITS as _DTYPE_STORAGE_BITS,
@@ -369,9 +375,106 @@ def _output_tree_bytes(
     return (source_bytes * out_bits + source_bits - 1) // source_bits
 
 
-def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
+WORKDIR = "workdir"
+CAS = "cas"
+
+
+@dataclass(frozen=True, slots=True)
+class DiskStage:
+    """One thing this job's pipeline writes, and the disk it writes it to."""
+
+    name: str
+    bytes: int
+    where: str = WORKDIR
+
+
+@dataclass(frozen=True, slots=True)
+class DiskDemand:
+    """Every byte the pipeline puts on disk, stage by stage.
+
+    Enumerated rather than totalled, because the defect this shape exists to
+    prevent (pgw#1666) was an OMITTED STAGE, not bad arithmetic: the publish
+    wrote a whole second copy of the produced tree and the total had no term
+    for it, so the guard passed and the job died at the last step having paid
+    for everything. A stage that writes nothing still appears, at zero — the
+    reader has to be able to see that it was ASKED.
+    """
+
+    stages: tuple[DiskStage, ...]
+    margin: int
+    notes: tuple[str, ...] = ()
+
+    @property
+    def required(self) -> int:
+        return sum(stage.bytes for stage in self.stages) + self.margin
+
+    def required_on(self, where: str) -> int:
+        return sum(stage.bytes for stage in self.stages if stage.where == where)
+
+    def describe(self) -> str:
+        gib = float(1024**3)
+        parts = [f"{stage.name} {stage.bytes / gib:.1f} GiB" for stage in self.stages]
+        parts.extend(self.notes)
+        parts.append(f"{self.margin / gib:.0f} GiB margin")
+        return "; ".join(parts)
+
+
+def _existing_ancestor(path: Path) -> Path:
+    probe = Path(path)
+    while not probe.exists() and probe.parent != probe:
+        probe = probe.parent
+    return probe
+
+
+PUBLISH_SOURCE = "publish-source"
+CAST_OUTPUT = "cast"
+NOT_POSSIBLE = "not-possible"
+
+
+def spec_actions(
+    specs: list[OutputSpec],
+    *,
+    publish_as_is: bool,
+    source_dtype: str,
+    explicit_outputs: bool,
+    cast_eligible: bool,
+) -> list[str]:
+    """What the run will DO with each output spec — one producer.
+
+    ``run_clone`` executes this list and ``plan_disk_demand`` prices it.
+    Splitting them is how pgw#1666 hid a SECOND under-count behind the first:
+    the budget read `strategy in _PUBLISH_AS_IS_STRATEGIES`, concluded
+    "publishes the source tree directly" and stopped — while the run went on
+    to CAST a whole second tree, which the budget then had no term for. The
+    two must never again be able to disagree about what happens.
+    """
+
+    actions: list[str] = []
+    for index, spec in enumerate(specs):
+        if not publish_as_is:
+            actions.append(CAST_OUTPUT)
+            continue
+        dtype_matches = (not source_dtype) or spec.dtype == source_dtype
+        if dtype_matches or not explicit_outputs:
+            actions.append(PUBLISH_SOURCE)
+        elif index == 0 and spec.file_type == "safetensors" and cast_eligible:
+            actions.append(CAST_OUTPUT)
+        else:
+            actions.append(NOT_POSSIBLE)
+    return actions
+
+
+def plan_disk_demand(
+    plan: Any, specs: list[OutputSpec], *, explicit_outputs: bool = True,
+) -> Optional[DiskDemand]:
+    """What this clone will write, derived from the stages it will run.
+
+    ``None`` when the plan is too odd to read — an unreadable plan is not a
+    refusal, it is an unmeasured job.
+    """
+
     if plan is None:
-        return
+        return None
     try:
         files = [(str(path), int(size)) for path, size, _ in plan.bank_files()]
         source_bytes = sum(size for _, size in files)
@@ -397,87 +500,133 @@ def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
             and _plan_has_no_repackager(plan)
         )
     except Exception:  # noqa: BLE001 — preflight is best-effort on odd plans
-        return
+        return None
     if source_bytes <= 0:
+        return None
+
+    source_layout = attrs.get("file_layout", "")
+    source_dtype = attrs.get("dtype", "")
+    source_type = attrs.get("file_type", "") or (
+        "gguf" if any(path.lower().endswith(".gguf") for path, _ in files)
+        else "safetensors"
+    )
+    publish_as_is = strategy in _PUBLISH_AS_IS_STRATEGIES or no_repackager
+    actions = spec_actions(
+        specs,
+        publish_as_is=publish_as_is,
+        source_dtype=source_dtype,
+        explicit_outputs=explicit_outputs,
+        cast_eligible=(strategy in _CAST_ELIGIBLE_PUBLISH_AS_IS_STRATEGIES
+                       or no_repackager),
+    )
+    shard_groups: dict[str, int] = {}
+    for path, size in files:
+        m = _SHARD_MEMBER_RE.match(path)
+        if m:
+            shard_groups[m.group("group")] = shard_groups.get(m.group("group"), 0) + size
+    sharded_bytes = sum(shard_groups.values())
+    measured_bits = int(getattr(plan, "source_storage_bits", 0) or 0)
+    source_bits = measured_bits or _DTYPE_STORAGE_BITS.get(
+        source_dtype, _UNRESOLVED_SOURCE_BITS)
+
+    stages = [DiskStage("source tree", source_bytes)]
+    notes: list[str] = []
+    output_sizes: list[int] = []
+    deshard_bytes = gguf_intermediate = repack = published_bytes = 0
+    reused_in_place = False
+
+    for spec, action in zip(specs, actions):
+        if action == NOT_POSSIBLE:
+            continue
+        # A spec the source already satisfies is HARDLINKED into its output
+        # tree rather than written; only a sharded safetensors set costs
+        # bytes, because de-sharding merges it into one new file per component.
+        in_place = action == PUBLISH_SOURCE or (
+            source_layout and spec.file_layout == source_layout
+            and spec.file_type == source_type
+            and (spec.dtype == "source"
+                 or (source_dtype and spec.dtype == source_dtype))
+        )
+        if in_place:
+            reused_in_place = True
+            published_bytes += source_bytes
+            if spec.file_type == "safetensors":
+                deshard_bytes += sharded_bytes
+            continue
+        size = _output_tree_bytes(spec, source_bytes, source_bits, measured_bits)
+        output_sizes.append(size)
+        published_bytes += size
+        if spec.file_type == "gguf" and spec.dtype not in _DIRECT_GGUF_ENCODINGS:
+            gguf_intermediate = max(
+                gguf_intermediate,
+                (source_bytes * 16 + source_bits - 1) // source_bits)
+        # A publish-as-is cast keeps the SOURCE's layout (`effective_layout` in
+        # `run_clone`), so it never repacks; only a real flavor build can.
+        layout = source_layout if publish_as_is else spec.file_layout
+        if spec.file_type != "gguf" and source_layout and layout != source_layout:
+            repack = max(repack, size)
+
+    if output_sizes:
+        stages.append(DiskStage(
+            f"{len(output_sizes)} materialized output tree(s)", sum(output_sizes)))
+    if deshard_bytes:
+        stages.append(DiskStage("one merged de-shard output", deshard_bytes))
+    if gguf_intermediate:
+        stages.append(DiskStage("one intermediate F16 GGUF tree", gguf_intermediate))
+    if repack:
+        stages.append(DiskStage("one layout-repack tree", repack))
+    if publish_as_is:
+        notes.append(f"{strategy} publishes the source tree directly")
+    if reused_in_place:
+        notes.append("hardlink passthrough")
+    if (output_sizes and not measured_bits
+            and source_dtype not in _DTYPE_STORAGE_BITS):
+        notes.append(
+            f"source dtype unreadable, assumed {_UNRESOLVED_SOURCE_BITS}-bit")
+
+    # The LAST stage of every clone is a publish, and it is the one the old
+    # budget forgot. Its cost is not guessed here: `publish_v2` states it.
+    stages.append(DiskStage(
+        "publish staging", publish_staging_bytes(published_bytes), where=CAS))
+    return DiskDemand(tuple(stages), _DISK_MARGIN_BYTES, tuple(notes))
+
+
+def _preflight_disk(
+    workdir: Path, plan: Any, specs: list[OutputSpec],
+    *, explicit_outputs: bool = True,
+) -> None:
+    """Refuse at $0 what would otherwise die at 250 GPU-s (pgw#1666)."""
+
+    demand = plan_disk_demand(plan, specs, explicit_outputs=explicit_outputs)
+    if demand is None:
         return
 
-    if strategy in _PUBLISH_AS_IS_STRATEGIES or no_repackager:
-        required = source_bytes + _DISK_MARGIN_BYTES
-        operation = f"{strategy} publishes the source tree directly"
-    else:
-        source_layout = attrs.get("file_layout", "")
-        source_dtype = attrs.get("dtype", "")
-        source_type = attrs.get("file_type", "") or (
-            "gguf" if any(path.lower().endswith(".gguf") for path, _ in files)
-            else "safetensors"
-        )
-        passthrough = [
-            spec for spec in specs
-            if source_layout and spec.file_layout == source_layout
-            and spec.file_type == source_type
-            and (spec.dtype == "source" or (source_dtype and spec.dtype == source_dtype))
-        ]
-        materialized = [spec for spec in specs if spec not in passthrough]
-        shard_groups: dict[str, int] = {}
-        for path, size in files:
-            m = _SHARD_MEMBER_RE.match(path)
-            if m:
-                shard_groups[m.group("group")] = shard_groups.get(m.group("group"), 0) + size
-        deshard_bytes = len(passthrough) * max(shard_groups.values(), default=0)
-        measured_bits = int(getattr(plan, "source_storage_bits", 0) or 0)
-        source_bits = measured_bits or _DTYPE_STORAGE_BITS.get(
-            source_dtype, _UNRESOLVED_SOURCE_BITS)
-        output_sizes = [
-            _output_tree_bytes(spec, source_bytes, source_bits, measured_bits)
-            for spec in materialized
-        ]
-        gguf_intermediate = max(
-            (
-                (source_bytes * 16 + source_bits - 1) // source_bits
-                for spec in materialized
-                if spec.file_type == "gguf"
-                and spec.dtype not in _DIRECT_GGUF_ENCODINGS
-            ),
-            default=0,
-        )
-        repack = max(
-            (
-                size for spec, size in zip(materialized, output_sizes)
-                if spec.file_type != "gguf"
-                and source_layout and spec.file_layout != source_layout
-            ),
-            default=0,
-        )
-        required = (
-            source_bytes + sum(output_sizes) + gguf_intermediate
-            + deshard_bytes + repack + _DISK_MARGIN_BYTES
-        )
-        parts = []
-        if passthrough:
-            parts.append("hardlink passthrough")
-        if materialized:
-            parts.append(f"{len(materialized)} materialized output tree(s)")
-        if deshard_bytes:
-            parts.append("one merged de-shard output")
-        if gguf_intermediate:
-            parts.append("one intermediate F16 GGUF tree")
-        if repack:
-            parts.append("one layout-repack tree")
-        if (materialized and not measured_bits
-                and source_dtype not in _DTYPE_STORAGE_BITS):
-            parts.append(
-                "source dtype unreadable, assumed "
-                f"{_UNRESOLVED_SOURCE_BITS}-bit")
-        operation = ", ".join(parts) or "source tree"
+    roots = {WORKDIR: _existing_ancestor(workdir),
+             CAS: _existing_ancestor(tensorhub_cas_dir())}
+    # One budget per FILESYSTEM: stages that share a device share its free
+    # space, and a CAS on its own mount is checked against its own.
+    devices: dict[Any, list[str]] = {}
+    for where, root in roots.items():
+        try:
+            device: Any = os.stat(root).st_dev
+        except OSError:
+            device = root
+        devices.setdefault(device, []).append(where)
 
-    free = shutil.disk_usage(workdir).free
-    if free < required:
-        gib = float(1024**3)
+    gib = float(1024**3)
+    for wheres in devices.values():
+        required = sum(demand.required_on(where) for where in wheres)
+        if not required:
+            continue
+        required += _DISK_MARGIN_BYTES
+        root = roots[wheres[0]]
+        free = shutil.disk_usage(root).free
+        if free >= required:
+            continue
         raise CloneDiskSpaceError(
             f"not enough disk for clone: need ~{required / gib:.1f} GiB free "
-            f"(source {source_bytes / gib:.1f} GiB; {operation}; "
-            f"{_DISK_MARGIN_BYTES / gib:.0f} GiB margin), have {free / gib:.1f} GiB "
-            f"at {workdir}")
+            f"({demand.describe()}), have {free / gib:.1f} GiB "
+            f"at {root}")
 
 def _reusable_flavor_tree(
     workdir: Path, spec_label: str, flavor_dir: Path,
@@ -638,7 +787,7 @@ def run_clone(
             logger.warning(
                 "clone source plan failed (download-skip disabled for this run): %s", exc)
 
-        _preflight_disk(workdir, plan, specs)
+        _preflight_disk(workdir, plan, specs, explicit_outputs=explicit_outputs)
 
         _progress(0.05, "clone.ingest")
         dl_bytes = {"done": 0}
@@ -681,14 +830,22 @@ def run_clone(
         no_repackager = strategy == "aio_singlefile" and (
             declared is None or not declared.supports_singlefile_to_diffusers)
         publish_as_is = strategy in _PUBLISH_AS_IS_STRATEGIES or no_repackager
+        source_dtype = str(source.attrs.get("dtype") or "").strip().lower()
+        # The SAME list the disk preflight priced (pgw#1666).
+        actions = spec_actions(
+            specs,
+            publish_as_is=publish_as_is,
+            source_dtype=source_dtype,
+            explicit_outputs=explicit_outputs,
+            cast_eligible=(strategy in _CAST_ELIGIBLE_PUBLISH_AS_IS_STRATEGIES
+                           or no_repackager),
+        )
 
         for i, spec in enumerate(specs):
             dtype_label = spec.dtype
             try:
                 if publish_as_is:
-                    source_dtype = str(source.attrs.get("dtype") or "").strip().lower()
-                    dtype_matches = (not source_dtype) or spec.dtype == source_dtype
-                    if dtype_matches or not explicit_outputs:
+                    if actions[i] == PUBLISH_SOURCE:
                         tree = source.dir
                         attrs = dict(source.attrs)
                         dtype_label = source_dtype or spec.dtype
@@ -700,9 +857,7 @@ def run_clone(
                             copy_non_weight_files(Path(tree), deshard_dir, skip_components=set())
                             deshard_mirror_tree(deshard_dir)
                             tree = deshard_dir
-                    elif i == 0 and spec.file_type == "safetensors" \
-                            and (strategy in _CAST_ELIGIBLE_PUBLISH_AS_IS_STRATEGIES
-                                 or no_repackager):
+                    elif actions[i] == CAST_OUTPUT:
                         effective_layout = (
                             source.layout if source.layout in _KNOWN_FILE_LAYOUTS
                             else SINGLE_FILE

--- a/src/gen_worker/hubio/client.py
+++ b/src/gen_worker/hubio/client.py
@@ -14,14 +14,18 @@ from typing import Any, Callable, Dict, Mapping, Optional, cast
 
 import requests
 from gen_worker._vendor.tensorfs import CASRef, RepositoryManifest
-from gen_worker.cas.admission import ingest_file
-from gen_worker.transfer.grants import TransferGrant, upload
+from gen_worker.cas.admission import stage_file
+from gen_worker.transfer.grants import (
+    ObjectRegion,
+    StagedRegions,
+    TransferGrant,
+    upload,
+)
 from gen_worker.transfer.journal import TransferJournal, TransferSession
 
 from .. import activity as _activity
 from .. import scratchrepo
 from ..http_origin import is_definite_hub_answer, response_is_from_hub
-from ..models.cache_paths import open_worker_cas
 from ..stall import SilenceWindow
 from .publish_state import JOURNAL_NAME, STATE_NAME, ProducerRecovery
 
@@ -359,15 +363,19 @@ class HubClient:
 
         repo_path = self._repo_path(destination_repo)
 
-        cas = open_worker_cas()
         entries = []
+        staged: dict[CASRef, ObjectRegion] = {}
         for f in files:
             if f.local_path is None:
                 raise HubPublishError(
                     f"publish_v2: {f.path!r} is a by-reference add; v2 declares "
                     "digests computed from local bytes"
                 )
-            entries.append(ingest_file(cas, Path(f.local_path), manifest_path=f.path))
+            planned = stage_file(Path(f.local_path), manifest_path=f.path)
+            entries.append(planned.entry)
+            for obj in planned.objects:
+                staged.setdefault(
+                    obj.digest, ObjectRegion(obj.path, obj.offset, obj.length))
         manifest = RepositoryManifest(tuple(entries))
         manifest_ref = manifest.digest()
 
@@ -528,7 +536,7 @@ class HubClient:
                        bytes=sum(g.size_bytes for g in grants), attempt=attempt)
                 report = upload(
                     grants,
-                    cas,
+                    StagedRegions(staged),
                     progress=(lambda _digest, n: part_progress(0, 0, n))
                     if callable(part_progress) else None,
                 )
@@ -649,6 +657,24 @@ class HubClient:
         )
 
 
+def publish_staging_bytes(published_bytes: int) -> int:
+    """Local disk `publish_v2` needs to publish `published_bytes` of tree.
+
+    ZERO, and this function exists so nobody has to remember that. A publish
+    stages BY REFERENCE (`cas.stage_file`): it hashes the producer's own
+    files and uploads byte ranges of them, so the only bytes it writes are
+    the ones already on disk. Any caller sizing a disk asks HERE rather than
+    guessing — pgw#1666 is what guessing cost: the preflight budgeted
+    `source + outputs + margin`, the publish silently copied the whole
+    published tree into the local CAS, and a 50 GB mirror died on ENOSPC
+    after paying for its download and its cast.
+    """
+
+    if published_bytes < 0:
+        raise ValueError("published bytes must not be negative")
+    return 0
+
+
 def files_from_tree(tree: Path, *, prefix: str = "") -> list[CommitFile]:
     """Build CommitFile entries for every regular file under ``tree``."""
     tree = Path(tree)
@@ -681,4 +707,5 @@ __all__ = [
     "CommitFile",
     "CommitResult",
     "files_from_tree",
+    "publish_staging_bytes",
 ]

--- a/src/gen_worker/transfer/grants.py
+++ b/src/gen_worker/transfer/grants.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import http.client
 import os
 import random
@@ -121,8 +122,58 @@ class TransferGrant:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class ObjectRegion:
+    """One object's bytes: a byte range of a file that already exists."""
+
+    path: Path
+    offset: int
+    length: int
+
+
+class ObjectSource(Protocol):
+    """Where an upload finds the bytes of one declared object."""
+
+    def region(self, digest: CASRef, size: int) -> ObjectRegion: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CASObjects:
+    """The local store as an upload source: one whole object per file."""
+
+    cas: LocalCAS
+
+    def region(self, digest: CASRef, size: int) -> ObjectRegion:
+        return ObjectRegion(self.cas.verify_object(digest, size=size), 0, size)
+
+
+@dataclass(frozen=True, slots=True)
+class StagedRegions:
+    """Objects that live inside the producer's own files, uncopied.
+
+    The bytes are re-hashed as they are sent (`_HTTPTransport.upload`), so a
+    region that no longer holds the declared object fails this transfer
+    instead of installing wrong bytes -- the same guarantee the CAS gives by
+    verifying before it sends, at one read instead of two.
+    """
+
+    objects: Mapping[CASRef, ObjectRegion]
+
+    def region(self, digest: CASRef, size: int) -> ObjectRegion:
+        found = self.objects.get(CASRef.parse(digest))
+        if found is None:
+            raise _TransferRefused(
+                f"{digest}: the plan grants an object this publish never "
+                "declared; nothing on this machine can satisfy it")
+        if found.length != size:
+            raise DigestMismatch(
+                f"{digest}: staged region is {found.length} bytes, "
+                f"the grant declares {size}")
+        return found
+
+
 class _GrantTransport(Protocol):
-    def upload(self, grant: TransferGrant, source: Path) -> None: ...
+    def upload(self, grant: TransferGrant, source: ObjectRegion) -> None: ...
 
     def download(self, grant: TransferGrant, destination: Path) -> None: ...
 
@@ -145,17 +196,33 @@ class _HTTPTransport:
         except (OSError, urllib.error.URLError) as exc:
             raise _TransientTransferError(str(exc)) from exc
 
-    def upload(self, grant: TransferGrant, source: Path) -> None:
-        if source.stat().st_size != grant.size_bytes:
+    def upload(self, grant: TransferGrant, source: ObjectRegion) -> None:
+        if source.length != grant.size_bytes:
             raise DigestMismatch(
-                f"{grant.digest}: upload source is {source.stat().st_size} bytes, "
+                f"{grant.digest}: upload source is {source.length} bytes, "
                 f"expected {grant.size_bytes}"
             )
 
         def body() -> Iterator[bytes]:
-            with source.open("rb") as handle:
-                while block := handle.read(self.block_bytes):
+            digest = hashlib.sha256()
+            remaining = source.length
+            with source.path.open("rb") as handle:
+                if source.offset:
+                    handle.seek(source.offset)
+                while remaining > 0:
+                    block = handle.read(min(remaining, self.block_bytes))
+                    if not block:
+                        raise DigestMismatch(
+                            f"{grant.digest}: {source.path} ended "
+                            f"{remaining} bytes short of the declared object")
+                    remaining -= len(block)
+                    digest.update(block)
                     yield block
+            if digest.hexdigest() != grant.digest.digest:
+                raise DigestMismatch(
+                    f"{grant.digest}: {source.path} bytes "
+                    f"[{source.offset}, {source.offset + source.length}) "
+                    f"hash to sha256:{digest.hexdigest()}")
 
         headers = dict(grant.headers)
         content_lengths = [
@@ -316,9 +383,13 @@ def _run_parallel(
     return report
 
 
+def _as_source(source: ObjectSource | LocalCAS) -> ObjectSource:
+    return CASObjects(source) if isinstance(source, LocalCAS) else source
+
+
 def _upload(
     grants: Sequence[TransferGrant],
-    source: LocalCAS,
+    source: ObjectSource | LocalCAS,
     *,
     transport: _GrantTransport,
     parallel: int = DEFAULT_PARALLEL,
@@ -326,12 +397,13 @@ def _upload(
     sleep: Callable[[float], None] = time.sleep,
     progress: Callable[[CASRef, int], None] | None = None,
 ) -> TransferReport:
+    objects = _as_source(source)
 
     def one(grant: TransferGrant) -> bool:
-        path = source.verify_object(grant.digest, size=grant.size_bytes)
+        region = objects.region(grant.digest, grant.size_bytes)
         _retry(
             grant,
-            lambda: transport.upload(grant, path),
+            lambda: transport.upload(grant, region),
             max_attempts=max_attempts,
             sleep=sleep,
         )
@@ -342,7 +414,7 @@ def _upload(
 
 def upload(
     grants: Sequence[TransferGrant],
-    source: LocalCAS,
+    source: ObjectSource | LocalCAS,
     *,
     parallel: int = DEFAULT_PARALLEL,
     max_attempts: int = 5,

--- a/tests/convert/test_publish_staging_pgw1666.py
+++ b/tests/convert/test_publish_staging_pgw1666.py
@@ -1,0 +1,326 @@
+"""pgw#1666 — the publish's bytes are the pipeline's bytes, and it says so.
+
+The measured defect: a 50.19 GB `clone-huggingface` + bf16 cast passed a
+preflight that demanded ~87 GiB, paid its whole download and its whole cast,
+and then died `OSError: [Errno 28]` inside `publish_v2` — which was copying
+the produced tree into the local CAS, a term the budget had no name for.
+
+Two halves, both here:
+  * the publish no longer writes that copy (it uploads byte RANGES of the
+    producer's own files), so the real need is what the budget already said;
+  * the budget ASKS the publish what it costs, so an omission like the one
+    that cost 250 GPU-s cannot come back silently.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fake_hub import _client, _FakeHub
+
+from gen_worker.convert.clone import (
+    CAS,
+    CloneDiskSpaceError,
+    OutputSpec,
+    _preflight_disk,
+    plan_disk_demand,
+    run_clone,
+)
+from gen_worker.convert.ingest import IngestedSource
+from gen_worker.hubio.client import CommitFile, files_from_tree
+from gen_worker.models.cache_paths import tensorhub_cas_dir
+
+GIB = 1024**3
+BF16 = OutputSpec(dtype="bf16", file_layout="multi-file", file_type="safetensors")
+
+
+def _bytes_under(root: Path) -> int:
+    if not root.exists():
+        return 0
+    return sum(p.stat().st_size for p in root.rglob("*") if p.is_file())
+
+
+def _safetensors(tensors: dict[str, tuple[str, int]]) -> bytes:
+    """One valid safetensors file: `name -> (dtype, element count)`."""
+
+    width = {"F32": 4, "BF16": 2}
+    header: dict[str, Any] = {}
+    offset = 0
+    for name, (dtype, count) in tensors.items():
+        end = offset + count * width[dtype]
+        header[name] = {"dtype": dtype, "shape": [count], "data_offsets": [offset, end]}
+        offset = end
+    blob = json.dumps(header).encode()
+    body = bytes(bytearray((i * 37 + 11) % 251 for i in range(offset)))
+    return struct.pack("<Q", len(blob)) + blob + body
+
+
+class _Ctx:
+    def __init__(self, server: Any) -> None:
+        self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+        self._worker_capability_token = "cap-token"
+        self.owner = "tensorhub"
+        self.request_id = "req-1666"
+        self.destination = {"repo": "tensorhub/fallback"}
+
+
+# ---------------------------------------------------------------- the copy
+
+
+def test_a_publish_writes_no_second_copy_of_the_tree_it_publishes(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """THE DEFECT, at fixture scale: publishing must not consume disk.
+
+    Pre-fix this stored every object under the CAS root — the whole tree
+    again, on the same filesystem, before a byte was uploaded.
+    """
+
+    tree = tmp_path / "flavor"
+    tree.mkdir()
+    (tree / "config.json").write_bytes(b'{"architectures":["Fake"]}')
+    (tree / "model.safetensors").write_bytes(
+        _safetensors({f"blocks.{i}.weight": ("F32", 4096) for i in range(8)}))
+    published = _bytes_under(tree)
+    assert published > 100_000
+
+    cas_root = tensorhub_cas_dir()
+    before = _bytes_under(cas_root)
+
+    result = _client(fake_hub).publish_v2(
+        destination_repo="acme/model", release="r1",
+        files=files_from_tree(tree),
+    )
+
+    assert result.checkpoint_id
+    assert result.uploaded == 10  # 8 tensors + header + config
+    assert _bytes_under(cas_root) - before == 0, (
+        "publish staged a local copy of the tree it was publishing")
+
+
+def test_the_bytes_the_hub_receives_are_the_bytes_on_disk(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """A range upload is only a saving if it sends the right range.
+
+    The fake hub refuses any PUT whose body does not hash to its key, so a
+    mis-seeked region cannot pass — and the declared per-tensor digests must
+    match the file's real bytes at those offsets.
+    """
+
+    raw = _safetensors({"a.weight": ("F32", 512), "b.weight": ("BF16", 1024)})
+    path = tmp_path / "model.safetensors"
+    path.write_bytes(raw)
+
+    _client(fake_hub).publish_v2(
+        destination_repo="acme/model", release="r1",
+        files=[CommitFile(path="model.safetensors", local_path=path,
+                          size_bytes=len(raw))],
+    )
+
+    declared = next(iter(_FakeHub.state["publishes"].values()))["files"][0]
+    offset = 0
+    for chunk in declared["chunks"]:
+        window = raw[offset:offset + int(chunk["len"])]
+        assert hashlib.sha256(window).hexdigest() == chunk["digest"]
+        assert chunk["digest"] in _FakeHub.state["v2_cas"]
+        offset += int(chunk["len"])
+    assert offset == len(raw)
+
+
+def test_a_grant_for_an_undeclared_object_is_refused_not_guessed(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """Staging by reference must not become "upload whatever is lying around"."""
+
+    from gen_worker._vendor.tensorfs.refs import CASRef
+    from gen_worker.transfer.grants import StagedRegions
+
+    source = StagedRegions({})
+    with pytest.raises(Exception) as excinfo:
+        source.region(CASRef("00" * 32), 7)
+    assert "never declared" in str(excinfo.value)
+
+
+# --------------------------------------------------------- the whole clone
+
+
+def _fake_plan(source_dir: Path) -> Any:
+    """The network-derived plan for a tree that is already on this disk."""
+
+    files = [
+        (p.relative_to(source_dir).as_posix(), p.stat().st_size,
+         hashlib.sha256(p.read_bytes()).hexdigest())
+        for p in sorted(source_dir.rglob("*")) if p.is_file()
+    ]
+    return SimpleNamespace(
+        provider="huggingface",
+        paths=[name for name, _, _ in files],
+        source_storage_bits=32,
+        classification=SimpleNamespace(
+            strategy="transformers",
+            attrs={"dtype": "fp32", "file_layout": "single-file",
+                   "file_type": "safetensors"},
+        ),
+        bank_files=lambda: list(files),
+    )
+
+
+def test_a_real_clone_stays_inside_the_disk_it_demanded(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole pipeline — plan, cast, publish — measured against its budget.
+
+    Sampled at the peak (the instant the uploader is handed its grants: the
+    source tree, the cast tree and everything staged coexist). Three bars,
+    because a 2 GiB margin will absorb a fixture-scale tree and prove nothing:
+    the peak is inside the demand, the publish's own contribution is ZERO, and
+    what the stage list does not name is journal-scale, not tree-scale.
+    """
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "config.json").write_bytes(b'{"architectures":["Fake"]}')
+    (source_dir / "model.safetensors").write_bytes(
+        _safetensors({f"blocks.{i}.weight": ("F32", 65536) for i in range(8)}))
+
+    plan = _fake_plan(source_dir)
+    demand = plan_disk_demand(plan, [BF16])
+    assert demand is not None
+    accounted = sum(stage.bytes for stage in demand.stages)
+
+    cas_root = tensorhub_cas_dir()
+    work_root = tmp_path / "work"
+    peak = {"pipeline": 0, "cas": 0}
+    real_upload = __import__(
+        "gen_worker.hubio.client", fromlist=["upload"]).upload
+
+    def _sampling_upload(*args: Any, **kwargs: Any) -> Any:
+        peak["pipeline"] = max(
+            peak["pipeline"],
+            _bytes_under(work_root) + _bytes_under(source_dir))
+        peak["cas"] = max(peak["cas"], _bytes_under(cas_root))
+        return real_upload(*args, **kwargs)
+
+    monkeypatch.setattr("gen_worker.hubio.client.upload", _sampling_upload)
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(work_root))
+    monkeypatch.setattr("gen_worker.convert.clone.plan_huggingface",
+                        lambda *a, **k: plan)
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.ingest_huggingface",
+        lambda source_ref, dest_dir, **kwargs: IngestedSource(
+            provider="huggingface", source_ref=source_ref,
+            source_revision="5be7df96", dir=source_dir, layout="single-file",
+            model_family="fake", model_family_variant="fake1",
+            classification=plan.classification,
+            attrs=dict(plan.classification.attrs),
+            metadata={"source_provider": "huggingface"},
+            repo_spec={"kind": "model", "library_name": "transformers"},
+        ))
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="fake/tree",
+        destination_repo="tensorhub/fake-tree", destination_release="r1",
+        outputs=[{"dtype": "bf16", "file_layout": "multi-file",
+                  "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert result.published and result.published[0]["dtype"] == "bf16"
+    assert peak["pipeline"] > 0, "the sampler never ran; the peak is unmeasured"
+    total = peak["pipeline"] + peak["cas"]
+    assert total <= demand.required, (
+        f"peak {total} bytes on disk against {demand.describe()}")
+    assert peak["cas"] == 0, (
+        f"the publish staged {peak['cas']} bytes of its own — the term that "
+        "made a 50 GB mirror die at ENOSPC after paying for everything")
+    assert total - accounted < 64 * 1024, (
+        f"peak {total} exceeds the {accounted} bytes the stage list names by "
+        f"more than a journal's worth: {demand.describe()}")
+
+
+# ------------------------------------------------------------ the accounting
+
+
+def _sensenova_plan() -> Any:
+    """se#840's tree as the plan measured it: 50.19 GB over 13 shards."""
+
+    shard = 50_190_000_000 // 13
+    files = [(f"model-{i:05d}-of-00013.safetensors", shard, f"{i:064x}")
+             for i in range(1, 14)]
+    files.append(("config.json", 4096, "c" * 64))
+    return SimpleNamespace(
+        provider="huggingface",
+        paths=[name for name, _, _ in files],
+        source_storage_bits=32,
+        classification=SimpleNamespace(
+            strategy="transformers",
+            attrs={"dtype": "fp32", "file_layout": "single-file",
+                   "file_type": "safetensors"},
+        ),
+        bank_files=lambda: list(files),
+    )
+
+
+def _with_free(monkeypatch: pytest.MonkeyPatch, free: int) -> None:
+    import shutil as _shutil
+
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _p: _shutil._ntuple_diskusage(  # type: ignore[attr-defined]
+            total=free * 2, used=free, free=free))
+
+
+def test_the_demand_names_the_publish_even_when_it_costs_nothing(
+    tmp_path: Path,
+) -> None:
+    """The stage the old budget had no name for is now always in the list."""
+
+    demand = plan_disk_demand(_sensenova_plan(), [BF16])
+    assert demand is not None
+    names = [stage.name for stage in demand.stages]
+    assert names == ["source tree", "1 materialized output tree(s)",
+                     "publish staging"]
+    assert demand.required_on(CAS) == 0
+    assert "publish staging 0.0 GiB" in demand.describe()
+
+
+def test_a_publish_that_stages_bytes_is_refused_at_zero_dollars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wiring, falsified: put the copy back and the guard fires FIRST.
+
+    `publish_staging_bytes` is the publish's own statement of what it writes.
+    Restoring the pre-fix answer (a whole local copy of the published tree)
+    must show up in the demand as a whole extra tree and refuse se#840's
+    mirror before it rents anything — instead of the 250 GPU-s / 41,950 uUSD
+    the real job spent to learn the same fact at `cas.ingest_file`.
+    """
+
+    plan = _sensenova_plan()
+    source_bytes = sum(size for _, size, _ in plan.bank_files())
+    cast_bytes = source_bytes // 2  # fp32 source, bf16 output
+    honest = plan_disk_demand(plan, [BF16])
+    assert honest is not None
+    assert honest.required == source_bytes + cast_bytes + 2 * GIB
+
+    monkeypatch.setattr("gen_worker.convert.clone.publish_staging_bytes",
+                        lambda published: published)
+    copies = plan_disk_demand(plan, [BF16])
+    assert copies is not None
+    assert copies.required_on(CAS) == cast_bytes
+    assert copies.required == honest.required + cast_bytes
+
+    # The pod that ran the real job had room for the honest demand and not
+    # for the true one. Pre-fix that pod was ADMITTED and billed.
+    _with_free(monkeypatch, honest.required + GIB)
+    with pytest.raises(CloneDiskSpaceError) as excinfo:
+        _preflight_disk(tmp_path, plan, [BF16])
+    assert "publish staging" in str(excinfo.value)
+    assert "not enough disk for clone" in str(excinfo.value)


### PR DESCRIPTION
Fixes the defect [se#840] measured live: conversion job `01a02884-8d12-7eb7-b4de-ff771103a859` (`clone-huggingface` of the 50.19 GB SenseNova tree + one bf16 cast) passed its disk preflight, paid for the whole download and the whole cast, and died `OSError: [Errno 28] No space left on device` inside `publish_v2 -> cas.ingest_file` — the last step. **250 GPU-s, 41,950 uUSD, nothing published.**

## Root cause, as confirmed and as CORRECTED

Filed cause: `_preflight_disk` budgets `source + outputs + margin` and does not count the local CAS copy the publish makes. True — and it is only half.

`publish_v2` walked every produced file into the local CAS with `put_bytes` before uploading a byte: **a full second copy of the published tree**, on the same filesystem, deleted minutes later.

**A hardlink cannot remove that term** (candidate 2 as filed): `cas.ingest_file` splits a safetensors file into one CAS object *per tensor* on the planner grid, so the objects are byte RANGES of the file, not the file. There is nothing to link. But the copy is still unnecessary — the producer's tree already holds those exact bytes and the uploader only needs to READ them.

**The second under-count, found while fixing the first:** the preflight re-derived what the run would do instead of reading it. For a `transformers`-strategy source it read `strategy in _PUBLISH_AS_IS_STRATEGIES`, concluded "publishes the source tree directly" and stopped — while `run_clone` went on to CAST a whole second tree. That is SenseNova's exact shape, so the guard was short by an entire output tree *before* the CAS copy is even considered.

## The fix

* **`cas.stage_file`** — same planner grid, same per-tensor digests, same identity guard as `ingest_file`, but it writes **nothing**: objects are recorded as `(path, offset, length)` of the producer's own files. `ingest_file` is untouched (admitting into the store is what a local cache wants; a publish is not a cache).
* **The uploader takes an `ObjectSource`** — a CAS object or a staged region — and streams the range, **re-hashing as it sends**, so a region that no longer holds its declared object fails that transfer instead of installing wrong bytes. One read instead of two. A grant for an object the publish never declared is refused by name, not guessed.
* **`plan_disk_demand`** returns a named `DiskStage` per thing the pipeline writes, including `publish staging`, whose bytes come from **`hubio.publish_staging_bytes`** — the publish's own statement — not a guess in the budget. A stage that writes nothing still appears, at zero: the reader has to see it was ASKED. Free space is checked **per filesystem**, so a CAS root on its own mount is measured against its own disk.
* **One producer for what the run will do** (`spec_actions`), consumed by both `run_clone` and the demand, so they can never again disagree. Riders: a de-shard is priced at every shard group it merges rather than the largest one; a publish-as-is cast is no longer charged for a repack it never performs.

## Red proof

Restoring only the pre-fix publish (`ingest_file` + upload-from-CAS) on this branch:

```
E  AssertionError: publish staged a local copy of the tree it was publishing
E  assert (131793 - 0) == 0
E  AssertionError: the publish staged 1049266 bytes of its own — the term that
   made a 50 GB mirror die at ENOSPC after paying for everything
```

1,049,266 B is the produced bf16 tree, exactly, in a **real end-to-end `run_clone`** (real plan, real cast, real publish against the fake hub — only the HTTP download is stubbed). Green after, with the peak on disk inside `demand.required`, the publish's own contribution at **zero**, and nothing unaccounted beyond a journal's worth.

`test_a_publish_that_stages_bytes_is_refused_at_zero_dollars` falsifies the wiring the other way: restore the pre-fix answer in `publish_staging_bytes` and the demand grows by a whole tree and refuses se#840's mirror **at \$0**, instead of at 250 GPU-s.

## Local verification

* `tests/convert` + the CAS/planner suites: **264 passed**
* the publish/CAS/transfer-touching selection across `tests/`: **485 passed**
* `mypy src/gen_worker tests`: clean, 656 files · `ruff check`: clean

[se#840]: https://github.com/cozy-creator/serverless-endpoints