### PR TITLE
pgw#1670: cover the hardlink write-through — the repack must not edit the INGEST tree through a link the cast made

### DIFF
--- a/tests/convert/test_tree_repack_pgw1670.py
+++ b/tests/convert/test_tree_repack_pgw1670.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import struct
 from pathlib import Path
 from types import SimpleNamespace
@@ -676,6 +677,54 @@ def test_a_bf16_source_asked_only_for_a_repack_is_still_repacked(
     assert published[0].path.resolve() != source_dir.resolve(), (
         "the SOURCE tree was handed to the publisher — the repack was skipped")
     assert _tensor_digests(source_dir), "the ingest tree was consumed rather than read"
+
+
+def test_the_repack_never_writes_through_a_hardlink_into_the_ingest_tree(
+    tmp_path: Path,
+) -> None:
+    """The silent-corruption hazard the clone's own flavor build creates.
+
+    `build_flavor_tree`'s cast arm calls `copy_non_weight_files`, which
+    HARDLINKS every non-weight file out of the INGEST tree into the flavor
+    tree — the config, the tokenizer documents, the card. The repack then moves
+    those files into `tokenizer/` and REWRITES one of them (`tokenizer_class`
+    -> `Qwen2TokenizerFast`). Writing through the link would edit the ingest
+    tree, which is the source every other flavor in the same run is built from,
+    and nothing downstream would notice.
+
+    Every other case in this file builds its tree with ordinary writes, so none
+    of them can see this. The fixture is the hardlinks.
+    """
+
+    source = _flat_tree(tmp_path / "ingest")
+    before = {p.name: p.read_bytes() for p in sorted(source.iterdir())}
+    inodes = {p.name: p.stat().st_ino for p in sorted(source.iterdir())}
+
+    flavor = tmp_path / "flavor"
+    flavor.mkdir()
+    for p in sorted(source.iterdir()):
+        if p.suffix == ".safetensors":
+            (flavor / p.name).write_bytes(p.read_bytes())  # the cast's own output
+        else:
+            os.link(p, flavor / p.name)  # exactly what copy_non_weight_files does
+    shared = [n for n, ino in inodes.items()
+              if n != "model.safetensors" and (flavor / n).stat().st_ino == ino]
+    assert len(shared) >= 5, f"the fixture did not hardlink: {shared}"
+
+    apply_tree_repack(flavor, require_tree_repack("sensenova-u1.mot"))
+
+    after = {p.name: p.read_bytes() for p in sorted(source.iterdir())}
+    assert after == before, (
+        "the repack wrote through a hardlink into the INGEST tree: "
+        f"{sorted(k for k in before if before[k] != after.get(k))}")
+    # And the override really did happen on the repacked side, so the
+    # comparison above is not vacuous.
+    assert json.loads(
+        (flavor / "tokenizer" / "tokenizer_config.json").read_text()
+    )["tokenizer_class"] == "Qwen2TokenizerFast"
+    assert json.loads(
+        (source / "tokenizer_config.json").read_text()
+    )["tokenizer_class"] == "Qwen2Tokenizer"
 
 
 # ------------------------------------ the REAL key set and the REAL config


### PR DESCRIPTION
`build_flavor_tree`'s cast arm calls `copy_non_weight_files`, which **hardlinks** every non-weight file out of the ingest tree into the flavor tree — the config, the tokenizer documents, the card. The repack then moves those into `tokenizer/` and **rewrites one of them** (`tokenizer_class` → `Qwen2TokenizerFast`).

Writing through the link edits the **ingest tree**, which is the source every other flavor in the same run is built from. Nothing downstream notices.

## Why this is a gap and not a bug

The engine already does the right thing: an overridden route writes a **new** file at the destination and only then unlinks the source. But nothing proved it. Every other case in `test_tree_repack_pgw1670.py` builds its tree with ordinary writes, so **none of them can see a hardlink at all** — the property was true by construction and untested by construction.

The fixture is the hardlinks: 6 non-weight files linked exactly the way `copy_non_weight_files` does them, then the ingest tree asserted byte-identical after the repack, with the override asserted to have landed on the repacked copy so the comparison is not vacuous.

## Red arm

The regression this catches is the one that looks reasonable — rewrite the JSON in place at the source path, then `os.replace` it to the destination:

```python
 doc = _load_json(src, where=where)
-_write_json(dst, _apply_fields({}, route.json_overrides, where=where, into=doc))
-src.unlink()
+_write_json(src, _apply_fields({}, route.json_overrides, where=where, into=doc))
+os.replace(src, dst)
```

Two lines a reader would wave through. Every other case stays green; this one fails with *"the repack wrote through a hardlink into the INGEST tree: ['tokenizer_config.json']"*.

## Verification

`tests/convert` **178/178** · `mypy src/gen_worker tests` clean over 664 files · `ruff check src/gen_worker` clean.

Closes the case recorded as owed on pgw#1670.