### PR TITLE
pgw#1667: the clone's PLAN phase declares a position, and the two phases that had silently stopped declaring one do again

### DIFF
--- a/changelog.d/pgw1667.md
+++ b/changelog.d/pgw1667.md
@@ -1,0 +1,24 @@
+- **pgw#1667: the clone's PLAN phase declares a position, and the two phases that had silently
+  stopped declaring one do again.** Job `01a02910` mirroring
+  `sensenova/SenseNova-U1.5-8B-MoT-Preview` (13 shards, 50.19 GB) died
+  `job_progress_stalled`/`zero_progress` at 604 GPU-s — *"declared position clone.plan 0 stopped
+  advancing 10m4s ago"* — without downloading a weight byte. `plan_huggingface` took no
+  `progress=` parameter at all, so `clone.plan`'s position was 0 for the whole phase by
+  construction while it walked a recursive repo tree and read safetensors headers; the bigger and
+  more sharded the source, the likelier it crossed the hub's 10-minute budget, and a re-queue paid
+  the same 600 GPU-s into the same wall. **The budget is not widened.** A position that does not
+  move is the only evidence of a wedged job that a heartbeat cannot fake; the producer owed a
+  position and now pays it, one per completed remote metadata item — every loop in there was
+  already a bounded, countable iteration. `plan_civitai` reports on the same contract (the two
+  are the only clone-source strategies in the repo). **A second, silent regression is fixed with
+  it**: `cd46c957` (the v1 SDK hardcut) deleted pgw#1397's position machinery out of `run_clone`
+  and its test in the same commit, so `clone.download` and `clone.publish` had gone back to
+  declaring a 0..1 fraction — `int(0.02) == 0` — and the next large mirror would have died in the
+  download for the identical reason. The position now lives in `convert/clone_position.py` rather
+  than in a closure inside a 300-line function, so the next refactor has to delete it on purpose.
+  Proven by execution: the committed test drives the real `plan_huggingface` over a 13-shard
+  source and `run_clone` end-to-end, replaying the hub's own strict-increase predicate — 17 ticks
+  emitted, 17 accepted. Reverted, the same probe accepts exactly one row, `clone.plan 0`, which is
+  the failed job's message verbatim. A plan that genuinely hangs still emits nothing and still
+  trips `zero_progress`, because a counter that ticks on its own manufactures exactly the liveness
+  this instrument exists to disprove.

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -41,6 +41,7 @@ from .ingest import (
     plan_civitai,
     plan_huggingface,
 )
+from .clone_position import ClonePosition
 from .keepalive import HubKeepalive
 from .publish import destination_release as _destination_release
 from .layout import canonical_model_family_from_variant, infer_model_family_variant_from_hint
@@ -742,13 +743,21 @@ def run_clone(
     explicit_outputs = bool(outputs)
     effective_hf_token = str(hf_token or "").strip() or str(getattr(ctx, "hf_token", "") or "").strip()
 
-    def _progress(p: float, stage: str) -> None:
+    def _emit_position(
+        fraction: float, stage: str, position: int, total: Optional[int]
+    ) -> None:
         fn = getattr(ctx, "progress", None)
-        if callable(fn):
-            try:
-                fn(p, stage=stage)
-            except Exception:
-                pass
+        if not callable(fn):
+            return
+        try:
+            fn(fraction, stage, position=float(position), total=total)
+        except Exception:
+            pass
+
+    position = ClonePosition(_emit_position)
+
+    def _progress(p: float, stage: str) -> None:
+        position.enter(p, stage)
 
     source_key = source_ref if provider == "huggingface" else str(civitai_model_version_id or 0)
     if source_revision:
@@ -766,6 +775,10 @@ def run_clone(
         mode = "replace" if overwrite_repo else "merge"
 
         _progress(0.02, "clone.plan")
+
+        def _plan_progress(done: int, total: Optional[int]) -> None:
+            position.units(0.02, "clone.plan", done, total)
+
         plan: Any = None
         try:
             if provider == "huggingface":
@@ -776,12 +789,14 @@ def run_clone(
                     gguf_quant=gguf_quant,
                     hf_token=effective_hf_token,
                     source_include=include,
+                    progress=_plan_progress,
                 )
             else:
                 plan = plan_civitai(
                     int(civitai_model_version_id or 0),
                     civitai_api_key=civitai_api_key,
                     gguf_quant=gguf_quant,
+                    progress=_plan_progress,
                 )
         except Exception as exc:
             logger.warning(
@@ -794,8 +809,9 @@ def run_clone(
 
         def _dl_progress(done: int, total: Optional[int]) -> None:
             dl_bytes["done"] = max(dl_bytes["done"], int(done or 0))
-            if total:
-                _progress(0.05 + 0.45 * min(1.0, done / total), "clone.download")
+            fraction = 0.05 + 0.45 * min(1.0, done / total) if total else 0.05
+            position.bytes_moved(
+                fraction, "clone.download", dl_bytes["done"], total)
 
         keepalive = HubKeepalive(
             hubclient, hubclient._repo_path(destination),
@@ -954,7 +970,19 @@ def run_clone(
             for k, v in attrs.items():
                 metadata.setdefault(f"attr_{k}", str(v))
 
-            _progress(0.55 + 0.4 * (i / max(1, len(specs))), f"clone.publish.{spec.label}")
+            publish_fraction = 0.55 + 0.4 * (i / max(1, len(specs)))
+            publish_phase = f"clone.publish.{spec.label}"
+            _progress(publish_fraction, publish_phase)
+            # The upload is the other leg that outlasts the phase budget on a
+            # real-sized model, and it has a byte channel of its own. Called
+            # from the uploader's threads; `ClonePosition` holds the lock.
+            uploaded_bytes = {"done": 0}
+
+            def _up_progress(_parts: int, _total_parts: int, n: int,
+                             *, _f: float = publish_fraction,
+                             _p: str = publish_phase) -> None:
+                uploaded_bytes["done"] += max(0, int(n or 0))
+                position.bytes_moved(_f, _p, uploaded_bytes["done"], None)
             commit = hubclient.publish_v2(
                 destination_repo=destination,
                 files=files,
@@ -974,6 +1002,7 @@ def run_clone(
                     "tree": str(tree),
                     "attrs": {str(k): str(v) for k, v in attrs.items()},
                 },
+                part_progress=_up_progress,
             )
             result.published.append({
                 "dtype": dtype_label,

--- a/src/gen_worker/convert/clone_position.py
+++ b/src/gen_worker/convert/clone_position.py
@@ -1,0 +1,76 @@
+"""The clone's DECLARED POSITION — one monotone integer the hub differences.
+
+Hub job liveness is position ADVANCE inside a phase budget: `AdvanceJobProgress`
+takes an int64 and accepts it only on a STRICT increase. So a phase that reports
+a 0..1 fraction (`int(0.02) == 0`) or reports nothing at all is indistinguishable
+from a wedged one the moment its budget expires, whatever it is really doing.
+
+The unit is MOVEMENT: one per MiB of bytes moved, one per completed remote item
+(a file enumerated, a header fetched). Only real work advances it — a counter
+that ticks on a clock manufactures exactly the liveness this instrument exists
+to disprove — and entering a phase counts once, because entering one is work.
+
+The position lives here rather than in a closure inside `run_clone` because that
+is where it was, and an unrelated refactor deleted it and its test together
+(pgw#1667): every phase of every clone went back to declaring nothing, and the
+next large job died at `clone.plan 0` having moved no bytes at all.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable, Optional
+
+#: The position's byte unit. MiB, not bytes: the hub stores an int64 and an
+#: operator reads it.
+MIB = 1024 * 1024
+
+#: ``(fraction, phase, position, total)`` — the position and its optional
+#: ceiling, plus the 0..1 fraction the user-facing feed renders.
+EmitFn = Callable[[float, str, int, Optional[int]], None]
+
+
+class ClonePosition:
+    """One clone job's position, monotone across every phase.
+
+    Thread-safe: the publish leg advances it from the uploader's threads while
+    the main thread is emitting phase entries.
+    """
+
+    def __init__(self, emit: EmitFn) -> None:
+        self._emit = emit
+        self._lock = threading.Lock()
+        self._position = 0
+        self._base = 0
+
+    def enter(self, fraction: float, phase: str) -> None:
+        """Enter a phase: one unit of movement, and the origin for its own units."""
+        with self._lock:
+            self._position += 1
+            self._base = self._position
+            self._emit(fraction, phase, self._position, None)
+
+    def units(
+        self, fraction: float, phase: str, done: int, total: Optional[int] = None
+    ) -> None:
+        """Advance to ``done`` completed work items within the current phase."""
+        self._advance(fraction, phase, int(done or 0),
+                      int(total) if total else None)
+
+    def bytes_moved(
+        self, fraction: float, phase: str, done: int, total: Optional[int] = None
+    ) -> None:
+        """Advance by the bytes this phase has actually moved."""
+        self._advance(fraction, phase, int(done or 0) // MIB,
+                      (int(total) // MIB) if total else None)
+
+    def _advance(
+        self, fraction: float, phase: str, done: int, total: Optional[int]
+    ) -> None:
+        with self._lock:
+            position = self._base + max(0, done)
+            if position <= self._position:
+                return
+            self._position = position
+            self._emit(fraction, phase, position,
+                       (self._base + total) if total else None)

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -47,6 +47,27 @@ logger = logging.getLogger(__name__)
 ProgressFn = Callable[[int, Optional[int]], None]
 
 
+class PlanTicker:
+    """The PLAN phase's position: completed remote metadata items, counted.
+
+    Planning does unbounded network work — a recursive repo-tree walk, side-file
+    fetches, safetensors header reads — before a weight byte moves, and the more
+    sharded the source the longer it runs. Reporting nothing while it runs is
+    what made a 13-shard source unmirrorable: the hub's phase budget expired on
+    a position frozen at 0 and killed a job that was working (pgw#1667). Every
+    loop in there is a bounded, countable iteration, so it can say so.
+    """
+
+    def __init__(self, progress: ProgressFn | None = None) -> None:
+        self._progress = progress
+        self._done = 0
+
+    def tick(self, n: int = 1) -> None:
+        self._done += max(0, int(n))
+        if self._progress is not None:
+            self._progress(self._done, None)
+
+
 class CloneDownloadError(RuntimeError):
     """Source download failed after bounded retries — the clone job fails cleanly instead of hanging."""
 
@@ -83,6 +104,7 @@ def _remote_safetensors_width(
     revision: str | None,
     filenames: Sequence[str],
     hf_token: str | None,
+    ticker: PlanTicker | None = None,
 ) -> tuple[str, int]:
     api = hf().HfApi(token=(hf_token or None))
     bytes_by_dtype: dict[str, int] = {}
@@ -95,8 +117,12 @@ def _remote_safetensors_width(
             meta = api.parse_safetensors_file_metadata(
                 repo_id, name, revision=revision)
         except Exception:  # noqa: BLE001 — any unreadable header just abstains
+            if ticker is not None:
+                ticker.tick()
             continue
         read += 1
+        if ticker is not None:
+            ticker.tick()
         for raw_dtype, params in (getattr(meta, "parameter_count", None) or {}).items():
             bits = _SAFETENSORS_DTYPE_BITS.get(str(raw_dtype).upper())
             if not bits:
@@ -172,12 +198,15 @@ def _hf_classification_inputs(
     repo_id: str,
     revision: str | None,
     hf_token: str | None,
+    ticker: PlanTicker | None = None,
 ) -> tuple[list[str], dict[str, int], dict[str, Any], dict[str, str]]:
     api = hf().HfApi(token=(hf_token or None))
+    tick = ticker.tick if ticker is not None else (lambda n=1: None)
     paths: list[str] = []
     sizes: dict[str, int] = {}
     content_ids: dict[str, str] = {}
     for entry in api.list_repo_tree(repo_id, revision=revision, recursive=True):
+        tick()
         path = str(getattr(entry, "path", "") or "")
         size = getattr(entry, "size", None)
         if not path or size is None:
@@ -204,6 +233,7 @@ def _hf_classification_inputs(
             side["config_json"] = json.loads(Path(local).read_text(encoding="utf-8"))
         except Exception:
             side["config_json"] = None
+        tick()
 
     if "config.json" not in paths and "model_index.json" not in paths:
         component_configs: dict[str, Any] = {}
@@ -222,6 +252,8 @@ def _hf_classification_inputs(
                     Path(local).read_text(encoding="utf-8"))
             except Exception:
                 continue
+            finally:
+                tick()
         if component_configs:
             side["component_configs"] = component_configs
 
@@ -236,12 +268,14 @@ def _hf_classification_inputs(
                     break
         except Exception:
             pass
+        tick()
         try:
             card = hf().ModelCard.load(repo_id, token=(hf_token or None))
             tags = getattr(card.data, "tags", None) or []
             side["readme_tags"] = [str(t) for t in tags]
         except Exception:
             pass
+        tick()
     return paths, sizes, side, content_ids
 
 
@@ -320,13 +354,21 @@ def plan_huggingface(
     gguf_quant: str | None = None,
     hf_token: str | None = None,
     source_include: Sequence[str] | None = None,
+    progress: ProgressFn | None = None,
 ) -> HFSourcePlan:
-    """Resolve + classify one HF repo from metadata alone (no weight bytes)."""
+    """Resolve + classify one HF repo from metadata alone (no weight bytes).
+
+    ``progress`` is ticked once per completed remote metadata item, so the
+    caller's declared position advances while this runs (pgw#1667).
+    """
     install_hf_http_timeouts()
+    ticker = PlanTicker(progress)
     try:
         repo_id, sha = resolve_hf_identity(source_ref, revision=revision, hf_token=hf_token)
+        ticker.tick()
         rev = sha or (str(revision).strip() if revision else None)
-        paths, sizes, side, content_ids = _hf_classification_inputs(repo_id, rev, hf_token)
+        paths, sizes, side, content_ids = _hf_classification_inputs(
+            repo_id, rev, hf_token, ticker)
     except _hf_access_error_classes() as exc:
         _raise_input_refusal(exc)
     if source_include:
@@ -343,7 +385,8 @@ def plan_huggingface(
         dtype_pref=tuple(dtype_preference or ("bf16", "fp16", "fp32")),
         gguf_quant=gguf_quant,
     )
-    bits = resolve_plan_source_width(classification, repo_id, rev, sizes, hf_token)
+    bits = resolve_plan_source_width(
+        classification, repo_id, rev, sizes, hf_token, ticker)
     return HFSourcePlan(
         repo_id=repo_id, revision=sha, paths=paths, sizes=sizes, side=side,
         classification=classification, content_ids=content_ids,
@@ -357,6 +400,7 @@ def resolve_plan_source_width(
     revision: str | None,
     sizes: Mapping[str, int],
     hf_token: str | None,
+    ticker: PlanTicker | None = None,
 ) -> int:
     """Read the selected weight set's real storage width off its safetensors headers; stamp the dtype when the filename heuristic came up empty, and return bits-per-parameter for the disk estimate."""
     selected = sorted(
@@ -368,7 +412,7 @@ def resolve_plan_source_width(
         return 0
     try:
         dtype, bits = _remote_safetensors_width(
-            repo_id, revision, selected, hf_token)
+            repo_id, revision, selected, hf_token, ticker)
     except Exception:  # noqa: BLE001 — an unresolvable width is not a refusal
         return 0
     if dtype and not str(classification.attrs.get("dtype") or "").strip():
@@ -379,14 +423,24 @@ def resolve_plan_source_width(
 def plan_civitai(
     model_version_id: int, *, civitai_api_key: str | None = None,
     gguf_quant: str | None = None,
+    progress: ProgressFn | None = None,
 ) -> CivitaiSourcePlan:
-    """Fetch one civitai model version's metadata (no downloads)."""
+    """Fetch one civitai model version's metadata (no downloads).
+
+    ``progress`` is ticked once per completed remote metadata item, on the same
+    contract as :func:`plan_huggingface` (pgw#1667). A civitai version is one
+    API call and one selection, so it is two ticks — but the phase says so
+    rather than declaring nothing.
+    """
 
     version_id = int(model_version_id or 0)
     if version_id <= 0:
         raise ValueError("civitai_model_version_id is required")
+    ticker = PlanTicker(progress)
     payload = fetch_civitai_model_version(version_id, api_key=(civitai_api_key or ""))
+    ticker.tick()
     files = _civitai_select_files(payload, gguf_quant=gguf_quant)
+    ticker.tick()
     return CivitaiSourcePlan(
         version_id=version_id,
         payload=payload,

--- a/tests/convert/test_clone_position_pgw1667.py
+++ b/tests/convert/test_clone_position_pgw1667.py
@@ -1,0 +1,341 @@
+"""What a clone SAYS while it is planning, and what a wedged one still says.
+
+pgw#1667, measured on pod `mb5zw02csftwjx`: job `01a02910` mirroring
+`sensenova/SenseNova-U1.5-8B-MoT-Preview` (13 shards, 50.19 GB) died
+`job_progress_stalled` / `zero_progress` at 604 GPU-s — *"declared position
+clone.plan 0 stopped advancing 10m4s ago"* — without downloading a weight byte.
+`plan_huggingface` took no `progress=` at all, so the phase's position was 0 by
+construction while it walked the repo tree and read safetensors headers, and the
+hub's 10-minute budget is the only thing that could happen next.
+
+The watchdog is right and is not touched here: a position that does not move is
+the only evidence of a wedged job that a heartbeat cannot fake. The producer owes
+a position, so every phase now declares one from real work units.
+
+TWO REGRESSIONS, one test file. `cd46c957` (the v1 SDK hardcut) deleted
+pgw#1397's position machinery out of `run_clone` and its test in the same commit
+— so `clone.download` and `clone.publish` had silently gone back to declaring
+nothing either, and the next large mirror would have died in the download for
+exactly the same reason. Both halves are asserted below.
+
+Revert-turns-red: drop `progress=` from `plan_huggingface` and the first test
+sees ONE position for the whole plan; restore `fn(p, stage=stage)` in
+`run_clone`'s emitter and the second sees `clone.plan 0` and nothing else, which
+is the failed job's message verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from gen_worker.convert.clone import run_clone
+from gen_worker.convert.ingest import (
+    IngestedSource,
+    plan_civitai,
+    plan_huggingface,
+)
+
+from fake_hub import _FakeHub
+
+#: SenseNova-U1.5-8B-MoT-Preview, as the failed job saw it.
+SHARDS = 13
+SOURCE_BYTES = 50_190_000_000
+
+
+# ---------------------------------------------------------------------------
+# The hub's own rules, replayed over what reached `ctx.progress`.
+# ---------------------------------------------------------------------------
+
+Tick = tuple[float, Any, Any, Any, Any]
+
+
+def _accepted(ticks: list[Tick]) -> list[tuple[float, str, int]]:
+    """`ParseRequestProgressPayload` takes `step = int(position)`, and
+    `AdvanceJobProgress` updates the row — and with it `progress_at`, the stall
+    clock — only on a STRICT increase. Every other tick is dropped."""
+    out: list[tuple[float, str, int]] = []
+    last: Optional[int] = None
+    for at, _fraction, stage, position, _total in ticks:
+        step = int(position) if position is not None else 0
+        if last is None or step > last:
+            last = step
+            out.append((at, str(stage), step))
+    return out
+
+
+def _longest_silence(ticks: list[Tick], until: float) -> float:
+    """The longest stretch with no accepted advance — what the `zero_progress`
+    budget is compared against."""
+    marks = [at for at, _stage, _step in _accepted(ticks)]
+    if not marks:
+        return until - (ticks[0][0] if ticks else until)
+    return max(
+        max((b - a for a, b in zip(marks, marks[1:])), default=0.0),
+        until - marks[-1],
+    )
+
+
+class _Ctx:
+    """Records what reached `ctx.progress`, with the arrival time."""
+
+    def __init__(self, server: Any = None) -> None:
+        if server is not None:
+            self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+        self._worker_capability_token = "cap-token"
+        self.owner = "tensorhub"
+        self.request_id = "req-1667"
+        self.destination = {"repo": "tensorhub/fallback"}
+        self.ticks: list[Tick] = []
+
+    def progress(self, progress: Any = None, stage: Any = None, *,
+                 step: Any = None, total: Any = None, position: Any = None,
+                 phase: Any = None) -> None:
+        self.ticks.append(
+            (time.monotonic(), progress, stage or phase, position, total))
+
+
+# ---------------------------------------------------------------------------
+# A 13-shard transformers source, served entirely from local bytes.
+# ---------------------------------------------------------------------------
+
+def _safetensors_bytes(params: int) -> bytes:
+    header = {"blocks.0.weight": {
+        "dtype": "BF16", "shape": [params], "data_offsets": [0, params * 2]}}
+    blob = json.dumps(header).encode("utf-8")
+    return struct.pack("<Q", len(blob)) + blob + b"\x00" * (params * 2)
+
+
+def _sensenova_remote(tmp_path: Path) -> Path:
+    remote = tmp_path / "remote"
+    remote.mkdir(parents=True)
+    (remote / "config.json").write_text(
+        json.dumps({"architectures": ["SenseNovaForCausalLM"],
+                    "model_type": "sensenova"}), encoding="utf-8")
+    (remote / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {}}), encoding="utf-8")
+    for name in ("tokenizer.json", "tokenizer_config.json", "README.md",
+                 "generation_config.json"):
+        (remote / name).write_text("{}", encoding="utf-8")
+    for i in range(1, SHARDS + 1):
+        (remote / f"model-{i:05d}-of-{SHARDS:05d}.safetensors").write_bytes(
+            _safetensors_bytes(4))
+    return remote
+
+
+def _fake_hf(remote: Path) -> Any:
+    files = sorted(p for p in remote.rglob("*") if p.is_file())
+
+    class _Api:
+        def __init__(self, token: str | None = None) -> None:
+            self.token = token
+
+        def repo_info(self, repo_id: str, revision: str | None = None) -> Any:
+            return SimpleNamespace(sha="a" * 40)
+
+        def list_repo_tree(self, repo_id: str, revision: str | None = None,
+                           recursive: bool = False) -> Any:
+            for p in files:
+                rel = p.relative_to(remote).as_posix()
+                size = (SOURCE_BYTES // SHARDS
+                        if rel.endswith(".safetensors") else p.stat().st_size)
+                yield SimpleNamespace(
+                    path=rel, size=size,
+                    lfs=SimpleNamespace(sha256=f"{abs(hash(rel)):064x}"[:64]),
+                    blob_id="")
+
+        def parse_safetensors_file_metadata(
+            self, repo_id: str, filename: str, *, revision: str | None = None,
+            repo_type: str | None = None, token: str | None = None,
+        ) -> Any:
+            raw = (remote / filename).read_bytes()
+            (n,) = struct.unpack("<Q", raw[:8])
+            header = json.loads(raw[8:8 + n])
+            counts: dict[str, int] = {}
+            for value in header.values():
+                params = 1
+                for dim in value.get("shape") or []:
+                    params *= int(dim)
+                counts[str(value["dtype"])] = (
+                    counts.get(str(value["dtype"]), 0) + params)
+            return SimpleNamespace(parameter_count=counts, metadata={})
+
+    return SimpleNamespace(
+        HfApi=_Api,
+        hf_hub_download=lambda repo_id, filename, revision=None, token=None:
+            str(remote / filename),
+        get_safetensors_metadata=lambda *a, **k: SimpleNamespace(
+            files_metadata={}),
+        ModelCard=SimpleNamespace(
+            load=lambda *a, **k: SimpleNamespace(
+                data=SimpleNamespace(tags=["text-generation"]))),
+        snapshot_download=lambda *a, **k: "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. The plan phase declares a position, per real work unit.
+# ---------------------------------------------------------------------------
+
+def test_the_plan_advances_its_position_once_per_remote_item(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The measured defect. Pre-fix `plan_huggingface` takes no `progress=`, so
+    the whole walk of a 13-shard repo declares nothing."""
+    fake = _fake_hf(_sensenova_remote(tmp_path))
+    monkeypatch.setattr("gen_worker.convert.ingest.hf", lambda: fake)
+
+    seen: list[int] = []
+    plan = plan_huggingface(
+        "sensenova/SenseNova-U1.5-8B-MoT-Preview",
+        progress=lambda done, _total: seen.append(done),
+    )
+
+    assert len(plan.paths) == SHARDS + 6
+    # One per enumerated file, plus the identity call, the config fetch, the
+    # metadata read, the model card and the header reads. The point is not the
+    # exact number — it is that it is not ONE.
+    assert len(seen) >= len(plan.paths)
+    assert seen == sorted(seen) and seen[0] == 1 and len(set(seen)) == len(seen)
+
+
+def test_plan_civitai_reports_on_the_same_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other clone source strategy — the sweep, not a special case. There
+    are exactly two `plan_*` strategies in this repo and both now report."""
+    payload = {"id": 1759168, "baseModel": "SDXL 1.0", "files": [
+        {"name": "juggernautXL.safetensors", "type": "Model",
+         "sizeKB": 6_776_582, "hashes": {"SHA256": "ab" * 32},
+         "primary": True}]}
+    monkeypatch.setattr("gen_worker.convert.ingest.fetch_civitai_model_version",
+                        lambda _v, api_key="": payload)
+
+    seen: list[int] = []
+    plan = plan_civitai(
+        1759168, progress=lambda done, _total: seen.append(done))
+    assert plan.version_id == 1759168
+    assert seen == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# 2. Every phase of a real clone declares one, and the hub accepts every tick.
+# ---------------------------------------------------------------------------
+
+def test_a_clone_declares_an_advancing_position_from_plan_to_upload(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#1397's proof, restored: `cd46c957` deleted the machinery and the
+    test together, and every phase went back to declaring `0`."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    fake = _fake_hf(_sensenova_remote(tmp_path))
+    monkeypatch.setattr("gen_worker.convert.ingest.hf", lambda: fake)
+
+    local = tmp_path / "source"
+    local.mkdir(parents=True)
+    (local / "config.json").write_text("{}", encoding="utf-8")
+    (local / "model.safetensors").write_bytes(b"\x00" * (300 * 1024 * 1024))
+    source = IngestedSource(
+        provider="huggingface",
+        source_ref="sensenova/SenseNova-U1.5-8B-MoT-Preview",
+        source_revision="a" * 40, dir=local, layout="single-file",
+        model_family="unknown", model_family_variant="unknown",
+        classification=None,
+        attrs={"dtype": "bf16", "file_layout": "single-file"},
+        metadata={"source_provider": "huggingface"},
+        repo_spec={"kind": "model", "library_name": ""},
+    )
+
+    def _fake_ingest(_ref: str, _dest: Path, **kwargs: Any) -> IngestedSource:
+        report = kwargs.get("progress")
+        if report is not None:
+            for tenth in range(11):
+                report(int(SOURCE_BYTES * tenth / 10), SOURCE_BYTES)
+        return source
+
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_huggingface",
+                        _fake_ingest)
+    monkeypatch.setattr("gen_worker.convert.clone._preflight_disk",
+                        lambda *a, **k: None)
+
+    ctx = _Ctx(fake_hub)
+    run_clone(
+        ctx, provider="huggingface",
+        source_ref="sensenova/SenseNova-U1.5-8B-MoT-Preview",
+        destination_repo="tensorhub/sensenova-u1", destination_release="r1",
+        target_layout="single-file",
+        outputs=[{"dtype": "bf16", "file_layout": "single-file",
+                  "file_type": "safetensors"}],
+    )
+
+    accepted = _accepted(ctx.ticks)
+    # Nothing the clone says is dropped by the hub's strict-increase predicate.
+    assert len(accepted) == len(ctx.ticks)
+    phases = [stage for _at, stage, _step in accepted]
+    # THE FILED DEFECT: the plan is not one row at 0 any more.
+    assert phases.count("clone.plan") > 1
+    assert phases.count("clone.download") == 10
+    # THE SILENT REGRESSION beside it: the upload advances the same position.
+    assert any(p.startswith("clone.publish.") for p in phases)
+    steps = [step for _at, _stage, step in accepted]
+    assert steps == sorted(steps) and len(set(steps)) == len(steps)
+    # MiB moved, so an operator reads the model's own size.
+    download_end = max(step for _at, stage, step in accepted
+                       if stage == "clone.download")
+    assert download_end == pytest.approx(SOURCE_BYTES // (1024 * 1024), rel=0.01)
+
+
+# ---------------------------------------------------------------------------
+# 3. The watchdog stays armed: a plan that genuinely hangs still reads as one.
+# ---------------------------------------------------------------------------
+
+_BUDGET_S = 0.4
+_HANG_S = 1.5
+
+
+def test_a_genuinely_hung_plan_still_reads_as_zero_progress(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fix must not buy liveness with a counter that ticks on its own.
+
+    Same `run_clone`, same emitter: a plan wedged on an unreachable Hugging Face
+    declares nothing — because nothing happened — and the hub's rule kills it,
+    exactly as it killed the real job. The healthy source in the test above,
+    replayed against the SAME budget, is silent for a small fraction of it.
+    """
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+
+    def _wedged(*_a: Any, **kwargs: Any) -> Any:
+        # It is HANDED a `progress=` and never calls it, which is what an
+        # unreachable remote looks like from in here.
+        assert kwargs.get("progress") is not None
+        time.sleep(_HANG_S)
+        raise TimeoutError("huggingface unreachable")
+
+    monkeypatch.setattr("gen_worker.convert.clone.plan_huggingface", _wedged)
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_huggingface",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            RuntimeError("the plan phase is the subject")))
+
+    ctx = _Ctx(fake_hub)
+    with pytest.raises(RuntimeError):
+        run_clone(
+            ctx, provider="huggingface",
+            source_ref="sensenova/SenseNova-U1.5-8B-MoT-Preview",
+            destination_repo="tensorhub/sensenova-u1",
+            destination_release="r1", target_layout="single-file",
+            outputs=[{"dtype": "bf16", "file_layout": "single-file",
+                      "file_type": "safetensors"}],
+        )
+
+    plan_ticks = [t for t in ctx.ticks if str(t[2]) == "clone.plan"]
+    assert len(plan_ticks) == 1, "a wedged plan must not manufacture ticks"
+    assert _longest_silence(plan_ticks, time.monotonic()) > _BUDGET_S


### PR DESCRIPTION
Job `01a02910` mirroring `sensenova/SenseNova-U1.5-8B-MoT-Preview` (13 shards,
50.19 GB) died `job_progress_stalled`/`zero_progress` at 604 GPU-s — "declared
position clone.plan 0 stopped advancing 10m4s ago, past the 10m0s phase budget"
— without downloading a weight byte. It spent its whole life inside
`plan_huggingface`, which took NO `progress=` parameter, so `clone.plan`'s
position was 0 for the entire phase by construction while it walked a recursive
`list_repo_tree`, fetched every side file, and read up to three remote
safetensors headers. The bigger and more sharded the source, the likelier it
crossed the hub's 10-minute budget — and the whole point of this endpoint is big
sharded sources. It requeued itself into the identical wall.

THE BUDGET IS NOT WIDENED. A position that does not move is the only evidence of
a wedged job that a heartbeat cannot fake, and the plan phase genuinely can wedge
on an unreachable Hugging Face. The producer owed a position; the hub does not
owe it a longer silence. Every loop in there was already a bounded, countable
iteration, so it now pays one — a tick per completed remote metadata item,
threaded through `_hf_classification_inputs` and `_remote_safetensors_width` on
the same `ProgressFn` contract `ingest_huggingface` has used one function away
all along. `plan_civitai` reports on the same contract: those two are the only
clone-source `plan_*` strategies in the repo, and this is one general fix over
both, not a special case for the source that happened to fail.

A SECOND, SILENT REGRESSION IS FIXED WITH IT, and it would have killed the very
next attempt one phase later. `cd46c957` (the v1 SDK hardcut) deleted pgw#1397's
position machinery out of `run_clone` — and `tests/convert/test_clone_liveness_
and_refusals.py`, its red arm, in the same commit. So `clone.download` and
`clone.publish` had quietly gone back to declaring a 0..1 FRACTION, which is
`int(0.02) == 0` for the whole run: the hub accepted exactly one row per job,
`clone.plan 0`, and a 50 GB fetch was indistinguishable from a wedge. The
position is restored as MOVEMENT UNITS — one per MiB moved (fetched, then
UPLOADED through `publish_v2`'s `part_progress`), one per completed remote
metadata item — one number rising across every phase, with the 0..1 fraction
riding beside it for the user-facing feed.

It lives in `convert/clone_position.py` rather than in a closure inside a
300-line function, which is the actual lesson of the revert: a named module with
an importing test has to be deleted on purpose.

PROVEN BY EXECUTION. The committed test drives the REAL `plan_huggingface` over
a 13-shard SenseNova-shaped source served from local bytes, and `run_clone`
end-to-end against the fake hub, replaying the hub's own predicate (`step =
int(position)`, accepted only on a STRICT increase): 17 ticks emitted, 17
accepted, `clone.plan` more than once, `clone.download` ten times ending at the
source's own MiB, `clone.publish.*` present. Reverted, the same probe accepts
ONE row — `clone.plan 0` — which is the failed job's message verbatim. The
watchdog arm is asserted separately and stays armed: a `plan_huggingface` that
is handed a `progress=` and hangs without calling it emits exactly one tick and
reads as `zero_progress`, because a counter that ticks on its own manufactures
exactly the liveness this instrument exists to disprove.

NOT FIXED HERE, and named rather than left silent: `clone.convert` still declares
one tick per flavor. `run_inline_conversion` has no byte channel, so a cast whose
weights are one component is a single unit — real work, honestly counted, but a
long enough cast on a large enough model would wedge the same way. That needs a
byte channel inside the caster, not a tick in the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)