### PR TITLE
pgw#1668 follow-up: the dtype-pin fence reads a component's NARROWEST dtype — pgw#1668 had disarmed it for half-violations

### DIFF
--- a/changelog.d/pgw1668-pin-fence.md
+++ b/changelog.d/pgw1668-pin-fence.md
@@ -1,0 +1,13 @@
+- **pgw#1668 follow-up: the component dtype-pin fence reads a component's NARROWEST dtype, not
+  what it is mostly.** pgw#1668 replaced a majority-by-tensor-count measure with a strict one and
+  disarmed this fence for the case it exists for. The old measure answered `bf16` for a component
+  that was 20 tensors cast and 3 not, so an fp32 pin refused it; the new one answers `mixed`, and
+  `dtype_bits("mixed")` is 0, which makes `is_narrowing` False against everything. **A fully
+  violated pin was refused and a HALF violated one published silently** — the fence got strictly
+  less able to fire the more of the component survived, which is backwards, and it was found by
+  testing the fence after the change rather than by reasoning that the change was contained. The
+  rollup is still what the checkpoint REPORTS (`mixed` is the honest label and the whole point of
+  pgw#1668); it is simply not a comparand, because a pin is violated by any tensor below it. The
+  fence now reads `component_narrowest_dtype` on both sides — the produced tree and the source
+  that excuses it — so a mirror of a tree that already ships narrow still passes. Red-armed: with
+  the comparison put back on the rollup, the half-violated case publishes, 5/5.

--- a/src/gen_worker/convert/dtype_pins.py
+++ b/src/gen_worker/convert/dtype_pins.py
@@ -110,10 +110,30 @@ def check_explicit_pin_conflict(
 
 
 def component_dtype(component_dir: Path | str) -> str:
-    """Majority on-disk dtype of one component's safetensors, '' if unreadable."""
+    """The dtype a component IS: one float dtype's token, ``'mixed'``, or ``''``."""
     from .ingest import detect_snapshot_dtype
 
     return detect_snapshot_dtype(Path(component_dir))
+
+
+def component_narrowest_dtype(component_dir: Path | str) -> str:
+    """The NARROWEST float dtype a component actually carries, ``''`` if unreadable.
+
+    A PIN is violated by any tensor below it, not by what the component is
+    mostly — so the pin fence reads this and never the rollup. pgw#1668 made
+    that distinction load-bearing: the rollup answers ``mixed`` for a component
+    that is half cast and half not, ``dtype_bits("mixed")`` is 0, and
+    ``is_narrowing`` is False for everything — so a HALF-violated pin published
+    silently while a fully-violated one was refused. The fence was strictly
+    less able to fire the more of the component survived.
+    """
+
+    from .ingest import snapshot_float_dtype_bytes
+
+    present = [d for d, b in snapshot_float_dtype_bytes(Path(component_dir)).items() if b > 0]
+    if not present:
+        return ""
+    return min(present, key=lambda d: dtype_bits(d) or (1 << 30))
 
 
 def component_dtypes_on_disk(tree: Path | str) -> Dict[str, str]:
@@ -156,18 +176,30 @@ def verify_produced_tree(
     tree: Path | str, *, source_dir: Optional[Path | str] = None,
     source_dtypes: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, str]:
-    """Publish gate."""
+    """Publish gate.
+
+    Returns the per-component dtype REPORT (the rollup, which is what a reader
+    of the checkpoint wants) and refuses on the per-component NARROWEST dtype,
+    which is the only thing a pin can be violated by. The two are deliberately
+    different reads of the same headers: ``mixed`` is an honest label and a
+    useless comparand.
+    """
+
     produced = component_dtypes_on_disk(tree)
     pins = component_pins(tree)
-    if source_dtypes is None:
-        source_dtypes = (component_dtypes_on_disk(source_dir)
-                         if source_dir is not None else {})
     classes = model_index_classes(tree)
+    explicit = source_dtypes is not None
     for comp, fact in pins.items():
-        got = produced.get(comp, "")
+        got = component_narrowest_dtype(Path(tree) / comp)
         if not got or not is_narrowing(got, fact.dtype):
             continue
-        src = str(source_dtypes.get(comp, "") or "")
+        # The source is allowed to have been below the pin already — a mirror
+        # of a tree that ships narrow is not this job narrowing it.
+        if explicit:
+            src = str((source_dtypes or {}).get(comp, "") or "")
+        else:
+            src = (component_narrowest_dtype(Path(source_dir) / comp)
+                   if source_dir is not None else "")
         if src and is_narrowing(src, fact.dtype):
             continue
         raise ComponentDtypePinViolation(
@@ -183,6 +215,7 @@ __all__ = [
     "check_explicit_pin_conflict",
     "component_dtype",
     "component_dtypes_on_disk",
+    "component_narrowest_dtype",
     "component_pins",
     "dtype_bits",
     "is_narrowing",

--- a/tests/convert/test_pin_fence_narrowest_pgw1668.py
+++ b/tests/convert/test_pin_fence_narrowest_pgw1668.py
@@ -1,0 +1,106 @@
+"""The pin fence reads a component's NARROWEST dtype, not what it is mostly.
+
+pgw#1668 replaced a majority-by-tensor-count measure with a strict one, and in
+doing so it disarmed this fence for exactly the case the fence exists for. The
+old measure answered `bf16` for a component that was 20 tensors cast and 3 not,
+so an fp32 pin refused it. The new one answers `mixed` — and `dtype_bits`
+of `mixed` is 0, which makes `is_narrowing` False against everything. **A pin
+that was fully violated was refused; a pin that was HALF violated published
+silently.** The fence got strictly less able to fire the more of the component
+survived, which is backwards.
+
+The rollup is still what the checkpoint REPORTS — `mixed` is the honest label.
+It is simply not a comparand: a pin is violated by any tensor below it.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker.convert.dtype_pins import (
+    ComponentDtypePinViolation,
+    component_dtypes_on_disk,
+    component_narrowest_dtype,
+    verify_produced_tree,
+)
+
+_W = {"F32": 4, "BF16": 2, "F16": 2, "I64": 8}
+
+
+def _safetensors(tensors: dict[str, tuple[str, int]]) -> bytes:
+    header: dict[str, Any] = {}
+    offset = 0
+    for name, (dtype, count) in tensors.items():
+        end = offset + count * _W[dtype]
+        header[name] = {"dtype": dtype, "shape": [count],
+                        "data_offsets": [offset, end]}
+        offset = end
+    blob = json.dumps(header).encode()
+    return struct.pack("<Q", len(blob)) + blob + bytes(offset)
+
+
+def _tree(root: Path, vae: dict[str, tuple[str, int]]) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakePipeline",
+        # AutoencoderKLWan carries an fp32 load pin in families.facts.
+        "vae": ["diffusers", "AutoencoderKLWan"],
+    }))
+    (root / "vae").mkdir(exist_ok=True)
+    (root / "vae" / "diffusion_pytorch_model.safetensors").write_bytes(
+        _safetensors(vae))
+    return root
+
+
+_ALL_F32 = {f"a{i}.weight": ("F32", 4096) for i in range(20)}
+_HALF_CAST = {**{f"a{i}.weight": ("BF16", 4096) for i in range(20)},
+              **{f"b{i}.weight": ("F32", 4096) for i in range(3)}}
+_ALL_CAST = {f"a{i}.weight": ("BF16", 4096) for i in range(20)}
+
+
+def test_a_HALF_violated_pin_is_refused_the_same_as_a_fully_violated_one(
+    tmp_path: Path,
+) -> None:
+    """THE REGRESSION. Both trees narrowed an fp32-pinned VAE below its pin;
+    only one of them used to be caught."""
+
+    source = _tree(tmp_path / "source", _ALL_F32)
+
+    for name, vae in (("half", _HALF_CAST), ("all", _ALL_CAST)):
+        tree = _tree(tmp_path / name, vae)
+        with pytest.raises(ComponentDtypePinViolation) as excinfo:
+            verify_produced_tree(tree, source_dir=source)
+        assert "'vae'" in str(excinfo.value)
+        assert "pinned to fp32" in str(excinfo.value)
+
+    # And the label the checkpoint carries is unchanged and still honest: the
+    # half-cast tree is genuinely mixed, and saying so is the point of pgw#1668.
+    assert component_dtypes_on_disk(tmp_path / "half") == {"vae": "mixed"}
+    assert component_narrowest_dtype(tmp_path / "half" / "vae") == "bf16"
+
+
+def test_a_component_that_honours_its_pin_still_publishes(tmp_path: Path) -> None:
+    """The fence must not fire on the tree the cast is SUPPOSED to produce —
+    a pinned component the cast stepped over, which is the normal outcome."""
+
+    source = _tree(tmp_path / "source", _ALL_F32)
+    tree = _tree(tmp_path / "produced", _ALL_F32)
+    assert verify_produced_tree(tree, source_dir=source) == {"vae": "fp32"}
+    assert component_narrowest_dtype(tree / "vae") == "fp32"
+
+
+def test_a_source_that_was_ALREADY_below_the_pin_is_not_this_jobs_narrowing(
+    tmp_path: Path,
+) -> None:
+    """Mirroring a tree that ships narrow is not narrowing it, and the source
+    is read by the same narrowest rule — otherwise a mixed SOURCE would stop
+    excusing a mixed produced tree and every such mirror would refuse."""
+
+    source = _tree(tmp_path / "source", _HALF_CAST)
+    tree = _tree(tmp_path / "produced", _HALF_CAST)
+    assert verify_produced_tree(tree, source_dir=source) == {"vae": "mixed"}


### PR DESCRIPTION
## What pgw#1668 broke, in its own file

pgw#1668 replaced a majority-by-tensor-count dtype measure with a strict one. That was right for the label and for the cast decision, and it **silently disarmed the publish gate** that refuses a component narrower than its load-dtype pin.

The old measure answered `bf16` for a component that was 20 tensors cast and 3 not, so an fp32 pin refused it. The new one answers `mixed`, and `dtype_bits("mixed")` is `0`, which makes `is_narrowing` False against everything:

```
produced component_dtypes: {'vae': 'mixed'}
is_narrowing('mixed','fp32') = False
is_narrowing('bf16','fp32')  = True
verify_produced_tree -> {'vae': 'mixed'}     # published
```

**A fully violated pin was refused and a HALF violated one published silently.** The fence got strictly less able to fire the more of the component survived, which is backwards.

Found by testing the fence after the change, not by reasoning that the change was contained. A refusal nobody re-armed after moving what it compares is a refusal that has stopped existing.

## The fix

The rollup is still what the checkpoint **reports** — `mixed` is the honest label and the whole point of pgw#1668. It is simply not a *comparand*: a pin is violated by **any** tensor below it, which is exact and needs no rollup. `component_narrowest_dtype` reads it off `snapshot_float_dtype_bytes`, and the fence uses it on **both** sides — the produced tree and the source that excuses it — so mirroring a tree that already ships narrow still passes rather than newly refusing.

## Red proof

`tests/convert/test_pin_fence_narrowest_pgw1668.py` — 3 cases: the half-violation and the full violation must be refused identically; a component that honours its pin still publishes; a source already below the pin still excuses the produced tree. With the comparison put back on the rollup, the half-violated case publishes — **5/5**.

`tests/convert` + the three dtype-pin suites: 188 passed. mypy clean over 660 files, ruff clean.