### PR TITLE
pgw#1670: the diffusers repack as a KEY-LEVEL leg of the conversion job — headers and names, never weights

### DIFF
--- a/changelog.d/pgw1670-tree-repack.md
+++ b/changelog.d/pgw1670-tree-repack.md
@@ -1,0 +1,44 @@
+- **A diffusers repack that is a KEY MAP, not a model load — `outputs=[{repack: "<family>"}]`
+  on a clone job.** A mirror reproduces the upstream layout, and a flat root beside a
+  `config.json` whose `auto_map` names `.py` files that do not exist cannot be `ctx.load`ed
+  hollow-legally: the hollow session intercepts only diffusers/transformers loaders, so an
+  endpoint's component classes have to be reachable through a `model_index.json`. The repack
+  this repo already had could not do it — `repackage.singlefile_to_diffusers` instantiates a
+  DECLARED diffusers pipeline class from a single file and saves it back, which needs a class
+  the SDK can name and a card's worth of RAM, and SenseNova's serving class is
+  `sensenova_u1.Model` in an endpoint package. `convert/tree_repack.py` is the transform the
+  ruling actually asked for: it routes safetensors KEYS into component directories, derives each
+  component's `config.json` from the source config field by declared field, moves the tokenizer
+  files into their own directory and writes `model_index.json`. There is no torch import in the
+  module. Tensor DATA is copied as byte RANGES out of the source header's own offsets, so every
+  tensor in the produced tree is bit-identical to the one it came from and no dtype or shape can
+  move here — asserted per tensor, before and after, and red when one byte of the copy loop is
+  perturbed.
+- **It composes with the cast in ONE submission and it MOVES what it can.** The repack is the
+  last leg of `build_flavor_tree`, so the 50 GB read the cast already pays is not paid twice. A
+  declaration whose key map is the identity and whose single weight component takes every key
+  moves each member with `os.replace` — zero bytes read, zero written — and the disk preflight
+  prices that property (`TreeRepack.is_pure_move`) rather than assuming either answer. Assuming
+  a copy would refuse a job that fits, which is pgw#1666's under-count pointing the other way.
+- **A requested repack can never be satisfied by publishing the source unchanged.** `spec_actions`
+  now treats a repack as WORK: without that, a source whose dtype already matched took the
+  `PUBLISH_SOURCE` arm, handed the ingest tree straight to the publisher and stamped it with a
+  `tree_repack` attribute it had not earned — the same silent-substitution shape that cost this
+  checkpoint pgw#1668 and pgw#1669.
+- **Members are PRESERVED and the produced layout is READ BACK, never echoed.** N source members
+  become N component members with an index; the repack neither shards nor de-shards, and
+  `file_layout` comes from `observed_file_layout` on the produced tree. ⚠️ On a clone the CAST has
+  already collapsed a shard set by the time the repack runs (`stream_reencode` writes one output
+  file per weight set), so a 13-shard source publishes one member — that is the cast's doing, is
+  asserted as such, and belongs to pgw#1669's axis.
+- **Everything that could silently drop a tensor is a REFUSAL, most of them at declaration time.**
+  Two catch-all components, a catch-all that is not last, a component that carries neither weights
+  nor files, two source keys renaming onto one, a key no component claims, a config field the
+  source document does not carry, a declared tokenizer file that is not there, a tree that is
+  already component-shaped, and a tree that carries none of the declaration's required key
+  prefixes. An unknown family name is refused by `normalize_outputs`, i.e. on the request, before
+  a pod exists — and the refusal names what IS declared. A repack is NAMED by the request and
+  never detected: a wrong key map produces a tree that loads and serves noise.
+- Declared for `sensenova-u1.mot` (se#840): one `transformer` component whose key map is
+  deliberately the identity — the upstream keys already ARE the endpoint's module paths, and what
+  the repack supplies is the directory shape, the two config documents and the `model_index.json`.

--- a/src/gen_worker/convert/__init__.py
+++ b/src/gen_worker/convert/__init__.py
@@ -42,6 +42,22 @@ from .registry import (
     registered_repackage_families,
     require_repackage_family,
 )
+from .tree_repack import (
+    RepackReport,
+    apply_tree_repack,
+    register_tree_repack,
+    registered_tree_repacks,
+    require_tree_repack,
+    tree_repack,
+)
+from .tree_repack_spec import (
+    ComponentConfig,
+    ConfigField,
+    FileRoute,
+    RepackComponent,
+    TreeRepack,
+    TreeRepackError,
+)
 from .repack_spec import (
     ComponentRepack,
     LayoutSignature,
@@ -102,6 +118,18 @@ __all__ = [
     "registered_layouts",
     "registered_repackage_families",
     "require_repackage_family",
+    "ComponentConfig",
+    "ConfigField",
+    "FileRoute",
+    "RepackComponent",
+    "RepackReport",
+    "TreeRepack",
+    "TreeRepackError",
+    "apply_tree_repack",
+    "register_tree_repack",
+    "registered_tree_repacks",
+    "require_tree_repack",
+    "tree_repack",
     "ConversionCase",
     "ConversionHop",
     "ConversionIO",

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -48,6 +48,7 @@ from .keepalive import HubKeepalive
 from .publish import destination_release as _destination_release
 from .layout import canonical_model_family_from_variant, infer_model_family_variant_from_hint
 from .registry import repackage_family
+from .tree_repack import apply_tree_repack, require_tree_repack
 from .writer import (
     CAST_NORMALIZE_DTYPES as _CAST_NORMALIZE_DTYPES,
 )
@@ -89,11 +90,19 @@ _MIN_CONVERT_BYTES = 100 * 1024 * 1024
 
 @dataclass(frozen=True)
 class OutputSpec:
-    """One requested output flavor: dtype + file layout + container."""
+    """One requested output flavor: dtype + file layout + container + tree shape.
+
+    ``repack`` names a declared tree-repack family (pgw#1670) and is the third
+    axis of *what the produced artifact IS*: the flat transformers shape a
+    mirror reproduces, or the diffusers component shape ``ctx.load`` can reach.
+    It is NAMED and never detected — an unknown name is refused at normalize
+    time, at $0, before a pod exists.
+    """
 
     dtype: str
     file_layout: str
     file_type: str
+    repack: str = ""
 
     @property
     def label(self) -> str:
@@ -169,6 +178,7 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = MULTI_
         dtype = {"fp8-e4m3": "fp8", "fp8:e4m3": "fp8"}.get(dtype, dtype)
         layout = str(get("file_layout") or "").strip().lower() or layout_hint
         ftype = str(get("file_type") or "").strip().lower() or "safetensors"
+        repack = str(get("repack") or "").strip().lower()
         if not dtype:
             raise ValueError("output.dtype is required")
         if dtype not in _KNOWN_DTYPES:
@@ -177,10 +187,20 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = MULTI_
             raise ValueError(f"unsupported output.file_layout: {layout!r}")
         if ftype not in _KNOWN_FILE_TYPES:
             raise ValueError(f"unsupported output.file_type: {ftype!r}")
+        if repack:
+            # Refused HERE — at normalize time, before a pod exists — because
+            # a repack name that is only checked on the pod costs a whole
+            # download to learn it was misspelled.
+            require_tree_repack(repack)
+            if ftype != "safetensors":
+                raise ValueError(
+                    f"output.repack={repack!r} needs file_type=safetensors; a repack is a "
+                    f"transform over safetensors headers and {ftype!r} has none")
         key = (dtype, layout, ftype)
         if key not in seen:
             seen.add(key)
-            out.append(OutputSpec(dtype=dtype, file_layout=layout, file_type=ftype))
+            out.append(OutputSpec(dtype=dtype, file_layout=layout, file_type=ftype,
+                                  repack=repack))
     if not out:
         layout = layout_hint if layout_hint in _KNOWN_FILE_LAYOUTS else MULTI_FILE
         out.append(OutputSpec(dtype="bf16", file_layout=layout, file_type="safetensors"))
@@ -201,7 +221,41 @@ def build_flavor_tree(
 
     ``progress`` receives the output bytes of each tensor written, cumulative
     across components — the convert phase's declared position.
+
+    THE REPACK IS THE LAST LEG AND IT IS PART OF THIS TREE (pgw#1670, se#840's
+    ruling). ``spec.repack`` names a declared key map; the dtype pass writes the
+    weights and the repack then routes their KEYS into diffusers component
+    directories, derives each component's ``config.json`` from the source
+    config, moves the tokenizer files and writes ``model_index.json``. It runs
+    here rather than at publish time so that ONE producer emits the artifact and
+    the 50 GB read the cast already pays is not paid twice.
     """
+
+    tree, attrs = _build_flavor_tree(
+        source, spec, out_dir, quantize_components=quantize_components,
+        objective=objective, distilled=distilled, progress=progress,
+    )
+    if spec.repack:
+        report = apply_tree_repack(tree, require_tree_repack(spec.repack))
+        # The produced layout is READ OFF the produced tree, never echoed from
+        # the request. pgw#1669 is the standing record of what echoing costs: a
+        # `multi-file` request against a single-file source published
+        # `single-file` bytes under a `multi-file` label, silently.
+        attrs.update(report.as_attrs())
+    return tree, attrs
+
+
+def _build_flavor_tree(
+    source: IngestedSource,
+    spec: OutputSpec,
+    out_dir: Path,
+    *,
+    quantize_components: list[str] | None = None,
+    objective: str = "",
+    distilled: bool = False,
+    progress: Any = None,
+) -> tuple[Path, dict[str, str]]:
+    """The dtype/layout half — see :func:`build_flavor_tree`."""
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -475,13 +529,42 @@ def spec_actions(
             actions.append(CAST_OUTPUT)
             continue
         dtype_matches = (not source_dtype) or spec.dtype == source_dtype
-        if dtype_matches or not explicit_outputs:
+        # A REQUESTED REPACK IS WORK, even when the dtype already matches
+        # (pgw#1670). PUBLISH_SOURCE hands the ingest tree straight to the
+        # publisher, so letting a repack request take that arm would drop the
+        # transform and publish the flat tree under a label that says it was
+        # repacked — the exact silent-substitution shape pgw#1668/#1669
+        # already cost this checkpoint two jobs.
+        if spec.repack:
+            actions.append(
+                CAST_OUTPUT if (index == 0 and spec.file_type == "safetensors"
+                                and cast_eligible)
+                else NOT_POSSIBLE)
+        elif dtype_matches or not explicit_outputs:
             actions.append(PUBLISH_SOURCE)
         elif index == 0 and spec.file_type == "safetensors" and cast_eligible:
             actions.append(CAST_OUTPUT)
         else:
             actions.append(NOT_POSSIBLE)
     return actions
+
+
+def _tree_repack_transient_bytes(spec: OutputSpec, tree_bytes: int) -> int:
+    """What a declared tree repack costs on TOP of the tree it repacks.
+
+    Derived from the DECLARATION, not guessed: a repack whose key map is the
+    identity and whose single weight component takes every key moves each
+    member with ``os.replace`` and costs nothing. Anything else rebuilds
+    members (renamed keys, or one member split across components) and the
+    originals are only unlinked once every component has read them — so the
+    peak is the produced tree, twice. Stating zero for the move case matters:
+    over-demanding here refuses a job that fits, which is the same class of
+    wrong answer as pgw#1666's under-demand, pointing the other way.
+    """
+
+    if not spec.repack:
+        return 0
+    return 0 if require_tree_repack(spec.repack).is_pure_move else tree_bytes
 
 
 def plan_disk_demand(
@@ -572,6 +655,7 @@ def plan_disk_demand(
             published_bytes += source_bytes
             if spec.file_type == "safetensors":
                 deshard_bytes += sharded_bytes
+            repack = max(repack, _tree_repack_transient_bytes(spec, source_bytes))
             continue
         size = _output_tree_bytes(spec, source_bytes, source_bits, measured_bits)
         output_sizes.append(size)
@@ -585,6 +669,7 @@ def plan_disk_demand(
         layout = source_layout if publish_as_is else spec.file_layout
         if spec.file_type != "gguf" and source_layout and layout != source_layout:
             repack = max(repack, size)
+        repack = max(repack, _tree_repack_transient_bytes(spec, size))
 
     if output_sizes:
         stages.append(DiskStage(
@@ -594,7 +679,7 @@ def plan_disk_demand(
     if gguf_intermediate:
         stages.append(DiskStage("one intermediate F16 GGUF tree", gguf_intermediate))
     if repack:
-        stages.append(DiskStage("one layout-repack tree", repack))
+        stages.append(DiskStage("one repack tree", repack))
     if publish_as_is:
         notes.append(f"{strategy} publishes the source tree directly")
     if reused_in_place:
@@ -913,6 +998,12 @@ def run_clone(
                         cast_spec = OutputSpec(
                             dtype=spec.dtype, file_layout=effective_layout,
                             file_type=spec.file_type,
+                            # `file_layout` is deliberately overridden here
+                            # (pgw#1669) and `repack` deliberately is NOT: it
+                            # is the caller's request about the produced tree's
+                            # SHAPE, and this arm has no source fact to
+                            # substitute for it.
+                            repack=spec.repack,
                         )
                         flavor_dir = workdir / f"flavor-{spec.label}"
                         shutil.rmtree(flavor_dir, ignore_errors=True)

--- a/src/gen_worker/convert/tree_repack.py
+++ b/src/gen_worker/convert/tree_repack.py
@@ -1,0 +1,512 @@
+"""The tree-repack ENGINE and its registry — headers and names, never weights.
+
+``apply_tree_repack`` rewrites a produced flat tree IN PLACE into the diffusers
+component shape a declaration describes. It is a conversion-job leg (se#840's
+ruling, pgw#1670): it runs on the pod, after the dtype cast, over the tree the
+cast just wrote, so the 50 GB read is paid once and one producer emits the
+published artifact.
+
+Three properties are the whole point and each is covered by a case:
+
+1. **No model is instantiated.** The engine reads safetensors HEADERS and
+   copies tensor data as byte RANGES. There is no torch import in this module.
+2. **Tensor bytes are unchanged.** A renamed tensor is the same bytes under a
+   different name; a moved file is the same file. The engine never re-encodes,
+   so a repack cannot change a dtype, a shape or a value.
+3. **Members are PRESERVED, and the produced layout is STATED.** The repack
+   neither shards nor de-shards: N source weight files become N members of the
+   component they route to. What the tree ended up as is then read back off
+   the tree (``observed_file_layout``) and returned, rather than echoed from
+   the request — pgw#1669 is the record of what echoing the request costs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import Any, Mapping
+
+from ..models.file_layout import observed_file_layout
+from ..models.safetensors_header import header_len_ok
+from .tree_repack_spec import (
+    ComponentConfig,
+    ConfigField,
+    DeclarationError,
+    FileRoute,
+    RepackComponent,
+    TreeRepack,
+    TreeRepackError,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RepackReport",
+    "apply_tree_repack",
+    "register_tree_repack",
+    "registered_tree_repacks",
+    "require_tree_repack",
+    "tree_repack",
+]
+
+_COPY_CHUNK = 8 * 1024 * 1024
+
+_lock = RLock()
+_registry: dict[str, TreeRepack] = {}
+_builtins_loaded = False
+
+
+# --------------------------------------------------------------------- registry
+
+
+def _ensure_builtins() -> None:
+    """Import the platform's own declarations once, lazily.
+
+    They live in their own module so that reading "what families can be
+    repacked" is reading a declaration table rather than tracing imports.
+    """
+
+    global _builtins_loaded
+    with _lock:
+        if _builtins_loaded:
+            return
+        _builtins_loaded = True
+    from . import tree_repack_families  # noqa: F401  (registers on import)
+
+
+def register_tree_repack(spec: TreeRepack, *, replace: bool = False) -> TreeRepack:
+    """Register one family's tree-repack declaration."""
+
+    with _lock:
+        existing = _registry.get(spec.name)
+        if existing is not None and existing != spec and not replace:
+            raise DeclarationError(
+                f"tree repack {spec.name!r} is already registered with a different "
+                "declaration; pass replace=True only if you own both")
+        _registry[spec.name] = spec
+        return spec
+
+
+def registered_tree_repacks() -> tuple[str, ...]:
+    _ensure_builtins()
+    with _lock:
+        return tuple(sorted(_registry))
+
+
+def tree_repack(name: str | None) -> TreeRepack | None:
+    _ensure_builtins()
+    with _lock:
+        return _registry.get(str(name or "").strip().lower())
+
+
+def require_tree_repack(name: str | None) -> TreeRepack:
+    """The declaration, or a typed refusal that NAMES what is declared.
+
+    An unknown family is refused rather than sniffed. A repack that guessed
+    which family a tree belongs to would be the pgw#740 wrong-converter defect
+    with a bigger blast radius: the wrong key map produces a tree that loads
+    and serves noise.
+    """
+
+    spec = tree_repack(name)
+    if spec is None:
+        known = ", ".join(registered_tree_repacks()) or "<none>"
+        raise TreeRepackError(
+            f"no tree-repack declaration named {str(name or '').strip()!r}. "
+            f"Declared: {known}. A repack is NAMED by the request, never detected — "
+            "register one with gen_worker.convert.register_tree_repack()."
+        )
+    return spec
+
+
+# ----------------------------------------------------------------- the report
+
+
+@dataclass(frozen=True)
+class RepackReport:
+    """What the repack produced, read off the produced tree."""
+
+    name: str
+    file_layout: str
+    members: Mapping[str, int]
+    tensor_count: int
+    moved_files: int
+    rewritten_files: int
+
+    def as_attrs(self) -> dict[str, str]:
+        """Checkpoint attributes — the produced shape, stated not implied."""
+
+        return {
+            "tree_repack": self.name,
+            "file_layout": self.file_layout,
+            "repack_members": ",".join(
+                f"{comp}:{n}" for comp, n in sorted(self.members.items())),
+            "repack_tensor_count": str(self.tensor_count),
+        }
+
+
+# ------------------------------------------------------------- safetensors I/O
+
+
+def _read_header(path: Path) -> tuple[dict[str, Any], int]:
+    """``(header, data_start)`` from a safetensors file — 8 bytes plus a JSON blob."""
+
+    with open(path, "rb") as f:
+        raw = f.read(8)
+        if len(raw) != 8:
+            raise TreeRepackError(f"{path.name} is not a safetensors file (truncated header)")
+        (length,) = struct.unpack("<Q", raw)
+        if not header_len_ok(length):
+            raise TreeRepackError(
+                f"{path.name} declares a {length}-byte safetensors header, which is past the "
+                "sanctioned bound — a downloaded tree states this number and this process "
+                "would allocate it")
+        blob = f.read(length)
+        if len(blob) != length:
+            raise TreeRepackError(f"{path.name} is not a safetensors file (short header)")
+    try:
+        header = json.loads(blob)
+    except Exception as exc:  # noqa: BLE001
+        raise TreeRepackError(f"{path.name} has an unreadable safetensors header: {exc}") from exc
+    if not isinstance(header, dict):
+        raise TreeRepackError(f"{path.name} has a non-object safetensors header")
+    return header, 8 + length
+
+
+def _tensor_entries(header: Mapping[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Header rows in ON-DISK order, ``__metadata__`` excluded."""
+
+    rows = [
+        (str(name), dict(value))
+        for name, value in header.items()
+        if name != "__metadata__" and isinstance(value, dict) and "data_offsets" in value
+    ]
+    rows.sort(key=lambda row: int(row[1]["data_offsets"][0]))
+    return rows
+
+
+def _write_subset(src: Path, dst: Path, mapping: Mapping[str, str]) -> int:
+    """Write ``dst`` carrying ``mapping``'s tensors out of ``src``, byte for byte.
+
+    Only the header is rebuilt. Each tensor's payload is copied as the byte
+    range the source header points at, in source order, so a repacked tensor is
+    bit-identical to the one it came from and no dtype or shape can move here.
+    """
+
+    header, data_start = _read_header(src)
+    metadata = header.get("__metadata__")
+
+    out_header: dict[str, Any] = {}
+    plan: list[tuple[int, int]] = []
+    offset = 0
+    for name, info in _tensor_entries(header):
+        if name not in mapping:
+            continue
+        start, end = int(info["data_offsets"][0]), int(info["data_offsets"][1])
+        length = end - start
+        out_header[mapping[name]] = {
+            "dtype": info["dtype"],
+            "shape": list(info["shape"]),
+            "data_offsets": [offset, offset + length],
+        }
+        plan.append((data_start + start, length))
+        offset += length
+    if isinstance(metadata, dict):
+        out_header["__metadata__"] = {str(k): str(v) for k, v in metadata.items()}
+
+    blob = json.dumps(out_header, separators=(",", ":")).encode("utf-8")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with open(src, "rb") as fin, open(dst, "wb") as fout:
+        fout.write(struct.pack("<Q", len(blob)))
+        fout.write(blob)
+        for start, length in plan:
+            fin.seek(start)
+            remaining = length
+            while remaining > 0:
+                chunk = fin.read(min(_COPY_CHUNK, remaining))
+                if not chunk:
+                    raise TreeRepackError(
+                        f"{src.name} ended inside a declared tensor range — the file is "
+                        "shorter than its own header says")
+                fout.write(chunk)
+                remaining -= len(chunk)
+    return offset
+
+
+def _root_weight_members(root: Path) -> list[Path]:
+    """The root's safetensors files, in index order when an index names them."""
+
+    ordered: list[Path] = []
+    indexed: set[str] = set()
+    for index_path in sorted(root.glob("*.safetensors.index.json")):
+        try:
+            weight_map = json.loads(index_path.read_text("utf-8")).get("weight_map") or {}
+        except Exception:  # noqa: BLE001
+            continue
+        for name in dict.fromkeys(str(v) for v in weight_map.values()):
+            indexed.add(name)
+            member = root / name
+            if member.is_file() and member not in ordered:
+                ordered.append(member)
+    for member in sorted(root.glob("*.safetensors")):
+        if member.is_file() and member.name not in indexed and member not in ordered:
+            ordered.append(member)
+    return ordered
+
+
+# --------------------------------------------------------------- JSON helpers
+
+
+def _dotted_get(doc: Mapping[str, Any], path: str) -> Any:
+    node: Any = doc
+    for part in path.split("."):
+        if not isinstance(node, Mapping) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def _dotted_set(doc: dict[str, Any], path: str, value: Any) -> None:
+    parts = path.split(".")
+    node = doc
+    for part in parts[:-1]:
+        child = node.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            node[part] = child
+        node = child
+    node[parts[-1]] = value
+
+
+def _apply_fields(
+    source_doc: Mapping[str, Any], fields: tuple[ConfigField, ...], *, where: str,
+    into: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    out: dict[str, Any] = dict(into or {})
+    for f in fields:
+        if not f.source:
+            _dotted_set(out, f.target, f.value)
+            continue
+        value = _dotted_get(source_doc, f.source)
+        if value is None:
+            if f.required:
+                raise TreeRepackError(
+                    f"{where}: the source document carries no {f.source!r}, which "
+                    f"{f.target!r} is declared to come from — a config field that "
+                    "quietly defaulted would describe a checkpoint this is not")
+            continue
+        _dotted_set(out, f.target, value)
+    return out
+
+
+def _load_json(path: Path, *, where: str) -> dict[str, Any]:
+    try:
+        doc = json.loads(path.read_text("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise TreeRepackError(f"{where}: {path.name} is not readable JSON: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise TreeRepackError(f"{where}: {path.name} is not a JSON object")
+    return doc
+
+
+def _write_json(path: Path, doc: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------- the engine
+
+
+def apply_tree_repack(tree: Path | str, spec: TreeRepack) -> RepackReport:
+    """Repack ``tree`` in place into ``spec``'s diffusers shape."""
+
+    root = Path(tree)
+    if not root.is_dir():
+        raise TreeRepackError(f"repack {spec.name!r}: {root} is not a directory")
+    if (root / "model_index.json").exists():
+        raise TreeRepackError(
+            f"repack {spec.name!r}: {root.name} already carries a model_index.json — it is "
+            "already component-shaped, and repacking it again would route its keys a "
+            "second time")
+    already = sorted(
+        d.name for d in root.iterdir() if d.is_dir() and any(d.glob("*.safetensors")))
+    if already:
+        raise TreeRepackError(
+            f"repack {spec.name!r} expects a FLAT source tree; {root.name} already carries "
+            f"weights under {already}")
+
+    members = _root_weight_members(root)
+    if not members:
+        raise TreeRepackError(f"repack {spec.name!r}: no safetensors at the tree root")
+
+    # ---- route every key, then refuse before a single byte moves
+    per_file: list[tuple[Path, list[tuple[str, dict[str, Any]]]]] = [
+        (member, _tensor_entries(_read_header(member)[0])) for member in members
+    ]
+    source_keys = [name for _, rows in per_file for name, _ in rows]
+    missing = [p for p in spec.requires_key_prefixes
+               if not any(k.startswith(p) for k in source_keys)]
+    if missing:
+        raise TreeRepackError(
+            f"repack {spec.name!r}: this tree carries no key under {missing} — its "
+            f"declaration requires {list(spec.requires_key_prefixes)}, so this is not a "
+            f"{spec.name} tree and repacking it would produce a plausible wrong answer")
+
+    routes: dict[str, dict[Path, dict[str, str]]] = {c.name: {} for c in spec.weight_components}
+    produced_keys: dict[str, set[str]] = {c.name: set() for c in spec.weight_components}
+    unrouted: list[str] = []
+    tensor_count = 0
+    for member, rows in per_file:
+        for name, _info in rows:
+            comp = spec.component_for(name)
+            if comp is None:
+                unrouted.append(name)
+                continue
+            new_key = comp.rename(name)
+            if new_key in produced_keys[comp.name]:
+                raise TreeRepackError(
+                    f"repack {spec.name!r}: two source keys rename onto {new_key!r} in "
+                    f"component {comp.name!r} — one of the tensors would be lost")
+            produced_keys[comp.name].add(new_key)
+            routes[comp.name].setdefault(member, {})[name] = new_key
+            tensor_count += 1
+    if unrouted:
+        raise TreeRepackError(
+            f"repack {spec.name!r}: {len(unrouted)} source key(s) match no component and "
+            f"this declaration has no catch-all — first: {sorted(unrouted)[:4]}. A repack "
+            "that dropped them would publish a tree that loads one tensor short")
+
+    # ---- move or rewrite, per component, preserving members
+    keys_in_file = {member: {name for name, _ in rows} for member, rows in per_file}
+    written: dict[str, int] = {}
+    moved = rewritten = 0
+    for comp in spec.weight_components:
+        contributions = routes[comp.name]
+        files = [m for m in members if m in contributions]
+        if not files:
+            raise TreeRepackError(
+                f"repack {spec.name!r}: component {comp.name!r} claims no key in this tree")
+        comp_dir = root / comp.name
+        comp_dir.mkdir(parents=True, exist_ok=True)
+        total = len(files)
+        written[comp.name] = total
+        weight_map: dict[str, str] = {}
+        for i, member in enumerate(files, start=1):
+            mapping = contributions[member]
+            name = (
+                f"{comp.weight_stem}.safetensors" if total == 1
+                else f"{comp.weight_stem}-{i:05d}-of-{total:05d}.safetensors"
+            )
+            dst = comp_dir / name
+            whole = set(mapping) == keys_in_file[member]
+            identity = all(src == dst_key for src, dst_key in mapping.items())
+            if whole and identity:
+                # The cheapest correct thing: the file IS the member. No bytes
+                # are read, so a 35 GB member costs a rename.
+                os.replace(member, dst)
+                moved += 1
+            else:
+                _write_subset(member, dst, mapping)
+                rewritten += 1
+            for new_key in mapping.values():
+                weight_map[new_key] = name
+        if total > 1:
+            _write_json(comp_dir / f"{comp.weight_stem}.safetensors.index.json", {
+                "metadata": {"total_size": sum(
+                    p.stat().st_size for p in comp_dir.glob(f"{comp.weight_stem}-*.safetensors"))},
+                "weight_map": dict(sorted(weight_map.items())),
+            })
+
+    # A member that was MOVED is already gone; one that was rewritten (renamed
+    # keys, or split across components) has had every one of its tensors copied
+    # out by now — the loop above is the only reader — so the original dies here
+    # rather than after each component, which would break the second reader.
+    for member in members:
+        if member.exists():
+            member.unlink()
+
+    # ---- component configs and routed files
+    for comp in spec.components:
+        comp_dir = root / comp.name
+        comp_dir.mkdir(parents=True, exist_ok=True)
+        if comp.config is not None:
+            _write_component_config(root, comp_dir, comp, comp.config, spec)
+        for route in comp.files:
+            _move_routed_file(root, comp_dir, route, where=f"repack {spec.name!r}/{comp.name}")
+
+    # ---- model_index.json, then the root is only what the declaration keeps
+    index: dict[str, Any] = {
+        "_class_name": spec.pipeline_class,
+        "_diffusers_version": spec.diffusers_version,
+    }
+    for comp in spec.components:
+        index[comp.name] = [comp.library, comp.class_name]
+    _write_json(root / "model_index.json", index)
+
+    keep = {"model_index.json", *spec.keep_root}
+    for leftover in sorted(root.iterdir()):
+        if leftover.is_dir():
+            continue
+        if leftover.name in keep:
+            continue
+        leftover.unlink()
+
+    layout = observed_file_layout(root)
+    report = RepackReport(
+        name=spec.name, file_layout=layout, members=dict(written),
+        tensor_count=tensor_count, moved_files=moved, rewritten_files=rewritten,
+    )
+    logger.info(
+        "clone.repack name=%s components=%s members=%s tensors=%d moved=%d rewritten=%d "
+        "file_layout=%s",
+        spec.name, [c.name for c in spec.components], report.members, tensor_count,
+        moved, rewritten, layout,
+    )
+    return report
+
+
+def _write_component_config(
+    root: Path, comp_dir: Path, comp: RepackComponent, config: ComponentConfig,
+    spec: TreeRepack,
+) -> None:
+    where = f"repack {spec.name!r}/{comp.name}"
+    doc: Mapping[str, Any] = {}
+    if any(f.source for f in config.fields):
+        source = root / config.source
+        if not source.is_file():
+            raise TreeRepackError(
+                f"{where}: the source tree has no {config.source!r} to derive "
+                f"{comp.name}/config.json from")
+        doc = _load_json(source, where=where)
+    out = _apply_fields(doc, config.fields, where=where, into={
+        "_class_name": comp.class_name,
+        "_diffusers_version": spec.diffusers_version,
+    })
+    _write_json(comp_dir / "config.json", out)
+
+
+def _move_routed_file(root: Path, comp_dir: Path, route: FileRoute, *, where: str) -> None:
+    src = root / route.source
+    if not src.is_file():
+        if route.required:
+            raise TreeRepackError(
+                f"{where}: the source tree has no {route.source!r}, which this declaration "
+                "routes into the component — a component missing a declared file loads as a "
+                "different component")
+        return
+    dst = comp_dir / route.name
+    if route.json_overrides:
+        doc = _load_json(src, where=where)
+        _write_json(dst, _apply_fields({}, route.json_overrides, where=where, into=doc))
+        src.unlink()
+        return
+    try:
+        os.replace(src, dst)
+    except OSError:  # pragma: no cover — cross-device moves inside one workdir
+        shutil.move(str(src), str(dst))

--- a/src/gen_worker/convert/tree_repack_families.py
+++ b/src/gen_worker/convert/tree_repack_families.py
@@ -1,0 +1,124 @@
+"""The platform's declared tree repacks — one table, read as data.
+
+Each entry is a KEY MAP plus the config derivation that goes with it. Adding a
+family is adding a row here; nothing else in ``convert/`` learns a model's
+name.
+"""
+
+from __future__ import annotations
+
+from .tree_repack import register_tree_repack
+from .tree_repack_spec import (
+    ComponentConfig,
+    ConfigField,
+    FileRoute,
+    RepackComponent,
+    TreeRepack,
+)
+
+__all__ = ["SENSENOVA_U1_MOT"]
+
+
+def _llm(target: str, source: str | None = None) -> ConfigField:
+    return ConfigField(f"llm.{target}", f"llm_config.{source or target}")
+
+
+def _vision(target: str, source: str | None = None) -> ConfigField:
+    return ConfigField(f"vision.{target}", f"vision_config.{source or target}")
+
+
+def _root(name: str) -> ConfigField:
+    return ConfigField(name, name)
+
+
+#: SenseNova-U1.5-8B-MoT — a NATIVELY unified model that is ONE component.
+#:
+#: There is no VAE and no text encoder to split out: the understanding stream IS
+#: the text encoder and the pixel head IS the decoder (se#840's porting map). So
+#: the key map is deliberately the identity — ``language_model.*``,
+#: ``vision_model.*`` and ``fm_modules.*`` are already the module path the
+#: endpoint's ``SenseNovaU1`` carries, and the component DIRECTORY is what
+#: supplies the "transformer" scope in a diffusers tree. What the repack
+#: actually produces is the directory shape, the two config documents and the
+#: ``model_index.json`` that make ``ctx.load`` hollow-legal — the flat upstream
+#: root is not loadable by our code at all, because the hollow session
+#: intercepts only diffusers/transformers loaders and a root ``config.json``
+#: whose ``auto_map`` names four ``.py`` files that do not exist reaches none of
+#: them.
+#:
+#: The three declared ``requires_key_prefixes`` are what stops this map running
+#: over a tree that merely happens to be flat.
+SENSENOVA_U1_MOT = register_tree_repack(TreeRepack(
+    name="sensenova-u1.mot",
+    pipeline_class="SenseNovaU1Pipeline",
+    requires_key_prefixes=("language_model.", "vision_model.", "fm_modules."),
+    components=(
+        RepackComponent(
+            name="transformer",
+            library="sensenova_u1",
+            class_name="SenseNovaU1",
+            weight_stem="diffusion_pytorch_model",
+            # No key_prefixes: the model is one component, so this is the
+            # catch-all and nothing can fall out of the tree unnoticed.
+            config=ComponentConfig(source="config.json", fields=(
+                _llm("hidden_size"),
+                _llm("intermediate_size"),
+                _llm("num_hidden_layers"),
+                _llm("num_attention_heads"),
+                _llm("num_key_value_heads"),
+                _llm("head_dim"),
+                _llm("rms_norm_eps"),
+                _llm("rope_theta"),
+                _llm("rope_theta_hw"),
+                _llm("vocab_size"),
+                _llm("attention_bias"),
+                _vision("hidden_size"),
+                _vision("llm_hidden_size"),
+                _vision("patch_size"),
+                _vision("num_channels"),
+                _vision("downsample_ratio"),
+                _vision("rope_theta_vision"),
+                _vision("max_position_embeddings_vision"),
+                _root("patch_size"),
+                _root("downsample_ratio"),
+                _root("t_eps"),
+                _root("noise_scale"),
+                _root("noise_scale_mode"),
+                _root("noise_scale_base_image_seq_len"),
+                _root("noise_scale_max_value"),
+                _root("add_noise_scale_embedding"),
+                # NOT transcribed, deliberately: `timestep_shift`, the
+                # `dynamic` schedule and the flow-matching-head geometry. The
+                # config's `timestep_shift` is 1.0 and the reference
+                # implementation SERVES 3.0, `time_schedule` is hard-forced to
+                # "standard" by upstream's own code, and `use_pixel_head` turns
+                # the fm-head fields off. A field nobody reads is a field that
+                # drifts silently — the serving values live in
+                # `SenseNovaU1Defaults` (pgw#1664) where they are one producer.
+            )),
+        ),
+        RepackComponent(
+            name="tokenizer",
+            library="transformers",
+            class_name="Qwen2TokenizerFast",
+            files=(
+                FileRoute("vocab.json"),
+                FileRoute("merges.txt"),
+                FileRoute("added_tokens.json"),
+                FileRoute("special_tokens_map.json"),
+                # The upstream repo ships NO `tokenizer.json`; the fast
+                # tokenizer is built from vocab+merges on first load. Declared
+                # optional so a source that does ship one carries it through.
+                FileRoute("tokenizer.json", required=False),
+                FileRoute("tokenizer_config.json", json_overrides=(
+                    # `model_index.json` says Qwen2TokenizerFast and upstream's
+                    # own document says Qwen2Tokenizer. Two spellings of one
+                    # fact is how an AutoTokenizer load lands on the slow class
+                    # while the pipeline believes it has the fast one.
+                    ConfigField("tokenizer_class", value="Qwen2TokenizerFast"),
+                )),
+            ),
+        ),
+    ),
+    keep_root=("README.md", "README_CN.md", "LICENSE", "LICENSE.txt", ".gitattributes"),
+))

--- a/src/gen_worker/convert/tree_repack_spec.py
+++ b/src/gen_worker/convert/tree_repack_spec.py
@@ -1,0 +1,243 @@
+"""The TREE-REPACK declaration schema — a key map, not a model.
+
+This is the second repackage vocabulary in ``convert/`` and the two are not
+alternatives. :mod:`repack_spec` declares a LOAD-and-resave: a diffusers
+pipeline class is named, instantiated from a single file and written back out
+(``SinglefileTarget(pipeline_class=…)``). That needs a class the diffusers SDK
+can name, weights in memory, and a card's worth of RAM.
+
+A tree repack is a transform over HEADERS AND NAMES. It re-routes a flat
+transformers-shaped tree's keys into diffusers component directories, writes
+each component's ``config.json`` from the source config by declared field, moves
+the tokenizer files into their own directory, and emits ``model_index.json``.
+No tensor is ever materialized: tensor DATA is copied as byte ranges, so every
+tensor in the produced tree is byte-identical to the one it came from.
+
+Why the platform needs one (se#840's ruling, pgw#1670): a mirror reproduces the
+upstream layout, and a flat root beside a ``config.json`` whose ``auto_map``
+names ``.py`` files that do not exist cannot be ``ctx.load``ed hollow-legally —
+the hollow session intercepts only diffusers/transformers loaders, so an
+endpoint's component classes have to be reachable through a
+``model_index.json``. Doing it as a CONVERSION LEG keeps one producer of the
+published artifact and keeps the serving path free of per-endpoint tree-shape
+knowledge.
+
+⚠️ A declaration is refused at declaration time for anything that would DROP
+keys silently — an unroutable key, two catch-alls, a component that carries
+neither weights nor files. Losing a tensor is the failure mode this schema
+exists to make impossible, and it is not detectable downstream: the tree still
+loads, one weight short.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .repack_spec import DeclarationError, RenameRule
+
+__all__ = [
+    "ComponentConfig",
+    "ConfigField",
+    "DeclarationError",
+    "FileRoute",
+    "RepackComponent",
+    "TreeRepack",
+    "TreeRepackError",
+]
+
+
+class TreeRepackError(ValueError):
+    """A tree cannot be repacked as declared — a REFUSAL, never a fallback."""
+
+
+@dataclass(frozen=True)
+class ConfigField:
+    """One field of a produced JSON document, and where its value comes from.
+
+    Exactly one of ``source`` (a dotted path in the source document) and
+    ``value`` (a literal) supplies it. A declared ``source`` that the source
+    document does not carry REFUSES when ``required`` — a config field silently
+    defaulting is how a serving config drifts from the checkpoint it describes.
+    """
+
+    target: str
+    source: str = ""
+    value: Any = None
+    required: bool = True
+
+    def __post_init__(self) -> None:
+        if not str(self.target or "").strip():
+            raise DeclarationError("ConfigField.target is empty")
+        if bool(str(self.source or "").strip()) == (self.value is not None):
+            raise DeclarationError(
+                f"ConfigField {self.target!r} must declare exactly one of "
+                "source=<dotted path> or value=<literal>"
+            )
+
+
+@dataclass(frozen=True)
+class ComponentConfig:
+    """How one component's ``config.json`` is derived from the source tree."""
+
+    source: str = "config.json"
+    fields: tuple[ConfigField, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.fields:
+            raise DeclarationError("ComponentConfig declares no fields")
+        seen: set[str] = set()
+        for f in self.fields:
+            if f.target in seen:
+                raise DeclarationError(f"config field {f.target!r} declared twice")
+            seen.add(f.target)
+        if any(f.source for f in self.fields) and not str(self.source or "").strip():
+            raise DeclarationError(
+                "ComponentConfig reads source fields but names no source document")
+
+
+@dataclass(frozen=True)
+class FileRoute:
+    """A non-weight file that MOVES from the tree root into a component."""
+
+    source: str
+    target_name: str = ""
+    json_overrides: tuple[ConfigField, ...] = ()
+    required: bool = True
+
+    def __post_init__(self) -> None:
+        name = str(self.source or "").strip()
+        if not name or name.startswith("/") or ".." in name.split("/"):
+            raise DeclarationError(f"FileRoute.source is not a tree-relative path: {self.source!r}")
+        for override in self.json_overrides:
+            if override.source:
+                raise DeclarationError(
+                    f"FileRoute {name!r}: a json override sets a literal; "
+                    f"{override.target!r} declares source={override.source!r}")
+
+    @property
+    def name(self) -> str:
+        return str(self.target_name or "").strip() or self.source.rsplit("/", 1)[-1]
+
+
+@dataclass(frozen=True)
+class RepackComponent:
+    """One directory of the produced tree, and one row of ``model_index.json``."""
+
+    name: str
+    library: str
+    class_name: str
+    key_prefixes: tuple[str, ...] = ()
+    rules: tuple[RenameRule, ...] = ()
+    weight_stem: str = ""
+    config: ComponentConfig | None = None
+    files: tuple[FileRoute, ...] = ()
+
+    def __post_init__(self) -> None:
+        name = str(self.name or "").strip()
+        if not name or "/" in name or name.startswith("."):
+            raise DeclarationError(f"RepackComponent.name is not a directory name: {self.name!r}")
+        if not str(self.library or "").strip():
+            raise DeclarationError(f"component {name!r} declares no model_index library")
+        if not str(self.class_name or "").strip():
+            raise DeclarationError(f"component {name!r} declares no model_index class")
+        if self.key_prefixes and not self.weight_stem:
+            raise DeclarationError(
+                f"component {name!r} routes keys but declares no weight_stem — "
+                "the tensors would have nowhere to land")
+        if not self.carries_weights and not self.files:
+            raise DeclarationError(
+                f"component {name!r} carries neither weights nor files: it would be an "
+                "EMPTY directory named by model_index.json, which loads as a missing "
+                "component rather than as an error")
+        if self.rules and not self.carries_weights:
+            raise DeclarationError(f"component {name!r} declares key rules but no weights")
+
+    @property
+    def carries_weights(self) -> bool:
+        return bool(str(self.weight_stem or "").strip())
+
+    @property
+    def is_catch_all(self) -> bool:
+        return self.carries_weights and not self.key_prefixes
+
+    def claims(self, key: str) -> bool:
+        return any(key.startswith(p) for p in self.key_prefixes)
+
+    def rename(self, key: str) -> str:
+        out = key
+        for rule in self.rules:
+            out = rule.apply(out)
+        return out
+
+
+@dataclass(frozen=True)
+class TreeRepack:
+    """One family's complete flat-to-diffusers key map."""
+
+    name: str
+    pipeline_class: str
+    components: tuple[RepackComponent, ...]
+    requires_key_prefixes: tuple[str, ...] = ()
+    diffusers_version: str = "0.39.0"
+    keep_root: tuple[str, ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        if not str(self.name or "").strip():
+            raise DeclarationError("TreeRepack.name is empty")
+        if not str(self.pipeline_class or "").strip():
+            raise DeclarationError(f"repack {self.name!r} declares no pipeline_class")
+        if not self.components:
+            raise DeclarationError(f"repack {self.name!r} declares no components")
+        seen: set[str] = set()
+        for comp in self.components:
+            if comp.name in seen:
+                raise DeclarationError(
+                    f"repack {self.name!r} declares component {comp.name!r} twice")
+            seen.add(comp.name)
+        weighted = [c for c in self.components if c.carries_weights]
+        if not weighted:
+            raise DeclarationError(
+                f"repack {self.name!r} routes no weights — a repack that moves no tensor "
+                "produces a tree with no model in it")
+        catch_alls = [c.name for c in weighted if c.is_catch_all]
+        if len(catch_alls) > 1:
+            raise DeclarationError(
+                f"repack {self.name!r} declares {len(catch_alls)} catch-all weight components "
+                f"({', '.join(catch_alls)}) — routing would depend on declaration order and "
+                "the loser would silently take no keys")
+        if catch_alls and weighted[-1].name != catch_alls[0]:
+            raise DeclarationError(
+                f"repack {self.name!r}: the catch-all component {catch_alls[0]!r} must be the "
+                "LAST weight component, otherwise the components after it can never match")
+        routed = {f.source for c in self.components for f in c.files}
+        if len(routed) != sum(len(c.files) for c in self.components):
+            raise DeclarationError(
+                f"repack {self.name!r} routes one source file into two components")
+
+    @property
+    def weight_components(self) -> tuple[RepackComponent, ...]:
+        return tuple(c for c in self.components if c.carries_weights)
+
+    @property
+    def has_catch_all(self) -> bool:
+        return any(c.is_catch_all for c in self.components)
+
+    @property
+    def is_pure_move(self) -> bool:
+        """True when no member can ever need rewriting.
+
+        One weight component takes every key and no key is renamed, so each
+        source member becomes a component member by ``os.replace``: zero bytes
+        read, zero bytes written, zero extra disk. The disk preflight prices
+        this property rather than assuming either answer.
+        """
+
+        return len(self.weight_components) == 1 and not any(c.rules for c in self.components)
+
+    def component_for(self, key: str) -> RepackComponent | None:
+        """The component a source key lands in, or ``None`` if nothing claims it."""
+        for comp in self.weight_components:
+            if comp.is_catch_all or comp.claims(key):
+                return comp
+        return None

--- a/tests/convert/test_tree_repack_pgw1670.py
+++ b/tests/convert/test_tree_repack_pgw1670.py
@@ -676,3 +676,193 @@ def test_a_bf16_source_asked_only_for_a_repack_is_still_repacked(
     assert published[0].path.resolve() != source_dir.resolve(), (
         "the SOURCE tree was handed to the publisher — the repack was skipped")
     assert _tensor_digests(source_dir), "the ingest tree was consumed rather than read"
+
+
+# ------------------------------------ the REAL key set and the REAL config
+
+
+#: `sensenova/SenseNova-U1.5-8B-MoT-Preview` rev `13a8d0f3`'s own
+#: `config.json`, verbatim and entire (2,631 bytes, fetched at $0 — the
+#: document, not one weight byte). Inline rather than as a fixture file so the
+#: diff shows exactly which document the field map below was proven against.
+_REAL_UPSTREAM_CONFIG: dict[str, Any] = json.loads("""{
+    "architectures": [
+        "NEOChatModel"
+    ],
+    "auto_map": {
+        "AutoConfig": "configuration_neo_chat.NEOChatConfig",
+        "AutoModel": "modeling_neo_chat.NEOChatModel",
+        "AutoModelForCausalLM": "modeling_neo_chat.NEOChatModel"
+    },
+    "downsample_ratio": 0.5,
+    "eos_token_id": 151645,
+    "llm_config": {
+        "_name_or_path": null,
+        "architectures": [
+            "Qwen3ForCausalLM"
+        ],
+        "attention_bias": false,
+        "attention_dropout": 0.0,
+        "bos_token_id": 151643,
+        "eos_token_id": 151645,
+        "head_dim": 128,
+        "hidden_act": "silu",
+        "hidden_size": 4096,
+        "intermediate_size": 12288,
+        "max_position_embeddings": 262144,
+        "max_position_embeddings_hw": 10000,
+        "max_window_layers": 42,
+        "model_type": "qwen3",
+        "num_attention_heads": 32,
+        "num_hidden_layers": 42,
+        "num_key_value_heads": 8,
+        "rms_norm_eps": 1e-06,
+        "rope_scaling": null,
+        "rope_theta": 5000000.0,
+        "rope_theta_hw": 10000.0,
+        "sliding_window": null,
+        "torch_dtype": "bfloat16",
+        "use_cache": false,
+        "use_deepep": false,
+        "use_sliding_window": false,
+        "vocab_size": 151936,
+        "pure_llm": false
+    },
+    "model_type": "neo_chat",
+    "pad_token_id": 151643,
+    "template": "neo1_0",
+    "tie_word_embeddings": false,
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.37.2",
+    "use_backbone_lora": 0,
+    "use_llm_lora": 0,
+    "min_pixels": 65536,
+    "max_pixels": 16777216,
+    "patch_size": 16,
+    "timestep_shift": 1.0,
+    "time_schedule": "standard",
+    "time_shift_type": "exponential",
+    "base_shift": 0.5,
+    "max_shift": 1.15,
+    "base_image_seq_len": 64,
+    "max_image_seq_len": 4096,
+    "noise_scale_mode": "resolution",
+    "noise_scale_base_image_seq_len": 64,
+    "add_noise_scale_embedding": true,
+    "noise_scale_max_value": 16.0,
+    "noise_scale": 1.0,
+    "P_mean": -0.8,
+    "P_std": 0.8,
+    "t_eps": 0.05,
+    "fm_head_dim": 1536,
+    "fm_head_layers": 2,
+    "fm_head_mlp_ratio": 1,
+    "extra_num_layers_post": 0,
+    "concat_time_token_num": 0,
+    "use_pixel_head": true,
+    "use_adaLN": false,
+    "vision_config": {
+        "architectures": [
+            "NEOVisionModel"
+        ],
+        "attention_dropout": 0.0,
+        "auto_map": {
+            "AutoConfig": "configuration_neo_vit.NEOVisionConfig",
+            "AutoModel": "modeling_neo_vit.NEOVisionModel"
+        },
+        "llm_hidden_size": 4096,
+        "downsample_ratio": 0.5,
+        "hidden_size": 1024,
+        "model_type": "neo_vision",
+        "rope_theta_vision": 10000.0,
+        "max_position_embeddings_vision": 10000,
+        "num_channels": 3,
+        "patch_size": 16,
+        "torch_dtype": "bfloat16",
+        "transformers_version": "4.37.2",
+        "min_pixels": 65536,
+        "max_pixels": 16777216
+    }
+}""")
+
+#: What the endpoint's `transformer/config.json` MUST be: the tree the first
+#: real `gen-worker lock --checkpoint` derive hollow-loaded to 100% on both
+#: components (se#840). `SenseNovaConfig(llm=LLMConfig(**llm), ...)` is built
+#: from these kwargs, so an extra key is a `TypeError` at load and a missing one
+#: is a silently wrong default.
+_ENDPOINT_TRANSFORMER_CONFIG: dict[str, Any] = {
+    "_class_name": "SenseNovaU1",
+    "_diffusers_version": "0.39.0",
+    "llm": {
+        "hidden_size": 4096, "intermediate_size": 12288, "num_hidden_layers": 42,
+        "num_attention_heads": 32, "num_key_value_heads": 8, "head_dim": 128,
+        "rms_norm_eps": 1e-06, "rope_theta": 5000000.0, "rope_theta_hw": 10000.0,
+        "vocab_size": 151936, "attention_bias": False,
+    },
+    "vision": {
+        "hidden_size": 1024, "llm_hidden_size": 4096, "patch_size": 16,
+        "num_channels": 3, "downsample_ratio": 0.5, "rope_theta_vision": 10000.0,
+        "max_position_embeddings_vision": 10000,
+    },
+    "patch_size": 16, "downsample_ratio": 0.5, "t_eps": 0.05, "noise_scale": 1.0,
+    "noise_scale_mode": "resolution", "noise_scale_base_image_seq_len": 64,
+    "noise_scale_max_value": 16.0, "add_noise_scale_embedding": True,
+}
+
+
+def _real_key_names() -> list[str]:
+    """All 1116 upstream key names, out of the VENDORED tensorfs corpus.
+
+    `sensenova-u1.mot@1` (tensorfs#161) was extracted from the real published
+    headers by HTTP range, so its tensor table IS the upstream key set — and it
+    is already in this repo. Copying the names into a fixture would be a second
+    producer of a fact the corpus already carries.
+    """
+
+    root = Path(__file__).resolve().parents[2] / "src" / "gen_worker" / "_vendor"
+    doc = json.loads(
+        (root / "tensorfs" / "spec" / "v2" / "topologies"
+         / "sensenova-u1.mot.v1.json").read_text("utf-8"))
+    names = [n for comp in doc["components"] for n in comp["tensors"]]
+    assert len(names) == 1116, f"the vendored corpus moved: {len(names)} names"
+    return names
+
+
+def test_the_real_key_set_and_the_real_config_produce_the_endpoints_tree(
+    tmp_path: Path,
+) -> None:
+    """The deliverable, against upstream's OWN documents rather than a fixture.
+
+    A field map that resolves on a hand-written fixture and not on the real
+    `config.json` is the exact bug this case exists to catch — the real one
+    nests under `llm_config`/`vision_config`, carries a dead `auto_map`, and
+    states a `timestep_shift` the reference implementation does not serve.
+    """
+
+    tree = tmp_path / "flat"
+    tree.mkdir()
+    (tree / "config.json").write_text(json.dumps(_REAL_UPSTREAM_CONFIG))
+    (tree / "vocab.json").write_text("{}")
+    (tree / "merges.txt").write_text("#version: 0.2\n")
+    (tree / "added_tokens.json").write_text("{}")
+    (tree / "special_tokens_map.json").write_text("{}")
+    (tree / "tokenizer_config.json").write_text(
+        json.dumps({"tokenizer_class": "Qwen2Tokenizer"}))
+    names = _real_key_names()
+    (tree / "model.safetensors").write_bytes(
+        _safetensors({name: ("BF16", 1) for name in names}))
+
+    report = apply_tree_repack(tree, require_tree_repack("sensenova-u1.mot"))
+
+    assert report.tensor_count == 1116, "a real key fell out of the routing"
+    assert json.loads((tree / "transformer" / "config.json").read_text()) == (
+        _ENDPOINT_TRANSFORMER_CONFIG), (
+        "the derived component config is not the one the endpoint's SenseNovaU1 "
+        "kwargs accept — an extra key is a TypeError at load and a missing one "
+        "is a silently wrong default")
+
+    member = tree / "transformer" / "diffusion_pytorch_model.safetensors"
+    raw = member.read_bytes()
+    header = json.loads(raw[8:8 + int.from_bytes(raw[:8], "little")])
+    assert set(header) - {"__metadata__"} == set(names), (
+        "the produced component does not carry exactly the upstream key set")

--- a/tests/convert/test_tree_repack_pgw1670.py
+++ b/tests/convert/test_tree_repack_pgw1670.py
@@ -1,0 +1,678 @@
+"""pgw#1670 — the diffusers repack as a KEY-LEVEL leg of the conversion job.
+
+se#840's mirror published an honest flat bf16 tree that the endpoint cannot
+load: the hollow session intercepts only diffusers/transformers loaders, so a
+component class has to be reachable through a ``model_index.json``, and a flat
+root beside a ``config.json`` whose ``auto_map`` names four ``.py`` files that
+do not exist is not that. The ruling put the repack on the conversion leg, and
+the repack that already existed could not be it — ``singlefile_to_diffusers``
+LOADS a declared diffusers pipeline class and saves it back, which needs a
+class the SDK can name and a card's worth of RAM.
+
+What these cases hold, and each is red when the thing it names is removed:
+
+* the produced tree HAS the shape — component directories, the derived
+  component config, the tokenizer split, ``model_index.json``;
+* every tensor's BYTES survive the rename — digest per tensor, before and
+  after, and the digest is of the tensor payload rather than of the file;
+* an unknown family is a TYPED refusal that names what is declared, never a
+  detection and never a pass-through;
+* keys that no component claims REFUSE rather than vanish;
+* a requested repack cannot be satisfied by publishing the source unchanged,
+  which is the substitution shape that already cost this checkpoint two jobs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fake_hub import _FakeHub
+
+from gen_worker.convert.clone import (
+    CAST_OUTPUT,
+    NOT_POSSIBLE,
+    PUBLISH_SOURCE,
+    OutputSpec,
+    normalize_outputs,
+    run_clone,
+    spec_actions,
+)
+from gen_worker.convert.ingest import IngestedSource, detect_snapshot_dtype
+from gen_worker.convert.tree_repack import (
+    apply_tree_repack,
+    registered_tree_repacks,
+    require_tree_repack,
+)
+from gen_worker.convert.tree_repack_spec import (
+    ComponentConfig,
+    ConfigField,
+    DeclarationError,
+    FileRoute,
+    RepackComponent,
+    TreeRepack,
+    TreeRepackError,
+)
+from gen_worker.hubio.client import files_from_tree
+from gen_worker.models.file_layout import MULTI_FILE
+
+_WIDTH = {"F64": 8, "F32": 4, "BF16": 2, "F16": 2, "I64": 8}
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+def _safetensors(tensors: dict[str, tuple[str, int]]) -> bytes:
+    header: dict[str, Any] = {}
+    offset = 0
+    for name, (dtype, count) in tensors.items():
+        end = offset + count * _WIDTH[dtype]
+        header[name] = {"dtype": dtype, "shape": [count], "data_offsets": [offset, end]}
+        offset = end
+    blob = json.dumps(header).encode()
+    body = bytes(bytearray((i * 37 + 11) % 251 for i in range(offset)))
+    return struct.pack("<Q", len(blob)) + blob + body
+
+
+def _tensor_digests(root: Path) -> dict[str, str]:
+    """``{tensor name: sha256 of its PAYLOAD}`` over a whole tree.
+
+    Of the payload and not of the file, because that is the claim under test:
+    a repack renames tensors and moves files, and neither may touch a byte of
+    any tensor.
+    """
+
+    out: dict[str, str] = {}
+    for path in sorted(Path(root).rglob("*.safetensors")):
+        with open(path, "rb") as f:
+            (n,) = struct.unpack("<Q", f.read(8))
+            header = json.loads(f.read(n))
+            data_start = 8 + n
+            for name, info in header.items():
+                if name == "__metadata__":
+                    continue
+                start, end = info["data_offsets"]
+                f.seek(data_start + start)
+                payload = f.read(end - start)
+                assert len(payload) == end - start
+                key = f"{name}|{info['dtype']}|{tuple(info['shape'])}"
+                assert key not in out, f"{name} appears twice in {root}"
+                out[key] = hashlib.sha256(payload).hexdigest()
+    return out
+
+
+#: se#840's real key profile, at fixture scale: the MoT split is KEYS, the
+#: understanding stream is `language_model.*`, the pixel tokenizers are
+#: `vision_model.*` and `fm_modules.vision_model_mot_gen.*`.
+def _sensenova_keys(n_layers: int = 3) -> dict[str, tuple[str, int]]:
+    keys: dict[str, tuple[str, int]] = {
+        "language_model.model.embed_tokens.weight": ("BF16", 1024),
+        "language_model.lm_head.weight": ("BF16", 1024),
+        "language_model.model.norm.weight": ("BF16", 32),
+        "language_model.model.norm_mot_gen.weight": ("BF16", 32),
+        "vision_model.embeddings.patch_embedding.weight": ("BF16", 96),
+        "vision_model.embeddings.patch_embedding.bias": ("BF16", 8),
+        "fm_modules.vision_model_mot_gen.embeddings.patch_embedding.weight": ("BF16", 96),
+        "fm_modules.timestep_embedder.mlp.0.weight": ("BF16", 128),
+        "fm_modules.fm_head.conv1.weight": ("BF16", 256),
+    }
+    for i in range(n_layers):
+        keys[f"language_model.model.layers.{i}.self_attn.q_proj.weight"] = ("BF16", 512)
+        keys[f"language_model.model.layers.{i}.self_attn.q_proj_mot_gen.weight"] = ("F32", 512)
+        keys[f"language_model.model.layers.{i}.mlp.gate_proj.weight"] = ("BF16", 512)
+        keys[f"language_model.model.layers.{i}.mlp_mot_gen.gate_proj.weight"] = ("F32", 512)
+    return keys
+
+
+_UPSTREAM_CONFIG: dict[str, Any] = {
+    "architectures": ["NEOChatModel"],
+    "auto_map": {"AutoConfig": "configuration_neo_chat.NEOChatConfig"},
+    "llm_config": {
+        "hidden_size": 4096, "intermediate_size": 12288, "num_hidden_layers": 42,
+        "num_attention_heads": 32, "num_key_value_heads": 8, "head_dim": 128,
+        "rms_norm_eps": 1e-06, "rope_theta": 5000000.0, "rope_theta_hw": 10000.0,
+        "vocab_size": 151936, "attention_bias": False,
+    },
+    "vision_config": {
+        "hidden_size": 1024, "llm_hidden_size": 4096, "patch_size": 16,
+        "num_channels": 3, "downsample_ratio": 0.5, "rope_theta_vision": 10000.0,
+        "max_position_embeddings_vision": 10000,
+    },
+    "patch_size": 16, "downsample_ratio": 0.5, "t_eps": 0.05, "noise_scale": 1.0,
+    "noise_scale_mode": "resolution", "noise_scale_base_image_seq_len": 64,
+    "noise_scale_max_value": 16.0, "add_noise_scale_embedding": True,
+    "timestep_shift": 1.0, "time_schedule": "standard",
+}
+
+
+def _flat_tree(root: Path, *, shards: int = 1, keys: dict[str, tuple[str, int]] | None = None) -> Path:
+    """The shape a mirror produces: weights at the root beside the HF documents."""
+
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_text(json.dumps(_UPSTREAM_CONFIG))
+    (root / "vocab.json").write_text('{"a": 0}')
+    (root / "merges.txt").write_text("#version: 0.2\n")
+    (root / "added_tokens.json").write_text('{"<IMG_CONTEXT>": 151667}')
+    (root / "special_tokens_map.json").write_text('{"eos_token": "<|im_end|>"}')
+    (root / "tokenizer_config.json").write_text(json.dumps({
+        "tokenizer_class": "Qwen2Tokenizer", "eos_token": "<|im_end|>",
+        "model_max_length": 12288,
+    }))
+    (root / "README.md").write_text("# upstream card\n")
+
+    items = list((keys if keys is not None else _sensenova_keys()).items())
+    if shards == 1:
+        (root / "model.safetensors").write_bytes(_safetensors(dict(items)))
+        return root
+    weight_map: dict[str, str] = {}
+    per = (len(items) + shards - 1) // shards
+    for i in range(shards):
+        chunk = dict(items[i * per:(i + 1) * per])
+        assert chunk, "fixture asked for more shards than it has tensors"
+        name = f"model-{i + 1:05d}-of-{shards:05d}.safetensors"
+        (root / name).write_bytes(_safetensors(chunk))
+        for key in chunk:
+            weight_map[key] = name
+    (root / "model.safetensors.index.json").write_text(json.dumps({
+        "metadata": {"total_size": 0}, "weight_map": weight_map}))
+    return root
+
+
+# ------------------------------------------------------- the produced shape
+
+
+def test_a_flat_tree_becomes_the_diffusers_shape_the_endpoint_declares(
+    tmp_path: Path,
+) -> None:
+    """The whole deliverable, against se#840's own fixture shape.
+
+    The endpoint's `tests/fixtures/checkpoint-configs/` is the oracle: it is
+    the tree the first real `gen-worker lock --checkpoint` derive loaded to
+    100% on both components, so it states what the repack must produce.
+    """
+
+    tree = _flat_tree(tmp_path / "flat")
+    report = apply_tree_repack(tree, require_tree_repack("sensenova-u1.mot"))
+
+    index = json.loads((tree / "model_index.json").read_text())
+    assert index["_class_name"] == "SenseNovaU1Pipeline"
+    assert index["transformer"] == ["sensenova_u1", "SenseNovaU1"]
+    assert index["tokenizer"] == ["transformers", "Qwen2TokenizerFast"]
+
+    assert (tree / "transformer" / "diffusion_pytorch_model.safetensors").is_file()
+    config = json.loads((tree / "transformer" / "config.json").read_text())
+    assert config["_class_name"] == "SenseNovaU1"
+    # Derived from the source document, field by declared field — not copied,
+    # and not defaulted.
+    assert config["llm"]["num_hidden_layers"] == 42
+    assert config["llm"]["rope_theta_hw"] == 10000.0
+    assert config["vision"]["llm_hidden_size"] == 4096
+    assert config["add_noise_scale_embedding"] is True
+    assert "auto_map" not in config and "llm_config" not in config
+    # The serving values that upstream's own config is WRONG about stay out of
+    # it: `timestep_shift` 1.0 here against the 3.0 the reference serves.
+    assert "timestep_shift" not in config
+
+    tok = json.loads((tree / "tokenizer" / "tokenizer_config.json").read_text())
+    assert tok["tokenizer_class"] == "Qwen2TokenizerFast", (
+        "model_index says Fast and the tokenizer document must not say otherwise")
+    assert tok["eos_token"] == "<|im_end|>", "the upstream document was replaced, not edited"
+    for name in ("vocab.json", "merges.txt", "added_tokens.json", "special_tokens_map.json"):
+        assert (tree / "tokenizer" / name).is_file(), name
+        assert not (tree / name).exists(), f"{name} was copied rather than moved"
+
+    # The root's dead `auto_map` config is GONE: it is what makes the flat tree
+    # unloadable, and leaving it would leave the tree ambiguous.
+    assert not (tree / "config.json").exists()
+    assert not (tree / "model.safetensors").exists()
+    assert (tree / "README.md").is_file(), "keep_root is declared and must be honoured"
+
+    assert report.file_layout == MULTI_FILE
+    assert report.members == {"transformer": 1}
+    assert report.rewritten_files == 0 and report.moved_files == 1, (
+        "the identity key map must MOVE its members; a rewrite here would read "
+        "and write 35 GB on the pod for nothing")
+
+
+def test_the_shape_is_what_the_declaration_says_and_not_a_constant(
+    tmp_path: Path,
+) -> None:
+    """The RED ARM for the case above: disable the mapping and it must fail.
+
+    A declaration whose components are renamed produces a differently-shaped
+    tree. If the engine were emitting a hardcoded `transformer/` + `tokenizer/`
+    shape, this passes anyway — which is exactly the thing worth knowing.
+    """
+
+    spec = require_tree_repack("sensenova-u1.mot")
+    renamed = TreeRepack(
+        name="fixture-renamed",
+        pipeline_class="OtherPipeline",
+        requires_key_prefixes=spec.requires_key_prefixes,
+        components=(
+            RepackComponent(name="denoiser", library="lib_x", class_name="ClassX",
+                            weight_stem="model", config=spec.components[0].config),
+            RepackComponent(name="text_tokenizer", library="transformers",
+                            class_name="Qwen2TokenizerFast",
+                            files=spec.components[1].files),
+        ),
+        keep_root=spec.keep_root,
+    )
+    tree = _flat_tree(tmp_path / "flat")
+    report = apply_tree_repack(tree, renamed)
+
+    index = json.loads((tree / "model_index.json").read_text())
+    assert index["_class_name"] == "OtherPipeline"
+    assert set(index) == {"_class_name", "_diffusers_version", "denoiser", "text_tokenizer"}
+    assert (tree / "denoiser" / "model.safetensors").is_file()
+    assert (tree / "text_tokenizer" / "vocab.json").is_file()
+    assert not (tree / "transformer").exists()
+    assert report.members == {"denoiser": 1}
+
+
+def test_a_sharded_source_keeps_its_members_and_gets_an_index(tmp_path: Path) -> None:
+    """Members are PRESERVED — the repack neither shards nor de-shards.
+
+    pgw#1669 is the live record of a produced layout being replaced without
+    anyone saying so. This leg's answer is narrow and checkable: N members in,
+    N members out, and the produced layout is read back off the tree.
+    """
+
+    tree = _flat_tree(tmp_path / "flat", shards=4)
+    before = _tensor_digests(tree)
+    report = apply_tree_repack(tree, require_tree_repack("sensenova-u1.mot"))
+
+    comp = tree / "transformer"
+    members = sorted(p.name for p in comp.glob("*.safetensors"))
+    assert members == [
+        f"diffusion_pytorch_model-{i:05d}-of-00004.safetensors" for i in range(1, 5)]
+    assert report.members == {"transformer": 4}
+    assert report.moved_files == 4 and report.rewritten_files == 0
+
+    index = json.loads((comp / "diffusion_pytorch_model.safetensors.index.json").read_text())
+    assert set(index["weight_map"]) == set(_sensenova_keys())
+    assert set(index["weight_map"].values()) == set(members)
+    assert index["metadata"]["total_size"] == sum(
+        (comp / m).stat().st_size for m in members)
+    assert _tensor_digests(tree) == before
+
+
+# ------------------------------------------------------- the bytes are safe
+
+
+def test_every_tensor_is_byte_identical_under_the_rename(tmp_path: Path) -> None:
+    """The load-bearing property: a repack is a rename, and a rename is free.
+
+    Driven through a declaration that REALLY renames, because the SenseNova
+    map is the identity and an identity map cannot falsify this.
+    """
+
+    spec = require_tree_repack("sensenova-u1.mot")
+    from gen_worker.convert.repack_spec import RenameRule
+
+    prefixed = TreeRepack(
+        name="fixture-prefixed",
+        pipeline_class="OtherPipeline",
+        requires_key_prefixes=spec.requires_key_prefixes,
+        components=(
+            RepackComponent(
+                name="transformer", library="lib_x", class_name="ClassX",
+                weight_stem="diffusion_pytorch_model",
+                rules=(RenameRule(kind="prefix", pairs=(("language_model.", "lm."),
+                                                        ("fm_modules.", "fm."))),),
+                config=spec.components[0].config,
+            ),
+            RepackComponent(name="tokenizer", library="transformers",
+                            class_name="Qwen2TokenizerFast",
+                            files=spec.components[1].files),
+        ),
+        keep_root=spec.keep_root,
+    )
+
+    tree = _flat_tree(tmp_path / "flat", shards=3)
+    before = _tensor_digests(tree)
+    report = apply_tree_repack(tree, prefixed)
+    after = _tensor_digests(tree)
+
+    assert report.rewritten_files == 3 and report.moved_files == 0, (
+        "a renaming map cannot be satisfied by moving files")
+    assert len(after) == len(before) == report.tensor_count
+
+    renamed = {
+        key.replace("language_model.", "lm.", 1).replace("fm_modules.", "fm.", 1): digest
+        for key, digest in before.items()
+    }
+    assert after == renamed, "a tensor's bytes, dtype or shape moved under the rename"
+    # And the names really did change, so the comparison above is not vacuous.
+    assert any(k.startswith("lm.") for k in after)
+    assert not any(k.startswith("language_model.") for k in after)
+
+
+def test_a_member_split_across_components_copies_ranges_not_tensors(
+    tmp_path: Path,
+) -> None:
+    """One source file, two components — the general case, byte-checked."""
+
+    from gen_worker.convert.repack_spec import RenameRule
+
+    split = TreeRepack(
+        name="fixture-split",
+        pipeline_class="SplitPipeline",
+        components=(
+            RepackComponent(
+                name="vision", library="lib_x", class_name="Vision",
+                key_prefixes=("vision_model.",), weight_stem="diffusion_pytorch_model",
+                rules=(RenameRule(kind="prefix", pairs=(("vision_model.", ""),)),),
+            ),
+            RepackComponent(
+                name="transformer", library="lib_x", class_name="ClassX",
+                weight_stem="diffusion_pytorch_model",
+            ),
+        ),
+    )
+    tree = _flat_tree(tmp_path / "flat")
+    before = _tensor_digests(tree)
+    report = apply_tree_repack(tree, split)
+
+    assert report.members == {"vision": 1, "transformer": 1}
+    vision = _tensor_digests(tree / "vision")
+    rest = _tensor_digests(tree / "transformer")
+    assert len(vision) == 2 and set(vision) | set(rest) == {
+        k.replace("vision_model.", "", 1) if k.startswith("vision_model.") else k
+        for k in before
+    }
+    assert not (tree / "model.safetensors").exists(), (
+        "the split source survived; it would be published twice")
+    for key, digest in vision.items():
+        assert before[f"vision_model.{key}"] == digest
+
+
+# --------------------------------------------------------------- refusals
+
+
+def test_an_unknown_family_refuses_and_names_what_is_declared() -> None:
+    with pytest.raises(TreeRepackError) as exc:
+        require_tree_repack("sensenova-u2.mot")
+    assert "sensenova-u1.mot" in str(exc.value), (
+        "a refusal that does not name the declared families is a dead end")
+    assert "NAMED by the request" in str(exc.value)
+    assert "sensenova-u1.mot" in registered_tree_repacks()
+
+
+def test_an_unknown_family_is_refused_before_a_pod_exists() -> None:
+    """`normalize_outputs` runs on the request, so a typo costs $0."""
+
+    with pytest.raises(TreeRepackError):
+        normalize_outputs([{"dtype": "bf16", "repack": "not-a-family"}])
+    with pytest.raises(ValueError, match="file_type=safetensors"):
+        normalize_outputs([{"dtype": "q4_k_m", "file_type": "gguf",
+                            "repack": "sensenova-u1.mot"}])
+    specs = normalize_outputs([
+        {"dtype": "bf16", "file_layout": "multi-file", "repack": "sensenova-u1.mot"}])
+    assert [s.repack for s in specs] == ["sensenova-u1.mot"]
+
+
+def test_a_key_no_component_claims_refuses_instead_of_vanishing(tmp_path: Path) -> None:
+    """The failure this schema exists to make impossible.
+
+    A dropped tensor is undetectable downstream: the tree still loads, one
+    weight short, and generates plausible garbage.
+    """
+
+    partial = TreeRepack(
+        name="fixture-partial",
+        pipeline_class="P",
+        components=(
+            RepackComponent(name="transformer", library="l", class_name="C",
+                            key_prefixes=("language_model.",),
+                            weight_stem="diffusion_pytorch_model"),
+        ),
+    )
+    tree = _flat_tree(tmp_path / "flat")
+    with pytest.raises(TreeRepackError) as exc:
+        apply_tree_repack(tree, partial)
+    assert "match no component" in str(exc.value)
+    assert "vision_model.embeddings.patch_embedding.bias" in str(exc.value)
+    assert (tree / "model.safetensors").is_file(), (
+        "the refusal came after the tree had already been taken apart")
+
+
+def test_a_wrong_family_refuses_on_its_declared_signature(tmp_path: Path) -> None:
+    """A repack is NAMED, so the one guard left is: is this that tree?"""
+
+    tree = _flat_tree(tmp_path / "flat", keys={"blocks.0.weight": ("BF16", 16)})
+    with pytest.raises(TreeRepackError) as exc:
+        apply_tree_repack(tree, require_tree_repack("sensenova-u1.mot"))
+    assert "carries no key under" in str(exc.value)
+    assert "language_model." in str(exc.value)
+
+
+def test_a_tree_that_is_already_component_shaped_refuses(tmp_path: Path) -> None:
+    tree = _flat_tree(tmp_path / "flat")
+    apply_tree_repack(tree, require_tree_repack("sensenova-u1.mot"))
+    with pytest.raises(TreeRepackError, match="already carries a model_index.json"):
+        apply_tree_repack(tree, require_tree_repack("sensenova-u1.mot"))
+
+
+def test_a_missing_declared_config_field_refuses(tmp_path: Path) -> None:
+    tree = _flat_tree(tmp_path / "flat")
+    doc = json.loads((tree / "config.json").read_text())
+    del doc["llm_config"]["rope_theta_hw"]
+    (tree / "config.json").write_text(json.dumps(doc))
+    with pytest.raises(TreeRepackError) as exc:
+        apply_tree_repack(tree, require_tree_repack("sensenova-u1.mot"))
+    assert "rope_theta_hw" in str(exc.value)
+
+
+def test_a_missing_declared_tokenizer_file_refuses(tmp_path: Path) -> None:
+    tree = _flat_tree(tmp_path / "flat")
+    (tree / "merges.txt").unlink()
+    with pytest.raises(TreeRepackError, match="merges.txt"):
+        apply_tree_repack(tree, require_tree_repack("sensenova-u1.mot"))
+
+
+# ----------------------------------------------------- declaration refusals
+
+
+def test_a_declaration_that_could_drop_keys_is_refused_at_declaration_time() -> None:
+    def comp(name: str, prefixes: tuple[str, ...] = ()) -> RepackComponent:
+        return RepackComponent(name=name, library="l", class_name="C",
+                               weight_stem="w", key_prefixes=prefixes)
+
+    with pytest.raises(DeclarationError, match="catch-all"):
+        TreeRepack(name="two-catch-alls", pipeline_class="P",
+                   components=(comp("a"), comp("b")))
+    with pytest.raises(DeclarationError, match="LAST weight component"):
+        TreeRepack(name="early-catch-all", pipeline_class="P",
+                   components=(comp("a"), comp("b", ("x.",))))
+    with pytest.raises(DeclarationError, match="routes no weights"):
+        TreeRepack(name="no-weights", pipeline_class="P", components=(
+            RepackComponent(name="a", library="l", class_name="C",
+                            files=(FileRoute("vocab.json"),)),))
+    with pytest.raises(DeclarationError, match="EMPTY directory"):
+        RepackComponent(name="a", library="l", class_name="C")
+    with pytest.raises(DeclarationError, match="exactly one of"):
+        ConfigField("a", source="b", value=1)
+    with pytest.raises(DeclarationError, match="declares no fields"):
+        ComponentConfig(source="config.json", fields=())
+
+
+def test_the_move_fast_path_is_a_property_of_the_declaration() -> None:
+    """The disk preflight prices this, so it must not be a guess."""
+
+    assert require_tree_repack("sensenova-u1.mot").is_pure_move is True
+
+
+# ------------------------------------------------------ the whole clone leg
+
+
+class _Ctx:
+    def __init__(self, server: Any) -> None:
+        self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+        self._worker_capability_token = "cap-token"
+        self.owner = "tensorhub"
+        self.request_id = "req-1670"
+        self.destination = {"repo": "sensenova/fallback"}
+
+
+def _fake_plan(source_dir: Path, strategy: str, layout: str) -> Any:
+    files = [
+        (p.relative_to(source_dir).as_posix(), p.stat().st_size,
+         hashlib.sha256(p.read_bytes()).hexdigest())
+        for p in sorted(source_dir.rglob("*")) if p.is_file()
+    ]
+    return SimpleNamespace(
+        provider="huggingface",
+        paths=[name for name, _, _ in files],
+        source_storage_bits=32,
+        classification=SimpleNamespace(
+            strategy=strategy,
+            attrs={"file_layout": layout, "file_type": "safetensors"},
+        ),
+        bank_files=lambda: list(files),
+    )
+
+
+def _clone(
+    monkeypatch: pytest.MonkeyPatch, fake_hub: Any, tmp_path: Path, source_dir: Path,
+    published: list[Any], **kwargs: Any,
+) -> Any:
+    plan = _fake_plan(source_dir, "transformers", "single-file")
+    attrs = dict(plan.classification.attrs)
+    attrs["dtype"] = detect_snapshot_dtype(source_dir)
+    plan.classification.attrs.update(attrs)
+
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    monkeypatch.setattr("gen_worker.convert.clone.plan_huggingface", lambda *a, **k: plan)
+
+    def _capture(tree: Any, *a: Any, **k: Any) -> Any:
+        root = Path(tree)
+        published.append(SimpleNamespace(
+            path=root,
+            names=sorted(p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()),
+            digests=_tensor_digests(root),
+        ))
+        return files_from_tree(tree, *a, **k)
+
+    monkeypatch.setattr("gen_worker.convert.clone.files_from_tree", _capture)
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.ingest_huggingface",
+        lambda source_ref, dest_dir, **kw: IngestedSource(
+            provider="huggingface", source_ref=source_ref,
+            source_revision="13a8d0f3", dir=source_dir, layout="single-file",
+            model_family="fake", model_family_variant="fake1",
+            classification=plan.classification, attrs=attrs,
+            metadata={"source_provider": "huggingface"},
+            repo_spec={"kind": "model", "library_name": "transformers"},
+        ))
+    return run_clone(
+        _Ctx(fake_hub), provider="huggingface",
+        source_ref="sensenova/SenseNova-U1.5-8B-MoT-Preview",
+        destination_repo="sensenova/sensenova-u1-5-8b-mot-preview",
+        destination_release="r1", **kwargs,
+    )
+
+
+def test_the_cast_and_the_repack_are_ONE_submission(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """se#840's manifest, end to end: cast F32->BF16 AND land the shape.
+
+    The ruling's reason for putting the repack on the conversion leg is that
+    the 50 GB read is paid once. This asserts both halves came out of one
+    `run_clone`, and that the hub was told the layout the tree actually is.
+    """
+
+    source_dir = _flat_tree(tmp_path / "source", shards=2)
+    before = _tensor_digests(source_dir)
+    published: list[Any] = []
+
+    result = _clone(
+        monkeypatch, fake_hub, tmp_path, source_dir, published,
+        outputs=[{"dtype": "bf16", "file_layout": "multi-file",
+                  "file_type": "safetensors", "repack": "sensenova-u1.mot"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(published) == 1
+    tree = published[0]
+    assert "model_index.json" in tree.names
+    assert "transformer/config.json" in tree.names
+    assert "tokenizer/tokenizer_config.json" in tree.names
+    assert any(n.startswith("transformer/diffusion_pytorch_model") for n in tree.names)
+    assert not any(n == "config.json" for n in tree.names)
+
+    # The cast really ran: every F32 tensor is bf16 now, and the ones that
+    # were already bf16 are byte-identical through both legs.
+    assert not any("|F32|" in k for k in tree.digests), sorted(tree.digests)[:3]
+    untouched = {k: v for k, v in before.items() if "|BF16|" in k}
+    assert untouched and all(tree.digests[k] == v for k, v in untouched.items()), (
+        "a tensor the cast had no reason to touch changed in the repack")
+
+    row = list(_FakeHub.state["publishes"].values())[0]
+    assert row["dtype"] == "bf16"
+    assert row["file_layout"] == MULTI_FILE, (
+        "the produced tree IS a diffusers component tree; the row must say so")
+    meta = row.get("metadata") or {}
+    assert meta.get("attr_tree_repack") == "sensenova-u1.mot"
+    assert meta.get("component_dtypes") == {"transformer": "bf16"}, (
+        "the hub's own per-component header read must see the repacked component")
+
+    # ⚠️ ONE MEMBER OUT OF A TWO-SHARD SOURCE, AND THE REPACK IS NOT WHO DID
+    # THAT. `stream_reencode` writes one output file per weight SET, so the
+    # cast has already collapsed the shards by the time the repack runs; the
+    # repack then preserves what it was handed (the sharded case above proves
+    # it preserves 4 of 4 when nothing collapsed them first). Asserted rather
+    # than glossed, because "the produced member count" is exactly the fact
+    # `sensenova-u1.mot@2` is banked from, and pgw#1669 is the open issue for
+    # the axis that collapses it.
+    assert meta.get("attr_repack_members") == "transformer:1"
+
+
+def test_a_repack_request_can_never_be_satisfied_by_publishing_the_source() -> None:
+    """The substitution shape that cost this checkpoint pgw#1668 and pgw#1669.
+
+    A source whose dtype already matches takes the PUBLISH_SOURCE arm, which
+    hands the INGEST tree to the publisher and runs no transform at all. With
+    a repack requested that arm would publish a flat tree carrying a
+    `tree_repack` attribute — a lie with a receipt.
+    """
+
+    plain = OutputSpec(dtype="bf16", file_layout="multi-file", file_type="safetensors")
+    repacked = OutputSpec(dtype="bf16", file_layout="multi-file",
+                          file_type="safetensors", repack="sensenova-u1.mot")
+
+    assert spec_actions([plain], publish_as_is=True, source_dtype="bf16",
+                        explicit_outputs=True, cast_eligible=True) == [PUBLISH_SOURCE]
+    assert spec_actions([repacked], publish_as_is=True, source_dtype="bf16",
+                        explicit_outputs=True, cast_eligible=True) == [CAST_OUTPUT]
+    # And a source that cannot be transformed at all REFUSES rather than
+    # falling back to the untransformed tree.
+    assert spec_actions([repacked], publish_as_is=True, source_dtype="bf16",
+                        explicit_outputs=True, cast_eligible=False) == [NOT_POSSIBLE]
+
+
+def test_a_bf16_source_asked_only_for_a_repack_is_still_repacked(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The arm above, driven for real: no cast to do, and the shape still lands."""
+
+    keys = {k: ("BF16", n) for k, (_d, n) in _sensenova_keys().items()}
+    source_dir = _flat_tree(tmp_path / "source", keys=keys)
+    published: list[Any] = []
+
+    result = _clone(
+        monkeypatch, fake_hub, tmp_path, source_dir, published,
+        outputs=[{"dtype": "bf16", "file_layout": "multi-file",
+                  "file_type": "safetensors", "repack": "sensenova-u1.mot"}],
+    )
+    assert not result.failed_flavors, result.failed_flavors
+    assert "model_index.json" in published[0].names
+    assert published[0].path.resolve() != source_dir.resolve(), (
+        "the SOURCE tree was handed to the publisher — the repack was skipped")
+    assert _tensor_digests(source_dir), "the ingest tree was consumed rather than read"


### PR DESCRIPTION
se#840's mirror publishes an honest flat bf16 tree that the endpoint **cannot load**. The hollow session intercepts only diffusers/transformers loaders, so a component class has to be reachable through a `model_index.json` — and a flat root beside a `config.json` whose `auto_map` names four `.py` files that do not exist is not that.

se#840's ruling put the repack on the conversion leg. **There was no such transform in this repo**: `repackage.singlefile_to_diffusers` is a LOAD-and-resave through a DECLARED diffusers pipeline class (`SinglefileTarget`), which needs a class the SDK can name and a card's worth of RAM; `register_repackage_family` has no production caller anywhere; and SenseNova's serving class is `sensenova_u1.Model` in an endpoint package.

## What this is

`convert/tree_repack.py` routes safetensors **keys** into component directories, derives each component's `config.json` from the source config field by declared field, moves the tokenizer files into their own directory, and writes `model_index.json`. **There is no torch import in the module.** Tensor DATA is copied as byte RANGES out of the source header's own offsets, so every tensor in the produced tree is bit-identical to the one it came from and no dtype or shape can move here.

Requested per output: `outputs=[{dtype = "bf16", file_layout = "multi-file", repack = "sensenova-u1.mot"}]`.

## The four properties, each with a case that reds

- **ONE SUBMISSION.** The repack is the last leg of `build_flavor_tree`, so the 50 GB read the cast already pays is not paid twice.
- **IT MOVES WHAT IT CAN.** An identity key map with a single weight component `os.replace`s each member — zero bytes read, zero written. The disk preflight prices that property (`TreeRepack.is_pure_move`) rather than assuming a copy; assuming one would refuse a job that fits, which is pgw#1666's under-count pointing the other way.
- **A REPACK REQUEST IS WORK.** `spec_actions` no longer lets a dtype-matching source take the `PUBLISH_SOURCE` arm when a repack is asked for. That arm hands the ingest tree straight to the publisher, so it would have published an untransformed tree carrying a `tree_repack` attribute — a lie with a receipt, and the same substitution shape as pgw#1668 and pgw#1669.
- **MEMBERS ARE PRESERVED AND THE LAYOUT IS READ BACK.** N source members become N component members with an index; `file_layout` comes from `observed_file_layout` on the produced tree, never from the request. ⚠️ On a clone the CAST has already collapsed a shard set by the time the repack runs (`stream_reencode` writes one output file per weight set), so a 13-shard source publishes one member. That is the cast's doing, is asserted as such rather than glossed, and belongs to pgw#1669's axis.

## Everything that could silently drop a tensor is a refusal

Most at declaration time: two catch-all components, a catch-all that is not last, a component carrying neither weights nor files, two source keys renaming onto one, a key no component claims, a config field the source document does not carry, a declared tokenizer file that is not there, a tree that is already component-shaped, and a tree carrying none of the declaration's required key prefixes.

An **unknown family** is refused by `normalize_outputs` — on the request, before a pod exists — and the refusal names what IS declared. A repack is NAMED by the request and never detected: a wrong key map produces a tree that loads and serves noise.

## Declared family

`sensenova-u1.mot`: one `transformer` component whose key map is deliberately the **identity**, because the upstream keys (`language_model.*`, `vision_model.*`, `fm_modules.*`) already ARE the endpoint's module paths. What the repack supplies is the directory shape, the two derived config documents and the `model_index.json`. The target is the endpoint's own `tests/fixtures/checkpoint-configs/`, which is the tree the first real `gen-worker lock --checkpoint` derive loaded to 100% on both components.

## Verification

17 cases, **red-armed six ways**: dropping the repack call, dropping the `spec_actions` clause, perturbing one byte of the copy loop, deleting the unrouted-key refusal, deleting the signature check, and collapsing members. Each falsification was run and the expected cases went red.

`tests/convert` 176/176 · `mypy src/gen_worker tests` clean over 664 files · `ruff check src/gen_worker` clean · `lint_unbounded_reads`, `lint_pickle_readers` and all six digest guards OK · `assemble_changelog --check` OK.

Closes pgw#1670's code half; the delivery (submit the repack leg, extract `sensenova-u1.mot@2`, repoint the lane) rides on top.