### PR TITLE
pgw#1668: the cast decision is an exact no-op test, not a majority — and the published dtype is the one the tree HAS

### DIFF
--- a/changelog.d/pgw1668.md
+++ b/changelog.d/pgw1668.md
@@ -23,7 +23,15 @@
   publish as `bf16` and now publishes as `mixed`, agreeing with the `component_dtypes` the hub
   derives from the same bytes. Red-armed at SenseNova's real header profile end-to-end through
   `run_clone`: with the count vote restored, four cases fail 5/5; with only the label reverted, the
-  pin case fails 5/5.
+  pin case fails 5/5. **And the phase this reaches now declares a position.** `clone.convert` used
+  to be instantaneous precisely because the cast was almost never chosen; making it run for real
+  turns it into the longest phase of a large clone, against a hub that kills a job whose declared
+  position stops advancing inside its budget — pgw#1667's wall, one phase over, and reachable for
+  the first time because of this change. The re-encode loop reports the output bytes of each
+  tensor as it lands, one position unit per MiB, threaded from `stream_reencode` up through
+  `run_inline_conversion` and `build_flavor_tree`. Red-armed at a fixture sized past the MiB unit
+  (a cast writing under 1 MiB advances nothing and would pass a weaker assertion): with the
+  reporting removed, the convert phase declares one entry tick and nothing else, 5/5.
   **Still owed and not claimed here:** the requested `file_layout` is still silently replaced by
   the source's on a publish-as-is cast (`multi-file` asked, `single-file` published). It is the
   same class of defect on a different axis and it needs the repackage support matrix, not a patch

--- a/changelog.d/pgw1668.md
+++ b/changelog.d/pgw1668.md
@@ -1,0 +1,31 @@
+- **pgw#1668: a clone casts when casting would change bytes, and it declares the dtype it
+  PRODUCED.** Job `01a02956` mirroring `sensenova/SenseNova-U1.5-8B-MoT-Preview` with
+  `outputs=[{dtype: "bf16"}]` SUCCEEDED in 349 GPU-s, moved 50.19 GB, and published the upstream
+  tree unchanged with `dtype: bf16` stamped on it — while the hub's own read of those same headers
+  said `component_dtypes: {"model": "mixed"}`. 50.19 GB in, 50.19 GB out; the ~15 GB of dead F32
+  the job existed to remove is still in every pull. Two functions in one file disagreed about what
+  dtype a tree is: `detect_snapshot_dtype` voted by TENSOR COUNT, and this checkpoint has 601
+  small BF16 norm/bias islands against 515 enormous F32 weights, so "bf16" won a vote that
+  *"would casting change any bytes?"* was never a vote about. **The vote is deleted rather than
+  re-weighted.** A majority — by count OR by bytes — cannot answer that question, and picking a
+  share at which a minority stops counting would be a threshold nobody derived. The measure is now
+  strict and weighed in bytes: a tree IS a dtype only when every FLOAT tensor in it is that dtype
+  (integer and boolean tensors ride through any cast untouched, so they cannot decide one), and
+  anything else is `mixed`. `mixed` is not a dtype a caller can request, so it matches no request
+  and the cast runs — while a genuinely uniform source still short-circuits to the cheap
+  publish-as-is path, which is now taken only when it is PROVABLY a no-op. The plan-side estimate
+  reads every selected header instead of the first three, because "uniformly bf16" is a claim
+  about tensors nobody looked at unless all of them were looked at. **The label is the second half
+  and is fixed separately**, because a right decision is not a right stamp: the published `dtype`
+  is read off the produced tree's own headers, not off the request and not off the flavor
+  builder's intent. The arm that proves the difference is a cast that a per-component fp32 pin
+  makes mixed on purpose — request `bf16`, `attrs["dtype"]` `bf16`, VAE still F32 — which used to
+  publish as `bf16` and now publishes as `mixed`, agreeing with the `component_dtypes` the hub
+  derives from the same bytes. Red-armed at SenseNova's real header profile end-to-end through
+  `run_clone`: with the count vote restored, four cases fail 5/5; with only the label reverted, the
+  pin case fails 5/5.
+  **Still owed and not claimed here:** the requested `file_layout` is still silently replaced by
+  the source's on a publish-as-is cast (`multi-file` asked, `single-file` published). It is the
+  same class of defect on a different axis and it needs the repackage support matrix, not a patch
+  at the publish call — `observed_file_layout` and the classifier's `attrs["file_layout"]`
+  disagree on a transformers root tree, so there is no honest derivation to drop in yet.

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -35,7 +35,9 @@ from .dtype_pins import (
     verify_produced_tree,
 )
 from .ingest import (
+    MIXED_DTYPE,
     IngestedSource,
+    detect_snapshot_dtype,
     ingest_civitai,
     ingest_huggingface,
     plan_civitai,
@@ -448,6 +450,16 @@ def spec_actions(
     "publishes the source tree directly" and stopped — while the run went on
     to CAST a whole second tree, which the budget then had no term for. The
     two must never again be able to disagree about what happens.
+
+    The question this asks is *"would casting to `spec.dtype` change any
+    bytes?"* — not *"what is this tree mostly?"*. `source_dtype` answers the
+    first because it is strict (``ingest.rollup_dtype``): a tree is a dtype
+    only when every float tensor in it is that dtype, and anything else is
+    ``mixed``. ``mixed`` is not a dtype a caller can request, so it matches
+    nothing and the cast runs — which is right, because a mixed tree WOULD
+    change under any target. Pre-pgw#1668 this line read a majority by tensor
+    COUNT and SenseNova-U1.5's 601 small BF16 islands out-voted its 30 GB F32
+    bulk, so a bf16 request "already matched" a tree that was not bf16.
     """
 
     actions: list[str] = []
@@ -582,8 +594,9 @@ def plan_disk_demand(
         notes.append("hardlink passthrough")
     if (output_sizes and not measured_bits
             and source_dtype not in _DTYPE_STORAGE_BITS):
+        why = "mixed" if source_dtype == MIXED_DTYPE else "unreadable"
         notes.append(
-            f"source dtype unreadable, assumed {_UNRESOLVED_SOURCE_BITS}-bit")
+            f"source dtype {why}, assumed {_UNRESOLVED_SOURCE_BITS}-bit")
 
     # The LAST stage of every clone is a publish, and it is the one the old
     # budget forgot. Its cost is not guessed here: `publish_v2` states it.
@@ -956,6 +969,17 @@ def run_clone(
                 })
                 continue
 
+            # THE DECLARED DTYPE IS READ OFF THE PRODUCED TREE (pgw#1668).
+            # `spec.dtype` is what was ASKED for and `attrs["dtype"]` is what
+            # the flavor builder INTENDED; neither is evidence. A publish-as-is
+            # of a mixed tree, a cast that skipped a pinned component, a
+            # `dtype="source"` passthrough — each lands bytes that no request
+            # describes, and the old label was the request. The tree's own
+            # headers are the only thing that cannot be wrong about it.
+            observed = detect_snapshot_dtype(Path(tree))
+            dtype_label = _dtype_token(
+                observed or str(attrs.get("dtype") or spec.dtype))
+
             metadata: dict[str, Any] = {k: v for k, v in source.metadata.items()}
             try:
                 from .size_walk import compute_size_facts
@@ -988,7 +1012,7 @@ def run_clone(
                 files=files,
                 release=release,
                 mode=mode if i == 0 else "merge",
-                dtype=str(attrs.get("dtype") or spec.dtype),
+                dtype=dtype_label,
                 file_layout=str(attrs.get("file_layout") or spec.file_layout),
                 file_type=str(attrs.get("file_type") or spec.file_type),
                 objective=objective_fact,

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -195,8 +195,13 @@ def build_flavor_tree(
     quantize_components: list[str] | None = None,
     objective: str = "",
     distilled: bool = False,
+    progress: Any = None,
 ) -> tuple[Path, dict[str, str]]:
-    """Materialize one output flavor as a local file tree."""
+    """Materialize one output flavor as a local file tree.
+
+    ``progress`` receives the output bytes of each tensor written, cumulative
+    across components — the convert phase's declared position.
+    """
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -233,6 +238,7 @@ def build_flavor_tree(
             source_path=groups[0][1], out_dir=out_dir, target_dtype=spec.dtype,
             target_file_type="gguf",
             source_repo_dir=(source_dir / groups[0][0]) if groups[0][0] else source_dir,
+            progress=progress,
         )
         attrs.update(result.attributes)
         return out_dir, attrs
@@ -320,6 +326,7 @@ def build_flavor_tree(
             source_path=entry, out_dir=dest, target_dtype=spec.dtype,
             target_file_type="safetensors", output_stem=stem or "model",
             source_repo_dir=comp_dir, fp8_block_scope=fp8_block_scope,
+            progress=progress,
         )
         attrs.update({k: v for k, v in result.attributes.items() if k not in attrs})
         converted.add(comp)
@@ -850,6 +857,18 @@ def run_clone(
             )
 
         _progress(0.5, "clone.convert")
+
+        # THE CAST IS THE LONGEST PHASE OF A REAL CLONE and until pgw#1668 it
+        # was almost never chosen, so it never had to say so. Now a 50 GB
+        # F32-dominant source really is re-encoded here, for tens of minutes,
+        # and a phase whose position does not advance inside the hub's budget
+        # is killed as wedged (pgw#1667). One unit per MiB written.
+        cast_bytes = {"done": 0}
+
+        def _cast_progress(n: int) -> None:
+            cast_bytes["done"] += max(0, int(n or 0))
+            position.bytes_moved(0.5, "clone.convert", cast_bytes["done"], None)
+
         from .convert import InlineConversionNotPossible
 
         result = CloneResult(destination_repo=destination, metadata=dict(source.metadata))
@@ -904,6 +923,7 @@ def run_clone(
                             quantize_components=quantize_components,
                             objective=objective_fact,
                             distilled=distilled_fact,
+                            progress=_cast_progress,
                         )
                         dtype_label = str(attrs.get("dtype") or spec.dtype)
                     else:
@@ -926,6 +946,7 @@ def run_clone(
                             quantize_components=quantize_components,
                             objective=objective_fact,
                             distilled=distilled_fact,
+                            progress=_cast_progress,
                         )
                     dtype_label = str(attrs.get("dtype") or spec.dtype)
                 dtype_label = _dtype_token(dtype_label)

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -112,8 +112,16 @@ def run_inline_conversion(
     output_stem: str = "model",
     source_repo_dir: Path | None = None,
     fp8_block_scope: bool = False,
+    progress: Any = None,
 ) -> InlineConversionResult:
-    """Run the appropriate inline conversion for the requested target_dtype."""
+    """Run the appropriate inline conversion for the requested target_dtype.
+
+    ``progress`` receives the output bytes of each tensor written. It is the
+    clone's declared position for the convert phase: this call is the whole of
+    a phase that runs for tens of minutes on a real checkpoint, and a position
+    that does not advance inside its budget is indistinguishable from a wedged
+    job (pgw#1667's rule, pgw#1668's newly reachable phase).
+    """
     dtype = _normalize(target_dtype)
     ftype = _normalize(target_file_type) or "safetensors"
     if dtype == "":
@@ -146,6 +154,7 @@ def run_inline_conversion(
             out_dir=out_dir,
             target_dtype=dtype,
             output_stem=output_stem,
+            progress=progress,
         )
 
     if dtype in _INLINE_FP8_STORAGE_DTYPES:
@@ -154,6 +163,7 @@ def run_inline_conversion(
             out_dir=out_dir,
             output_stem=output_stem,
             block_scope=fp8_block_scope,
+            progress=progress,
         )
 
     raise InlineConversionNotPossible(
@@ -168,6 +178,7 @@ def _run_cast_inline(
     out_dir: Path,
     target_dtype: str,
     output_stem: str,
+    progress: Any = None,
 ) -> InlineConversionResult:
     import torch
 
@@ -189,6 +200,7 @@ def _run_cast_inline(
         Path(out_dir),
         target_dtype=torch_dtype,
         output_stem=output_stem,
+        progress=progress,
     )
 
     output_paths = [Path(p) for p in result.get("output_paths") or []]
@@ -215,11 +227,12 @@ def _run_fp8_storage_inline(
     out_dir: Path,
     output_stem: str,
     block_scope: bool = False,
+    progress: Any = None,
 ) -> InlineConversionResult:
 
     result = streaming_fp8_storage_cast(
         Path(source_path), Path(out_dir), output_stem=output_stem,
-        block_scope=block_scope,
+        block_scope=block_scope, progress=progress,
     )
     attrs = {
         "dtype": "fp8",

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -25,7 +25,7 @@ from gen_worker.models.download import (
 
 from ..net import hf, install_hf_http_timeouts
 from ..models.materialized_view import third_party_dir
-from ..models.safetensors_header import header_len_ok
+from ..models.safetensors_header import FLOAT_DTYPES, header_len_ok
 from .classifier import RepoClassification, apply_source_include, classify_repo
 from .layout import detect_huggingface_source_layout
 from ..models.file_layout import SINGLE_FILE
@@ -96,7 +96,34 @@ _SAFETENSORS_DTYPE_BITS = {
     "F16": 16, "BF16": 16, "I16": 16, "U16": 16,
     "F8_E4M3": 8, "F8_E5M2": 8, "I8": 8, "U8": 8, "BOOL": 8,
 }
-_MAX_DTYPE_HEADER_READS = 3
+MIXED_DTYPE = "mixed"
+
+
+def rollup_dtype(bytes_by_dtype: Mapping[str, int]) -> str:
+    """The ONE dtype a float-tensor mass distribution IS — or ``MIXED_DTYPE``.
+
+    Strict on purpose, and it is the whole of pgw#1668. Two questions used to
+    be answered by two different measures that disagreed: *"would casting this
+    tree change any bytes?"* (the CAST decision) and *"what dtype is this
+    tree?"* (the published LABEL). The old label was a majority by TENSOR
+    COUNT, so SenseNova-U1.5's 601 BF16 norm/bias islands out-voted its 30 GB
+    F32 bulk: a bf16 request "already matched", nothing was cast, and 50 GB of
+    F32-dominant weights were published stamped ``bf16``.
+
+    A majority — by count OR by bytes — cannot answer the first question at
+    all, because the question is not *what is this tree mostly*. So there is no
+    majority here and no threshold to pick: one float dtype present means the
+    tree IS that dtype and a cast to it is provably a no-op; more than one
+    means a cast to ANY target rewrites bytes, and the honest name for the
+    tree is ``mixed``. One rule, so the decision and the label cannot drift.
+    """
+
+    present = {str(d) for d, b in bytes_by_dtype.items() if int(b) > 0}
+    if not present:
+        return ""
+    if len(present) > 1:
+        return MIXED_DTYPE
+    return next(iter(present))
 
 
 def _remote_safetensors_width(
@@ -106,13 +133,19 @@ def _remote_safetensors_width(
     hf_token: str | None,
     ticker: PlanTicker | None = None,
 ) -> tuple[str, int]:
+    """``(dtype token, bits per parameter)`` for a REMOTE weight set.
+
+    Every selected header is read, not a sample: "this tree is uniformly bf16"
+    is a claim about tensors nobody looked at unless all of them were looked
+    at, and it is the claim the cast decision turns on. One small range read
+    per shard, ticked, against a plan phase that already reports its position.
+    """
+
     api = hf().HfApi(token=(hf_token or None))
-    bytes_by_dtype: dict[str, int] = {}
+    float_bits_by_dtype: dict[str, int] = {}
+    total_bits = 0
     total_params = 0
-    read = 0
     for name in filenames:
-        if read >= _MAX_DTYPE_HEADER_READS:
-            break
         try:
             meta = api.parse_safetensors_file_metadata(
                 repo_id, name, revision=revision)
@@ -120,27 +153,34 @@ def _remote_safetensors_width(
             if ticker is not None:
                 ticker.tick()
             continue
-        read += 1
         if ticker is not None:
             ticker.tick()
         for raw_dtype, params in (getattr(meta, "parameter_count", None) or {}).items():
-            bits = _SAFETENSORS_DTYPE_BITS.get(str(raw_dtype).upper())
+            key = str(raw_dtype).upper()
+            bits = _SAFETENSORS_DTYPE_BITS.get(key)
             if not bits:
                 continue
-            key = str(raw_dtype).upper()
-            bytes_by_dtype[key] = bytes_by_dtype.get(key, 0) + bits * int(params)
+            total_bits += bits * int(params)
             total_params += int(params)
-    if not bytes_by_dtype or total_params <= 0:
+            if key in FLOAT_DTYPES:
+                token = _SAFETENSORS_DTYPE_NAMES.get(key, key.lower())
+                float_bits_by_dtype[token] = (
+                    float_bits_by_dtype.get(token, 0) + bits * int(params))
+    if total_params <= 0:
         return "", 0
-    top = max(bytes_by_dtype, key=lambda k: bytes_by_dtype[k])
-    bits_per_param = max(1, sum(bytes_by_dtype.values()) // total_params)
-    return _SAFETENSORS_DTYPE_NAMES.get(top, ""), bits_per_param
+    bits_per_param = max(1, total_bits // total_params)
+    return rollup_dtype(float_bits_by_dtype), bits_per_param
 
 
-def detect_snapshot_dtype(root: Path) -> str:
-    """Majority weight dtype across a snapshot's safetensors headers ('bf16' / 'fp16' / 'fp32' / 'fp8', '' when undetectable)."""
+def snapshot_float_dtype_bytes(root: Path) -> dict[str, int]:
+    """``{dtype token: tensor-data bytes}`` over every FLOAT tensor in a tree.
 
-    counts: dict[str, int] = {}
+    Bytes, from each tensor's own ``data_offsets`` — the same thing the disk
+    preflight and the hub's header audit weigh. Non-float tensors are excluded
+    because a cast copies them through untouched (see ``FLOAT_DTYPES``).
+    """
+
+    by_dtype: dict[str, int] = {}
     try:
         for p in sorted(Path(root).rglob("*.safetensors")):
             with open(p, "rb") as f:
@@ -151,15 +191,31 @@ def detect_snapshot_dtype(root: Path) -> str:
                 if not header_len_ok(n):
                     continue
                 header = json.loads(f.read(n))
+            if not isinstance(header, dict):
+                continue
             for value in header.values():
-                if isinstance(value, dict) and "dtype" in value:
-                    counts[str(value["dtype"])] = counts.get(str(value["dtype"]), 0) + 1
-    except (OSError, ValueError):
-        return ""
-    if not counts:
-        return ""
-    top = max(counts, key=lambda k: counts[k])
-    return _SAFETENSORS_DTYPE_NAMES.get(top, "")
+                if not isinstance(value, dict) or "dtype" not in value:
+                    continue
+                key = str(value["dtype"]).upper()
+                if key not in FLOAT_DTYPES:
+                    continue
+                offsets = list(value.get("data_offsets") or ())
+                if len(offsets) != 2:
+                    continue
+                span = int(offsets[1]) - int(offsets[0])
+                if span <= 0:
+                    continue
+                token = _SAFETENSORS_DTYPE_NAMES.get(key, key.lower())
+                by_dtype[token] = by_dtype.get(token, 0) + span
+    except (OSError, TypeError, ValueError):
+        return {}
+    return by_dtype
+
+
+def detect_snapshot_dtype(root: Path) -> str:
+    """The dtype a snapshot IS — one float dtype's token, ``'mixed'``, or ``''`` when undetectable."""
+
+    return rollup_dtype(snapshot_float_dtype_bytes(root))
 
 
 @dataclass

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -256,8 +256,7 @@ def iter_source_tensors(
             yield entry.name, name, tensor
 
 
-_ST_FLOAT_DTYPES: frozenset[str] = frozenset(
-    {"F64", "F32", "F16", "BF16", "F8_E4M3", "F8_E5M2"})
+from gen_worker.models.safetensors_header import FLOAT_DTYPES as _ST_FLOAT_DTYPES
 
 
 def stream_reencode(

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -266,8 +266,17 @@ def stream_reencode(
     out_st_dtype_for: Any,
     transform: Any,
     output_stem: str,
+    progress: Any = None,
 ) -> dict[str, Any]:
-    """Two-pass streaming re-encode over safetensors input(s)."""
+    """Two-pass streaming re-encode over safetensors input(s).
+
+    ``progress`` is called with the OUTPUT bytes of each tensor as it lands —
+    the clone's declared position for the convert phase. A cast of a real
+    checkpoint runs for tens of minutes and this loop is the whole of it, so
+    without it the phase reports one entry tick and then nothing (pgw#1667's
+    shape, in the one phase that only does real work once a cast is actually
+    chosen — which is what pgw#1668 made happen).
+    """
     from safetensors import safe_open
 
     shards_in = _resolve_input_shards(Path(input_path))
@@ -318,6 +327,8 @@ def stream_reencode(
                         f"planned {out_dtype}")
                 w.write_tensor(name, _tensor_to_bytes(result))
                 del t, result
+                if progress is not None:
+                    progress(size_map.get(name, 0))
     finally:
         for f in handles.values():
             try:
@@ -340,6 +351,7 @@ def streaming_dtype_cast(
     *,
     target_dtype: "torch.dtype",
     output_stem: str = "model",
+    progress: Any = None,
 ) -> dict[str, Any]:
     """Cast float tensors to ``target_dtype``, streaming directly into N shards."""
     target_st = torch_dtype_to_st(target_dtype)
@@ -355,7 +367,7 @@ def streaming_dtype_cast(
     return stream_reencode(
         Path(input_path), Path(out_dir),
         out_st_dtype_for=out_st_dtype_for, transform=transform,
-        output_stem=output_stem,
+        output_stem=output_stem, progress=progress,
     )
 
 
@@ -403,6 +415,7 @@ def streaming_fp8_storage_cast(
     output_stem: str = "model",
     skip_patterns: tuple[str, ...] = FP8_SKIP_TENSOR_PATTERNS,
     block_scope: bool = False,
+    progress: Any = None,
 ) -> dict[str, Any]:
     """Produce the fp8-E4M3 storage flavor of one weight set, streaming."""
     import torch
@@ -422,7 +435,7 @@ def streaming_fp8_storage_cast(
     return stream_reencode(
         Path(input_path), Path(out_dir),
         out_st_dtype_for=out_st_dtype_for, transform=transform,
-        output_stem=output_stem,
+        output_stem=output_stem, progress=progress,
     )
 
 
@@ -798,6 +811,7 @@ def streaming_fp8_te_cast(
     *,
     castable_keys: frozenset[str],
     output_stem: str = "model",
+    progress: Any = None,
 ) -> dict[str, Any]:
     """fp8-E4M3 storage cast of one transformers weight set: exactly the ``castable_keys`` (the loader's block-window weight set) become F8_E4M3 (clamp ±448 first — torch's cast does not saturate); every ..."""
     import torch
@@ -815,7 +829,7 @@ def streaming_fp8_te_cast(
     return stream_reencode(
         Path(input_path), Path(out_dir),
         out_st_dtype_for=out_st_dtype_for, transform=transform,
-        output_stem=output_stem,
+        output_stem=output_stem, progress=progress,
     )
 
 

--- a/src/gen_worker/models/safetensors_header.py
+++ b/src/gen_worker/models/safetensors_header.py
@@ -9,6 +9,14 @@ from typing import Any, Dict
 
 MAX_HEADER_BYTES: int = 100 << 20
 
+# The safetensors storage dtypes a dtype cast REWRITES. Everything else
+# (indices, masks, ids) is copied through unchanged, so it can neither make a
+# cast necessary nor make one a no-op. Stated once because two places ask the
+# same question: the writer, deciding what to re-encode, and the header reader,
+# deciding what a tree's dtype IS.
+FLOAT_DTYPES: frozenset[str] = frozenset(
+    {"F64", "F32", "F16", "BF16", "F8_E4M3", "F8_E5M2"})
+
 
 def header_len_ok(n: int) -> bool:
     """Whether a declared safetensors header length is plausible."""
@@ -50,4 +58,5 @@ def read_metadata(path: Path | str, *, why: str) -> Dict[str, Any]:
     return meta if isinstance(meta, dict) else {}
 
 
-__all__ = ["MAX_HEADER_BYTES", "header_len_ok", "read_header", "read_metadata"]
+__all__ = ["FLOAT_DTYPES", "MAX_HEADER_BYTES", "header_len_ok", "read_header",
+           "read_metadata"]

--- a/tests/convert/test_cast_decision_pgw1668.py
+++ b/tests/convert/test_cast_decision_pgw1668.py
@@ -413,3 +413,92 @@ def test_a_cast_that_a_PIN_made_mixed_declares_mixed_not_the_request(
     assert _wire_dtype() == MIXED_DTYPE, (
         "a tree with an fp32 component was published as bf16")
     assert result.published[0]["dtype"] == MIXED_DTYPE
+
+
+# ------------------------------------------------ the phase the fix reaches
+
+
+class _RecordingCtx(_Ctx):
+    """A ctx that keeps what reached `ctx.progress`, the way the hub sees it."""
+
+    def __init__(self, server: Any) -> None:
+        super().__init__(server)
+        self.ticks: list[tuple[str, int]] = []
+
+    def progress(self, progress: Any = None, stage: Any = None, *,
+                 step: Any = None, total: Any = None, position: Any = None,
+                 phase: Any = None) -> None:
+        self.ticks.append((str(stage or phase), int(position or 0)))
+
+
+def _accepted(ticks: list[tuple[str, int]]) -> list[tuple[str, int]]:
+    """`AdvanceJobProgress` updates the row — and with it the stall clock —
+    only on a STRICT increase. Every other tick is dropped."""
+
+    out: list[tuple[str, int]] = []
+    last = -1
+    for stage, position in ticks:
+        if position > last:
+            last = position
+            out.append((stage, position))
+    return out
+
+
+def test_the_CAST_declares_a_position_because_it_is_now_the_longest_phase(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#1667's rule, in the phase this fix made reachable.
+
+    `clone.convert` used to be instantaneous on a publish-as-is source, because
+    the cast was almost never chosen — a majority vote said the tree already
+    matched. Now a 50 GB F32-dominant source really is re-encoded there, for
+    tens of minutes, against a hub that kills a job whose declared position
+    stops advancing inside its budget. Entering the phase is one tick; the
+    re-encode has to be the rest.
+
+    The fixture is sized past the position's MiB unit on purpose: a cast that
+    writes less than 1 MiB advances nothing and would pass a weaker assertion
+    while proving nothing about a real one.
+    """
+
+    mib = 1024 * 1024
+    source_dir = _tree(tmp_path / "source", {
+        # 4 x 1 MiB of BF16 output from 2 MiB of F32 input, plus the islands
+        # that make the tree mixed in the first place.
+        **{f"blocks.{i}.mlp.weight": ("F32", mib // 2) for i in range(4)},
+        **{f"blocks.{i}.norm.weight": ("BF16", 8) for i in range(601)},
+    })
+    ctx = _RecordingCtx(fake_hub)
+
+    plan = _fake_plan(source_dir, "transformers", "single-file")
+    attrs = dict(plan.classification.attrs)
+    attrs["dtype"] = detect_snapshot_dtype(source_dir)
+    plan.classification.attrs.update(attrs)
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    monkeypatch.setattr("gen_worker.convert.clone.plan_huggingface",
+                        lambda *a, **k: plan)
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.ingest_huggingface",
+        lambda source_ref, dest_dir, **kw: IngestedSource(
+            provider="huggingface", source_ref=source_ref,
+            source_revision="13a8d0f3", dir=source_dir, layout="single-file",
+            model_family="fake", model_family_variant="fake1",
+            classification=plan.classification, attrs=attrs,
+            metadata={"source_provider": "huggingface"},
+            repo_spec={"kind": "model", "library_name": "transformers"},
+        ))
+
+    result = run_clone(
+        ctx, provider="huggingface", source_ref="sensenova/fake",
+        destination_repo="sensenova/fake-tree", destination_release="r1",
+        outputs=[{"dtype": "bf16", "file_layout": "multi-file",
+                  "file_type": "safetensors"}],
+    )
+    assert not result.failed_flavors, result.failed_flavors
+
+    convert = [p for stage, p in _accepted(ctx.ticks) if stage == "clone.convert"]
+    assert len(convert) >= 4, (
+        f"the cast declared {len(convert)} accepted position(s) while writing "
+        f"4 MiB — a frozen position is a job the hub kills as wedged: "
+        f"{_accepted(ctx.ticks)}")
+    assert convert == sorted(set(convert)), "positions must strictly increase"

--- a/tests/convert/test_cast_decision_pgw1668.py
+++ b/tests/convert/test_cast_decision_pgw1668.py
@@ -1,0 +1,415 @@
+"""pgw#1668 — a clone casts when casting would change bytes, and declares what it produced.
+
+The measured defect: `clone-huggingface` of SenseNova-U1.5-8B-MoT-Preview with
+`outputs=[{dtype: "bf16"}]` SUCCEEDED in 349 GPU-s, moved 50.19 GB, and
+published the UPSTREAM tree unchanged with `dtype: bf16` on it. The hub's own
+header read of the same bytes said `component_dtypes: {"model": "mixed"}`.
+
+Two functions in one file disagreed about what dtype a tree is. The cast
+decision asked a majority by TENSOR COUNT, and this checkpoint has 601 small
+BF16 norm/bias islands against 515 enormous F32 weights — so "bf16" won a vote
+that "would casting change any bytes?" was never a vote about. The label was
+then the REQUEST rather than the bytes, so the lie was stamped as well as told.
+
+The shape of the fix, and what these cases hold:
+  * one measure, weighed by BYTES and strict — a tree IS a dtype only when
+    every float tensor in it is that dtype, and anything else is `mixed`;
+  * `mixed` is not requestable, so it matches no request and the cast RUNS;
+  * a uniform source still short-circuits — the cheap path is taken when it is
+    provably a no-op, not when a majority guesses it is;
+  * the published `dtype` is READ OFF the produced tree, so no arm can stamp a
+    clean token on mixed bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fake_hub import _FakeHub
+
+from gen_worker.convert.clone import (
+    CAST_OUTPUT,
+    PUBLISH_SOURCE,
+    OutputSpec,
+    run_clone,
+    spec_actions,
+)
+from gen_worker.hubio.client import files_from_tree
+
+from gen_worker.convert.ingest import (
+    MIXED_DTYPE,
+    IngestedSource,
+    detect_snapshot_dtype,
+    rollup_dtype,
+    snapshot_float_dtype_bytes,
+)
+
+_WIDTH = {"F64": 8, "F32": 4, "BF16": 2, "F16": 2, "I64": 8}
+
+
+def _safetensors(tensors: dict[str, tuple[str, int]]) -> bytes:
+    """One valid safetensors file: `name -> (dtype, element count)`."""
+
+    header: dict[str, Any] = {}
+    offset = 0
+    for name, (dtype, count) in tensors.items():
+        end = offset + count * _WIDTH[dtype]
+        header[name] = {"dtype": dtype, "shape": [count], "data_offsets": [offset, end]}
+        offset = end
+    blob = json.dumps(header).encode()
+    body = bytes(bytearray((i * 37 + 11) % 251 for i in range(offset)))
+    return struct.pack("<Q", len(blob)) + blob + body
+
+
+def _sensenova_shaped() -> dict[str, tuple[str, int]]:
+    """se#840's real header profile, at fixture scale.
+
+    601 BF16 tensors of 1116 — a tensor-count majority — against an F32 bulk
+    that is 98% of the bytes. This is the exact shape that defeats a count
+    vote and does not defeat a byte one.
+    """
+
+    islands = {f"blocks.{i}.norm.weight": ("BF16", 8) for i in range(601)}
+    bulk = {f"blocks.{i}.mlp.weight": ("F32", 4096) for i in range(30)}
+    return {**islands, **bulk}
+
+
+def _uniform_bf16() -> dict[str, tuple[str, int]]:
+    return {f"blocks.{i}.mlp.weight": ("BF16", 4096) for i in range(30)}
+
+
+def _tree(root: Path, tensors: dict[str, tuple[str, int]]) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_bytes(b'{"architectures":["Fake"]}')
+    (root / "model.safetensors").write_bytes(_safetensors(tensors))
+    return root
+
+
+def _published_dtypes(root: Path) -> set[str]:
+    """Every float storage dtype actually present in a tree's headers."""
+
+    out: set[str] = set()
+    for p in sorted(Path(root).rglob("*.safetensors")):
+        with open(p, "rb") as f:
+            (n,) = struct.unpack("<Q", f.read(8))
+            header = json.loads(f.read(n))
+        out |= {str(v["dtype"]) for v in header.values()
+                if isinstance(v, dict) and "dtype" in v}
+    return out
+
+
+def _bytes_under(root: Path) -> int:
+    return sum(p.stat().st_size for p in Path(root).rglob("*") if p.is_file())
+
+
+# ------------------------------------------------------------- the measure
+
+
+def test_the_dtype_of_a_tree_is_weighed_in_bytes_and_a_mixed_tree_says_so(
+    tmp_path: Path,
+) -> None:
+    """THE DEFECT, isolated: the count vote and the bytes point opposite ways.
+
+    Both halves are asserted, because "not bf16" alone would pass on a
+    function that returned nothing at all.
+    """
+
+    tree = _tree(tmp_path / "src", _sensenova_shaped())
+
+    mass = snapshot_float_dtype_bytes(tree)
+    assert mass == {"bf16": 601 * 8 * 2, "fp32": 30 * 4096 * 4}
+    assert mass["fp32"] > 40 * mass["bf16"], "fixture is not F32-dominant"
+
+    # The vote the fix deleted, reconstructed here so the two are compared
+    # on the same bytes rather than on a memory of what the old one did.
+    with open(tree / "model.safetensors", "rb") as f:
+        (n,) = struct.unpack("<Q", f.read(8))
+        header = json.loads(f.read(n))
+    counts: dict[str, int] = {}
+    for value in header.values():
+        counts[str(value["dtype"])] = counts.get(str(value["dtype"]), 0) + 1
+    assert max(counts, key=lambda k: counts[k]) == "BF16", (
+        "the fixture no longer reproduces the count majority that caused this")
+
+    assert detect_snapshot_dtype(tree) == MIXED_DTYPE
+
+
+def test_a_uniform_tree_is_named_and_an_empty_one_abstains(tmp_path: Path) -> None:
+    """Strictness must not turn every tree into `mixed` — that would be the
+    same defect pointing the other way, and it would cast forever."""
+
+    assert detect_snapshot_dtype(_tree(tmp_path / "bf16", _uniform_bf16())) == "bf16"
+    # Non-float tensors ride along untouched by any cast, so they cannot make
+    # a tree mixed.
+    mixedish = {**_uniform_bf16(), "position_ids": ("I64", 512)}
+    assert detect_snapshot_dtype(_tree(tmp_path / "ints", mixedish)) == "bf16"
+    (tmp_path / "empty").mkdir()
+    assert detect_snapshot_dtype(tmp_path / "empty") == ""
+    assert rollup_dtype({"bf16": 0}) == ""
+
+
+# ------------------------------------------------------------ the decision
+
+
+@pytest.mark.parametrize(
+    "source_dtype, expected",
+    [("mixed", CAST_OUTPUT), ("fp32", CAST_OUTPUT), ("bf16", PUBLISH_SOURCE)],
+)
+def test_the_cast_runs_unless_it_is_provably_a_no_op(
+    source_dtype: str, expected: str,
+) -> None:
+    """`mixed` matches no request, which is the whole decision."""
+
+    assert spec_actions(
+        [OutputSpec(dtype="bf16", file_layout="multi-file",
+                    file_type="safetensors")],
+        publish_as_is=True, source_dtype=source_dtype,
+        explicit_outputs=True, cast_eligible=True,
+    ) == [expected]
+
+
+# --------------------------------------------------------- the whole clone
+
+
+class _Ctx:
+    def __init__(self, server: Any) -> None:
+        self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+        self._worker_capability_token = "cap-token"
+        self.owner = "tensorhub"
+        self.request_id = "req-1668"
+        self.destination = {"repo": "tensorhub/fallback"}
+
+
+def _pinned_pipeline_tree(root: Path) -> Path:
+    """A diffusers tree one of whose components a bf16 cast MUST NOT touch.
+
+    `AutoencoderKLWan` carries an fp32 load pin (`families.facts`), so a
+    tree-wide bf16 cast converts the transformer and steps over the VAE. What
+    comes out is genuinely mixed while the request, and every attribute
+    derived from it, still says `bf16`.
+    """
+
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakePipeline",
+        "transformer": ["diffusers", "FakeTransformer"],
+        "vae": ["diffusers", "AutoencoderKLWan"],
+    }))
+    for comp in ("transformer", "vae"):
+        (root / comp).mkdir(exist_ok=True)
+        (root / comp / "config.json").write_bytes(b"{}")
+        (root / comp / "diffusion_pytorch_model.safetensors").write_bytes(
+            _safetensors({f"{comp}.{i}.weight": ("F32", 4096) for i in range(8)}))
+    return root
+
+
+def _fake_plan(source_dir: Path, strategy: str, layout: str) -> Any:
+    files = [
+        (p.relative_to(source_dir).as_posix(), p.stat().st_size,
+         hashlib.sha256(p.read_bytes()).hexdigest())
+        for p in sorted(source_dir.rglob("*")) if p.is_file()
+    ]
+    return SimpleNamespace(
+        provider="huggingface",
+        paths=[name for name, _, _ in files],
+        source_storage_bits=32,
+        classification=SimpleNamespace(
+            strategy=strategy,
+            attrs={"file_layout": layout, "file_type": "safetensors"},
+        ),
+        bank_files=lambda: list(files),
+    )
+
+
+def _clone(
+    monkeypatch: pytest.MonkeyPatch, fake_hub: Any, tmp_path: Path,
+    source_dir: Path, published: list[Any] | None = None,
+    strategy: str = "transformers", layout: str = "single-file", **kwargs: Any,
+) -> Any:
+    """Everything but the network, with the dtype MEASURED rather than declared.
+
+    The download is faked (nothing here rents a pod), but `attrs["dtype"]` is
+    produced by the same call the real `ingest_huggingface` makes on the
+    materialized snapshot (`ingest.py`, `on_disk_dtype = detect_snapshot_dtype(
+    dest_dir)`) — so the fixture states bytes, not verdicts.
+    """
+
+    plan = _fake_plan(source_dir, strategy, layout)
+    attrs = dict(plan.classification.attrs)
+    attrs["dtype"] = detect_snapshot_dtype(source_dir)
+    plan.classification.attrs.update(attrs)
+
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    monkeypatch.setattr("gen_worker.convert.clone.plan_huggingface",
+                        lambda *a, **k: plan)
+
+    # The tree HANDED TO THE PUBLISHER — the run deletes its workdir, and the
+    # thing under test is which bytes went to the hub, not which files
+    # survived the cleanup.
+    if published is not None:
+        def _capture(tree: Any, *a: Any, **k: Any) -> Any:
+            root = Path(tree)
+            published.append(SimpleNamespace(
+                path=root,
+                is_the_source_tree=(root.resolve() == source_dir.resolve()),
+                storage_dtypes=_published_dtypes(root),
+                per_component={
+                    d.name: _published_dtypes(d) for d in sorted(root.iterdir())
+                    if d.is_dir() and any(d.rglob("*.safetensors"))},
+                dtype=detect_snapshot_dtype(root),
+                bytes=_bytes_under(root),
+            ))
+            return files_from_tree(tree, *a, **k)
+
+        monkeypatch.setattr("gen_worker.convert.clone.files_from_tree", _capture)
+
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.ingest_huggingface",
+        lambda source_ref, dest_dir, **kw: IngestedSource(
+            provider="huggingface", source_ref=source_ref,
+            source_revision="13a8d0f3", dir=source_dir, layout=layout,
+            model_family="fake", model_family_variant="fake1",
+            classification=plan.classification, attrs=attrs,
+            metadata={"source_provider": "huggingface"},
+            repo_spec={"kind": "model", "library_name": "transformers"},
+        ))
+    return run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="sensenova/fake",
+        destination_repo="sensenova/fake-tree", destination_release="r1",
+        **kwargs,
+    )
+
+
+def _wire_dtype() -> str:
+    """The dtype as the HUB received it, not as the producer remembers it."""
+
+    published = list(_FakeHub.state["publishes"].values())
+    assert len(published) == 1, published
+    return str(published[0].get("dtype") or "")
+
+
+def test_a_mixed_tree_asked_for_bf16_is_CAST_not_relabelled(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """se#840's job, end to end: 50.19 GB in must not be 50.19 GB out.
+
+    Pre-fix this published the source unchanged and stamped it `bf16`. The
+    three things that were wrong are the three things asserted: the cast ran,
+    every F32 tensor is gone, and the tree shrank.
+    """
+
+    source_dir = _tree(tmp_path / "source", _sensenova_shaped())
+    source_bytes = _bytes_under(source_dir)
+    published: list[Any] = []
+
+    result = _clone(
+        monkeypatch, fake_hub, tmp_path, source_dir, published,
+        outputs=[{"dtype": "bf16", "file_layout": "multi-file",
+                  "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(result.published) == 1
+    assert len(published) == 1
+    tree = published[0]
+
+    assert not tree.is_the_source_tree, (
+        "the SOURCE tree was handed to the publisher — no cast ran")
+    assert tree.storage_dtypes == {"BF16"}, (
+        f"an F32 tensor survived a bf16 cast: {sorted(tree.storage_dtypes)}")
+    assert tree.bytes < source_bytes, (
+        f"the produced tree is {tree.bytes} bytes against a {source_bytes}-byte "
+        "source: nothing was rewritten")
+    # The label and the bytes, checked against each other rather than each
+    # against the request.
+    assert tree.dtype == "bf16"
+    assert _wire_dtype() == tree.dtype == result.published[0]["dtype"]
+
+
+def test_a_uniform_bf16_source_asked_for_bf16_still_publishes_as_is(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cheap path survives, and that is not incidental.
+
+    A rule that cast whenever it was unsure would pay a full re-encode on
+    every already-correct mirror. The source tree itself is what gets
+    published — no flavor tree is built at all.
+    """
+
+    source_dir = _tree(tmp_path / "source", _uniform_bf16())
+    published: list[Any] = []
+
+    result = _clone(
+        monkeypatch, fake_hub, tmp_path, source_dir, published,
+        outputs=[{"dtype": "bf16", "file_layout": "multi-file",
+                  "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(published) == 1
+    assert published[0].is_the_source_tree, (
+        "a provably no-op cast materialized a whole second tree")
+    assert published[0].bytes == _bytes_under(source_dir)
+    assert _wire_dtype() == "bf16"
+
+
+def test_a_publish_as_is_of_a_mixed_tree_declares_MIXED(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The second half of the lie: the label was the REQUEST.
+
+    With no explicit outputs the source is published as-is by design — that
+    arm is correct. What was not correct is stamping it with the default
+    `bf16` spec. The bytes are mixed, so the checkpoint says mixed, and it
+    agrees with the `component_dtypes` the hub derives from the same headers.
+    """
+
+    source_dir = _tree(tmp_path / "source", _sensenova_shaped())
+
+    result = _clone(monkeypatch, fake_hub, tmp_path, source_dir)
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert _wire_dtype() == MIXED_DTYPE
+    assert result.published[0]["dtype"] == MIXED_DTYPE
+
+
+def test_a_cast_that_a_PIN_made_mixed_declares_mixed_not_the_request(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The label must come off the TREE, and this is the arm that proves it.
+
+    Everywhere else the honest measure alone already lands the right token,
+    because the intent and the outcome agree. Here they cannot: the request is
+    bf16, the flavor builder's `attrs["dtype"]` is bf16, the cast runs — and it
+    steps over an fp32-pinned VAE by design, so the tree that reaches the hub
+    is mixed. Reading the label off the request or off the builder's intent
+    stamps `bf16` on it; reading it off the produced headers cannot.
+    """
+
+    source_dir = _pinned_pipeline_tree(tmp_path / "source")
+    published: list[Any] = []
+
+    result = _clone(
+        monkeypatch, fake_hub, tmp_path, source_dir, published,
+        strategy="diffusers_pipeline", layout="multi-file",
+        outputs=[{"dtype": "bf16", "file_layout": "multi-file",
+                  "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(published) == 1
+    tree = published[0]
+    # The cast DID run and the pin DID hold — without both, this case is not
+    # testing a mixed produced tree at all.
+    assert tree.storage_dtypes == {"BF16", "F32"}, sorted(tree.storage_dtypes)
+    assert tree.per_component == {"transformer": {"BF16"}, "vae": {"F32"}}
+
+    assert _wire_dtype() == MIXED_DTYPE, (
+        "a tree with an fp32 component was published as bf16")
+    assert result.published[0]["dtype"] == MIXED_DTYPE

--- a/tests/convert/test_p8_convert_publish_contract.py
+++ b/tests/convert/test_p8_convert_publish_contract.py
@@ -48,7 +48,7 @@ def _install_fake_ingest(monkeypatch: pytest.MonkeyPatch, source: IngestedSource
 
 def _stub_build_flavor_tree(monkeypatch: pytest.MonkeyPatch, calls: list) -> None:
     def fake_build_flavor_tree(source, spec, out_dir, *, quantize_components=None,
-                                objective="", distilled=False):
+                                objective="", distilled=False, progress=None):
         calls.append({"dtype": spec.dtype, "file_layout": spec.file_layout})
         out_dir.mkdir(parents=True, exist_ok=True)
         (out_dir / "model.safetensors").write_bytes(b"\x01" * 32)


### PR DESCRIPTION
## The measurement

Job `01a02956` mirrored `sensenova/SenseNova-U1.5-8B-MoT-Preview` with `outputs=[{dtype: "bf16"}]`, **SUCCEEDED** in 349 GPU-s, moved 50.19 GB, and published the **upstream tree unchanged** with `dtype: bf16` stamped on it — while the hub's own read of those same headers said `component_dtypes: {"model": "mixed"}`.

```
requested:  dtype bf16, file_layout multi-file
published:  dtype bf16, file_layout single-file, 50,192,263,960 bytes
            component_dtypes = {"model": "mixed"}  (source: safetensors-headers)
upstream:   50,192,375,454 bytes
```

50.19 GB in, 50.19 GB out. The ~15 GB of dead F32 the job existed to remove is in every pull, forever, and nothing warned.

## The mechanism

`spec_actions` decided CAST vs PUBLISH-AS-IS on `spec.dtype == source_dtype`, and `source_dtype` was `detect_snapshot_dtype` — a **majority by TENSOR COUNT**. This checkpoint has 601 small BF16 norm/bias islands against 515 enormous F32 weights, so "bf16" won a vote that *"would casting change any bytes?"* was never a vote about, and the source was then stamped with the dtype that was **asked for**.

## The fix — the vote is DELETED, not re-weighted

Weighing the same majority by bytes answers *"what is this tree mostly"*, which is a different question, and it needs a share at which a minority stops counting — a threshold nobody derived. So there is no majority here:

* a tree **IS** a dtype only when every FLOAT tensor in it is that dtype; anything else is `mixed`;
* `mixed` is not requestable, so it matches no request and the **cast runs**;
* a genuinely uniform source still short-circuits — the cheap path is taken exactly when it is **provably** a no-op;
* integer/boolean tensors are excluded because a cast copies them through untouched (`safetensors_header.FLOAT_DTYPES`, now stated once; the writer's private copy of the same set is deleted).

Two riders from the same read: the plan-side estimate read only the **first three** headers and called the answer the tree's dtype (cap deleted — every selected header is read, ticked into the position pgw#1667 gave that phase), and `_remote_safetensors_width` (plan, top-by-bytes) and `detect_snapshot_dtype` (run, top-by-count) returned **different tokens for the same tree**, so the preflight and the run could disagree about whether a cast happens.

## The label is a separate fix

A right decision is not a right stamp. The published `dtype` is now read off the **produced tree's own headers**. The arm that proves the difference is a cast a per-component fp32 pin makes mixed on purpose — request `bf16`, `attrs["dtype"]` `bf16`, VAE still F32 — which used to publish as `bf16` and now publishes as `mixed`, agreeing with the `component_dtypes` the hub derives from the same bytes.

## Red proofs

`tests/convert/test_cast_decision_pgw1668.py` — 9 cases, end to end through `run_clone` against the fake hub on SenseNova's real header profile, asserting the dtype the **hub received on the wire**.

| mutation (fix otherwise intact) | red |
|---|---|
| `detect_snapshot_dtype` restored to the tensor-COUNT majority | **4 failed, 5/5** |
| only the label reverted to `attrs["dtype"] or spec.dtype` | **1 failed, 5/5** (the pin case — the only arm where intent and outcome differ) |

## Not claimed

The requested `file_layout` is still silently replaced by the source's on a publish-as-is cast. Same class, different axis, and there is no honest derivation to drop in: `observed_file_layout` reads a transformers root tree as `multi-file` while the classifier calls it `single-file`. It needs the repackage support matrix, not a patch at the publish call — filed separately.