### PR TITLE
pgw#1671: the drive's step budget is the PLATFORM's — count rounds at the marked module

### DIFF
--- a/src/gen_worker/graphs/discovery.py
+++ b/src/gen_worker/graphs/discovery.py
@@ -198,6 +198,7 @@ def discover_lane(
     dynamic_dims: DimPolicy | bool | None = None,
     static_bind: bool = False,
     notes: list[str] | None = None,
+    on_round: Callable[[str, int], None] | None = None,
 ) -> LaneGraphs:
     """Run the author's code once, derive every observed graph, state the rest.
 
@@ -235,6 +236,7 @@ def discover_lane(
         dynamic_dims=dynamic_dims,
         static_bind=static_bind,
         notes=notes,
+        on_round=on_round,
     )
 
 
@@ -300,6 +302,7 @@ def discover_modules(
     dynamic_dims: DimPolicy | bool | None = None,
     static_bind: bool = False,
     notes: list[str] | None = None,
+    on_round: Callable[[str, int], None] | None = None,
 ) -> LaneGraphs:
     """Discovery over MARKED modules (the imperative ``ctx.compile`` surface).
 
@@ -348,6 +351,16 @@ def discover_modules(
     the trace pays structural-variant count, never bucket count. A cover
     whose bind is refused falls back to its own direct static export, loudly.
 
+    ``on_round`` (pgw#1671) is called ``(target, round)`` each time a marked
+    module's FIRST-seen call signature comes round again — i.e. each time the
+    author's loop starts another step, whatever its arm count and whether or
+    not it calls the callback ``ctx.step_callback()`` handed it. It may RAISE,
+    and raising is the point: the drive's step budget is otherwise enforceable
+    only by author cooperation, and an author who never calls the callback
+    drives the whole schedule under a hollow session with no error and no
+    output. se#840 measured that shape at 139 s per payload x 24 payloads,
+    which reads as a hung ``torch.export`` and is not one.
+
     ``notes``, when a caller passes a list, receives every demotion sentence
     that is otherwise only a ``logger.warning`` — a refused symbolic export,
     a guard-contradicted range, a refused bind. The derive puts them in the
@@ -381,6 +394,8 @@ def discover_modules(
 
     observed: dict[str, dict[str, _ObservedCall]] = {path: {} for path in targets}
     handles = []
+    first_key: dict[str, str] = {}
+    rounds: dict[str, int] = {}
 
     def _recorder(path: str) -> Callable[..., None]:
         def record(
@@ -388,6 +403,21 @@ def discover_modules(
         ) -> None:
             call = _ObservedCall(args=tuple(args), kwargs=tuple(kwargs.items()))
             key = _signature_of(args) + "|" + _signature_of(dict(kwargs))
+            # pgw#1671: a ROUND is the marked module's first-seen call
+            # signature coming round again. A denoise loop repeats its
+            # signatures once per timestep whatever its arm count, so this
+            # counts the author's STEPS at the seam the platform owns rather
+            # than at a callback the author may never invoke. `on_round` may
+            # raise; it is called BEFORE the call is recorded, so a stop lands
+            # on a round boundary and every signature of the completed rounds
+            # is already banked.
+            if path not in first_key:
+                first_key[path] = key
+                rounds[path] = 1
+            elif key == first_key[path]:
+                rounds[path] += 1
+                if on_round is not None:
+                    on_round(path, rounds[path])
             observed[path].setdefault(key, call)
 
         return record

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -87,7 +87,7 @@ import json
 import types
 import traceback
 import typing
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType, ModuleType
@@ -939,6 +939,51 @@ def _is_wrapper(value: Any) -> bool:
     return hasattr(value, "__dict__") and isinstance(getattr(value, "__dict__"), dict)
 
 
+def _round_guard(
+    said: str, request_ctx: Any, notes: list[str]
+) -> Callable[[str, int], None]:
+    """Stop a drive whose author loop does not honour the step budget (pgw#1671).
+
+    `ctx.step_callback()` hands the author a callable that raises
+    `StepBudgetReached` on the budget-th call. That is the whole enforcement,
+    and it is CONSENSUAL: an author who accepts the callback and never invokes
+    it -- or never asks for one -- drives the entire sampling schedule against
+    FAKE weights, with no error, no warning and no output, and the derive is
+    read as a hung `torch.export` it never reached (se#840: 139 s per payload,
+    x 24 auto-enumerated payloads).
+
+    Discovery counts ROUNDS at the marked module itself, which is the platform's
+    own seam. Stopping on a round boundary loses nothing that has been seen: by
+    definition of "round" every signature of the completed rounds is banked. It
+    can only lose a signature a LATER step would have introduced -- so it says
+    so, in the lock, by name.
+    """
+
+    told: set[str] = set()
+
+    def guard(target: str, rounds: int) -> None:
+        budget = request_ctx.step_budget
+        if budget is None or rounds <= budget:
+            return
+        sentence = (
+            f"{said}: the drive was STOPPED at step {budget} of target "
+            f"{target!r} by the platform, not by the endpoint. This "
+            f"endpoint's sampling loop does not call the callback "
+            f"`ctx.step_callback()` returns, so the trace step budget is "
+            f"unenforceable from the entrypoint and the drive would run the "
+            f"whole schedule against fake weights. Every graph the completed "
+            f"step produced is banked; a shape only a LATER step introduces "
+            f"is NOT, and will mint on first live encounter. Call the "
+            f"callback once per step."
+        )
+        if sentence not in told:
+            told.add(sentence)
+            notes.append(sentence)
+        raise StepBudgetReached
+
+    return guard
+
+
 def _named_marked_modules(instance: Any, marked: list[Any]) -> dict[str, Any]:
 
     candidates: dict[int, str] = {}
@@ -1486,11 +1531,12 @@ def _derive_lane_item(
                                     unservable.append(row)
 
             notes: list[str] = []
+            on_round = _round_guard(said, request_ctx, notes)
             try:
                 lane_graphs = torchcg.discover_modules(
                     handle, modules, drive, program_sink=program_sink,
                     session=session, dynamic_dims=dynamic_dims,
-                    static_bind=static_bind, notes=notes,
+                    static_bind=static_bind, notes=notes, on_round=on_round,
                 )
                 if set(lane_graphs.targets) - {
                     record.target for record in lane_graphs.graphs
@@ -1500,6 +1546,7 @@ def _derive_lane_item(
                         handle, modules, drive, program_sink=program_sink,
                         session=session, dynamic_dims=dynamic_dims,
                         static_bind=static_bind, notes=notes,
+                        on_round=on_round,
                     )
                 _refuse_a_dead_accelerator(said, session)
             except DeriveError:

--- a/tests/release_fixtures/budget_ignoring_endpoint.py
+++ b/tests/release_fixtures/budget_ignoring_endpoint.py
@@ -1,0 +1,77 @@
+"""An endpoint whose sampling loop NEVER calls the step callback (pgw#1671).
+
+The shape se#840 shipped and could not see: the entrypoint asks for no
+``ctx.step_callback`` at all, so the derive's step budget has nothing to raise
+out of and the drive runs the whole schedule against fake weights — silently.
+On a 17.5B model at 2048x2048 that is 139 s per payload and reads as a hung
+``torch.export`` the drive never reached.
+
+The unet call count is written to ``$GEN_WORKER_ROUND_PROBE`` so a test can
+assert what the drive actually did, not what it reported.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import msgspec
+import torch
+from diffusers import StableDiffusionPipeline
+
+from gen_worker import STATIC, LoadContext, Model, RequestContext, entrypoint, lane
+from gen_worker.demand import MiB, const, per_mp_batch
+from gen_worker.models import SDXL
+from lane_contracts import TINY_DIFFUSERS_FP32
+
+#: What the drive is asked for. Every one of these is a full pass of the marked
+#: module, and without a budget the drive pays all of them.
+STEPS = 8
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class Out(msgspec.Struct):
+    model_used: str
+
+
+def _count_one(*_: Any, **__: Any) -> None:
+    probe = os.environ.get("GEN_WORKER_ROUND_PROBE")
+    if not probe:
+        return
+    with open(probe, "a", encoding="utf-8") as handle:
+        handle.write("1\n")
+
+
+class BudgetIgnoringModel(
+    Model[SDXL],
+    lanes={TINY_DIFFUSERS_FP32: lane(
+        request=const(MiB(64)) + per_mp_batch(MiB(16)),
+    )},
+    shapes={"aspect": STATIC},
+):
+    pipe: Any
+
+    def load(self, ctx: LoadContext[SDXL]) -> None:
+        self.pipe = ctx.load(StableDiffusionPipeline)
+        self.pipe.unet.register_forward_pre_hook(_count_one)
+        self.pipe.unet = ctx.compile(self.pipe.unet)
+
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In, model: BudgetIgnoringModel) -> Out:
+    ctx.raise_if_cancelled()
+    with torch.inference_mode():
+        # NO `callback_on_step_end=ctx.step_callback(...)`. That omission is
+        # the whole fixture.
+        model.pipe(
+            prompt=payload.prompt,
+            num_inference_steps=STEPS,
+            guidance_scale=0.0,
+            width=32,
+            height=32,
+            output_type="pil",
+        )
+    return Out(model_used=ctx.checkpoint_ref)

--- a/tests/test_release_derive_round_guard_pgw1671.py
+++ b/tests/test_release_derive_round_guard_pgw1671.py
@@ -1,0 +1,136 @@
+"""pgw#1671 — the drive's step budget is the PLATFORM's, not the author's.
+
+`ctx.step_callback()` hands an author a callable that raises `StepBudgetReached`
+on the budget-th call, and until now that was the ONLY enforcement: an endpoint
+that never invoked it drove the entire sampling schedule against fake weights,
+with no error, no warning and no output. se#840 spent two lanes reading that as
+a hung `torch.export` — 21 minutes with the export never entered.
+
+Discovery now counts ROUNDS at the marked module itself (the first-seen call
+signature coming round again is the author's next step, whatever its arm count)
+and stops the drive on a round boundary, loudly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+import gen_worker._vendor.torchcg  # noqa: E402,F401
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+
+LOCK = (
+    "version = 1\n"
+    '\n[[package]]\nname = "torch"\nversion = "2.13.0"\n'
+    '\n[[package]]\nname = "triton"\nversion = "3.7.1"\n'
+    '\n[[package]]\nname = "nvidia-cublas"\nversion = "13.1.1.3"\n'
+    '\n[[package]]\nname = "diffusers"\nversion = "0.39.0"\n'
+)
+
+
+@pytest.fixture(scope="module")
+def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import tiny_tree
+    finally:
+        sys.path.remove(str(FIXTURES))
+    return tiny_tree.save_config_only(tmp_path_factory.mktemp("round-guard-configs"))
+
+
+def _derive(tree: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
+    from gen_worker.release.derive import derive_release
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    probe = tmp_path / "unet-calls"
+    monkeypatch.setenv("GEN_WORKER_ROUND_PROBE", str(probe))
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(LOCK)
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        import budget_ignoring_endpoint
+
+        result = derive_release(
+            budget_ignoring_endpoint,
+            checkpoint_dir=tree,
+            lockfile=lockfile,
+            trace_workers=1,
+        )
+    finally:
+        sys.path.remove(str(FIXTURES))
+    calls = len(probe.read_text().split()) if probe.exists() else 0
+    return result, calls, budget_ignoring_endpoint.STEPS
+
+
+def test_a_loop_that_ignores_the_budget_is_STOPPED_at_the_budget(
+    tree: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The measurement, not the intention: how many times did the marked module
+    actually run — against a CONTROL run of the same fixture with no budget at
+    all, so the number means something without knowing how many extra passes
+    the export stage makes.
+
+    The fixture asks for 8 steps and never calls the callback. Before this
+    change the drive paid all 8, and on a real endpoint that is the difference
+    between 5 s and 139 s PER PAYLOAD, times the whole auto-enumerated fan.
+    """
+    from gen_worker.release import derive as derive_module
+
+    _result, guarded, steps = _derive(tree, tmp_path, monkeypatch)
+
+    # The control: the same fixture, same drive, no budget in force.
+    monkeypatch.setattr(derive_module, "TRACE_STEP_BUDGET", None)
+    control_result, unguarded, _ = _derive(tree, tmp_path / "control", monkeypatch)
+
+    assert steps == 8
+    assert unguarded >= steps, (
+        f"the control only ran the marked module {unguarded} times for "
+        f"{steps} steps — the probe is not measuring the drive"
+    )
+    assert control_result.warnings == (), (
+        "the control reported a stop it did not make"
+    )
+    # Measured on this fixture: 18 control vs 6 guarded, over 2 derive items —
+    # per item 8 driven steps + 1 export pass, against 1 driven step + the
+    # blocked entry to the next + 1 export pass. The probe cannot separate the
+    # export's re-run from the drive's, so the claim is the RATIO: a guarded
+    # drive costs at most half of an unguarded one, and grows with the export
+    # stage rather than with the author's schedule.
+    assert guarded * 2 <= unguarded, (
+        f"the drive ran the marked module {guarded} times against a control's "
+        f"{unguarded} for a step budget of 1 — the guard did not stop a loop "
+        f"that ignores the callback"
+    )
+
+
+def test_the_stop_is_SAID_in_the_lock_and_names_what_it_may_have_cost(
+    tree: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A silent stop would be the same defect one layer down: the author would
+    see a derive that finished and never learn its loop was cut, nor that a
+    shape only a later step introduces was not banked."""
+    result, _calls, _steps = _derive(tree, tmp_path, monkeypatch)
+    said = {w for w in result.warnings if "STOPPED at step" in w}
+    assert said, f"no stop was reported; warnings were {list(result.warnings)!r}"
+    (sentence,) = said
+    assert "ctx.step_callback()" in sentence
+    assert "will mint on first live encounter" in sentence
+
+
+def test_the_completed_step_s_graphs_are_STILL_derived(
+    tree: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stop lands on a round boundary, so everything the completed step
+    showed is banked. A guard that cost the lane its graphs would be worse than
+    the hang it replaces."""
+    result, _calls, _steps = _derive(tree, tmp_path, monkeypatch)
+    assert result.lane_graphs
+    assert all(graphs for graphs in result.lane_graphs.values())
+    assert result.unmarked_lanes == ()


### PR DESCRIPTION
`ctx.step_callback()` hands an author a callable that raises `StepBudgetReached`
on the budget-th call, and that was the ONLY enforcement of `TRACE_STEP_BUDGET`.
It is consensual: an endpoint that accepts the callback and never invokes it —
or never asks for one — drives its whole sampling schedule against fake weights
with no error, no warning and no output.

Measured on se#840's sensenova-u1: 50 steps x 2 guidance arms x 1.37 s = 139 s
per payload, x 24 auto-enumerated cells. Two lanes read that as a hung
`torch.export` and named the dynamic KV length; the export was never entered.
A derive that neither finishes nor fails is the third outcome, and it was also
unattributable.

THE FIX. Discovery already hooks every marked module and computes a per-call
signature for dedup. A ROUND is that module's FIRST-seen signature coming round
again — a sampling loop repeats its signatures once per timestep whatever its
arm count, so this counts the author's STEPS at the seam the platform owns
rather than at a callback the author may never call.
`discover_modules(..., on_round=)` fires on each new round;
`derive.py::_round_guard` raises `StepBudgetReached` past the budget, which the
payload loop already catches.

Stopping on a round BOUNDARY is what makes it safe: by definition every
signature of the completed rounds is banked. It can only cost a signature a
LATER step would have introduced, so the stop is a WARNING in the lock saying
exactly that — never a silent truncation. The guard is inert when
`step_budget is None`, so the derive's own no-budget fallback pass is unchanged.

Tests: a fixture endpoint that never asks for a step callback, driven through
`derive_release` against its OWN control run with the budget lifted (measured 18
marked-module calls vs 6 over two derive items), plus the stop sentence in
`result.warnings` and the completed step's graphs still being derived. All three
falsified against the pre-guard tree: 2 of 3 red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)